### PR TITLE
fix: Remove path alias from src directory

### DIFF
--- a/.storybook/tsconfig.json
+++ b/.storybook/tsconfig.json
@@ -4,7 +4,14 @@
     "lib": ["dom", "es2016", "es2017"],
     "allowJs": true,
     "declaration": false,
-    "target": "es5"
+    "target": "es5",
+    "paths": {
+      "~/*": ["*"],
+      "@/*": ["src/*"],
+      "@components/*": ["src/components/*"],
+      "@components": ["src/components/index"],
+      "*": ["@types/*"]
+    }
   },
   "exclude": []
 }

--- a/jest.config.js
+++ b/jest.config.js
@@ -17,10 +17,7 @@ module.exports = {
   */
   moduleNameMapper: {
     '\\.(jpg|jpeg|png|gif|webp|svg|ttf|woff|woff2)$':
-      '<rootDir>/__tests__/fileMock.js',
-    '^~/(.*)': '<rootDir>/$1',
-    '^@/(.*)': '<rootDir>/src/$1',
-    '^@components/(.*)': '<rootDir>/src/components/$1'
+      '<rootDir>/__tests__/fileMock.js'
   },
   moduleFileExtensions: ['js', 'jsx', 'ts', 'tsx']
 }

--- a/src/components/styles/withClasses/test.tsx
+++ b/src/components/styles/withClasses/test.tsx
@@ -1,8 +1,8 @@
 import React from 'react'
 import { render, cleanup, RenderResult } from 'react-testing-library'
-import Button from '@components/Button'
-import Picasso from '@components/Picasso'
 
+import Button from '../../Button'
+import Picasso from '../../Picasso'
 import withClasses from './withClasses'
 
 const TestComponent = (props: any) => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,10 +17,6 @@
     "baseUrl": ".",
     "typeRoots": ["node_modules/@types", "@types"],
     "paths": {
-      "~/*": ["*"],
-      "@/*": ["src/*"],
-      "@components/*": ["src/components/*"],
-      "@components": ["src/components/index"],
       "*": ["@types/*"]
     }
   },


### PR DESCRIPTION
[FX-NNNN](https://toptal-core.atlassian.net/browse/FX-NNNN)

### Description

Remove alias capability from ./src. You can still use aliasing for storybook and stories but not directly in /src. 

In future we can add capability back by using module-alias or babel plugins to resolve alias.

https://github.com/Microsoft/TypeScript/issues/10866#issuecomment-456436702

### Review

- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that visuals specs are green [See the documentation](/README.md#fixing-broken-visual-tests-inside-a-pr)
