### PR TITLE
fix(Table): sync styles with base

### DIFF
--- a/src/components/TableRow/styles.ts
+++ b/src/components/TableRow/styles.ts
@@ -5,7 +5,7 @@ import { PicassoProvider } from '../Picasso'
 
 PicassoProvider.override(() => ({}))
 
-export default ({ palette, spacing }: Theme) =>
+export default ({ palette, spacing, transitions }: Theme) =>
   createStyles({
     root: {
       height: 'auto',
@@ -23,5 +23,9 @@ export default ({ palette, spacing }: Theme) =>
       borderBottom: `${spacing.borderWidth} solid ${palette.grey.lighter}`
     },
 
-    hover: {}
+    hover: {
+      transition: transitions.create('background-color', {
+        duration: transitions.duration.shortest
+      })
+    }
   })


### PR DESCRIPTION
[FX-300](https://toptal-core.atlassian.net/browse/FX-300)

### Description

Use blue color, the same as used for MenuItem

### How to test

- check demo, hover over a row at selectable table

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| ![image](https://user-images.githubusercontent.com/1291032/60178253-b5082d00-9823-11e9-9c35-4fc945c3e871.png) | ![image](https://user-images.githubusercontent.com/1291032/60178200-973ac800-9823-11e9-8e61-0821302727dc.png) |

### Review

- [ ] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that visuals specs are green [See the documentation](https://github.com/toptal/picasso/blob/master/README.md#fixing-broken-visual-tests-inside-a-pr)
