### PR TITLE
fix(OutlinedInput): spread props for TextField support

### DIFF
--- a/src/components/OutlinedInput/OutlinedInput.tsx
+++ b/src/components/OutlinedInput/OutlinedInput.tsx
@@ -75,9 +75,12 @@ const OutlinedInput: FunctionComponent<Props> = ({
   error,
   startAdornment,
   endAdornment,
-  onChange
+  onChange,
+  ...rest
 }) => (
   <MUIOutlinedInput
+    // eslint-disable-next-line react/jsx-props-no-spreading
+    {...rest}
     classes={{
       root: cx(classes.root, classes[`root${capitalize(width!)}`]),
       input: classes.input,

--- a/src/components/TextField/TextField.tsx
+++ b/src/components/TextField/TextField.tsx
@@ -96,6 +96,8 @@ export const TextField: FunctionComponent<Props> = ({
 
   return (
     <OutlinedInput
+      // eslint-disable-next-line react/jsx-props-no-spreading
+      {...inputProps}
       className={className}
       style={style}
       classes={{
@@ -122,8 +124,6 @@ export const TextField: FunctionComponent<Props> = ({
       endAdornment={iconPosition === 'end' && IconAdornment}
       startAdornment={iconPosition === 'start' && IconAdornment}
       onChange={onChange}
-      // eslint-disable-next-line react/jsx-props-no-spreading
-      {...inputProps}
     >
       {children}
     </OutlinedInput>


### PR DESCRIPTION
We need to pass props to allow back-compatibility for TextField.inputProps. 

PR https://github.com/toptal/picasso/pull/526/files will make it unified but for know we need to be backward-compatible.