### PR TITLE
fix(page-header): prevent header from moving when dropdown is open

### DIFF
--- a/src/components/PageHeader/PageHeader.tsx
+++ b/src/components/PageHeader/PageHeader.tsx
@@ -48,7 +48,7 @@ export const PageHeader: FunctionComponent<Props> = ({
 
   return (
     <header
-      className={cx(classes.root, classes[variant!], className)}
+      className={cx('mui-fixed', classes.root, classes[variant!], className)}
       style={style}
     >
       <div className={contentClassnames}>

--- a/src/components/PageHeader/__snapshots__/test.tsx.snap
+++ b/src/components/PageHeader/__snapshots__/test.tsx.snap
@@ -6,7 +6,7 @@ exports[`Page.Header default render 1`] = `
     class="Picasso-root"
   >
     <header
-      class="PageHeader-root PageHeader-light"
+      class="mui-fixed PageHeader-root PageHeader-light"
     >
       <div
         class="PageHeader-content"
@@ -55,7 +55,7 @@ exports[`Page.Header render with link 1`] = `
     class="Picasso-root"
   >
     <header
-      class="PageHeader-root PageHeader-light"
+      class="mui-fixed PageHeader-root PageHeader-light"
     >
       <div
         class="PageHeader-content"


### PR DESCRIPTION
Fixes #505

### Description

According to
https://v3.material-ui.com/getting-started/faq/#why-do-the-fixed-positioned-elements-move-when-a-modal-is-opened
we need to apply `mui-fixed` class to all elements with `position:fixed` in order to prevent them from
moving on modal opening.

### How to test

- Force page to have scrollbar (set `Show scroll bars` to `Always` in OSX General settings)
- Open PageHeader.Menu dropdown

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| ![screencast 2019-06-27 08-18-10 2019-06-27 08_20_23](https://user-images.githubusercontent.com/2437969/60241859-91d98e00-98b4-11e9-8538-7b3d79e76ee1.gif) | ![screencast 2019-06-27 08-19-33 2019-06-27 08_21_08](https://user-images.githubusercontent.com/2437969/60241878-9aca5f80-98b4-11e9-8f26-611f67321e17.gif) |

### Review

- n/a Annotate all `props` in component with documentation
- n/a Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure that visuals specs are green [See the documentation](https://github.com/toptal/picasso/blob/master/README.md#fixing-broken-visual-tests-inside-a-pr)
