### PR TITLE
Fix palette name syntax for overriding MUI theme

### DIFF
--- a/_templates/new-component/new/component.ejs.t
+++ b/_templates/new-component/new/component.ejs.t
@@ -20,4 +20,4 @@ const <%= Name %> = props => {
 <%= Name %>.defaultProps = {
 }
 
-export default withStyles(styles.<%= Name %>)(<%= Name %>)
+export default withStyles(styles)(<%= Name %>)

--- a/_templates/new-component/new/styles.ejs.t
+++ b/_templates/new-component/new/styles.ejs.t
@@ -6,11 +6,9 @@ to: components/<%= h.changeCase.pascalCase(name) %>/styles.js
 -%>
 import { PicassoProvider } from '../Picasso'
 
-PicassoProvider.override(({ pallete }) => ({
+PicassoProvider.override(({ palette }) => ({
 
 }))
 
-export default {
-  <%= Name %>: {
-  }
-}
+export default ({ palette }) => ({
+})

--- a/components/Button/styles.js
+++ b/components/Button/styles.js
@@ -58,7 +58,7 @@ export const createButtonVariant = (
   border
 ) => variant(background, border)
 
-PicassoProvider.override(({ pallete }) => ({
+PicassoProvider.override(({ palette }) => ({
   MuiButton: {
     root: {
       textTransform: 'none',
@@ -67,43 +67,43 @@ PicassoProvider.override(({ pallete }) => ({
     },
     containedPrimary: createButtonVariant(
       VARIANTS.containedPrimary,
-      pallete.primary.main,
-      pallete.primary.main
+      palette.primary.main,
+      palette.primary.main
     ),
     containedSecondary: createButtonVariant(
       VARIANTS.containedSecondary,
-      pallete.secondary.main,
-      pallete.secondary.main
+      palette.secondary.main,
+      palette.secondary.main
     ),
     outlinedPrimary: createButtonVariant(
       VARIANTS.outlinedPrimary,
-      pallete.primary.main,
-      pallete.primary.main
+      palette.primary.main,
+      palette.primary.main
     ),
     outlinedSecondary: createButtonVariant(
       VARIANTS.outlinedSecondary,
-      pallete.secondary.main,
-      pallete.secondary.main
+      palette.secondary.main,
+      palette.secondary.main
     ),
     outlined: createButtonVariant(
       VARIANTS.outlined,
-      pallete.grey[50],
-      pallete.grey[100]
+      palette.grey[50],
+      palette.grey[100]
     ),
     flat: createButtonVariant(
       VARIANTS.flat,
-      pallete.grey[100],
-      pallete.grey[100]
+      palette.grey[100],
+      palette.grey[100]
     ),
     flatPrimary: createButtonVariant(
       VARIANTS.flat,
-      pallete.primary.main,
-      pallete.primary.main
+      palette.primary.main,
+      palette.primary.main
     ),
     flatSecondary: createButtonVariant(
       VARIANTS.flat,
-      pallete.secondary.main,
-      pallete.secondary.main
+      palette.secondary.main,
+      palette.secondary.main
     )
   }
 }))

--- a/components/Checkbox/styles.js
+++ b/components/Checkbox/styles.js
@@ -1,5 +1,4 @@
 import { PicassoProvider } from '../Picasso'
-import pallete from '../Picasso/pallete'
 
 PicassoProvider.override(() => ({
   MuiCheckbox: {
@@ -20,36 +19,36 @@ PicassoProvider.override(() => ({
   }
 }))
 
-export default {
+export default ({ palette }) => ({
   root: {
     '&:hover $uncheckedIcon': {
-      border: `1px solid ${pallete.primary.main}`
+      border: `1px solid ${palette.primary.main}`
     }
   },
   disabled: {
     '&:hover $uncheckedIcon': {
-      border: `1px solid ${pallete.grey[50]}`
+      border: `1px solid ${palette.grey[50]}`
     }
   },
   checkedIcon: {
     height: '1em',
     width: '1em',
     transition: 'all .1s ease',
-    background: pallete.primary.main,
-    border: `1px solid ${pallete.primary.dark}`
+    background: palette.primary.main,
+    border: `1px solid ${palette.primary.dark}`
   },
   uncheckedIcon: {
     height: '1em',
     width: '1em',
     transition: 'all .1s ease',
-    background: pallete.common.white,
-    border: `1px solid ${pallete.grey[50]}`
+    background: palette.common.white,
+    border: `1px solid ${palette.grey[50]}`
   },
   indeterminateIcon: {
     height: '1em',
     width: '1em',
     transition: 'all .1s ease',
-    background: pallete.primary.main,
-    border: `1px solid ${pallete.primary.dark}`
+    background: palette.primary.main,
+    border: `1px solid ${palette.primary.dark}`
   }
-}
+})

--- a/components/FormControlLabel/styles.js
+++ b/components/FormControlLabel/styles.js
@@ -1,6 +1,6 @@
 import { PicassoProvider } from '../Picasso'
 
-PicassoProvider.override(({ pallete }) => ({
+PicassoProvider.override(({ palette }) => ({
   MuiFormControlLabel: {
     root: {
       marginLeft: 0,
@@ -10,7 +10,7 @@ PicassoProvider.override(({ pallete }) => ({
       display: 'inline-flex',
       alignItems: 'center',
 
-      color: pallete.text.primary,
+      color: palette.text.primary,
       lineHeight: '1em',
       fontWeight: 300,
 

--- a/components/InputLabel/styles.js
+++ b/components/InputLabel/styles.js
@@ -1,6 +1,6 @@
 import { PicassoProvider } from '../Picasso'
 
-PicassoProvider.override(({ pallete }) => ({
+PicassoProvider.override(({ palette }) => ({
   MuiInputLabel: {
     outlined: {
       transform: 'translate(0.75em, 1em) scale(1)',
@@ -13,7 +13,7 @@ PicassoProvider.override(({ pallete }) => ({
     shrink: {},
 
     error: {
-      color: pallete.error.text
+      color: palette.error.text
     }
   }
 }))

--- a/components/List/styles.js
+++ b/components/List/styles.js
@@ -1,9 +1,9 @@
 import { PicassoProvider } from '../Picasso'
 
-PicassoProvider.override(({ pallete }) => ({
+PicassoProvider.override(({ palette }) => ({
   MuiList: {
     root: {
-      border: `solid 1px ${pallete.primary.main}`
+      border: `solid 1px ${palette.primary.main}`
     }
   }
 }))

--- a/components/MenuItem/styles.js
+++ b/components/MenuItem/styles.js
@@ -1,9 +1,9 @@
 import { PicassoProvider } from '../Picasso'
 
-PicassoProvider.override(({ pallete }) => ({
+PicassoProvider.override(({ palette }) => ({
   MuiMenuItem: {
     root: {
-      borderTop: `1px solid ${pallete.grey[50]}`,
+      borderTop: `1px solid ${palette.grey[50]}`,
       lineHeight: '1em',
       padding: '0.7em',
       height: 'auto',
@@ -13,17 +13,17 @@ PicassoProvider.override(({ pallete }) => ({
       },
 
       '&:hover': {
-        backgroundColor: pallete.blue.light,
+        backgroundColor: palette.blue.light,
 
         '&$selected': {
-          backgroundColor: pallete.blue.light,
-          color: pallete.primary.main
+          backgroundColor: palette.blue.light,
+          color: palette.primary.main
         }
       },
 
       '&$selected': {
-        backgroundColor: pallete.blue.light,
-        color: pallete.primary.main
+        backgroundColor: palette.blue.light,
+        color: palette.primary.main
       }
     },
     selected: {}

--- a/components/OutlinedInput/styles.js
+++ b/components/OutlinedInput/styles.js
@@ -1,10 +1,10 @@
 import { PicassoProvider } from '../Picasso'
 
-PicassoProvider.override(({ pallete }) => ({
+PicassoProvider.override(({ palette }) => ({
   MuiOutlinedInput: {
     root: {
       '& $notchedOutline': {
-        borderColor: pallete.grey[50],
+        borderColor: palette.grey[50],
         borderRadius: 0
       },
 
@@ -17,7 +17,7 @@ PicassoProvider.override(({ pallete }) => ({
       '&:hover': {
         '&:not($disabled)&:not($focused)&:not($error)': {
           '& $notchedOutline': {
-            borderColor: pallete.primary.main
+            borderColor: palette.primary.main
           }
         }
       }

--- a/components/Picasso/Picasso.jsx
+++ b/components/Picasso/Picasso.jsx
@@ -2,11 +2,11 @@ import { createMuiTheme, MuiThemeProvider } from '@material-ui/core/styles'
 import React from 'react'
 import PT from 'prop-types'
 
-import pallete from './pallete'
+import palette from './palette'
 import Provider from './PicassoProvider'
 
 const picasso = {
-  pallete,
+  palette,
   props: {
     MuiButtonBase: {
       disableRipple: true

--- a/components/Picasso/palette.js
+++ b/components/Picasso/palette.js
@@ -1,4 +1,4 @@
-const pallete = {
+const palette = {
   common: {
     black: '#000000',
     white: '#ffffff'
@@ -27,4 +27,4 @@ const pallete = {
   }
 }
 
-export default pallete
+export default palette

--- a/components/Radio/Radio.jsx
+++ b/components/Radio/Radio.jsx
@@ -30,4 +30,4 @@ const Radio = props => {
   )
 }
 
-export default withStyles(styles.Radio)(Radio)
+export default withStyles(styles)(Radio)

--- a/components/Radio/styles.js
+++ b/components/Radio/styles.js
@@ -1,5 +1,4 @@
 import { PicassoProvider } from '../Picasso'
-import pallete from '../Picasso/pallete'
 
 const setBorderColor = borderColor => ({
   '&:before': {
@@ -14,23 +13,23 @@ const setCircleColor = borderColor => ({
   }
 })
 
-const createColorVariant = color => ({
+const createColorVariant = (mainColor, disabledColor) => ({
   '&$checked': {
-    ...setBorderColor(color),
-    ...setCircleColor(color)
+    ...setBorderColor(mainColor),
+    ...setCircleColor(mainColor)
   },
   '&$disabled': {
     opacity: 0.5,
     cursor: 'not-allowed',
     pointerEvents: 'auto',
-    ...setBorderColor(pallete.grey[100])
+    ...setBorderColor(disabledColor)
   },
   '&:hover': {
-    ...setBorderColor(color)
+    ...setBorderColor(mainColor)
   }
 })
 
-PicassoProvider.override(({ pallete, transitions }) => ({
+PicassoProvider.override(({ palette, transitions }) => ({
   MuiRadio: {
     root: {
       fontSize: '16px',
@@ -40,21 +39,21 @@ PicassoProvider.override(({ pallete, transitions }) => ({
       padding: '0',
 
       margin: '0.25em 0.5em',
-      ...createColorVariant(pallete.grey[100]),
+      ...createColorVariant(palette.grey[100], palette.grey[100]),
       animationDuration: transitions.duration.short,
       animationTimingFunction: transitions.easing.easeIn,
       transitionDuration: transitions.duration.short,
       transitionTimingFunction: transitions.easing.easeOut
     },
-    colorPrimary: createColorVariant(pallete.primary.main),
-    colorSecondary: createColorVariant(pallete.primary.main), // secondary is set to primary by purpose
-    disabled: createColorVariant(pallete.grey[100]),
+    colorPrimary: createColorVariant(palette.primary.main, palette.grey[100]),
+    colorSecondary: createColorVariant(palette.primary.main, palette.grey[100]), // secondary is set to primary by purpose
+    disabled: createColorVariant(palette.grey[100], palette.grey[100]),
 
     checked: {}
   }
 }))
 
-const centeredCircle = {
+const centeredCircle = palette => ({
   position: 'absolute',
   width: '100%',
   height: '100%',
@@ -64,39 +63,37 @@ const centeredCircle = {
   transform: 'translate(-50%, -50%)',
   content: '""',
   borderColor: 'inherit',
-  background: pallete.common.white,
+  background: palette.common.white,
   pointerEvents: 'none',
   transition: 'border-color',
   transitionDuration: 'inherit',
   transitionTimingFunction: 'inherit'
-}
+})
 
-export default {
-  Radio: {
-    '@keyframes fade-in': {
-      '0%': {
-        opacity: 0
-      },
-      '100%': {
-        opacity: 1
-      }
+export default ({ palette }) => ({
+  '@keyframes fade-in': {
+    '0%': {
+      opacity: 0
     },
-    icon: {
-      '&:before': {
-        ...centeredCircle,
-        border: `1px solid ${pallete.common.black}`
-      },
-      '&:after': {
-        ...centeredCircle,
-        width: 'initial',
-        height: 'initial',
-        borderWidth: '0.25em',
-        borderStyle: 'solid',
-        display: 'none',
-        animation: 'fade-in',
-        animationDuration: 'inherit',
-        animationTimingFunction: 'inherit'
-      }
+    '100%': {
+      opacity: 1
+    }
+  },
+  icon: {
+    '&:before': {
+      ...centeredCircle(palette),
+      border: `1px solid ${palette.common.black}`
+    },
+    '&:after': {
+      ...centeredCircle(palette),
+      width: 'initial',
+      height: 'initial',
+      borderWidth: '0.25em',
+      borderStyle: 'solid',
+      display: 'none',
+      animation: 'fade-in',
+      animationDuration: 'inherit',
+      animationTimingFunction: 'inherit'
     }
   }
-}
+})


### PR DESCRIPTION
 ### Description

Fix naming for `palette` (`pallete` -> `palette`)

Change the usage of `palette`:

> Component.jsx
```
export default withStyles(styles)(Component)
```
> style.js
```
PicassoProvider.override(() => ({ }))
export default ({ palette }) => ({})
```
