### PR TITLE
chore(ci): increase specs timeout

### DIFF
--- a/ci/jobs/picasso-pr-specs/Jenkinsfile
+++ b/ci/jobs/picasso-pr-specs/Jenkinsfile
@@ -17,7 +17,7 @@ pipeline {
   options {
     ansiColor('xterm')
     timestamps()
-    timeout(time: 10, unit: 'MINUTES')
+    timeout(time: 15, unit: 'MINUTES')
     skipDefaultCheckout()
   }
 


### PR DESCRIPTION
### Description

Some of the builds failed because of timeout value at jenkins - (10 mins), average time of running specs currently is `9:40`, so here is a workaround until Milos merges his improved visual testing.