### PR TITLE
chore: remove packages moved to davinci

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,8 +75,6 @@
     "@types/react-dom": "^16.8.4",
     "@types/storybook__react": "^4.0.0",
     "@types/styled-components": "^4.1.15",
-    "@typescript-eslint/eslint-plugin": "^1.9.0",
-    "@typescript-eslint/parser": "^1.9.0",
     "babel-loader": "^8.0.6",
     "brace": "^0.11.1",
     "chalk": "^2.4.1",


### PR DESCRIPTION
No ticket

### Description

eslint related packages were moved to davinci, those lines are leftovers.
Since davinci has them as deps, lockfile is not changed.

### How to test

- wait for tests to pass

### Review

- [ ] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that visuals specs are green [See the documentation](https://github.com/toptal/picasso/blob/master/README.md#fixing-broken-visual-tests-inside-a-pr)
