### PR TITLE
docs(changelog): fix link to Select documentation in the changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,7 +57,7 @@
 * removed `variant` prop
 * removed `label` prop
 
-> You can check [Select](https://picasso.toptal.net/feature-base-sync/?path=/story/forms-folder--select) documentation.
+> You can check [Select](https://picasso.toptal.net/?path=/story/forms-folder--select) documentation.
 
 #### Stepper
 


### PR DESCRIPTION
no-ticket

### Description

Link to document attached to changelog to ease transition to 2.0 is dead.

### How to test

- Read the changelog for 2.0

### Review

- [ ] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that visuals specs are green [See the documentation](https://github.com/toptal/picasso/blob/master/README.md#fixing-broken-visual-tests-inside-a-pr)
