### PR TITLE
Added Accordion component (collapsable panel)

### DIFF
--- a/components/Accordion/Accordion.example.jsx
+++ b/components/Accordion/Accordion.example.jsx
@@ -1,0 +1,133 @@
+/* eslint-disable react/no-multi-comp, react/require-optimization, react/prop-types */
+import React from 'react'
+import { storiesOf } from '@storybook/react'
+
+import StoryTeller from '../../.storybook/StoryTeller'
+import Accordion from './'
+import Spacer from '../Spacer'
+import Button from '../Button'
+
+const stories = storiesOf('Accordion', module)
+
+class ExpandedControl extends React.Component {
+  constructor () {
+    super()
+
+    this.state = {
+      expanded: false
+    }
+
+    this.handleClick = this.handleClick.bind(this)
+  }
+
+  handleClick () {
+    const { expanded } = this.state
+
+    this.setState({
+      expanded: !expanded
+    })
+  }
+
+  render () {
+    const { children } = this.props
+    const { expanded } = this.state
+
+    return (
+      <div style={{ display: 'flex', flexDirection: 'column' }}>
+        <Spacer bottom={2}>
+          <Button onClick={this.handleClick}>Expand/Collapse</Button>
+        </Spacer>
+
+        <div>{React.cloneElement(children, { expanded })}</div>
+      </div>
+    )
+  }
+}
+
+const SummaryDogDefinitionPanel = () => <div>What is a dog?</div>
+const DetailsDogDefinitionPanel = () => (
+  <div>
+    A dog is a type of domesticated animal. Known for its loyalty and
+    faithfulness, it can be found as a welcome guest in many households across
+    the world.
+  </div>
+)
+
+// Chapter Accordion
+
+const teller = new StoryTeller(
+  'Accordion',
+  'Accordions store information behind collapsible sections, allowing for more information to be stored in a limited amount of space.'
+)
+const chapter = teller.addChapter()
+
+chapter.addSection(
+  'Default',
+  'Styled sections is a default behaviour of Accordion when `expanded` prop is not specified (uncontrolled).',
+  () => (
+    <div style={{ width: '430px' }}>
+      <Accordion
+        Details={<DetailsDogDefinitionPanel />}
+        Summary={<SummaryDogDefinitionPanel />}
+      />
+    </div>
+  )
+)
+
+chapter.addSection(
+  'Controlled',
+  'You can control of expansion or collapsing of the Details panel by passing `expanded` prop.',
+  () => (
+    <ExpandedControl>
+      <Accordion Details={<DetailsDogDefinitionPanel />} expanded={false} />
+    </ExpandedControl>
+  )
+)
+stories.addWithChapters('Accordion', teller.toStory())
+
+// Chapter Accordion Group
+
+const tellerGroup = new StoryTeller(
+  'Group',
+  'Default Accordions with styled sections in a group.'
+)
+const chapterGroup = tellerGroup.addChapter()
+
+const SummaryDogKindPanel = () => <div>What kinds of dogs are there?</div>
+const DetailsDogKindPanel = () => (
+  <div>
+    There are many breeds of dogs. Each breed varies in size and temperament.
+    Owners often select a breed of dog that they find to be compatible with
+    their own lifestyle and desires from a companion.
+  </div>
+)
+const SummaryDogAcquirePanel = () => <div>How do you acquire a dog?</div>
+const DetailsDogAcquirePanel = () => (
+  <div>
+    Three common ways for a prospective owner to acquire a dog is from pet
+    shops, private owners, or shelters. A pet shop may be the most convenient
+    way to buy a dog. Buying a dog from a private owner allows you to assess the
+    pedigree and upbringing of your dog before choosing to take it home. Lastly,
+    finding your dog from a shelter, helps give a good home to a dog who may not
+    find one so readily.
+  </div>
+)
+
+chapterGroup.addSection('Default', null, () => (
+  <div style={{ width: '430px' }}>
+    <Accordion
+      Details={<DetailsDogDefinitionPanel />}
+      Summary={<SummaryDogDefinitionPanel />}
+    />
+    <Accordion
+      Details={<DetailsDogKindPanel />}
+      Summary={<SummaryDogKindPanel />}
+    />
+    <Accordion
+      Details={<DetailsDogAcquirePanel />}
+      Summary={<SummaryDogAcquirePanel />}
+    />
+  </div>
+))
+
+stories.addWithChapters('Accordion Group', tellerGroup.toStory())

