### PR TITLE
Minor design issues with select

### DIFF
--- a/components/Select/Select.tsx
+++ b/components/Select/Select.tsx
@@ -83,7 +83,7 @@ const Select: React.FunctionComponent<Props> = props => {
     variant === 'outlined' ? (
       <OutlinedInput
         classes={{
-          input: classes.input
+          input: hasLabel ? classes.inputWithLabel : classes.input
         }}
         fullWidth={fullWidth}
         labelWidth={0}
@@ -91,7 +91,7 @@ const Select: React.FunctionComponent<Props> = props => {
     ) : (
       <Input
         classes={{
-          input: classes.input
+          input: hasLabel ? classes.inputWithLabel : classes.input
         }}
         fullWidth={fullWidth}
       />
@@ -100,9 +100,11 @@ const Select: React.FunctionComponent<Props> = props => {
   const select = (
     <MUISelect
       className={cx(className, {
-        [classes.root]: !fullWidth,
-        [classes.rootWithLabel]: hasLabel
+        [classes.root]: !fullWidth
       })}
+      classes={{
+        icon: classes.icon
+      }}
       displayEmpty
       id={id}
       input={outlinedInput}
@@ -139,7 +141,6 @@ const Select: React.FunctionComponent<Props> = props => {
           shrink: classes.labelShrink
         }}
         htmlFor={id}
-        shrink
         variant={variant}
       >
         {label}

--- a/components/Select/__snapshots__/test.jsx.snap
+++ b/components/Select/__snapshots__/test.jsx.snap
@@ -37,7 +37,7 @@ exports[`renders dropdown select 1`] = `
       />
       <svg
         aria-hidden="true"
-        class="MuiSvgIcon-root MuiSelect-icon"
+        class="MuiSvgIcon-root MuiSelect-icon Select-icon"
         focusable="false"
         role="presentation"
         viewBox="0 0 24 24"
@@ -94,7 +94,7 @@ exports[`renders native select 1`] = `
       </select>
       <svg
         aria-hidden="true"
-        class="MuiSvgIcon-root MuiSelect-icon"
+        class="MuiSvgIcon-root MuiSelect-icon Select-icon"
         focusable="false"
         role="presentation"
         viewBox="0 0 24 24"

--- a/components/Select/story/WithLabel-example.jsx
+++ b/components/Select/story/WithLabel-example.jsx
@@ -9,7 +9,6 @@ const WithLabelLabelExample = () => (
 )
 
 const OPTIONS = [
-  { value: '', text: 'None' },
   { value: '1', text: 'Option 1' },
   { value: '2', text: 'Option 2' },
   { value: '3', text: 'Option 3' },

--- a/components/Select/styles.ts
+++ b/components/Select/styles.ts
@@ -1,6 +1,8 @@
 import { PicassoProvider } from '../Picasso'
 
-import '../InputBase/styles'
+import '../FormControl/styles'
+import '../InputLabel/styles'
+import '../OutlinedInput/styles'
 import '../MenuItem/styles'
 import '../List/styles'
 
@@ -25,21 +27,32 @@ export default () => ({
     wrap: 'nowrap'
   },
   root: {
-    width: '14em'
-  },
-  rootWithLabel: {
-    marginTop: '1.2em'
+    width: '14em',
+    fontSize: '18px'
   },
   input: {
     fontSize: 'inherit',
-    padding: '.9em .7em .67em'
+    padding: '.8em .7em .73em',
+    border: 'solid 1px transparent',
+    height: '1em'
+  },
+  inputWithLabel: {
+    fontSize: 'inherit',
+    padding: '1.2em .7em .33em',
+    border: 'solid 1px transparent',
+    height: '1em'
+  },
+  icon: {
+    right: 'calc(.7em - 10px)'
   },
   placeholder: {
     opacity: 0.4
   },
   label: {
+    transform: 'translate(.7em, .9em) scale(1)',
+
     '&$labelShrink': {
-      transform: 'translate(0, 0) scale(.75)'
+      transform: 'translate(.7em, .3em) scale(.75)'
     }
   },
   labelShrink: {}

--- a/components/TextField/TextField.tsx
+++ b/components/TextField/TextField.tsx
@@ -2,14 +2,26 @@ import React from 'react'
 import MUITextField from '@material-ui/core/TextField'
 import InputAdornment from '@material-ui/core/InputAdornment'
 import { withStyles } from '@material-ui/core/styles'
+import { OutlinedInputProps } from '@material-ui/core/OutlinedInput'
+import { InputLabelProps } from '@material-ui/core/InputLabel'
 
+import { Classes } from '../styles/types'
 import styles from './styles'
 
-const TextField = props => {
+interface Props {
+  classes: Classes
+  className?: string
+  iconPosition?: 'start' | 'end'
+  Icon: React.ReactNode
+  InputProps: OutlinedInputProps
+  InputLabelProps: Partial<InputLabelProps>
+}
+
+const TextField: React.FunctionComponent<Props> = props => {
   const {
     Icon,
     iconPosition,
-    InputProps = {},
+    InputProps = {} as OutlinedInputProps,
     InputLabelProps = {},
     classes,
     children,

--- a/components/TextField/styles.ts
+++ b/components/TextField/styles.ts
@@ -6,7 +6,8 @@ import '../OutlinedInput/styles'
 export default {
   input: {
     fontSize: '18px',
-    padding: '1.2em .7em .2em'
+    padding: '1.2em .7em .33em',
+    height: '1em'
   },
   label: {
     transform: 'translate(.7em, .9em) scale(1)',

--- a/package.json
+++ b/package.json
@@ -113,5 +113,8 @@
       "git add"
     ]
   },
-  "sideEffects": false
+  "sideEffects": [
+    "**/styles.ts",
+    "**/styles.js"
+  ]
 }


### PR DESCRIPTION
 ### Description

Here are some fixes that we found with the Select component.

1. Size of Native Select component was not the same as for other non-native options
2. Padding was a little bit off for all Select components vertically
3. Carret icon for Select component was not properly padded from the right
4. With Label example was with the shrunk label, but we need the same look as for TextField to be able to group them in forms