### PR TITLE
chore(docs): add how to add icon link

### DIFF
--- a/src/components/Icon/story/index.jsx
+++ b/src/components/Icon/story/index.jsx
@@ -27,6 +27,11 @@ page
       description: 'Style applied to SVG element'
     }
   ])
+  .addTextSection(
+    `
+  Didn't find a required Icon? Feel free to add it yourself - [how to add icon](https://github.com/toptal/picasso#add-icon)
+  `
+  )
   .addExample('Icon/story/List.example.jsx', 'List of all icons')
   .addExample('Icon/story/Default.example.jsx', 'Default')
   .addExample('Icon/story/Size.example.jsx', {


### PR DESCRIPTION
### Description

Add a link to the Picasso docs about how to add the icon.

So far looks like this:

<img width="1280" alt="Screenshot 2019-06-26 at 12 52 03" src="https://user-images.githubusercontent.com/2836281/60170511-3a361680-9811-11e9-8da2-d61d698d8f37.png">

