### PR TITLE
Ugrade to the latest docgen package

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "raw-loader": "^1.0.0",
     "react": "^16.8.4",
     "react-ace": "^6.3.2",
-    "react-docgen-typescript-loader": "^3.0.1",
+    "react-docgen-typescript-loader": "^3.1.0",
     "react-dom": "^16.8.4",
     "react-markdown": "^4.0.6",
     "react-source-render": "^2.0.0-beta.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11013,16 +11013,16 @@ react-dev-utils@^7.0.0, react-dev-utils@^7.0.1:
     strip-ansi "5.0.0"
     text-table "0.2.0"
 
-react-docgen-typescript-loader@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/react-docgen-typescript-loader/-/react-docgen-typescript-loader-3.0.1.tgz#889aa472450c8db82ea0355656a307806ec74e77"
-  integrity sha512-SAVMFdW5p76pVMS6c7Jl1mGM5EZLVBWJ+rfoTvEaC2SeDgSFflnkM8eJGZVhty+7FSefvOJcBBz2rMkciphERA==
+react-docgen-typescript-loader@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/react-docgen-typescript-loader/-/react-docgen-typescript-loader-3.1.0.tgz#09cacf872617c97f946ee920d2239f51d543be41"
+  integrity sha512-gY+b7RkRPty5ZN4NMQ+jwx9MzTVuIj6LJCwdWRAi1+nrHJfH2gMMytQfxFdzQ7BlgD4COWnSE8Ixtl2L62kCRw==
   dependencies:
     "@webpack-contrib/schema-utils" "^1.0.0-beta.0"
-    loader-utils "^1.1.0"
-    react-docgen-typescript "^1.9.0"
+    loader-utils "^1.2.3"
+    react-docgen-typescript "^1.12.3"
 
-react-docgen-typescript@^1.9.0:
+react-docgen-typescript@^1.12.3:
   version "1.12.3"
   resolved "https://registry.yarnpkg.com/react-docgen-typescript/-/react-docgen-typescript-1.12.3.tgz#fe62a5ce82e93573e316366e53adfe8273121c70"
   integrity sha512-s1XswWs4ykNdWKsPyfM4qptV5dT8nnjnVi2IcjoS/vGlRNYrc0TkW0scVOrinHZ+ndKhPqA4iVNrdwhxZBzJcg==


### PR DESCRIPTION
### Description

This guy finally merged - https://github.com/strothj/react-docgen-typescript-loader/pull/40 
so this PR just upgrading to that new version to speed-up our build. On my machine, I can see around 49 sec, when previous took around 2,5 min
