### PR TITLE
fix(radio): fix interface definition for radio group

### DIFF
--- a/src/components/Radio/Radio.tsx
+++ b/src/components/Radio/Radio.tsx
@@ -1,11 +1,11 @@
-import React, { FunctionComponent, ReactNode } from 'react'
+import React, { FunctionComponent } from 'react'
 import cx from 'classnames'
 import MUIRadio, { RadioProps } from '@material-ui/core/Radio'
 import RadioGroup from '@material-ui/core/RadioGroup'
 import { withStyles } from '@material-ui/core/styles'
 
 import FormControlLabel from '../FormControlLabel'
-import { StandardProps } from '../Picasso'
+import { PicassoComponent, StandardProps } from '../Picasso'
 import styles from './styles'
 
 const FallbackIcon = () => null
@@ -24,11 +24,11 @@ export interface Props extends StandardProps {
 }
 
 // should be moved to some global interfaces place
-interface GroupFunctionalComponent<T> extends FunctionComponent<T> {
-  Group: ReactNode
+interface StaticProps {
+  Group: typeof RadioGroup
 }
 
-export const Radio: GroupFunctionalComponent<Props> = ({
+export const Radio: FunctionComponent<Props> & StaticProps = ({
   classes: { root, icon, label: labelClass, ...otherClasses },
   className,
   style,
@@ -81,4 +81,4 @@ Radio.displayName = 'Radio'
 
 Radio.Group = RadioGroup
 
-export default withStyles(styles)(Radio)
+export default withStyles(styles)(Radio) as PicassoComponent<Props, StaticProps>

--- a/src/components/Radio/__snapshots__/test.tsx.snap
+++ b/src/components/Radio/__snapshots__/test.tsx.snap
@@ -1,5 +1,65 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Radio.Group renders radio in group 1`] = `
+<div>
+  <div
+    class="MuiFormGroup-root"
+    role="radiogroup"
+  >
+    <label
+      class="MuiFormControlLabel-root FormControlLabel-root Radio-label"
+    >
+      <span
+        class="MuiButtonBase-root MuiIconButton-root MuiPrivateSwitchBase-root MuiRadio-root Radio-icon"
+      >
+        <span
+          class="MuiIconButton-label"
+        >
+          <input
+            class="MuiPrivateSwitchBase-input"
+            type="radio"
+            value="VALUE+1"
+          />
+        </span>
+        <span
+          class="MuiTouchRipple-root"
+        />
+      </span>
+      <span
+        class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label"
+      >
+        LABEL+1
+      </span>
+    </label>
+    <label
+      class="MuiFormControlLabel-root FormControlLabel-root Radio-label"
+    >
+      <span
+        class="MuiButtonBase-root MuiIconButton-root MuiPrivateSwitchBase-root MuiRadio-root Radio-icon"
+      >
+        <span
+          class="MuiIconButton-label"
+        >
+          <input
+            class="MuiPrivateSwitchBase-input"
+            type="radio"
+            value="VALUE+2"
+          />
+        </span>
+        <span
+          class="MuiTouchRipple-root"
+        />
+      </span>
+      <span
+        class="MuiTypography-root MuiTypography-body1 MuiFormControlLabel-label"
+      >
+        LABEL+2
+      </span>
+    </label>
+  </div>
+</div>
+`;
+
 exports[`disabled radio button renders disabled version 1`] = `
 <div>
   <span

--- a/src/components/Radio/test.tsx
+++ b/src/components/Radio/test.tsx
@@ -45,3 +45,16 @@ describe('radio button', () => {
     expect(container).toMatchSnapshot()
   })
 })
+
+describe('Radio.Group', () => {
+  test('renders radio in group', () => {
+    const { container }: RenderResult = render(
+      <Radio.Group>
+        <Radio label='LABEL+1' value='VALUE+1' />
+        <Radio label='LABEL+2' value='VALUE+2' />
+      </Radio.Group>
+    )
+
+    expect(container).toMatchSnapshot()
+  })
+})


### PR DESCRIPTION
### Description

TS Complier highlighted `Radio.Group` with the following error:

```
Error:(98, 26) TS2339: Property 'Group' does not exist on type 'ComponentType<Pick<PropsWithChildren<Props>, "children" | "label" | "style" | "className" | "onChange" | "value" | "disabled" | "checked"> & StyledComponentProps<"label" | "icon" | "@keyframes fade-in">>'.
  Property 'Group' does not exist on type 'ComponentClass<Pick<PropsWithChildren<Props>, "children" | "label" | "style" | "className" | "onChange" | "value" | "disabled" | "checked"> & StyledComponentProps<"label" | "icon" | "@keyframes fade-in">, any>'.
```


### How to test

Try to use `Radio.Group` anywhere in your code.

### Screenshots

<img width="430" alt="topteam-old  ~:Projects:toptal:topteam-old  -  :frontend:src:modules:okrs:components:OKRForm:index tsx  topteam-old  2019-05-27 12-30-12" src="https://user-images.githubusercontent.com/1824723/58410654-3fba0880-807b-11e9-879f-39cc3537fa4b.png">

<img width="211" alt="picasso  ~:Projects:toptal:picasso  -  :src:components:Radio:test tsx  picasso  2019-05-27 12-30-53" src="https://user-images.githubusercontent.com/1824723/58410689-52344200-807b-11e9-92e2-018ff827a8cc.png">



### Review

- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [x] Ensure that visuals specs are green [See the documentation](/README.md#fixing-broken-visual-tests-inside-a-pr)
