### PR TITLE
[FX-45] Prepare tsconfig for storybook

### DIFF
--- a/.storybook/components/PicassoBook/components/PropsTable/EnumsList.tsx
+++ b/.storybook/components/PicassoBook/components/PropsTable/EnumsList.tsx
@@ -1,32 +1,32 @@
 import { withStyles } from '@material-ui/core/styles'
 
 import React from 'react'
-import _ from 'lodash'
 
-import { ClassNameMap } from '@material-ui/core/styles/withStyles'
+import { Classes } from '../../../../../components/styles/types'
+import { PropTypeDocumentation } from '../../../../utils/documentationGenerator'
 import cx from 'classnames'
 
 import styles from './styles'
 
 interface Props {
-  enums: string[]
-  classes: Partial<ClassNameMap<string>>
-  type: { enums: string[] }
+  enums?: string[]
+  classes: Classes
+  type: string | PropTypeDocumentation
 }
 
 const trim = (value: string) => String(value).replace(/\'|\"/gi, '')
 
 const EnumsList: React.FunctionComponent<Props> = props => {
   const { enums, classes, type } = props
-  let enumList: string[] = enums
+  let enumList = enums
 
-  if (!_.isArray(enums)) {
-    if (_.isArray(type.enums)) {
-      enumList = type.enums
+  if (!Array.isArray(enums)) {
+    if (Array.isArray((type as PropTypeDocumentation).enums)) {
+      enumList = (type as PropTypeDocumentation).enums
     }
   }
 
-  if (!_.isArray(enumList)) return null
+  if (!Array.isArray(enumList)) return null
 
   return (
     <div className={classes.enums}>

--- a/.storybook/components/PicassoBook/components/PropsTable/PropsTable.tsx
+++ b/.storybook/components/PicassoBook/components/PropsTable/PropsTable.tsx
@@ -8,10 +8,13 @@ import TableHead from '@material-ui/core/TableHead'
 import TableRow from '@material-ui/core/TableRow'
 import TableBody from '@material-ui/core/TableBody'
 import Table from '@material-ui/core/Table'
-import { ClassNameMap } from '@material-ui/core/styles/withStyles'
 import cx from 'classnames'
 
-import { PropDocumentation } from '../../../../utils/documentationGenerator'
+import { Classes } from '../../../../../components/styles/types'
+import {
+  PropDocumentation,
+  PropTypeDocumentation
+} from '../../../../utils/documentationGenerator'
 import PropTypeTableCell from './PropTypeTableCell'
 import EnumsList from './EnumsList'
 import Description from './Description'
@@ -19,11 +22,12 @@ import styles from './styles'
 
 interface Props {
   documentation: PropDocumentation[]
-  classes: Partial<ClassNameMap<string>>
+  classes: Classes
 }
 
 function renderRows({ documentation, classes }: Props): JSX.Element {
-  const isEnum = type => type === 'enum' || (type && type.name === 'enum')
+  const isEnum = (type: string | PropTypeDocumentation) =>
+    type === 'enum' || (type as PropTypeDocumentation).name === 'enum'
 
   return (
     <Fragment>

--- a/.storybook/components/PicassoBook/components/PropsTable/styles.ts
+++ b/.storybook/components/PicassoBook/components/PropsTable/styles.ts
@@ -1,6 +1,6 @@
 import { Theme } from '@material-ui/core/styles'
 
-export default ({ palette }: { palette: Theme }) => ({
+export default ({ palette }: Theme) => ({
   root: {
     width: '100%'
   },

--- a/.storybook/tsconfig.json
+++ b/.storybook/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "lib": ["dom", "es2016", "es2017"]
+  },
+  "exclude": []
+}

--- a/.storybook/utils/documentationGenerator.ts
+++ b/.storybook/utils/documentationGenerator.ts
@@ -1,4 +1,5 @@
 import _ from 'lodash'
+import { ComponentDoc, PropItemType } from 'react-docgen-typescript/lib/parser'
 
 export interface PropTypeDocumentation {
   name: string
@@ -31,7 +32,7 @@ const ENUM_TYPE_REGEX = /enum/
 const ENUM_VALUES_REGEX = /.*\|.*/
 
 class DocumentationGenerator {
-  resolveType(type: any): PropTypeDocumentation {
+  resolveType(type: PropItemType): PropTypeDocumentation {
     if (!type) {
       return {} as PropTypeDocumentation
     }
@@ -52,7 +53,7 @@ class DocumentationGenerator {
 
       if (type.value && _.isArray(type.value)) {
         baseShape = {
-          enums: type.value.map(({ value }) => value)
+          enums: type.value.map(({ value }: any) => value)
         }
       }
 
@@ -93,7 +94,7 @@ class DocumentationGenerator {
     return _.merge({} as PropDocumentationMap, ...sources)
   }
 
-  transform(generatedDocumentation: any): PropDocumentationMap {
+  transform(generatedDocumentation: ComponentDoc): PropDocumentationMap {
     const { props: propDocs } = generatedDocumentation
 
     return _.mapValues(propDocs, (propDoc, propName) => {

--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -1,7 +1,10 @@
 const webpack = require('webpack')
+const path = require('path')
 
 // example: /components/Button/Button.tsx
 const COMPONENT_DECLARATION_FILE_REGEXP = /components\/(.*)\/\1.tsx$/
+
+const tsConfigFile = path.join(process.cwd(), './.storybook/tsconfig.json')
 
 module.exports = (baseConfig, env, config) => {
   config.module.rules.push({
@@ -11,7 +14,7 @@ module.exports = (baseConfig, env, config) => {
       {
         loader: require.resolve('ts-loader'),
         options: {
-          transpileOnly: true
+          configFile: tsConfigFile
         }
       }
     ]
@@ -24,13 +27,13 @@ module.exports = (baseConfig, env, config) => {
       {
         loader: require.resolve('ts-loader'),
         options: {
-          transpileOnly: true
+          configFile: tsConfigFile
         }
       },
       {
         loader: require.resolve('react-docgen-typescript-loader'),
         options: {
-          tsconfigPath: './tsconfig.json',
+          tsconfigPath: tsConfigFile,
           skipPropsWithoutDoc: true
         }
       }


### PR DESCRIPTION
[FX-45](https://toptal-core.atlassian.net/browse/FX-45)

### Description

In this PR I've started to use extended `tsconfig.json` for Storybook, also included there `ES2017` lib to be able to use `Object.values`, `Object.entries`, etc. features.

Has been removed flag `transpileOnly` from the config, because it gives us some performance boost for the build process, but let us do some type check errors in the code. Because this flag was disabled I've also fixed a few type check errors.
