### PR TITLE
chore: add node_modules from dev to docker visuals

### DIFF
--- a/bin/run-in-docker
+++ b/bin/run-in-docker
@@ -21,6 +21,7 @@ DOCKER_CMD="docker run -t -i --rm --name $PICASSO_IMAGE \
  -v ${PWD}/.storybook:/app/.storybook \
  -v ${PWD}/bin:/app/bin \
  -v ${PWD}/__diff_output__:/app/__diff_output__ \
+ -v ${PWD}/node_modules:/app/node_modules
  -e NPM_TOKEN=$NPM_TOKEN \
  -e GIT_SHA=$GIT_SHA \
  $PICASSO_IMAGE:$PKG_VERSION"


### PR DESCRIPTION
### Description

Guys, because it's really painful to run visual tests, even partially, I've tried to do something with `yarn install` for local dev env.
So I've tried to experiment with it a bit and in this solution, I've just shared `node_modules` of my Picasso root with docker `app` folder. So what happened:

- I have all my `node_modules` installed in `root`
- when I run the first time `yarn test:visual -u` I see `yarn install` working and installing the packages
- when I run the second time `yarn test:visual -u`, then `yarn install` says that all packages are up to date and  does nothing
- I thought that the original `root` `node_modules` folder will be corrupted, but when I do `yarn storybook` from the `root` it works fine.

So what do you think guys?