### PR TITLE
feat(TextField): add support of native input attributes

### DIFF
--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -14,11 +14,17 @@ const tsLoader = {
     configFile: tsConfigFile
   }
 }
+
+const SKIP_PATTERN = /node_modules\/@types\/react\/index.d.ts/
 const tsDocgenLoader = {
   loader: require.resolve('react-docgen-typescript-loader'),
   options: {
     tsconfigPath: tsConfigFile,
-    skipPropsWithoutDoc: true
+    propFilter: prop => {
+      if (prop.description.length === 0) return false
+
+      return !SKIP_PATTERN.test(prop.parent.fileName)
+    }
   }
 }
 
@@ -27,7 +33,7 @@ const defaultLoaders =
 
 module.exports = ({ config }) => {
   config.entry = ['@babel/polyfill', ...config.entry]
-  
+
   config.module.rules.push({
     test: /\.(ts|tsx)$/,
     oneOf: [

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -1,4 +1,9 @@
-import React, { FunctionComponent, ReactNode, ChangeEvent } from 'react'
+import React, {
+  FunctionComponent,
+  ReactNode,
+  ChangeEvent,
+  InputHTMLAttributes
+} from 'react'
 import cx from 'classnames'
 import MUITextField from '@material-ui/core/TextField'
 import { withStyles } from '@material-ui/core/styles'
@@ -9,8 +14,13 @@ import { StandardProps } from '../Picasso'
 import styles from './styles'
 
 type IconPosition = 'start' | 'end'
+/**
+ * Alias for all valid HTML props for `<input>` element.
+ * Does not include React's `ref` or `key`.
+ */
+type HTMLInputProps = InputHTMLAttributes<HTMLInputElement>
 
-export interface Props extends StandardProps {
+export interface Props extends StandardProps, HTMLInputProps {
   /** The id of the `input` element. */
   id?: string
   /** Name attribute of the input element */
@@ -71,7 +81,8 @@ export const TextField: FunctionComponent<Props> = ({
   rows,
   rowsMax,
   type,
-  onChange
+  onChange,
+  ...rest
 }) => {
   if (icon) {
     const IconAdornment = (
@@ -95,6 +106,8 @@ export const TextField: FunctionComponent<Props> = ({
     }
   }
 
+  const { defaultValue, ...inputHtmlProps } = rest
+
   return (
     <MUITextField
       id={id}
@@ -115,6 +128,7 @@ export const TextField: FunctionComponent<Props> = ({
         [classes.rootFullWidth]: fullWidth
       })}
       InputProps={{
+        ...inputHtmlProps,
         ...inputProps,
         classes: {
           root: cx(classes.root, {
@@ -125,6 +139,7 @@ export const TextField: FunctionComponent<Props> = ({
         }
       }}
       onChange={onChange}
+      defaultValue={defaultValue as string}
     >
       {children}
     </MUITextField>

--- a/src/components/TextField/__snapshots__/test.tsx.snap
+++ b/src/components/TextField/__snapshots__/test.tsx.snap
@@ -111,3 +111,49 @@ exports[`Icon prop renders icon at the end 1`] = `
   </div>
 </div>
 `;
+
+exports[`Native html attributes adds native props to the input 1`] = `
+<div>
+  <div
+    class="Picasso-root"
+  >
+    <div
+      class="MuiFormControl-root TextField-rootFixedWidth"
+    >
+      <div
+        class="MuiInputBase-root MuiOutlinedInput-root TextField-root MuiInputBase-disabled MuiOutlinedInput-disabled MuiInputBase-formControl"
+        form="formId"
+        list="listId"
+        required=""
+        tabindex="-1"
+      >
+        <fieldset
+          aria-hidden="true"
+          class="MuiPrivateNotchedOutline-root MuiOutlinedInput-notchedOutline"
+          style="padding-left: 8px;"
+        >
+          <legend
+            class="MuiPrivateNotchedOutline-legend"
+            style="width: 0.01px;"
+          >
+            <span>
+              ​
+            </span>
+          </legend>
+        </fieldset>
+        <input
+          aria-invalid="false"
+          autocomplete="autocomplete"
+          class="MuiInputBase-input MuiOutlinedInput-input TextField-input MuiInputBase-disabled MuiOutlinedInput-disabled MuiInputBase-inputType"
+          disabled=""
+          name="name"
+          readonly=""
+          required=""
+          type="button"
+          value="value"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/src/components/TextField/test.tsx
+++ b/src/components/TextField/test.tsx
@@ -40,3 +40,27 @@ describe('Icon prop', () => {
     expect(container).toMatchSnapshot()
   })
 })
+
+describe('Native html attributes', () => {
+  test('adds native props to the input', () => {
+    const { container } = render(
+      <Picasso loadFonts={false}>
+        <TextField
+          readOnly
+          required
+          disabled
+          autoFocus
+          tabIndex={-1}
+          type='button'
+          value='value'
+          name='name'
+          list='listId'
+          form='formId'
+          autoComplete='autocomplete'
+        />
+      </Picasso>
+    )
+
+    expect(container).toMatchSnapshot()
+  })
+})


### PR DESCRIPTION
[FX-252](https://toptal-core.atlassian.net/browse/FX-252)

### Description

In scope of this ticket we agreed to provide a solution for a single component (TextField) as a result of investigation.

We agreed that props that are not listed explicitly should be passed to the input (not wrapper).

For the further extending support of native props (attributes) we will have another ticket in scope of which we will be able to use solution from the current ticket.

Popular libs that were checked:

Grommet, Semantic UI, Blueprint, Material UI , Ant, Bootstrap, material-components-web-react, react-foundation. 

Only Ant, Blueprint and material-components-web-react rely on types:

### Ant

`Omit<React.InputHTMLAttributes<HTMLInputElement>, ‘size’ | ‘prefix’>`

### Blueprint

`React.InputHTMLAttributes<HTMLInputElement>`

### material components web react

`<button {...props as React.HTMLProps<HTMLButtonElement>}>`

Ant's solution is very specific (they have collisions between their props and html attributes),
Blueprint's solution is simple and solid, material components web react use very similar approach.

### Semantic UI 

Semantic UI shows an interesting approach of passing codebase through the babel plugin and define a static props with really used props (class based approach), then they spread only props that are not used already in the component. 

### How to test

- check test.ts, all the props mentioned on MDN are passed there, so jest should fail if something is broken

### Review

- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure that visuals specs are green [See the documentation](https://github.com/toptal/picasso/blob/master/README.md#fixing-broken-visual-tests-inside-a-pr)
