### PR TITLE
chore(docs): Speedup storybook builds on CI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,13 +25,13 @@ RUN apk update && apk upgrade && \
       jq \
       chromium
 
-# Tell Puppeteer to skip installing Chrome. We'll be using the installed package.
-# Puppeteer v1.9.0 works with Chromium 71.
-ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD true
+RUN /usr/bin/chromium-browser --version
 
 # Run everything after as non-privileged user.
 COPY . /app
 WORKDIR /app
+
+RUN ls -la /app
 
 # Add user so we don't need --no-sandbox.
 RUN addgroup -S pptruser

--- a/bin/run-in-docker
+++ b/bin/run-in-docker
@@ -4,6 +4,7 @@ BLUE='\033[0;34m'
 NC='\033[0m'
 PICASSO_IMAGE='picasso'
 PKG_VERSION=`node -p "require('./package.json').version"`
+GIT_SHA=`git rev-parse --short=8 HEAD`
 
 if [[ "$(docker images -q $PICASSO_IMAGE:$PKG_VERSION 2> /dev/null)" == "" ]]; then
   docker build -t $PICASSO_IMAGE:$PKG_VERSION .
@@ -20,7 +21,9 @@ DOCKER_CMD="docker run -t -i --rm \
  -v ${PWD}/.storybook:/app/.storybook \
  -v ${PWD}/bin:/app/bin \
  -v ${PWD}/__diff_output__:/app/__diff_output__ \
- -e NPM_TOKEN=$NPM_TOKEN $PICASSO_IMAGE:$PKG_VERSION"
+ -e NPM_TOKEN=$NPM_TOKEN \
+ -e GIT_SHA=$GIT_SHA \
+ $PICASSO_IMAGE:$PKG_VERSION"
 
 echo -e "${BLUE} Running command inside docker ... ${NC}"
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@toptal/picasso",
-  "version": "0.1.0-beta.16",
+  "version": "0.1.0-beta.17",
   "description": "",
   "main": "build/index.js",
   "module": "build/index.js",
@@ -15,7 +15,7 @@
     "lint": "yarn run lint:path .",
     "storybook": "start-storybook -p 9001 -s ./.storybook/public -c .storybook",
     "storybook:cache": "CACHE=1 start-storybook -p 9001 -s ./.storybook/public -c .storybook",
-    "build:storybook": "build-storybook -s ./.storybook/public -c .storybook -o build/storybook",
+    "build:storybook": "CACHE=1 build-storybook -s ./.storybook/public -c .storybook -o build/storybook",
     "release:pre": "yarn version --new-version prerelease",
     "build": "yarn run generate:icons && cross-env NODE_ENV=production ./bin/build",
     "build:watch": "cross-env ./bin/build --watch",

--- a/puppeteer/reporter.js
+++ b/puppeteer/reporter.js
@@ -3,6 +3,7 @@
 const fs = require('fs')
 const path = require('path')
 const ejs = require('ejs')
+const exec = require('child_process').execSync
 
 const config = require('./config')
 const { createSnapshotName, assignOutputDir } = require('./utils')


### PR DESCRIPTION
No ticket

### Description

Hackathon for storybook

## CPU Specs
i7-8700K, 32 GB RAM, SSD

### master branch
`yarn test:visual` (in docker) - **340 seconds**

<img width="535" alt="Screen Shot 2019-04-24 at 9 56 50 PM" src="https://user-images.githubusercontent.com/324488/56689746-17399a00-66dc-11e9-8479-b012307b05c3.png">

`yarn build:storybook` - **134 seconds**
<img width="563" alt="Screen Shot 2019-04-24 at 10 02 00 PM" src="https://user-images.githubusercontent.com/324488/56689975-a181fe00-66dc-11e9-8f0b-26d837e7fd5a.png">

### this branch
`yarn test:visual` (in docker) - **167 seconds**
<img width="501" alt="Screen Shot 2019-04-24 at 10 10 24 PM" src="https://user-images.githubusercontent.com/324488/56690465-caef5980-66dd-11e9-86fb-7330aca88c8c.png">

`yarn build:storybook` - **12 seconds** [hot cache]
<img width="567" alt="Screen Shot 2019-04-24 at 10 04 18 PM" src="https://user-images.githubusercontent.com/324488/56690093-ef970180-66dc-11e9-8aaa-a12fe96be1bb.png">

`yarn build:storybook` - **67 seconds** [cold cache]
<img width="484" alt="Screen Shot 2019-04-24 at 10 06 10 PM" src="https://user-images.githubusercontent.com/324488/56690203-31c04300-66dd-11e9-99c0-763fccc28ca1.png">


### Review

- [ ] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that visuals specs are green [See the documentation](/README.md#fixing-broken-visual-tests-inside-a-pr)
