### PR TITLE
fix(container): add missing values to the `justifyContent` enum

### DIFF
--- a/src/components/Container/Container.tsx
+++ b/src/components/Container/Container.tsx
@@ -4,9 +4,15 @@ import { BaseProps, SpacingType, spacingToEm } from '../Picasso'
 
 type DirectionType = 'row' | 'column'
 
-type AlignItemsType = 'flex-start' | 'flex-end' | 'center' | 'stretch'
+type AlignItemsType =
+  | 'flex-start'
+  | 'flex-end'
+  | 'center'
+  | 'stretch'
+  | 'baseline'
 type JustifyContentType =
-  | 'start'
+  | 'flex-start'
+  | 'flex-end'
   | 'center'
   | 'space-between'
   | 'space-around'


### PR DESCRIPTION
### Description

Need to add a missing values of the `justify-content` attribute to the `justifyContent` enum.


### Review

- [ ] Annotate all `props` in component with documentation
- [x] Ensure that visuals specs are green [See the documentation](https://github.com/toptal/picasso/blob/master/README.md#fixing-broken-visual-tests-inside-a-pr)
