### PR TITLE
chore: pin TS 3.3 because of performance of 3.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
     "styled-components": "^4.2.0",
     "ts-jest": "^24.0.2",
     "ts-loader": "^5.4.5",
-    "typescript": "^3.4.5",
+    "typescript": "3.3.4000",
     "yargs": "^13.2.4"
   },
   "husky": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -14862,10 +14862,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^3.4.5:
-  version "3.4.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.4.5.tgz#2d2618d10bb566572b8d7aad5180d84257d70a99"
-  integrity sha512-YycBxUb49UUhdNMU5aJ7z5Ej2XGmaIBL0x34vZ82fn3hGvD+bgrMrVDpatgz2f7YxUMJxMkbWxJZeAvDxVe7Vw==
+typescript@3.3.4000:
+  version "3.3.4000"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.3.4000.tgz#76b0f89cfdbf97827e1112d64f283f1151d6adf0"
+  integrity sha512-jjOcCZvpkl2+z7JFn0yBOoLQyLoIkNZAs/fYJkUG6VKy6zLPHJGfQJYFHzibB6GJaF/8QrcECtlQ5cpvRHSMEA==
 
 ua-parser-js@^0.7.18:
   version "0.7.19"


### PR DESCRIPTION
### Description

There is an issue with TS https://github.com/Microsoft/TypeScript/issues/30819 that in conjunction with [latest updates of `@types/react`](https://github.com/DefinitelyTyped/DefinitelyTyped/commit/e2e5298c1f2d2ea96fba2413b5bbe767f11c01f6#diff-96b72df8b13a8a590e4f160cbc51f40c) slows down our storybook build.

[Long read](https://github.com/microsoft/TypeScript/issues/30819#issuecomment-481060116) about how that happened

#### Results after reverting packages on my machine

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| 2.5 min for manager and 3.17 min for preview | 42 s for manager and 56 s for preview |

### Caveats

`yarn build:storybook` takes a couple of seconds more with `@types/react@16.8.14`

Be sure we don't use features that work only in `3.4+` TS - https://github.com/Microsoft/TypeScript/wiki/Breaking-Changes#typescript-34

Next version `3.5` works better, but still has worse performance than `3.3`, upgrade should be considered after the release

### How to test

- run `rm -rf node_modules && yarn && yarn storybook` and check time

### Review

~- [ ] Annotate all `props` in component with documentation~
~- [ ] Create `examples` for component~
- [x] Ensure that deployed demo has expected results and good examples

~- [ ] Ensure that visuals specs are green [See the documentation](/README.md#fixing-broken-visual-tests-inside-a-pr)~
