### PR TITLE
chore(docs): update PropsTable style

### DIFF
--- a/.storybook/components/PicassoBook/components/PropsTable/PropTypeTableCell.tsx
+++ b/.storybook/components/PicassoBook/components/PropsTable/PropTypeTableCell.tsx
@@ -2,7 +2,7 @@ import React, { FunctionComponent } from 'react'
 import _ from 'lodash'
 
 import { withStyles } from '@material-ui/core/styles'
-import TableCell from '@material-ui/core/TableCell'
+import { Table } from '@components'
 import { ClassNameMap } from '@material-ui/core/styles/withStyles'
 
 import Tooltip from '@components/Tooltip'
@@ -20,12 +20,12 @@ const PropTypeTableCell: FunctionComponent<Props> = props => {
   const { type, className, classes } = props
 
   if (_.isString(type)) {
-    return <TableCell>{type}</TableCell>
+    return <Table.Cell>{type}</Table.Cell>
   }
 
   if (type.description) {
     return (
-      <TableCell className={className}>
+      <Table.Cell className={className}>
         <Tooltip
           content={<Markdown>{type.description}</Markdown>}
           classes={{ tooltip: classes.tooltip }}
@@ -35,14 +35,14 @@ const PropTypeTableCell: FunctionComponent<Props> = props => {
             <sup>?</sup>
           </div>
         </Tooltip>
-      </TableCell>
+      </Table.Cell>
     )
   }
 
   return (
-    <TableCell className={className}>
+    <Table.Cell className={className}>
       <span>{type.name}</span>
-    </TableCell>
+    </Table.Cell>
   )
 }
 

--- a/.storybook/components/PicassoBook/components/PropsTable/PropsTable.tsx
+++ b/.storybook/components/PicassoBook/components/PropsTable/PropsTable.tsx
@@ -1,12 +1,7 @@
 import React, { Fragment, FunctionComponent } from 'react'
 import { withStyles } from '@material-ui/core/styles'
-import _ from 'lodash'
 
-import TableCell from '@material-ui/core/TableCell'
-import TableHead from '@material-ui/core/TableHead'
-import TableRow from '@material-ui/core/TableRow'
-import TableBody from '@material-ui/core/TableBody'
-import Table from '@material-ui/core/Table'
+import { Table } from '@components'
 import cx from 'classnames'
 
 import { Classes } from '@components/styles/types'
@@ -32,22 +27,22 @@ function renderRows({ documentation, classes }: Props): JSX.Element {
     <Fragment>
       {documentation.map(
         ({ name, type, defaultValue, description, enums, required }) => (
-          <TableRow key={name}>
-            <TableCell>
+          <Table.Row key={name}>
+            <Table.Cell>
               <span className={classes.propName}>{name}</span>
               <span className={classes.requiredTag}>{required ? '*' : ''}</span>
-            </TableCell>
+            </Table.Cell>
             <PropTypeTableCell className={classes.typeCell} type={type} />
-            <TableCell className={classes.defaultValueCell}>
+            <Table.Cell className={classes.defaultValueCell}>
               {defaultValue && (
                 <span className={classes.highlight}>{defaultValue}</span>
               )}
-            </TableCell>
-            <TableCell className={classes.descriptionCell}>
+            </Table.Cell>
+            <Table.Cell className={classes.descriptionCell}>
               <Description description={description} propName={name} />
               {isEnum(type) && <EnumsList type={type} enums={enums} />}
-            </TableCell>
-          </TableRow>
+            </Table.Cell>
+          </Table.Row>
         )
       )}
     </Fragment>
@@ -60,23 +55,19 @@ const PropsTable: FunctionComponent<Props> = props => {
   return (
     <div className={classes.root}>
       <Table className={classes.table}>
-        <TableHead>
-          <TableRow>
-            <TableCell className={cx(classes.header, classes.name)}>
-              Name
-            </TableCell>
-            <TableCell className={cx(classes.header, classes.type)}>
-              Type
-            </TableCell>
-            <TableCell className={cx(classes.header, classes.defaultValue)}>
+        <Table.Head>
+          <Table.Row>
+            <Table.Cell className={cx(classes.name)}>Name</Table.Cell>
+            <Table.Cell className={cx(classes.type)}>Type</Table.Cell>
+            <Table.Cell className={cx(classes.defaultValue)}>
               Default
-            </TableCell>
-            <TableCell className={cx(classes.header, classes.description)}>
+            </Table.Cell>
+            <Table.Cell className={cx(classes.description)}>
               Description
-            </TableCell>
-          </TableRow>
-        </TableHead>
-        <TableBody>{renderRows(props)}</TableBody>
+            </Table.Cell>
+          </Table.Row>
+        </Table.Head>
+        <Table.Body>{renderRows(props)}</Table.Body>
       </Table>
     </div>
   )

--- a/.storybook/components/PicassoBook/components/PropsTable/styles.ts
+++ b/.storybook/components/PicassoBook/components/PropsTable/styles.ts
@@ -5,10 +5,6 @@ export default ({ palette }: Theme) =>
     root: {
       width: '100%'
     },
-    header: {
-      fontWeight: 600,
-      fontSize: '1.2rem'
-    },
     table: {
       width: '100%'
     },

--- a/.storybook/components/PicassoBook/components/TabsSection/TabsSection.tsx
+++ b/.storybook/components/PicassoBook/components/TabsSection/TabsSection.tsx
@@ -1,11 +1,8 @@
 import React, { Fragment, FunctionComponent, ReactNode } from 'react'
 import { withStyles } from '@material-ui/core/styles'
 
-import Tabs from '@material-ui/core/Tabs'
-import Tab from '@material-ui/core/Tab'
-
 import { Classes } from '@components/styles/types'
-import { Paper } from '@components'
+import { Paper, Container } from '@components'
 
 import TabsSectionHeader from './TabsSectionHeader'
 
@@ -31,23 +28,21 @@ const TabsSection: FunctionComponent<Props> = props => {
   const hasMultiple = tabs.length > 1
 
   return (
-    <Fragment>
-      {hasMultiple && (
-        <TabsSectionHeader
-          tabs={tabs}
-          selectedTab={selectedTab}
-          onChange={handleChange}
-        />
-      )}
-      {tabs.map(
-        (tab, index) =>
-          index === selectedTab && (
-            <Paper key={tab.name} className='component-section-container'>
-              {tab.content}
-            </Paper>
-          )
-      )}
-    </Fragment>
+    <Paper>
+      <Container padded='medium'>
+        {hasMultiple && (
+          <TabsSectionHeader
+            tabs={tabs}
+            selectedTab={selectedTab}
+            onChange={handleChange}
+          />
+        )}
+        {tabs.map(
+          (tab, index) =>
+            index === selectedTab && <div key={tab.name}>{tab.content}</div>
+        )}
+      </Container>
+    </Paper>
   )
 }
 

--- a/.storybook/components/PicassoBook/components/TabsSection/TabsSectionHeader.tsx
+++ b/.storybook/components/PicassoBook/components/TabsSection/TabsSectionHeader.tsx
@@ -1,11 +1,8 @@
-import React, { Fragment, FunctionComponent, ReactNode } from 'react'
+import React, { Fragment, FunctionComponent } from 'react'
 import { withStyles } from '@material-ui/core/styles'
 
-import Tabs from '@material-ui/core/Tabs'
-import Tab from '@material-ui/core/Tab'
-
 import { Classes } from '@components/styles/types'
-import { Typography, Paper, Container } from '@components'
+import { Typography, Tabs } from '@components'
 
 import { TabOptions } from './TabsSection'
 import styles from './styles'
@@ -22,27 +19,14 @@ const TabsSectionHeader: FunctionComponent<Props> = props => {
 
   return (
     <Fragment>
-      <Paper classes={{ root: classes.tabsHeader }}>
-        <Tabs
-          value={selectedTab}
-          onChange={onChange}
-          indicatorColor='primary'
-          textColor='primary'
-        >
-          {tabs.map(tab => (
-            <Tab
-              key={tab.name}
-              label={<Typography weight='semibold'>{tab.name}</Typography>}
-              classes={{ root: classes.tabRoot }}
-            />
-          ))}
-        </Tabs>
-      </Paper>
-      <Container bottom={1}>
-        <Typography weight='semibold' className={classes.description}>
-          {tabs[selectedTab].description}
-        </Typography>
-      </Container>
+      <Tabs value={selectedTab} onChange={onChange}>
+        {tabs.map(tab => (
+          <Tabs.Tab key={tab.name} label={tab.name} />
+        ))}
+      </Tabs>
+      <Typography weight='semibold' className={classes.description}>
+        {tabs[selectedTab].description}
+      </Typography>
     </Fragment>
   )
 }

--- a/.storybook/components/PicassoBook/components/TabsSection/styles.ts
+++ b/.storybook/components/PicassoBook/components/TabsSection/styles.ts
@@ -2,14 +2,12 @@ import { Theme, createStyles } from '@material-ui/core/styles'
 
 export default ({ palette }: Theme) =>
   createStyles({
-    tabsHeader: {
-      marginBottom: '1rem',
-      padding: '0.5rem'
-    },
-    tabRoot: {
-      textTransform: 'initial'
+    tabs: {
+      marginBottom: '1rem'
     },
     description: {
-      fontSize: '0.75em'
+      fontSize: '0.75em',
+      marginTop: '0.5rem',
+      marginBottom: '1rem'
     }
   })

--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -50,7 +50,7 @@
   }
   .component-section-container {
     display: flex;
-    padding: 20px;
+    padding: 2rem;
     justify-content: center;
   }
   .chapter-header {


### PR DESCRIPTION
After Base Sync we can use new Table and Tabs styles

### Description



### Screenshots

Before:
![image](https://user-images.githubusercontent.com/437214/60423680-637eea00-9bf7-11e9-9445-60f4d3585e66.png)
After:                                 
![image](https://user-images.githubusercontent.com/437214/60423754-87dac680-9bf7-11e9-96c2-049b50139965.png)