--- a/components/Accordion/Accordion.jsx
+++ b/components/Accordion/Accordion.jsx
@@ -1,0 +1,55 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { withStyles } from '@material-ui/core/styles'
+import MUIExpansionPanel from '@material-ui/core/ExpansionPanel'
+import ChevronRightIcon from '@material-ui/icons/ChevronRight'
+
+import styles from './styles'
+import ExpansionPanelSummary from '../ExpansionPanelSummary'
+import ExpansionPanelDetails from '../ExpansionPanelDetails'
+
+const Accordion = props => {
+  const { classes, Summary, Details, expanded, ...rest } = props
+
+  const isControlledVariant = expanded === undefined
+
+  return (
+    <MUIExpansionPanel expanded={expanded} {...rest}>
+      {Summary && (
+        <ExpansionPanelSummary
+          classes={{
+            root: isControlledVariant ? classes.defaultSummary : null
+          }}
+          data-testid='panel-summary'
+          expandIcon={<ChevronRightIcon className={classes.expandIcon} />}
+        >
+          {Summary}
+        </ExpansionPanelSummary>
+      )}
+      <ExpansionPanelDetails
+        classes={{ root: isControlledVariant ? classes.defaultDetails : null }}
+      >
+        {Details}
+      </ExpansionPanelDetails>
+    </MUIExpansionPanel>
+  )
+}
+
+Accordion.propTypes = {
+  Details: PropTypes.node.isRequired,
+  Summary: PropTypes.node,
+  classes: PropTypes.shape({
+    expandIcon: PropTypes.string
+  }),
+  expanded: PropTypes.bool,
+  onChange: PropTypes.func
+}
+
+Accordion.defaultProps = {
+  Summary: null,
+  classes: null,
+  expanded: undefined,
+  onChange: () => {}
+}
+
+export default withStyles(styles)(Accordion)

--- a/components/Accordion/__snapshots__/test.jsx.snap
+++ b/components/Accordion/__snapshots__/test.jsx.snap
@@ -1,0 +1,183 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`controlled version should render collapsed version 1`] = `
+<div>
+  <div
+    class="MuiPaper-root MuiPaper-elevation1 MuiExpansionPanel-root"
+  >
+    <div
+      aria-hidden="true"
+      class="MuiCollapse-container"
+      style="min-height: 0px;"
+    >
+      <div
+        class="MuiCollapse-wrapper"
+      >
+        <div
+          class="MuiCollapse-wrapperInner"
+        >
+          <div
+            class="MuiExpansionPanelDetails-root ExpansionPanelDetails-root"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`controlled version should render expanded version 1`] = `
+<div>
+  <div
+    class="MuiPaper-root MuiPaper-elevation1 MuiExpansionPanel-root MuiExpansionPanel-expanded"
+  >
+    <div
+      class="MuiCollapse-container MuiCollapse-entered"
+      style="min-height: 0px;"
+    >
+      <div
+        class="MuiCollapse-wrapper"
+      >
+        <div
+          class="MuiCollapse-wrapperInner"
+        >
+          <div
+            class="MuiExpansionPanelDetails-root ExpansionPanelDetails-root"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`default version for sections should render default version 1`] = `
+<div>
+  <div
+    class="MuiPaper-root MuiPaper-elevation1 MuiExpansionPanel-root"
+  >
+    <div
+      aria-expanded="false"
+      class="MuiButtonBase-root MuiExpansionPanelSummary-root WithStyles-ExpansionPanelSummary--root Accordion-defaultSummary"
+      data-testid="panel-summary"
+      role="button"
+      tabindex="0"
+    >
+      <div
+        class="MuiExpansionPanelSummary-content"
+      />
+      <div
+        aria-hidden="true"
+        class="MuiButtonBase-root MuiIconButton-root MuiExpansionPanelSummary-expandIcon"
+        role="button"
+        tabindex="-1"
+      >
+        <span
+          class="MuiIconButton-label"
+        >
+          <svg
+            aria-hidden="true"
+            class="MuiSvgIcon-root-50 Accordion-expandIcon-3"
+            focusable="false"
+            role="presentation"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M10 6L8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z"
+            />
+            <path
+              d="M0 0h24v24H0z"
+              fill="none"
+            />
+          </svg>
+        </span>
+        <span
+          class="MuiTouchRipple-root"
+        />
+      </div>
+    </div>
+    <div
+      aria-hidden="true"
+      class="MuiCollapse-container"
+      style="min-height: 0px;"
+    >
+      <div
+        class="MuiCollapse-wrapper"
+      >
+        <div
+          class="MuiCollapse-wrapperInner"
+        >
+          <div
+            class="MuiExpansionPanelDetails-root ExpansionPanelDetails-root Accordion-defaultDetails"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`default version for sections should render expanded version after click on summary 1`] = `
+<div>
+  <div
+    class="MuiPaper-root MuiPaper-elevation1 MuiExpansionPanel-root MuiExpansionPanel-expanded"
+  >
+    <div
+      aria-expanded="true"
+      class="MuiButtonBase-root MuiExpansionPanelSummary-root WithStyles-ExpansionPanelSummary--root Accordion-defaultSummary MuiExpansionPanelSummary-expanded"
+      data-testid="panel-summary"
+      role="button"
+      tabindex="0"
+    >
+      <div
+        class="MuiExpansionPanelSummary-content MuiExpansionPanelSummary-expanded"
+      />
+      <div
+        aria-hidden="true"
+        class="MuiButtonBase-root MuiIconButton-root MuiExpansionPanelSummary-expandIcon MuiExpansionPanelSummary-expanded"
+        role="button"
+        tabindex="-1"
+      >
+        <span
+          class="MuiIconButton-label"
+        >
+          <svg
+            aria-hidden="true"
+            class="MuiSvgIcon-root-121 Accordion-expandIcon-74"
+            focusable="false"
+            role="presentation"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M10 6L8.59 7.41 13.17 12l-4.58 4.59L10 18l6-6z"
+            />
+            <path
+              d="M0 0h24v24H0z"
+              fill="none"
+            />
+          </svg>
+        </span>
+        <span
+          class="MuiTouchRipple-root"
+        />
+      </div>
+    </div>
+    <div
+      class="MuiCollapse-container"
+      style="min-height: 0px; height: 0px;"
+    >
+      <div
+        class="MuiCollapse-wrapper"
+      >
+        <div
+          class="MuiCollapse-wrapperInner"
+        >
+          <div
+            class="MuiExpansionPanelDetails-root ExpansionPanelDetails-root Accordion-defaultDetails"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/components/Accordion/index.js
+++ b/components/Accordion/index.js
@@ -1,0 +1,1 @@
+export { default } from './Accordion'

