### PR TITLE
fix(button): accept and proxy 'type' prop

### DIFF
--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -55,6 +55,8 @@ export interface Props extends StandardProps {
   circular?: boolean
   /** HTML title of Button component */
   title?: string
+  /** HTML type of Button component **/
+  type?: 'button' | 'reset' | 'submit'
 }
 
 interface StaticProps {
@@ -79,7 +81,8 @@ export const Button: FunctionComponent<Props> & StaticProps = ({
   onClick,
   circular,
   title,
-  value
+  value,
+  type
 }) => {
   const {
     icon: iconClass,
@@ -135,6 +138,7 @@ export const Button: FunctionComponent<Props> & StaticProps = ({
       disabled={disabled}
       title={title}
       value={value}
+      type={type}
     >
       <Container
         inline
@@ -165,6 +169,7 @@ Button.defaultProps = {
   loading: false,
   onClick: () => {},
   size: 'medium',
+  type: 'button',
   variant: 'default'
 }
 


### PR DESCRIPTION
### Description

Button does not accept `type` property, so it can't by specified `type="submit"` for it to work as a form submit buttom. This fixes that by accepting `type` property and proxying it to the wrapped `Button` component from MUI.

### How to test

I tested this in storybook.
Use `Button` component inside a `form`:

~~~jsx
<form onsubmit={ev => {
  ev.preventDefault()
  console.log('I WAS CALLED')
}}>
  <Button type="submit">Submit</Button>
</form>
~~~

Check how this code currently won't submit handler triggered.
Switch to this branch. Now it get's triggered.

### Review

- [x] Annotate all `props` in component with documentation
- Create `examples` for component
- Ensure that deployed demo has expected results and good examples
- [ ] Ensure that visuals specs are green [See the documentation](/README.md#fixing-broken-visual-tests-inside-a-pr)
