### PR TITLE
Add docker image for ci build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,5 +32,3 @@ RUN chown -R pptruser:pptruser /home/pptruser
 RUN chown -R pptruser:pptruser /app
 
 USER pptruser
-
-RUN yarn install

--- a/bin/test-visual
+++ b/bin/test-visual
@@ -19,10 +19,12 @@ echo "Running visual tests inside docker ..."
 
 if [[ "$1" == "-u" ]]; then
   echo "Updating snapshots to a current version ..."
-  $DOCKER_CMD sh -c "yarn build:storybook; \
+  $DOCKER_CMD sh -c "yarn install; \
+  yarn build:storybook; \
   /app/node_modules/.bin/jest --config='./puppeteer/puppeteer.jest.config.js' -u"
 else
-  $DOCKER_CMD sh -c "yarn build:storybook; \
+  $DOCKER_CMD sh -c "yarn install; \
+  yarn build:storybook; \
   /app/node_modules/.bin/jest --config='./puppeteer/puppeteer.jest.config.js'"
 fi
 

--- a/ci/jobs/build-image/Jenkinsfile
+++ b/ci/jobs/build-image/Jenkinsfile
@@ -1,0 +1,69 @@
+@Library('globalLibrary@master') _
+
+image = null
+
+pipeline {
+  agent { label 'slave_aws' }
+
+  options {
+    ansiColor('xterm')
+    timestamps()
+    timeout(time: 10, unit: 'MINUTES')
+    buildDiscarder(logRotator(numToKeepStr: '20'))
+    skipDefaultCheckout()
+  }
+
+  parameters {
+    string(name: 'BRANCH', defaultValue: 'master', description: 'Branch or tag to build')
+  }
+
+  environment {
+    GCE_ACCOUNT_KEY = credentials('jenkins-storage-administrator')
+  }
+
+  stages {
+    stage('Git checkout') {
+      steps {
+        info "== Checking out ${params.BRANCH} =="
+        gitCheckout(
+          branches: params.BRANCH,
+          credentials: [username: 'git', description: 'jenkins/picasso'],
+          url: 'git@github.com:toptal/picasso.git',
+          additionalBehaviours: [
+            cleanBeforeCheckout: true
+          ])
+        success "== Checked out ${params.BRANCH} at ${gitCommit()}"
+      }
+    }//checkout
+
+    stage('Build image') {
+      steps {
+        script {
+          version = sh(returnStdout: true, script: 'git describe --tags --always').trim()
+
+          sh "gcloud auth activate-service-account --key-file=$GCE_ACCOUNT_KEY"
+
+          if (!isDockerImagePresentRemotely('gcr.io/compute-engine-1069/picasso', version)) {
+            image = docker.build("compute-engine-1069/picasso:${version}", ".")
+            success "== Built image for version ${version} =="
+          } else {
+            success "== Found image for version ${version} =="
+          }
+        }
+      }
+    }//build image
+
+    stage('Push image') {
+      steps {
+        script {
+          if (image) {
+            docker.withRegistry('https://gcr.io/compute-engine-1069/') {
+              image.push('latest')
+            }
+            success "== Pushed image with tag :latest =="
+          }
+        }
+      }
+    }//push image
+  }
+}

--- a/ci/jobs/picasso-master-release/Jenkinsfile
+++ b/ci/jobs/picasso-master-release/Jenkinsfile
@@ -47,6 +47,22 @@ pipeline {
       }
     }//stage
 
+    stage('Build new Docker image') {
+      steps {
+        info "== Building new docker image"
+        script {
+          downStreamBuilds[0] = buildWithParameters(
+            jobName: 'picasso-build-image',
+            propagate: false,
+            wait: true,
+            parameters: [
+              BRANCH: 'master'
+            ]
+          )
+        }
+      }
+    }
+
     stage('Run release') {
       steps {
 
@@ -72,7 +88,7 @@ pipeline {
       steps {
         info "== Deploying docs"
         script {
-          downStreamBuilds[0] = buildWithParameters(
+          downStreamBuilds[1] = buildWithParameters(
             jobName: "picasso-docs",
             propagate: false,
             wait: true,
@@ -87,7 +103,8 @@ pipeline {
     stage('Build results') {
       steps {
         script {
-          helper.printBuildsResults([ downStreamBuilds[0] ], "picasso-docs")
+          helper.printBuildsResults([ downStreamBuilds[0] ], "picasso-build-image")
+          helper.printBuildsResults([ downStreamBuilds[1] ], "picasso-docs")
           helper.setBuildStatus(downStreamBuilds)
         }
       }

--- a/ci/jobs/picasso-pr-specs/Jenkinsfile
+++ b/ci/jobs/picasso-pr-specs/Jenkinsfile
@@ -4,7 +4,11 @@ ghHelper = new helpers.GithubNotifyHelper()
 def FAILURE_REASON
 
 pipeline {
-  agent { dockerfile true }
+  agent {
+      docker {
+          image 'gcr.io/compute-engine-1069/picasso'
+      }
+  }
 
   options {
     ansiColor('xterm')
@@ -39,6 +43,12 @@ pipeline {
         info "Git branch: ${gitBranch()}"
         success 'Checkout finished'
       }
+    }//stage
+
+    stage('Yarn install') {
+      steps {
+        sh 'yarn install'
+      } //steps
     }//stage
 
     stage('Run linter') {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "test": "jest",
     "test:watch": "jest --watchAll",
-    "test-visual": "./bin/test-visual",
+    "test:visual": "./bin/test-visual",
     "lint:path": "eslint --ext=.js,.jsx,.ts,.tsx --color --fix",
     "lint": "yarn run lint:path .",
     "storybook": "start-storybook -p 9001 -c .storybook",


### PR DESCRIPTION
### Description

- Add job to build docker image for CI jobs
- Move `yarn install` out from `Dockerfile`
- Rename visual test script command to `test:visual`