--- a/components/Accordion/styles.js
+++ b/components/Accordion/styles.js
@@ -1,0 +1,17 @@
+export default ({ palette }) => ({
+  defaultSummary: {
+    padding: '0 2.4em',
+    color: palette.common.black,
+    fontSize: '1.25em',
+    fontWeight: 700
+  },
+  defaultDetails: {
+    padding: '0 3em',
+    lineHeight: '1.5em',
+    color: palette.text.primary
+  },
+  expandIcon: {
+    fontSize: '1.5em',
+    color: palette.primary.main
+  }
+})

--- a/components/Accordion/test.jsx
+++ b/components/Accordion/test.jsx
@@ -1,0 +1,70 @@
+/* eslint-disable react/no-multi-comp */
+import React from 'react'
+import { render, fireEvent, cleanup } from 'react-testing-library'
+
+import Accordion from './index'
+
+const renderAccordion = (props = {}) => {
+  return render(<Accordion {...props} />)
+}
+
+afterEach(cleanup)
+
+const Summary = () => <div>Fryderyk Chopin</div>
+
+const Details = () => (
+  <div>
+    Fryderyk Chopin was born in Żelazowa Wola, 46 kilometres west of Warsaw, in
+    what was then the Duchy of Warsaw, a Polish state established by Napoleon.
+    The parish baptismal record gives his birthday as 22 February 1810, and
+    cites his given names in the Latin form Fridericus Franciscus (in Polish, he
+    was Fryderyk Franciszek). However, the composer and his family used the
+    birthdate 1 March, which is now generally accepted as the correct date.
+  </div>
+)
+
+describe('default version for sections', () => {
+  let api
+
+  beforeEach(() => {
+    api = renderAccordion({
+      Details,
+      Summary
+    })
+  })
+
+  test('should render default version', () => {
+    const { container } = api
+
+    expect(container).toMatchSnapshot()
+  })
+
+  test('should render expanded version after click on summary', () => {
+    const { container, getByTestId } = api
+    const summary = getByTestId('panel-summary')
+
+    fireEvent.click(summary)
+
+    expect(container).toMatchSnapshot()
+  })
+})
+
+describe('controlled version', () => {
+  test('should render expanded version', () => {
+    const { container } = renderAccordion({
+      Details,
+      expanded: true
+    })
+
+    expect(container).toMatchSnapshot()
+  })
+
+  test('should render collapsed version', () => {
+    const { container } = renderAccordion({
+      Details,
+      expanded: false
+    })
+
+    expect(container).toMatchSnapshot()
+  })
+})

