### PR TITLE
[FX-75] Refactor to use children props where possible

### DIFF
--- a/components/Button/Button.jsx
+++ b/components/Button/Button.jsx
@@ -107,7 +107,7 @@ Button.propTypes = {
   /** Show button in the active state (left mouse button down) */
   active: PropTypes.bool,
   /** Content of Button component */
-  children: PropTypes.node,
+  children: PropTypes.oneOfType([PropTypes.node, PropTypes.string]),
   focused: PropTypes.bool,
   /** Take the full width of a container */
   fullWidth: PropTypes.bool,

--- a/components/Label/Label.tsx
+++ b/components/Label/Label.tsx
@@ -1,7 +1,7 @@
+import React, { FunctionComponent } from 'react'
 import { withStyles } from '@material-ui/core/styles'
 import { ClassNameMap } from '@material-ui/core/styles/withStyles'
 import CloseIcon from '@material-ui/icons/Close'
-import React from 'react'
 
 import Chip from '../Chip'
 import LabelGroup from '../LabelGroup'
@@ -10,7 +10,7 @@ import styles from './styles'
 interface Props {
   classes: Partial<ClassNameMap<string>>
   /** Text content of the `Label` component */
-  label?: string
+  children: React.ReactNode
   /** A callback which is invoked after remove `Icon` is clicked
    *
    * Please note that specifying this callback automatically adds remove `Icon` as children of the `Label`
@@ -20,13 +20,12 @@ interface Props {
   variant?: 'flat' | 'success' | 'error'
 }
 
-// should be moved to some global interfaces place
-interface GroupFunctionalComponent<T> extends React.FunctionComponent<T> {
-  Group: React.ReactNode
+type LabeComponentType<P> = FunctionComponent<P> & {
+  Group: typeof LabelGroup
 }
 
-export const Label: GroupFunctionalComponent<Props> = props => {
-  const { classes, variant, ...rest } = props
+export const Label: LabeComponentType<Props> = props => {
+  const { classes, variant, children, ...rest } = props
 
   const rootClass = variant ? classes[variant] : ''
 
@@ -40,14 +39,15 @@ export const Label: GroupFunctionalComponent<Props> = props => {
           role='button'
         />
       }
+      label={children}
       {...rest}
     />
   )
 }
 
 Label.defaultProps = {
+  children: '',
   classes: {},
-  label: undefined,
   onDelete: undefined,
   variant: undefined
 }

--- a/components/Label/__snapshots__/test.tsx.snap
+++ b/components/Label/__snapshots__/test.tsx.snap
@@ -12,7 +12,9 @@ exports[`dismissable label should render dismissable label 1`] = `
     >
       <span
         class="MuiChip-label"
-      />
+      >
+        Label
+      </span>
       <svg
         aria-hidden="true"
         aria-label="delete icon"
@@ -46,7 +48,9 @@ exports[`renders default variant 1`] = `
     >
       <span
         class="MuiChip-label"
-      />
+      >
+        Label
+      </span>
     </div>
   </div>
 </div>
@@ -64,7 +68,9 @@ exports[`renders error variant 1`] = `
     >
       <span
         class="MuiChip-label"
-      />
+      >
+        Label
+      </span>
     </div>
   </div>
 </div>
@@ -82,7 +88,9 @@ exports[`renders flat variant 1`] = `
     >
       <span
         class="MuiChip-label"
-      />
+      >
+        Label
+      </span>
     </div>
   </div>
 </div>
@@ -100,7 +108,9 @@ exports[`renders success variant 1`] = `
     >
       <span
         class="MuiChip-label"
-      />
+      >
+        Label
+      </span>
     </div>
   </div>
 </div>

--- a/components/Label/story/Default.example.jsx
+++ b/components/Label/story/Default.example.jsx
@@ -3,7 +3,7 @@ import { Label } from '@toptal/picasso'
 
 const LabelDefaultExample = () => (
   <div>
-    <Label label='Javascript' />
+    <Label>Javascript</Label>
   </div>
 )
 

--- a/components/Label/story/Dismissible.example.jsx
+++ b/components/Label/story/Dismissible.example.jsx
@@ -3,7 +3,7 @@ import { Label } from '@toptal/picasso'
 
 const LabelDismissibleExample = () => (
   <div>
-    <Label label='React JS' onDelete={handleDelete} />
+    <Label onDelete={handleDelete}>React JS</Label>
   </div>
 )
 

--- a/components/Label/story/Flat.example.jsx
+++ b/components/Label/story/Flat.example.jsx
@@ -3,7 +3,7 @@ import { Label } from '@toptal/picasso'
 
 const LabelFlatExample = () => (
   <div>
-    <Label label='Ember JS' variant='flat' />
+    <Label variant='flat'>Ember JS</Label>
   </div>
 )
 

--- a/components/Label/story/Statuses.example.jsx
+++ b/components/Label/story/Statuses.example.jsx
@@ -4,9 +4,9 @@ import { Label, Container } from '@toptal/picasso'
 const LabelDefaultExample = () => (
   <div>
     <Container inline right={1}>
-      <Label label="Yay! It's done!" variant='success' />
+      <Label variant='success'>Yay! It&#39;s done!</Label>
     </Container>
-    <Label label='Nope! Please, try one more time' variant='error' />
+    <Label variant='error'>Nope! Please, try one more time</Label>
   </div>
 )
 

--- a/components/Label/test.tsx
+++ b/components/Label/test.tsx
@@ -4,10 +4,10 @@ import { render, fireEvent, cleanup, RenderResult } from 'react-testing-library'
 import Label from './index'
 import Picasso from '../Picasso'
 
-const renderLabel = (props = {}) => {
+const renderLabel = (children: string, props = {}) => {
   return render(
     <Picasso loadFonts={false}>
-      <Label {...props} />
+      <Label {...props}>{children}</Label>
     </Picasso>
   )
 }
@@ -15,25 +15,25 @@ const renderLabel = (props = {}) => {
 afterEach(cleanup)
 
 test('renders default variant', () => {
-  const { container } = renderLabel()
+  const { container } = renderLabel('Label')
 
   expect(container).toMatchSnapshot()
 })
 
 test('renders flat variant', () => {
-  const { container } = renderLabel({ variant: 'flat' })
+  const { container } = renderLabel('Label', { variant: 'flat' })
 
   expect(container).toMatchSnapshot()
 })
 
 test('renders success variant', () => {
-  const { container } = renderLabel({ variant: 'success' })
+  const { container } = renderLabel('Label', { variant: 'success' })
 
   expect(container).toMatchSnapshot()
 })
 
 test('renders error variant', () => {
-  const { container } = renderLabel({ variant: 'error' })
+  const { container } = renderLabel('Label', { variant: 'error' })
 
   expect(container).toMatchSnapshot()
 })
@@ -44,7 +44,7 @@ describe('dismissable label', () => {
 
   beforeEach(() => {
     onDelete = jest.fn()
-    api = renderLabel({ onDelete })
+    api = renderLabel('Label', { onDelete })
   })
   test('should render dismissable label', () => {
     const { container } = api

--- a/components/Loader/Loader.jsx
+++ b/components/Loader/Loader.jsx
@@ -17,7 +17,7 @@ const getSize = size => {
 }
 
 export const Loader = props => {
-  const { label, classes, variant, size, inline, className, value } = props
+  const { children, classes, variant, size, inline, className, value } = props
 
   return (
     <div
@@ -34,12 +34,14 @@ export const Loader = props => {
         variant={variant}
       />
 
-      {label && <div className={classes.label}>{label}</div>}
+      {children && <div className={classes.label}>{children}</div>}
     </div>
   )
 }
 
 Loader.propTypes = {
+  /** Text content for the `Loader` */
+  children: PropTypes.oneOfType([PropTypes.node, PropTypes.string]),
   /** Extra css classes to be passed to `Loader` */
   className: PropTypes.string,
   classes: PropTypes.shape({
@@ -47,8 +49,6 @@ Loader.propTypes = {
   }).isRequired,
   /** Shows loader as part of other inline elements such as text */
   inline: PropTypes.bool,
-  /** Text label for the `Loader` */
-  label: PropTypes.string,
   /** Size of the `Loader` */
   size: PropTypes.oneOf(['small', 'default', 'large']),
   /** Current value for the `static` or `indeterminate` loaders */
@@ -58,9 +58,9 @@ Loader.propTypes = {
 }
 
 Loader.defaultProps = {
+  children: null,
   className: undefined,
   inline: false,
-  label: null,
   size: 'default',
   value: 0,
   variant: 'indeterminate'

--- a/components/Loader/__snapshots__/test.jsx.snap
+++ b/components/Loader/__snapshots__/test.jsx.snap
@@ -3,12 +3,12 @@
 exports[`props combo 1`] = `
 <div>
   <div
-    class="Loader-wrapper"
+    class="Loader-wrapper Loader-inline"
   >
     <div
       class="MuiCircularProgress-root CircularProgress-root Loader-spinner MuiCircularProgress-colorPrimary MuiCircularProgress-indeterminate"
       role="progressbar"
-      style="width: 40px; height: 40px;"
+      style="width: 80px; height: 80px;"
     >
       <svg
         class="MuiCircularProgress-svg"
@@ -23,6 +23,11 @@ exports[`props combo 1`] = `
           stroke-width="3.6"
         />
       </svg>
+    </div>
+    <div
+      class="Loader-label"
+    >
+      Testing
     </div>
   </div>
 </div>

--- a/components/Loader/story/ControlledValue.example.jsx
+++ b/components/Loader/story/ControlledValue.example.jsx
@@ -4,9 +4,13 @@ import { Loader, Container } from '@toptal/picasso'
 const LoaderControlledValueExample = () => (
   <div>
     <Container bottom={2}>
-      <Loader label='50%' value={50} variant='static' />
+      <Loader value={50} variant='static'>
+        50%
+      </Loader>
     </Container>
-    <Loader label='13%' value={13} variant='determinate' />
+    <Loader value={13} variant='determinate'>
+      13%
+    </Loader>
   </div>
 )
 

--- a/components/Loader/story/Indeterminate.example.jsx
+++ b/components/Loader/story/Indeterminate.example.jsx
@@ -3,7 +3,7 @@ import { Loader } from '@toptal/picasso'
 
 const LoaderIndeterminateExample = () => (
   <div>
-    <Loader indeterminate label='Loading...' />
+    <Loader indeterminate>Loading...</Loader>
   </div>
 )
 

--- a/components/Loader/story/Sizes.example.jsx
+++ b/components/Loader/story/Sizes.example.jsx
@@ -4,12 +4,12 @@ import { Loader, Container } from '@toptal/picasso'
 const LoaderSizesExample = () => (
   <div>
     <Container bottom={2}>
-      <Loader label='small' size='small' />
+      <Loader size='small'>small</Loader>
     </Container>
     <Container bottom={2}>
-      <Loader label='default' size='default' />
+      <Loader size='default'>default</Loader>
     </Container>
-    <Loader label='large' size='large' />
+    <Loader size='large'>large</Loader>
   </div>
 )
 

--- a/components/Loader/story/WithLabel.example.jsx
+++ b/components/Loader/story/WithLabel.example.jsx
@@ -3,7 +3,7 @@ import { Loader } from '@toptal/picasso'
 
 const LoaderWithLabelExample = () => (
   <div>
-    <Loader label='Loading...' />
+    <Loader>Loading...</Loader>
   </div>
 )
 

--- a/components/Loader/test.jsx
+++ b/components/Loader/test.jsx
@@ -10,9 +10,8 @@ const renderLoader = (children, props = {}) => {
 afterEach(cleanup)
 
 test('props combo', () => {
-  const { container } = renderLoader({
+  const { container } = renderLoader('Testing', {
     inline: true,
-    label: 'Testing',
     size: 'large',
     indeterminate: true
   })

--- a/components/Tooltip/Tooltip.tsx
+++ b/components/Tooltip/Tooltip.tsx
@@ -12,12 +12,12 @@ type TriggerType = 'hover' | 'click'
 
 type PlacementType = 'bottom' | 'left' | 'right' | 'top'
 
-type ContentType = string | ReactNode
-
 interface Props {
   classes: Classes
+  /** Trigger element for tooltip */
+  children: React.ReactNode
   /** Content to be rendered inside tooltip */
-  content?: ContentType
+  content?: React.ReactNode
   /** Whether tooltip should display arrow */
   arrow?: boolean
   /** Select color variant to use */

--- a/components/Typography/Typography.tsx
+++ b/components/Typography/Typography.tsx
@@ -26,6 +26,8 @@ interface Props {
   /** Font variant inner text */
   variant?: VariantType
   classes: Classes
+  /** Text content */
+  children?: React.ReactNode
   className?: string
   /** Text align of the inner text */
   align?: PropTypes.Alignment


### PR DESCRIPTION
[FX-75](https://toptal-core.atlassian.net/browse/FX-75)

### Description

`Label`, `Loader`, `Typography` components were affected.

The conclusion we've agreed on:
> No `content` at all for now and will change the API for couple components like Label, Button to use > `children` instead of `label`/`text`? But Checkbox we will leave with `label`