### PR TITLE
chore: adjust commitlint to support PascalCase in scope

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,6 +1,7 @@
 module.exports = {
   extends: ['@commitlint/config-conventional'],
   rules: {
-    'type-enum': [1, 'always', ['chore', 'feat', 'fix', 'docs']]
+    'type-enum': [1, 'always', ['chore', 'feat', 'fix', 'docs']],
+    'scope-case': [2, 'always', ['pascal-case', 'lowercase']]
   }
 }


### PR DESCRIPTION
### Description

Update commitlint rules to support `PascalCase` for the scope (e.g. `fix(TextField): blabla`

### How to test

- run danger locally or check it's report in this PR

### Review

- [ ] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that visuals specs are green [See the documentation](https://github.com/toptal/picasso/blob/master/README.md#fixing-broken-visual-tests-inside-a-pr)
