### PR TITLE
[FX-66] Fix Icon mangled names inside prod build

### DIFF
--- a/components/Icon/Cog.jsx
+++ b/components/Icon/Cog.jsx
@@ -7,4 +7,5 @@ const SvgCog = props => (
   </svg>
 )
 
+SvgCog.displayName = 'SvgCog'
 export default SvgCog

--- a/components/Icon/IconsLibrary.tsx
+++ b/components/Icon/IconsLibrary.tsx
@@ -7,7 +7,7 @@ class IconsLibrary {
 
   static add (...icons: any[]) {
     icons.forEach(icon => {
-      this.listOfImportedIcons[icon.name] = icon
+      this.listOfImportedIcons[icon.displayName] = icon
     })
   }
 }

--- a/components/Icon/Logo.jsx
+++ b/components/Icon/Logo.jsx
@@ -9,4 +9,5 @@ const SvgLogo = props => (
   </svg>
 )
 
+SvgLogo.displayName = 'SvgLogo'
 export default SvgLogo

--- a/components/Icon/LogoEmblem.jsx
+++ b/components/Icon/LogoEmblem.jsx
@@ -6,4 +6,5 @@ const SvgLogoEmblem = props => (
   </svg>
 )
 
+SvgLogoEmblem.displayName = 'SvgLogoEmblem'
 export default SvgLogoEmblem

--- a/components/Icon/generatorTemplate.js
+++ b/components/Icon/generatorTemplate.js
@@ -1,0 +1,16 @@
+const template = (
+  { template },
+  opts,
+  { imports, componentName, props, jsx, exports }
+) => {
+  const displayName = `'${componentName.name}'`
+
+  return template.ast`
+    ${imports}
+    const ${componentName} = (${props}) => ${jsx}
+    ${componentName}.displayName = ${displayName}
+    ${exports}
+  `
+}
+
+module.exports = template

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "build:storybook": "build-storybook -c .storybook -o build/storybook",
     "release:pre": "yarn version --new-version prerelease",
     "build": "yarn run build:svg && cross-env NODE_ENV=production ./bin/build",
-    "build:svg": "svgr -d components/Icon --ext jsx components/Icon/svg",
+    "build:svg": "svgr -d components/Icon --ext jsx --template components/Icon/generatorTemplate.js components/Icon/svg",
     "build:watch": "cross-env ./bin/build --watch",
     "symlink": "cross-env ./bin/symlink --link",
     "symlink:off": "cross-env ./bin/symlink --unlink",


### PR DESCRIPTION
[FX-66](https://toptal-core.atlassian.net/browse/FX-66)

### Description

We are using `function` name as `Icon` identifier inside the `IconsLibrary` hashmap. However as you build `Picasso` webpack will mangle the names to like `$he`, `$ag` and etc. Therefore on lookup of name it fails, as `SvgLogo` doesn't exists. We need to generate `displayName` for each component which luckily is possible with overriding default `ast` template for SVGR. 

### How to test

Steps to reproduce are described here https://github.com/toptal/activation-wizard-frontend/pull/28

### Screenshots

![Screen Shot 2019-03-18 at 1 59 02 PM](https://user-images.githubusercontent.com/324488/54532086-3465a500-4987-11e9-9c48-6549982f2a41.png)

### Review

- [ ] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that visuals specs are green [See the documentation](/README.md#fixing-broken-visual-tests-inside-a-pr)