--- a/components/Accordion/visual.test.jsx
+++ b/components/Accordion/visual.test.jsx
@@ -1,0 +1,4 @@
+import { assertVisuals } from '../../puppeteer'
+
+test('Default', assertVisuals('Accordion', 'Accordion'))
+test('Group', assertVisuals('Accordion', 'Accordion Group'))

--- a/components/ExpansionPanelDetails/ExpansionPanelDetails.jsx
+++ b/components/ExpansionPanelDetails/ExpansionPanelDetails.jsx
@@ -1,0 +1,11 @@
+import React from 'react'
+import { withStyles } from '@material-ui/core/styles'
+import MUIExpansionPanelDetails from '@material-ui/core/ExpansionPanelDetails'
+
+import styles from './styles'
+
+const ExpansionPanelDetails = props => {
+  return <MUIExpansionPanelDetails {...props} />
+}
+
+export default withStyles(styles)(ExpansionPanelDetails)

--- a/components/ExpansionPanelDetails/index.js
+++ b/components/ExpansionPanelDetails/index.js
@@ -1,0 +1,1 @@
+export { default } from './ExpansionPanelDetails'

--- a/components/ExpansionPanelDetails/styles.js
+++ b/components/ExpansionPanelDetails/styles.js
@@ -1,0 +1,13 @@
+import { PicassoProvider } from '../Picasso'
+
+PicassoProvider.override(() => ({
+  MuiExpansionPanelDetails: {
+    root: {
+      padding: 0
+    }
+  }
+}))
+
+export default {
+  root: {}
+}

--- a/components/ExpansionPanelSummary/ExpansionPanelSummary.jsx
+++ b/components/ExpansionPanelSummary/ExpansionPanelSummary.jsx
@@ -1,0 +1,10 @@
+import { withStyles } from '@material-ui/core/styles'
+import MUIExpansionPanelSummary from '@material-ui/core/ExpansionPanelSummary'
+
+import styles from './styles'
+
+// We can't create here intermediate object for ExpansionPanelSummary
+// because MUI ExpansionPanel use type check to set Summary in the
+// correct place of the markdown
+// https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/ExpansionPanel/ExpansionPanel.js#L144
+export default withStyles(styles)(MUIExpansionPanelSummary)

--- a/components/ExpansionPanelSummary/index.js
+++ b/components/ExpansionPanelSummary/index.js
@@ -1,0 +1,1 @@
+export { default } from './ExpansionPanelSummary'

--- a/components/ExpansionPanelSummary/styles.js
+++ b/components/ExpansionPanelSummary/styles.js
@@ -1,0 +1,22 @@
+import { PicassoProvider } from '../Picasso'
+
+PicassoProvider.override(() => ({
+  MuiExpansionPanelSummary: {
+    root: {
+      padding: 0
+    },
+    expandIcon: {
+      transform: 'translateY(-50%) rotate(90deg)',
+      left: 0,
+      right: 'unset',
+
+      '&$expanded': {
+        transform: 'translateY(-50%) rotate(0deg)'
+      }
+    }
+  }
+}))
+
+export default {
+  root: {}
+}


### PR DESCRIPTION
[PICAS-29](https://youtrack.toptal.net/youtrack/issue/PICAS-29)

 ### Description

Add initial component Accordion.

Accordion component contains default styled section-based accordion:
<img width="1079" alt="screenshot 2019-01-23 at 15 41 46" src="https://user-images.githubusercontent.com/2836281/51614202-6fb69b00-1f25-11e9-8c4a-af29454fa535.png">

And other variant - controlled expandable panel, which will be using for implementing Search component, for example:
<img width="1070" alt="screenshot 2019-01-23 at 15 41 58" src="https://user-images.githubusercontent.com/2836281/51614258-8fe65a00-1f25-11e9-91a1-580f18583533.png">


