### PR TITLE
fix: [FX-154] Fix padding after removing padding for root

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -9,6 +9,9 @@
   .story {
     padding: 20px;
   }
+  .markdown-body {
+    padding: 20px;
+  }
   .story-title {
     margin: 0;
   }


### PR DESCRIPTION
[FX-154](https://toptal-core.atlassian.net/browse/FX-154)

### Description

Looks like after removing padding for `#root` in https://github.com/toptal/picasso/pull/301/ it works well for visual snapshots, but not for storybook UI. So this PR is fixing that.