### PR TITLE
fix(storybook): wrong Icon import path

### DIFF
--- a/.storybook/components/CodeExample/CodeExample.tsx
+++ b/.storybook/components/CodeExample/CodeExample.tsx
@@ -34,7 +34,7 @@ const imports: {
   'styled-components': styled,
   '@toptal/picasso': require('@components'),
   '@toptal/picasso/utils': require('@components/utils'),
-  '@toptal/picasso/Icons': require('@components/Icon')
+  '@toptal/picasso/Icon': require('@components/Icon')
 }
 
 const resolver = (path: string) => imports[path]

--- a/src/components/Button/story/CircularIconButton.example.jsx
+++ b/src/components/Button/story/CircularIconButton.example.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { Button } from '@toptal/picasso'
-import { Cog } from '@toptal/picasso/Icons'
+import { Cog } from '@toptal/picasso/Icon'
 
 const ButtonIconButtonsExample = () => (
   <div>

--- a/src/components/Button/story/IconButtons.example.jsx
+++ b/src/components/Button/story/IconButtons.example.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { Button } from '@toptal/picasso'
-import { Cog } from '@toptal/picasso/Icons'
+import { Cog } from '@toptal/picasso/Icon'
 
 const ButtonIconButtonsExample = () => (
   <div>

--- a/src/components/Button/story/IconButtonsWithText.example.jsx
+++ b/src/components/Button/story/IconButtonsWithText.example.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { Button } from '@toptal/picasso'
-import { Cog } from '@toptal/picasso/Icons'
+import { Cog } from '@toptal/picasso/Icon'
 
 const ButtonIconButtonsWithTextExample = () => (
   <div>

--- a/src/components/Icon/story/Color.example.jsx
+++ b/src/components/Icon/story/Color.example.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { Container } from '@toptal/picasso'
-import { Cog } from '@toptal/picasso/Icons'
+import { Cog } from '@toptal/picasso/Icon'
 
 const IconExample = () => (
   <div>

--- a/src/components/Icon/story/Default.example.jsx
+++ b/src/components/Icon/story/Default.example.jsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Cog } from '@toptal/picasso/Icons'
+import { Cog } from '@toptal/picasso/Icon'
 
 const IconExample = () => (
   <div>

--- a/src/components/Icon/story/List.example.jsx
+++ b/src/components/Icon/story/List.example.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { Grid, Paper, Typography, Container } from '@toptal/picasso'
-import * as icons from '@toptal/picasso/Icons'
+import * as icons from '@toptal/picasso/Icon'
 
 /** We don't want to render internal icons */
 // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/src/components/Icon/story/Size.example.jsx
+++ b/src/components/Icon/story/Size.example.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { Container } from '@toptal/picasso'
-import { Cog } from '@toptal/picasso/Icons'
+import { Cog } from '@toptal/picasso/Icon'
 
 const IconExample = () => (
   <div>

--- a/src/components/Icon/story/WithText.example.jsx
+++ b/src/components/Icon/story/WithText.example.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { Container } from '@toptal/picasso'
-import { Cog } from '@toptal/picasso/Icons'
+import { Cog } from '@toptal/picasso/Icon'
 
 const IconWithTextExample = () => (
   <div>

--- a/src/components/TextField/story/WithIcon.example.jsx
+++ b/src/components/TextField/story/WithIcon.example.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { TextField } from '@toptal/picasso'
-import { Cog } from '@toptal/picasso/Icons'
+import { Cog } from '@toptal/picasso/Icon'
 
 const TextFieldWithIconExample = () => (
   <div>


### PR DESCRIPTION
### Description

Fixies #308 

Actually, it should've been the opposite: `Icons` the right name for the component but it's a breaking change, so I wouldn't go for it right now.

### Review

- (n/a) Annotate all `props` in component with documentation
- (n/a) Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure that visuals specs are green [See the documentation](/README.md#fixing-broken-visual-tests-inside-a-pr)
