### PR TITLE
Fix hot reload

### DIFF
--- a/.storybook/components/CodeExample/CodeExample.tsx
+++ b/.storybook/components/CodeExample/CodeExample.tsx
@@ -48,6 +48,19 @@ class CodeExample extends React.Component<Props> {
     return require(`!raw-loader!../../../components/${src}`)
   }
 
+  /* This function is needed to avoid memoization of the source code
+   * in SourceRender component (`react-source-code` package). Hot reload
+   * does not work properly if the memoization is happening.
+   * Issue: https://github.com/layershifter/react-source-render/issues/10
+   */
+  avoidSourceCodeMemoization = (sourceCode: string) => {
+    return `
+      ${sourceCode}
+
+      function resetCode() { ${Math.random()} }
+    `
+  }
+
   handleShowEditor = () => {
     const { isEditorVisible } = this.state
     this.setState({ isEditorVisible: !isEditorVisible })
@@ -73,7 +86,7 @@ class CodeExample extends React.Component<Props> {
         <SourceRender
           render={renderInTestPicasso}
           resolver={resolver}
-          source={sourceCode}>
+          source={this.avoidSourceCodeMemoization(sourceCode)}>
           <SourceRender.Consumer>
             {({ element }: RenderResult) => element}
           </SourceRender.Consumer>
@@ -104,7 +117,7 @@ class CodeExample extends React.Component<Props> {
       <SourceRender
         render={renderInPicasso}
         resolver={resolver}
-        source={sourceCode}>
+        source={this.avoidSourceCodeMemoization(sourceCode)}>
         <div className={classes.root}>
           <div className={classes.component}>
             <Container className={classes.componentRenderer} top={2} bottom={2}>


### PR DESCRIPTION
### Description

I know this is horrible... maybe you guys can help with the better idea how to fix that.
The issue is in the `memoize` of all the functions which do code evaluation in `react-source-render` library. 

https://github.com/layershifter/react-source-render/blob/master/src/createElementFromSource/transformSource.js#L31
and
https://github.com/layershifter/react-source-render/blob/master/src/createElementFromSource/createComponentFromSource.js#L16

they are using `https://www.npmjs.com/package/fast-memoize` package, which works basically with the values of the args. So it creates the hash from `JSON.stringify(arguments)` and compare it in between the function calls. So the values are basically are comparing as values, but not references.
