### PR TITLE
chore: fix missing lint:path command for icons generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,6 @@ In order to run `yarn` commands we need to mount current `components` directory 
 | Command                       | Description                                                               |
 | ----------------------------- | ------------------------------------------------------------------------- |
 | **yarn lint**                 | Lint all files                                                            |
-| **yarn lint:path pathToFile** | Lint specific file                                                        |
 | **yarn test**                 | Run unit tests                                                            |
 | **yarn test -u**              | Update jest snapshots to current version                                  |
 | **yarn test:watch**           | Run unit tests in watch mode                                              |

--- a/bin/generate-icons
+++ b/bin/generate-icons
@@ -26,5 +26,5 @@ for icon in $ICON_FULL_PATH/svg/*.svg; do
   echo "export { default as $name } from './$name'" >> src/components/Icon/index.ts
 done
 
-yarn lint:path $ICON_FULL_PATH
+davinci syntax lint code $ICON_FULL_PATH
 yarn prettier-standard $ICON_FULL_PATH/**/*.tsx


### PR DESCRIPTION
### Description

`yarn lint:path` was replaced by using `davinci` cli
