### PR TITLE
Add types file in Page folder

### DIFF
--- a/components/Footer/Footer.tsx
+++ b/components/Footer/Footer.tsx
@@ -3,7 +3,8 @@ import { withStyles } from '@material-ui/core/styles'
 import cx from 'classnames'
 
 import { Classes } from '../styles/types'
-import { PageContext, PageContextProps } from '../Page'
+import { PageContext } from '../Page'
+import { PageContextProps } from '../Page/types'
 import styles from './styles'
 
 interface Props {

--- a/components/Header/Header.tsx
+++ b/components/Header/Header.tsx
@@ -3,7 +3,8 @@ import { withStyles } from '@material-ui/core/styles'
 import cx from 'classnames'
 
 import { Logo, Container, Typography } from '../'
-import { PageContext, PageContextProps } from '../Page'
+import { PageContext } from '../Page'
+import { PageContextProps } from '../Page/types'
 import styles from './styles'
 import { Classes } from '../styles/types'
 

--- a/components/Page/Page.tsx
+++ b/components/Page/Page.tsx
@@ -3,9 +3,10 @@ import { withStyles } from '@material-ui/core/styles'
 
 import Header from '../Header'
 import Footer from '../Footer'
-import { Classes } from '../styles/types'
-import styles from './styles'
 import PageContent from '../PageContent'
+import { Classes } from '../styles/types'
+import { PageContextProps } from './types'
+import styles from './styles'
 
 interface Props {
   /** Component becomes responsive with width 100% and overrides width prop */
@@ -17,10 +18,6 @@ interface Props {
   classes: Classes
   /** Children components (Page.Header, Page.Content, Page.Footer) */
   children: React.ReactNode
-}
-
-export interface PageContextProps {
-  fullWidth?: boolean
 }
 
 export const PageContext = React.createContext<PageContextProps>(

--- a/components/Page/index.ts
+++ b/components/Page/index.ts
@@ -1,1 +1,1 @@
-export { default, PageContext, PageContextProps } from './Page'
+export { default, PageContext } from './Page'

--- a/components/Page/types.ts
+++ b/components/Page/types.ts
@@ -1,0 +1,3 @@
+export interface PageContextProps {
+  fullWidth?: boolean
+}

--- a/components/PageContent/PageContent.tsx
+++ b/components/PageContent/PageContent.tsx
@@ -3,7 +3,8 @@ import { withStyles } from '@material-ui/core/styles'
 import cx from 'classnames'
 
 import { Classes } from '../styles/types'
-import { PageContext, PageContextProps } from '../Page'
+import { PageContext } from '../Page'
+import { PageContextProps } from '../Page/types'
 import styles from './styles'
 
 interface Props {

--- a/components/PageContent/styles.ts
+++ b/components/PageContent/styles.ts
@@ -2,9 +2,6 @@ import { Theme, createStyles } from '@material-ui/core/styles'
 
 export default ({ layout }: Theme) =>
   createStyles({
-    fullWidth: {
-      maxWidth: '100%'
-    },
     root: {
       flex: 1,
       width: '100%',
@@ -16,5 +13,8 @@ export default ({ layout }: Theme) =>
       flexGrow: 1,
       maxWidth: layout.contentWidth,
       padding: '0 1rem'
+    },
+    fullWidth: {
+      maxWidth: '100%'
     }
   })


### PR DESCRIPTION
Initial implementation extracted type of PageContext into types.ts. I tried to add index.d.ts but for some reason it doesn't work, I will investigate it further.

Bug
![image](https://user-images.githubusercontent.com/11500666/53971911-1c2b9580-40fe-11e9-9808-89cd060cc449.png)

