### PR TITLE
fix(modal): pass paperProps to enable custom styling of Modal dialog

### DIFF
--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -2,6 +2,7 @@ import React, { FunctionComponent, ReactNode } from 'react'
 import { withStyles } from '@material-ui/core/styles'
 import Dialog from '@material-ui/core/Dialog'
 import CloseIcon from '@material-ui/icons/Close'
+import { PaperProps } from '@material-ui/core/Paper'
 
 import ModalTitle from '../ModalTitle'
 import ModalContent from '../ModalContent'
@@ -27,6 +28,7 @@ export interface Props extends StandardProps {
   /** If `true`, the backdrop is not rendered */
   hideBackdrop?: boolean
   transitionDuration?: number
+  paperProps?: PaperProps
 }
 
 interface StaticProps {
@@ -47,7 +49,8 @@ export const Modal: FunctionComponent<Props> & StaticProps = props => {
     style,
     container,
     hideBackdrop,
-    transitionDuration
+    transitionDuration,
+    paperProps
   } = props
   const { closeButton, ...restClasses } = classes
 
@@ -57,7 +60,7 @@ export const Modal: FunctionComponent<Props> & StaticProps = props => {
       className={className}
       style={style}
       container={container}
-      PaperProps={{ elevation: 2 }}
+      PaperProps={{ ...paperProps, elevation: 2 }}
       hideBackdrop={hideBackdrop}
       onBackdropClick={onBackdropClick}
       onClose={onClose}


### PR DESCRIPTION
(no ticket)

### Description

Extended Modal component with `paperProps` to allow for customization of underlying `Paper` component.

### Review

- [n/a] Annotate all `props` in component with documentation
- [n/a] Create `examples` for component
- [n/a] Ensure that deployed demo has expected results and good examples
- [x] Ensure that visuals specs are green [See the documentation](https://github.com/toptal/picasso/blob/master/README.md#fixing-broken-visual-tests-inside-a-pr)
