### PR TITLE
Adding padding to Container and gutter to Typography

### DIFF
--- a/.storybook/components/CodeExample/CodeExample.tsx
+++ b/.storybook/components/CodeExample/CodeExample.tsx
@@ -140,7 +140,7 @@ class CodeExample extends Component<Props> {
       >
         <div className={classes.root}>
           <div className={classes.component}>
-            <Container className={classes.componentRenderer} top={2} bottom={2}>
+            <Container className={classes.componentRenderer} mt={2} mb={2}>
               <SourceRender.Consumer>
                 {({ element }: RenderResult) => element}
               </SourceRender.Consumer>

--- a/src/components/Accordion/story/Controlled.example.jsx
+++ b/src/components/Accordion/story/Controlled.example.jsx
@@ -19,7 +19,7 @@ const AccordionControlledExample = () => {
 }
 
 const DetailsDogDefinitionPanel = () => (
-  <Container bottom={2} top={2}>
+  <Container mb={2} mt={2}>
     A dog is a type of domesticated animal. Known for its loyalty and
     faithfulness, it can be found as a welcome guest in many households across
     the world.

--- a/src/components/Avatar/story/Sizes.example.jsx
+++ b/src/components/Avatar/story/Sizes.example.jsx
@@ -10,21 +10,21 @@ const AvatarSizesExample = () => (
           src='./jacqueline-with-flowers-1954-square.jpg'
         />
       </Container>
-      <Container inline left={1}>
+      <Container inline ml={1}>
         <Avatar
           size='small'
           alt='Jacqueline Roque. Pablo Picasso, 1954. Small'
           src='./jacqueline-with-flowers-1954-square.jpg'
         />
       </Container>
-      <Container inline left={1}>
+      <Container inline ml={1}>
         <Avatar
           size='medium'
           alt='Jacqueline Roque. Pablo Picasso, 1954. Medium'
           src='./jacqueline-with-flowers-1954-square.jpg'
         />
       </Container>
-      <Container inline left={1}>
+      <Container inline ml={1}>
         <Avatar
           size='large'
           alt='Jacqueline Roque. Pablo Picasso, 1954. Large'
@@ -33,17 +33,17 @@ const AvatarSizesExample = () => (
       </Container>
     </Container>
 
-    <Container top={1}>
+    <Container mt={1}>
       <Container inline>
         <Avatar name='Jacqueline Roque' />
       </Container>
-      <Container inline left={1}>
+      <Container inline ml={1}>
         <Avatar size='small' name='Jacqueline Roque' />
       </Container>
-      <Container inline left={1}>
+      <Container inline ml={1}>
         <Avatar size='medium' name='Jacqueline Roque' />
       </Container>
-      <Container inline left={1}>
+      <Container inline ml={1}>
         <Avatar size='large' name='Jacqueline Roque' />
       </Container>
     </Container>

--- a/src/components/Avatar/story/Variants.example.jsx
+++ b/src/components/Avatar/story/Variants.example.jsx
@@ -10,10 +10,10 @@ const AvatarVariantsExample = () => (
         src='./jacqueline-with-flowers-1954-square.jpg'
       />
     </Container>
-    <Container inline left={1}>
+    <Container inline ml={1}>
       <Avatar size='medium' name='Jacqueline Roque' />
     </Container>
-    <Container inline left={1}>
+    <Container inline ml={1}>
       <Avatar
         variant='portrait'
         size='medium'
@@ -21,7 +21,7 @@ const AvatarVariantsExample = () => (
         src='./jacqueline-with-flowers-1954-square.jpg'
       />
     </Container>
-    <Container inline left={1}>
+    <Container inline ml={1}>
       <Avatar
         variant='landscape'
         size='medium'

--- a/src/components/Checkbox/story/Controlled.example.jsx
+++ b/src/components/Checkbox/story/Controlled.example.jsx
@@ -3,7 +3,7 @@ import { Checkbox, Container } from '@toptal/picasso'
 
 const CheckboxControlledExample = () => (
   <div>
-    <Container bottom={1}>
+    <Container mb={1}>
       <Checkbox checked={false} id='checkbox-unchecked' label='Unchecked' />
     </Container>
     <Checkbox checked id='checkbox-checked' label='Checked' />

--- a/src/components/Checkbox/story/Disabled.example.jsx
+++ b/src/components/Checkbox/story/Disabled.example.jsx
@@ -3,7 +3,7 @@ import { Checkbox, Container } from '@toptal/picasso'
 
 const CheckboxDisabledExample = () => (
   <div>
-    <Container bottom={1}>
+    <Container mb={1}>
       <Checkbox checked={false} disabled label='Unchecked' />
     </Container>
     <Checkbox checked disabled label='Checked' />

--- a/src/components/Container/Container.tsx
+++ b/src/components/Container/Container.tsx
@@ -13,14 +13,34 @@ type JustifyContentType =
   | 'space-evenly'
 
 interface Props extends BaseProps {
-  /** marginTop for the container calculated as `${top}em` */
-  top?: number
-  /** marginBottom for the container calculated as `${bottom}em` */
-  bottom?: number
-  /** marginLeft for the container calculated as `${left}em` */
-  left?: number
-  /** marginRight for the container calculated as `${right}em` */
-  right?: number
+  /** margin for the container calculated in `em` */
+  m?: number
+  /** margin-top for the container calculated in `em` */
+  mt?: number
+  /** margin-bottom for the container calculated in `em` */
+  mb?: number
+  /** margin-left for the container calculated in `em` */
+  ml?: number
+  /** margin-right for the container calculated in `em` */
+  mr?: number
+  /** margin-left and margin-right shorthand for the container calculated in `em` */
+  mx?: number
+  /** margin-top and margin-bottom shorthand for the container calculated in `em` */
+  my?: number
+  /** padding for the container calculated in `em` */
+  p?: number
+  /** padding-top for the container calculated in `em` */
+  pt?: number
+  /** padding-bottom for the container calculated in `em` */
+  pb?: number
+  /** padding-left for the container calculated in `em` */
+  pl?: number
+  /** padding-right for the container calculated in `em` */
+  pr?: number
+  /** padding-left and padding-right shorthand for the container calculated in `em` */
+  px?: number
+  /** padding-top and padding-bottom shorthand for the container calculated in `em` */
+  py?: number
   /** Whether container should act as inline element `display: inline-block` */
   inline?: boolean
   /** Use flexbox */
@@ -38,10 +58,20 @@ interface Props extends BaseProps {
 export const Container: FunctionComponent<Props> = ({
   children,
   className,
-  top,
-  bottom,
-  left,
-  right,
+  m,
+  mt,
+  mb,
+  ml,
+  mr,
+  mx,
+  my,
+  p,
+  pt,
+  pb,
+  pl,
+  pr,
+  px,
+  py,
   inline,
   flex,
   direction,
@@ -52,14 +82,32 @@ export const Container: FunctionComponent<Props> = ({
   const display = flex ? 'flex' : 'block'
   const inlineDisplay = flex ? 'inline-flex' : 'inline-block'
 
+  const margins = {
+    ...(m && { margin: `${m}em` }),
+    ...(mx && { marginLeft: `${mx}em`, marginRight: `${mx}em` }),
+    ...(my && { marginTop: `${my}em`, marginBottom: `${my}em` }),
+    ...(mt && { marginTop: `${mt}em` }),
+    ...(mb && { marginBottom: `${mb}em` }),
+    ...(ml && { marginLeft: `${ml}em` }),
+    ...(mr && { marginRight: `${mr}em` })
+  }
+
+  const paddings = {
+    ...(p && { padding: `${p}em` }),
+    ...(px && { paddingLeft: `${px}em`, paddingRight: `${px}em` }),
+    ...(py && { paddingTop: `${py}em`, paddingBottom: `${py}em` }),
+    ...(pt && { paddingTop: `${pt}em` }),
+    ...(pb && { paddingBottom: `${pb}em` }),
+    ...(pl && { paddingLeft: `${pl}em` }),
+    ...(pr && { paddingRight: `${pr}em` })
+  }
+
   return (
     <div
       className={className}
       style={{
-        marginTop: top + 'em',
-        marginBottom: bottom + 'em',
-        marginLeft: left + 'em',
-        marginRight: right + 'em',
+        ...margins,
+        ...paddings,
         display: inline ? inlineDisplay : display,
         ...(direction && { flexDirection: direction }),
         ...(alignItems && { alignItems: alignItems }),
@@ -73,11 +121,7 @@ export const Container: FunctionComponent<Props> = ({
 }
 
 Container.defaultProps = {
-  bottom: 0,
-  inline: false,
-  left: 0,
-  right: 0,
-  top: 0
+  inline: false
 }
 
 export default Container

--- a/src/components/Container/story/Default.example.jsx
+++ b/src/components/Container/story/Default.example.jsx
@@ -3,8 +3,8 @@ import { Container } from '@toptal/picasso'
 
 const ContainerDefaultExample = () => (
   <div>
-    <Container bottom={5}>Some text</Container>
-    <Container left={1}>Some more text</Container>
+    <Container mb={5}>Some text</Container>
+    <Container ml={1}>Some more text</Container>
   </div>
 )
 

--- a/src/components/Container/story/Inline.example.jsx
+++ b/src/components/Container/story/Inline.example.jsx
@@ -3,7 +3,7 @@ import { Container } from '@toptal/picasso'
 
 const ContainerInlineExample = () => (
   <div>
-    <Container inline right={5}>
+    <Container inline mr={5}>
       <span>Some inline text</span>
     </Container>
     <span>Another inline text</span>

--- a/src/components/Grid/story/Direction.example.jsx
+++ b/src/components/Grid/story/Direction.example.jsx
@@ -3,10 +3,8 @@ import { Grid, Button, Container, Typography } from '@toptal/picasso'
 
 const GridDirectionExample = () => (
   <div>
-    <Container bottom={4}>
-      <Container bottom={1}>
-        <Typography>Row direction</Typography>
-      </Container>
+    <Container mb={4}>
+      <Typography gutterBottom={1}>Row direction</Typography>
 
       <Grid direction='row'>
         <Grid.Item>
@@ -18,9 +16,7 @@ const GridDirectionExample = () => (
       </Grid>
     </Container>
 
-    <Container bottom={1}>
-      <Typography>Column direction</Typography>
-    </Container>
+    <Typography gutterBottom={1}>Column direction</Typography>
 
     <Grid direction='column'>
       <Grid.Item>

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -35,11 +35,11 @@ export const Header: FunctionComponent<Props> = ({
     <header className={cx(classes.root, className)} style={style}>
       <div className={contentClassnames}>
         <div className={classes.left}>
-          <Container right={1} flex direction='row' alignItems='center'>
+          <Container mr={1} flex direction='row' alignItems='center'>
             <Logo variant='white' />
           </Container>
           <div className={classes.divider} />
-          <Container left={1}>
+          <Container ml={1}>
             <Typography className={classes.title} weight='light'>
               {title}
             </Typography>

--- a/src/components/Icon/story/Color.example.jsx
+++ b/src/components/Icon/story/Color.example.jsx
@@ -4,7 +4,7 @@ import { Cog } from '@toptal/picasso/Icons'
 
 const IconExample = () => (
   <div>
-    <Container inline right={1}>
+    <Container inline mr={1}>
       <Cog color='red' />
     </Container>
     <Cog style={{ color: 'green' }} />

--- a/src/components/Icon/story/List.example.jsx
+++ b/src/components/Icon/story/List.example.jsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Grid, Paper, Typography } from '@toptal/picasso'
+import { Grid, Paper, Typography, Container } from '@toptal/picasso'
 import * as icons from '@toptal/picasso/Icons'
 
 /** We don't want to render internal icons */
@@ -15,12 +15,11 @@ const IconListExample = () => (
         return (
           <Grid.Item key={iconName}>
             <Paper>
-              <div
+              <Container
+                p={1}
+                pb={0.5}
                 style={{
-                  padding: '1rem',
-                  paddingBottom: '0.5rem',
-                  minWidth: '6rem',
-                  height: '5rem'
+                  minWidth: '6rem'
                 }}
               >
                 <Grid alignItems='center' direction='column' spacing={8}>
@@ -31,7 +30,7 @@ const IconListExample = () => (
                     <Typography variant='caption'>{iconName}</Typography>
                   </Grid.Item>
                 </Grid>
-              </div>
+              </Container>
             </Paper>
           </Grid.Item>
         )

--- a/src/components/Icon/story/Size.example.jsx
+++ b/src/components/Icon/story/Size.example.jsx
@@ -4,7 +4,7 @@ import { Cog } from '@toptal/picasso/Icons'
 
 const IconExample = () => (
   <div>
-    <Container inline right={1}>
+    <Container inline mr={1}>
       <Cog size={2} />
     </Container>
     <Cog style={{ width: '3em', height: '3em' }} />

--- a/src/components/Icon/story/WithText.example.jsx
+++ b/src/components/Icon/story/WithText.example.jsx
@@ -9,7 +9,7 @@ const IconWithTextExample = () => (
       Vertical alignment of the icon with the same height as text
     </div>
 
-    <Container flex direction='row' alignItems='center' top={1}>
+    <Container flex direction='row' alignItems='center' mt={1}>
       <Cog size={1.5} style={{ marginRight: '0.5em' }} />
       Vertical alignment of the icon with bigger height than text
     </Container>

--- a/src/components/Image/story/Variants.example.jsx
+++ b/src/components/Image/story/Variants.example.jsx
@@ -10,7 +10,7 @@ const ImageVariantsExample = () => (
         style={{ width: '250px', height: '250px' }}
       />
     </Container>
-    <Container left={1} inline>
+    <Container ml={1} inline>
       <Image
         variant='circular'
         alt='Circular image'

--- a/src/components/Label/story/Statuses.example.jsx
+++ b/src/components/Label/story/Statuses.example.jsx
@@ -3,7 +3,7 @@ import { Label, Container } from '@toptal/picasso'
 
 const LabelDefaultExample = () => (
   <div>
-    <Container inline right={1}>
+    <Container inline mr={1}>
       <Label variant='success'>Yay! It&#39;s done!</Label>
     </Container>
     <Label variant='error'>Nope! Please, try one more time</Label>

--- a/src/components/Loader/story/Sizes.example.jsx
+++ b/src/components/Loader/story/Sizes.example.jsx
@@ -3,10 +3,10 @@ import { Loader, Container } from '@toptal/picasso'
 
 const LoaderSizesExample = () => (
   <div>
-    <Container bottom={2}>
+    <Container mb={2}>
       <Loader size='small'>small</Loader>
     </Container>
-    <Container bottom={2}>
+    <Container mb={2}>
       <Loader size='medium'>medium</Loader>
     </Container>
     <Loader size='large'>large</Loader>

--- a/src/components/Logo/story/Variants.example.jsx
+++ b/src/components/Logo/story/Variants.example.jsx
@@ -4,11 +4,11 @@ import { Logo, Container } from '@toptal/picasso'
 const LogoVariantsExample = () => (
   <div>
     <div>
-      <LogoContainer bgcolor='#ffffff' inline right={1}>
+      <LogoContainer bgcolor='#ffffff' inline mr={1}>
         <Logo />
       </LogoContainer>
 
-      <LogoContainer bgcolor='#204ecf' inline right={1}>
+      <LogoContainer bgcolor='#204ecf' inline mr={1}>
         <Logo variant='white' />
       </LogoContainer>
 
@@ -17,12 +17,12 @@ const LogoVariantsExample = () => (
       </LogoContainer>
     </div>
 
-    <Container top={2}>
-      <LogoContainer bgcolor='#ffffff' inline right={1}>
+    <Container mt={2}>
+      <LogoContainer bgcolor='#ffffff' inline mr={1}>
         <Logo emblem />
       </LogoContainer>
 
-      <LogoContainer bgcolor='#204ecf' inline right={1}>
+      <LogoContainer bgcolor='#204ecf' inline mr={1}>
         <Logo emblem variant='white' />
       </LogoContainer>
 
@@ -34,7 +34,7 @@ const LogoVariantsExample = () => (
 )
 
 const LogoContainer = ({ children, bgcolor, ...rest }) => (
-  <Container {...rest} style={{ backgroundColor: bgcolor, padding: '2em' }}>
+  <Container {...rest} p={2} style={{ backgroundColor: bgcolor }}>
     {children}
   </Container>
 )

--- a/src/components/Page/story/Default.example.jsx
+++ b/src/components/Page/story/Default.example.jsx
@@ -32,7 +32,7 @@ const OPTIONS = [
 ]
 
 const Content = () => (
-  <Container bottom={1} left={1} right={1} top={1}>
+  <Container m={1}>
     <Typography align='center' variant='h1'>
       Default example
     </Typography>

--- a/src/components/Page/story/FullWidth.example.jsx
+++ b/src/components/Page/story/FullWidth.example.jsx
@@ -32,7 +32,7 @@ const OPTIONS = [
 ]
 
 const Content = () => (
-  <Container bottom={1} left={1} right={1} top={1}>
+  <Container m={1}>
     <Typography align='center' variant='h1'>
       FullWidth example
     </Typography>

--- a/src/components/Page/story/Scroll.example.jsx
+++ b/src/components/Page/story/Scroll.example.jsx
@@ -14,7 +14,7 @@ const PageScrollExample = () => (
 )
 
 const Content = () => (
-  <Container bottom={1} left={1} right={1} top={1}>
+  <Container m={1}>
     <Typography align='center' variant='h1'>
       Scrollable example
     </Typography>

--- a/src/components/PageContent/story/Default.example.jsx
+++ b/src/components/PageContent/story/Default.example.jsx
@@ -10,7 +10,7 @@ const PageContentDefaultExample = () => (
 )
 
 const Content = () => (
-  <Container bottom={1} left={1} right={1} top={1}>
+  <Container m={1}>
     <Typography align='center' variant='h1'>
       Default example
     </Typography>

--- a/src/components/Paper/story/Default.example.jsx
+++ b/src/components/Paper/story/Default.example.jsx
@@ -4,17 +4,15 @@ import { Paper, Typography, Container } from '@toptal/picasso'
 const PaperDefaultExample = () => (
   <div style={{ width: '25rem' }}>
     <Paper>
-      <div style={{ padding: '1rem' }}>
-        <Container bottom={1}>
-          <Typography variant='h3' weight='bold'>
-            This is paper
-          </Typography>
-        </Container>
+      <Container p={1}>
+        <Typography variant='h3' weight='bold' gutterBottom={1}>
+          This is paper
+        </Typography>
         <Typography>
           Paper can be used to build surface or other elements for your
           application.
         </Typography>
-      </div>
+      </Container>
     </Paper>
   </div>
 )

--- a/src/components/Select/story/Types.example.jsx
+++ b/src/components/Select/story/Types.example.jsx
@@ -3,10 +3,10 @@ import { Select, Container } from '@toptal/picasso'
 
 const SelectTypesExample = () => (
   <div>
-    <Container inline right={2}>
+    <Container inline mr={2}>
       <Select options={OPTIONS} placeholder='Default...' width='auto' />
     </Container>
-    <Container inline right={2}>
+    <Container inline mr={2}>
       <Select
         options={OPTIONS}
         placeholder='Default...'

--- a/src/components/Stepper/story/Default.example.jsx
+++ b/src/components/Stepper/story/Default.example.jsx
@@ -4,13 +4,13 @@ import { Stepper, Container } from '@toptal/picasso'
 const StepperDefaultExample = () => (
   <div>
     <Stepper steps={['Step 1', 'Step 2', 'Step 3', 'Step 4']} />
-    <Container top={1}>
+    <Container mt={1}>
       <Stepper active={1} steps={['Step 1', 'Step 2', 'Step 3', 'Step 4']} />
     </Container>
-    <Container top={1}>
+    <Container mt={1}>
       <Stepper active={3} steps={['Step 1', 'Step 2', 'Step 3', 'Step 4']} />
     </Container>
-    <Container top={1}>
+    <Container mt={1}>
       <Stepper active={4} steps={['Step 1', 'Step 2', 'Step 3', 'Step 4']} />
     </Container>
   </div>

--- a/src/components/Stepper/story/Variants.example.jsx
+++ b/src/components/Stepper/story/Variants.example.jsx
@@ -5,7 +5,7 @@ const StepperVariantsExample = () => (
   <div>
     <Typography>Default:</Typography>
     <Stepper steps={['Step 1', 'Step 2', 'Step 3', 'Step 4']} />
-    <Container top={1}>
+    <Container mt={1}>
       <Typography>Without labels:</Typography>
       <Stepper hideLabels steps={['Step 1', 'Step 2', 'Step 3', 'Step 4']} />
     </Container>

--- a/src/components/Tooltip/story/Arrow.example.jsx
+++ b/src/components/Tooltip/story/Arrow.example.jsx
@@ -10,12 +10,12 @@ const TooltipArrowExample = () => (
       paddingTop: '3rem'
     }}
   >
-    <Container bottom={3} left={2} right={2} top={3} inline>
+    <Container my={3} mx={2} inline>
       <Tooltip content='Content' open placement='top'>
         <Button>Arrow</Button>
       </Tooltip>
     </Container>
-    <Container bottom={3} left={2} right={2} top={3} inline>
+    <Container my={3} mx={2} inline>
       <Tooltip arrow={false} content='Content' open placement='top'>
         <Button>No Arrow</Button>
       </Tooltip>

--- a/src/components/Tooltip/story/Interactive.example.jsx
+++ b/src/components/Tooltip/story/Interactive.example.jsx
@@ -3,12 +3,12 @@ import { Tooltip, Button, Container } from '@toptal/picasso'
 
 const TooltipArrowExample = () => (
   <div style={{ textAlign: 'center' }}>
-    <Container bottom={3} left={2} right={2} top={3} inline>
+    <Container my={3} mx={2} inline>
       <Tooltip content='You can not hover inside!' placement='top'>
         <Button>Non interactive</Button>
       </Tooltip>
     </Container>
-    <Container bottom={3} left={2} right={2} top={3} inline>
+    <Container my={3} mx={2} inline>
       <Tooltip content='Hover inside' interactive placement='top'>
         <Button>Interactive</Button>
       </Tooltip>

--- a/src/components/Tooltip/story/Placement.example.jsx
+++ b/src/components/Tooltip/story/Placement.example.jsx
@@ -6,7 +6,7 @@ const placements = ['left', 'bottom', 'top', 'right']
 const TooltipPlacementExample = () => (
   <div style={{ width: '800px', height: '230px', padding: '3rem 6rem' }}>
     {placements.map(placement => (
-      <Container key={placement} bottom={3} left={2} right={2} top={3} inline>
+      <Container key={placement} my={3} mx={2} inline>
         <Tooltip arrow content='Content' open placement={placement}>
           <Button>{placement}</Button>
         </Tooltip>

--- a/src/components/Tooltip/story/Trigger.example.jsx
+++ b/src/components/Tooltip/story/Trigger.example.jsx
@@ -3,12 +3,12 @@ import { Tooltip, Button, Container } from '@toptal/picasso'
 
 const TooltipArrowExample = () => (
   <div style={{ textAlign: 'center' }}>
-    <Container bottom={3} left={2} right={2} top={3} inline>
+    <Container my={3} mx={2} inline>
       <Tooltip content='Some content...' placement='top' trigger='hover'>
         <Button>Hover</Button>
       </Tooltip>
     </Container>
-    <Container bottom={3} left={2} right={2} top={3} inline>
+    <Container my={3} mx={2} inline>
       <Tooltip content='Some content...' placement='top' trigger='click'>
         <Button>Click</Button>
       </Tooltip>

--- a/src/components/Tooltip/story/Variant.example.jsx
+++ b/src/components/Tooltip/story/Variant.example.jsx
@@ -10,12 +10,12 @@ const TooltipArrowExample = () => (
       paddingTop: '3rem'
     }}
   >
-    <Container bottom={3} left={2} right={2} top={3} inline>
+    <Container my={3} mx={2} inline>
       <Tooltip content='Content' open placement='top' variant='light'>
         <Button>Light</Button>
       </Tooltip>
     </Container>
-    <Container bottom={3} left={2} right={2} top={3} inline>
+    <Container my={3} mx={2} inline>
       <Tooltip content='Content' open placement='top' variant='dark'>
         <Button>Dark</Button>
       </Tooltip>

--- a/src/components/Typography/Typography.tsx
+++ b/src/components/Typography/Typography.tsx
@@ -35,6 +35,8 @@ interface Props extends StandardProps {
   weight?: WeightType
   /** Invert color */
   invert?: boolean
+  /** Adds bottom margin */
+  gutterBottom?: number
 }
 
 interface Variants {
@@ -70,7 +72,15 @@ const resolveRootClass = (props: Props) => {
 }
 
 export const Typography: FunctionComponent<Props> = props => {
-  const { variant, children, align, className, style, inline } = props
+  const {
+    variant,
+    children,
+    align,
+    className,
+    style,
+    inline,
+    gutterBottom
+  } = props
   const resolvedVariant = VARIANTS[variant!]
   const rootClass = resolveRootClass(props)
 
@@ -81,7 +91,10 @@ export const Typography: FunctionComponent<Props> = props => {
       classes={{
         root: rootClass
       }}
-      style={style}
+      style={{
+        ...(gutterBottom && { marginBottom: `${gutterBottom}em` }),
+        ...style
+      }}
       variant={resolvedVariant}
       inline={inline}
     >

--- a/src/components/Typography/story/Alignment.example.jsx
+++ b/src/components/Typography/story/Alignment.example.jsx
@@ -1,14 +1,14 @@
 import React from 'react'
-import { Typography, Container } from '@toptal/picasso'
+import { Typography } from '@toptal/picasso'
 
 const TypographyAlignmentExample = () => (
   <div>
-    <Container bottom={1}>
-      <Typography align='left'>Left</Typography>
-    </Container>
-    <Container bottom={1}>
-      <Typography align='center'>Center</Typography>
-    </Container>
+    <Typography align='left' gutterBottom={1}>
+      Left
+    </Typography>
+    <Typography align='center' gutterBottom={1}>
+      Center
+    </Typography>
     <Typography align='right'>Right</Typography>
   </div>
 )

--- a/src/components/Typography/story/Headings.example.jsx
+++ b/src/components/Typography/story/Headings.example.jsx
@@ -1,24 +1,26 @@
 import React from 'react'
-import { Typography, Container } from '@toptal/picasso'
+import { Typography } from '@toptal/picasso'
 
 const TypographyHeadingsExample = () => (
   <div>
-    <Container bottom={1}>
-      <Typography variant='h1'>Heading 1</Typography>
-    </Container>
-    <Container bottom={1}>
-      <Typography variant='h2'>Heading 2</Typography>
-    </Container>
-    <Container bottom={1}>
-      <Typography variant='h3'>Heading 3</Typography>
-    </Container>
-    <Container bottom={1}>
-      <Typography variant='h4'>Heading 4</Typography>
-    </Container>
-    <Container bottom={1}>
-      <Typography variant='h5'>Heading 5</Typography>
-    </Container>
-    <Typography variant='h6'>Heading 6</Typography>
+    <Typography variant='h1' gutterBottom={1}>
+      Heading 1
+    </Typography>
+    <Typography variant='h2' gutterBottom={1}>
+      Heading 2
+    </Typography>
+    <Typography variant='h3' gutterBottom={1}>
+      Heading 3
+    </Typography>
+    <Typography variant='h4' gutterBottom={1}>
+      Heading 4
+    </Typography>
+    <Typography variant='h5' gutterBottom={1}>
+      Heading 5
+    </Typography>
+    <Typography variant='h6' gutterBottom={1}>
+      Heading 6
+    </Typography>
   </div>
 )
 

--- a/src/components/Typography/story/Types.example.jsx
+++ b/src/components/Typography/story/Types.example.jsx
@@ -1,17 +1,15 @@
 import React from 'react'
-import { Typography, Container } from '@toptal/picasso'
+import { Typography } from '@toptal/picasso'
 
 const TypographyTypesExample = () => (
   <div>
-    <Container bottom={1}>
-      <Typography variant='large'>Large paragraph</Typography>
-    </Container>
-    <Container bottom={1}>
-      <Typography>Paragraph</Typography>
-    </Container>
-    <Container bottom={1}>
-      <Typography variant='small'>Small paragraph</Typography>
-    </Container>
+    <Typography variant='large' gutterBottom={1}>
+      Large paragraph
+    </Typography>
+    <Typography gutterBottom={1}>Paragraph</Typography>
+    <Typography variant='small' gutterBottom={1}>
+      Small paragraph
+    </Typography>
     <Typography variant='caption'>Caption</Typography>
   </div>
 )

--- a/src/components/Typography/story/Weights.example.jsx
+++ b/src/components/Typography/story/Weights.example.jsx
@@ -1,20 +1,20 @@
 import React from 'react'
-import { Typography, Container } from '@toptal/picasso'
+import { Typography } from '@toptal/picasso'
 
 const TypographyWeightsExample = () => (
   <div>
-    <Container bottom={1}>
-      <Typography weight='thin'>Thin</Typography>
-    </Container>
-    <Container bottom={1}>
-      <Typography weight='light'>Light</Typography>
-    </Container>
-    <Container bottom={1}>
-      <Typography weight='regular'>Regular</Typography>
-    </Container>
-    <Container bottom={1}>
-      <Typography weight='semibold'>Semibold</Typography>
-    </Container>
+    <Typography weight='thin' gutterBottom={1}>
+      Thin
+    </Typography>
+    <Typography weight='light' gutterBottom={1}>
+      Light
+    </Typography>
+    <Typography weight='regular' gutterBottom={1}>
+      Regular
+    </Typography>
+    <Typography weight='semibold' gutterBottom={1}>
+      Semibold
+    </Typography>
     <Typography weight='bold'>Bold</Typography>
   </div>
 )

--- a/src/components/UserBadge/story/Custom.example.jsx
+++ b/src/components/UserBadge/story/Custom.example.jsx
@@ -15,7 +15,7 @@ const UserBadgeCustomExample = () => (
       }
     >
       <Typography variant='h5'>Worked as</Typography>
-      <Container left={0.5}>
+      <Container ml={0.5}>
         <Typography variant='caption'>UI specialist</Typography>
         <Typography variant='caption'>Painter</Typography>
         <Typography variant='caption'>Student</Typography>


### PR DESCRIPTION
### Description

Change `Container` component to hold similiar interface as MUI `Box` with margins and paddings. Also add `gutterBottom` to `Typography` to reduce need for wrapping it with `Container` each time.

**Questions:**
- what do you think about new interfaces?
- maybe `gutterBottom` can also be `boolean` to add default `x rem` because it depends on font-size so for `h1` will be bigger and for `caption` smaller, we can talk to designers to standardize it
- for `margins` and `paddings` would you like `SizeType` or `number`?

### How to test

Open Container and Typography page in storybook

### Review

- [ ] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that visuals specs are green [See the documentation](/README.md#fixing-broken-visual-tests-inside-a-pr)
