### PR TITLE
Add error state for Text Field component

### DIFF
--- a/components/InputBase/styles.js
+++ b/components/InputBase/styles.js
@@ -1,10 +1,14 @@
 import { PicassoProvider } from '../Picasso'
 
-PicassoProvider.override(({ typography }) => ({
+PicassoProvider.override(({ typography, palette }) => ({
   MuiInputBase: {
     input: {
       fontSize: typography.inputSize,
       lineHeight: '1.2em'
+    },
+    error: {
+      color: palette.error.dark,
+      backgroundColor: palette.error.lighter
     }
   }
 }))

--- a/components/Picasso/config/palette.js
+++ b/components/Picasso/config/palette.js
@@ -23,7 +23,8 @@ const palette = {
   error: {
     lighter: '#fff6f6',
     light: '#f8b1b4',
-    main: '#f05359'
+    main: '#f05359',
+    dark: '#9f3a38'
   },
   common: {
     black: '#000',

--- a/components/TextField/TextField.example.jsx
+++ b/components/TextField/TextField.example.jsx
@@ -6,6 +6,7 @@ import TextField from './'
 
 storiesOf('TextField', module)
   .add('text', () => <TextField label='Search...' />)
+  .add('error', () => <TextField error label='Search...' />)
   .add('text with Icon', () => (
     <TextField Icon={<SearchIcon />} label='Search...' />
   ))

--- a/components/TextField/visual.test.jsx
+++ b/components/TextField/visual.test.jsx
@@ -1,6 +1,7 @@
 import { assertVisuals } from '../../puppeteer'
 
 test('Text', assertVisuals('TextField', 'text'))
+test('Error', assertVisuals('TextField', 'error'))
 test('With icon', assertVisuals('TextField', 'text with Icon'))
 test('Select', assertVisuals('TextField', 'select'))
 test('Textarea', assertVisuals('TextField', 'textarea'))


### PR DESCRIPTION
[PICAS-52](https://youtrack.toptal.net/youtrack/issue/PICAS-52)

 ### Description

Add error state for Text Field to storybook.

<img width="519" alt="screenshot 2019-01-23 at 17 29 27" src="https://user-images.githubusercontent.com/2836281/51621277-7567ad00-1f34-11e9-904c-d6905cb71114.png">
