### PR TITLE
Change eslint rule sort-default-prop-types to sort-prop-types

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -42,7 +42,7 @@
     "react/jsx-child-element-spacing": 0,
     "react/forbid-component-props": 0,
     "react/prefer-stateless-function": 0,
-    "react/sort-prop-types": 0,
+    "react/sort-default-prop-types": 0,
     "react/sort-comp": [
       "error",
       {

--- a/components/Button/Button.jsx
+++ b/components/Button/Button.jsx
@@ -68,8 +68,8 @@ Button.propTypes = {
   color: PropTypes.string,
   compact: PropTypes.bool,
   icon: PropTypes.node,
-  variant: PropTypes.string,
-  loading: PropTypes.bool
+  loading: PropTypes.bool,
+  variant: PropTypes.string
 }
 
 Button.defaultProps = {

--- a/components/Loader/Loader.jsx
+++ b/components/Loader/Loader.jsx
@@ -40,15 +40,15 @@ const Loader = props => {
 }
 
 Loader.propTypes = {
-  label: PropTypes.string,
-  variant: PropTypes.oneOf(['determinate', 'indeterminate', 'static']),
-  size: PropTypes.oneOf(['small', 'default', 'large']),
-  inline: PropTypes.bool,
+  className: PropTypes.string,
   classes: PropTypes.shape({
     root: PropTypes.string
   }).isRequired,
-  className: PropTypes.string,
-  value: PropTypes.number
+  inline: PropTypes.bool,
+  label: PropTypes.string,
+  size: PropTypes.oneOf(['small', 'default', 'large']),
+  value: PropTypes.number,
+  variant: PropTypes.oneOf(['determinate', 'indeterminate', 'static'])
 }
 
 Loader.defaultProps = {

--- a/components/Select/Select.jsx
+++ b/components/Select/Select.jsx
@@ -62,15 +62,15 @@ const Select = props => {
 }
 
 Select.propTypes = {
+  native: PropTypes.bool,
+  onChange: PropTypes.func,
   options: PropTypes.arrayOf(
     PropTypes.shape({
       key: PropTypes.string,
       value: PropTypes.string.isRequired,
       text: PropTypes.oneOfType([PropTypes.node, PropTypes.string]).isRequired
     })
-  ).isRequired,
-  native: PropTypes.bool,
-  onChange: PropTypes.func
+  ).isRequired
 }
 
 Select.defaultProps = {


### PR DESCRIPTION
[PICAS-60](https://youtrack.toptal.net/youtrack/issue/PICAS-60)

 ### Description

So, in docs of eslint react plugin https://github.com/yannickcr/eslint-plugin-react rule `sort-default-prop-types` marked as *not-fixable*, so `--fix` flag doesn't make any effect. We can fix it for them later, but for now my proposition is to disable this rule, but instead, enable rule for `props` `sort-prop-types` which is *fixable* and will not be painful for us to use it.

👍 ?