### PR TITLE
fix(TextField): pass native attributes correctly to the input

### DIFF
--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -106,8 +106,6 @@ export const TextField: FunctionComponent<Props> = ({
     }
   }
 
-  const { defaultValue, ...inputHtmlProps } = rest
-
   return (
     <MUITextField
       id={id}
@@ -127,8 +125,10 @@ export const TextField: FunctionComponent<Props> = ({
       className={cx(classes.rootFixedWidth, className, {
         [classes.rootFullWidth]: fullWidth
       })}
+      // html attributes
+      inputProps={rest}
+      // props that are not html attributes
       InputProps={{
-        ...inputHtmlProps,
         ...inputProps,
         classes: {
           root: cx(classes.root, {
@@ -139,7 +139,6 @@ export const TextField: FunctionComponent<Props> = ({
         }
       }}
       onChange={onChange}
-      defaultValue={defaultValue as string}
     >
       {children}
     </MUITextField>

--- a/src/components/TextField/__snapshots__/test.tsx.snap
+++ b/src/components/TextField/__snapshots__/test.tsx.snap
@@ -122,10 +122,6 @@ exports[`Native html attributes adds native props to the input 1`] = `
     >
       <div
         class="MuiInputBase-root MuiOutlinedInput-root TextField-root MuiInputBase-disabled MuiOutlinedInput-disabled MuiInputBase-formControl"
-        form="formId"
-        list="listId"
-        required=""
-        tabindex="-1"
       >
         <fieldset
           aria-hidden="true"
@@ -146,9 +142,12 @@ exports[`Native html attributes adds native props to the input 1`] = `
           autocomplete="autocomplete"
           class="MuiInputBase-input MuiOutlinedInput-input TextField-input MuiInputBase-disabled MuiOutlinedInput-disabled MuiInputBase-inputType"
           disabled=""
+          form="formId"
+          list="listId"
           name="name"
           readonly=""
           required=""
+          tabindex="-1"
           type="button"
           value="value"
         />

--- a/src/components/TextField/story/Multiline.example.jsx
+++ b/src/components/TextField/story/Multiline.example.jsx
@@ -11,12 +11,7 @@ const TextFieldMultilineExample = () => {
   return (
     <Container flex inline>
       <Container right='small'>
-        <TextField
-          multiline
-          rows={4}
-          value={value}
-          handleChange={handleChange}
-        />
+        <TextField multiline rows={4} value={value} onChange={handleChange} />
       </Container>
       <Container right='small'>
         <TextField multiline rows={4} placeholder='Placeholder' />


### PR DESCRIPTION
No ticket

### Description

Native props were passed to the wrong place, this PR fixes this wrong behaviour

### How to test

- try to pass some native attribute and check that it exists on input node inside TextField

### Review

- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that visuals specs are green [See the documentation](https://github.com/toptal/picasso/blob/master/README.md#fixing-broken-visual-tests-inside-a-pr)
