### PR TITLE
Truncate svg dynamic classnames parts using jss snapshot serializer

### DIFF
--- a/__tests__/jss-snapshot-serializer.js
+++ b/__tests__/jss-snapshot-serializer.js
@@ -30,13 +30,32 @@ const markElementsProcessed = nodes => {
   })
 }
 
+const getClassName = element => {
+  // eslint-disable-next-line no-undef
+  if (element.className instanceof SVGAnimatedString) {
+    return element.className.baseVal
+  }
+
+  return element.className
+}
+
+const setClassName = (element, className) => {
+  // eslint-disable-next-line no-undef
+  if (element.className instanceof SVGAnimatedString) {
+    element.className.baseVal = className
+    return
+  }
+
+  element.className = className
+}
+
 const removeNonDeterministicClassParts = elements => {
   elements.forEach(element => {
     if (!element.className) return
 
-    const classNameProp = element.className
+    const classNameProp = getClassName(element)
 
-    if (!classNameProp || typeof classNameProp !== 'string') return
+    if (!classNameProp) return
 
     const deterministicClassNames = classNameProp
       .trim()
@@ -54,7 +73,7 @@ const removeNonDeterministicClassParts = elements => {
         return className.substring(0, secondLastDashPosition)
       })
 
-    element.className = deterministicClassNames.join(' ')
+    setClassName(element, deterministicClassNames.join(' '))
   })
 }
 

--- a/components/Accordion/__snapshots__/test.jsx.snap
+++ b/components/Accordion/__snapshots__/test.jsx.snap
@@ -77,7 +77,7 @@ exports[`default version for sections should render default version 1`] = `
         >
           <svg
             aria-hidden="true"
-            class="MuiSvgIcon-root-50 Accordion-expandIcon-3"
+            class="MuiSvgIcon-root Accordion-expandIcon"
             focusable="false"
             role="presentation"
             viewBox="0 0 24 24"
@@ -143,7 +143,7 @@ exports[`default version for sections should render expanded version after click
         >
           <svg
             aria-hidden="true"
-            class="MuiSvgIcon-root-121 Accordion-expandIcon-74"
+            class="MuiSvgIcon-root Accordion-expandIcon"
             focusable="false"
             role="presentation"
             viewBox="0 0 24 24"

--- a/components/Label/__snapshots__/test.jsx.snap
+++ b/components/Label/__snapshots__/test.jsx.snap
@@ -12,7 +12,7 @@ exports[`dismissable label should render dismissable label 1`] = `
     />
     <svg
       aria-hidden="true"
-      class="MuiSvgIcon-root-151 Label-deleteIcon-124 MuiChip-deleteIcon-146"
+      class="MuiSvgIcon-root Label-deleteIcon MuiChip-deleteIcon"
       data-testid="icon-delete"
       focusable="false"
       role="presentation"

--- a/components/Loader/__snapshots__/test.jsx.snap
+++ b/components/Loader/__snapshots__/test.jsx.snap
@@ -11,11 +11,11 @@ exports[`props combo 1`] = `
       style="width: 40px; height: 40px;"
     >
       <svg
-        class="MuiCircularProgress-svg-11"
+        class="MuiCircularProgress-svg"
         viewBox="22 22 44 44"
       >
         <circle
-          class="MuiCircularProgress-circle-12 MuiCircularProgress-circleIndeterminate-14"
+          class="MuiCircularProgress-circle MuiCircularProgress-circleIndeterminate"
           cx="44"
           cy="44"
           fill="none"

--- a/components/Select/__snapshots__/test.jsx.snap
+++ b/components/Select/__snapshots__/test.jsx.snap
@@ -23,7 +23,7 @@ exports[`renders dropdown select 1`] = `
       />
       <svg
         aria-hidden="true"
-        class="MuiSvgIcon-root-86 MuiSelect-icon-55"
+        class="MuiSvgIcon-root MuiSelect-icon"
         focusable="false"
         role="presentation"
         viewBox="0 0 24 24"
@@ -66,7 +66,7 @@ exports[`renders native select 1`] = `
       </select>
       <svg
         aria-hidden="true"
-        class="MuiSvgIcon-root-39 MuiSelect-icon-8"
+        class="MuiSvgIcon-root MuiSelect-icon"
         focusable="false"
         role="presentation"
         viewBox="0 0 24 24"

--- a/components/TextField/__snapshots__/test.jsx.snap
+++ b/components/TextField/__snapshots__/test.jsx.snap
@@ -27,7 +27,7 @@ exports[`Icon prop renders icon at the beginning 1`] = `
       >
         <svg
           aria-hidden="true"
-          class="MuiSvgIcon-root-94"
+          class="MuiSvgIcon-root"
           focusable="false"
           role="presentation"
           viewBox="0 0 24 24"
@@ -85,7 +85,7 @@ exports[`Icon prop renders icon at the end 1`] = `
       >
         <svg
           aria-hidden="true"
-          class="MuiSvgIcon-root-43"
+          class="MuiSvgIcon-root"
           focusable="false"
           role="presentation"
           viewBox="0 0 24 24"


### PR DESCRIPTION
 ### Description

The JSS snapshot serializer was failing for svg elements and now the fix I promised you, guys 😃 
Now it's truncating dynamic part of the class names from svg elements as well for snapshot testing.