### PR TITLE
feat(Dropdown): add `onOpen`, `onClose` event handlers

### DIFF
--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -41,6 +41,10 @@ export interface Props extends StandardProps, HTMLAttributes<HTMLDivElement> {
   disableAutoFocus?: boolean
   /** Disable close on generic close events */
   disableAutoClose?: boolean
+  /** Callback invoked when component is opened */
+  onOpen?(): void
+  /** Callback invoked when component is closed */
+  onClose?(): void
 }
 
 interface StaticProps {
@@ -76,6 +80,8 @@ export const Dropdown: FunctionComponent<Props> & StaticProps = ({
   anchorOrigin,
   disableAutoClose,
   disableAutoFocus,
+  onOpen,
+  onClose,
   ...rest
 }) => {
   const contentRef = useRef<HTMLElement>()
@@ -87,7 +93,10 @@ export const Dropdown: FunctionComponent<Props> & StaticProps = ({
 
   const handleAnchorClick = (
     event: React.MouseEvent<HTMLDivElement, MouseEvent>
-  ) => setAnchorEl(event.currentTarget)
+  ) => {
+    setAnchorEl(event.currentTarget)
+    onOpen!()
+  }
 
   const handlePopoverEntering = () => focus()
 
@@ -129,6 +138,7 @@ export const Dropdown: FunctionComponent<Props> & StaticProps = ({
     }
 
     setAnchorEl(undefined)
+    onClose!()
   }
 
   const focus = () => {
@@ -216,6 +226,8 @@ Dropdown.defaultProps = {
   disableAutoClose: false,
   disableAutoFocus: false,
   offset: {},
+  onClose: () => {},
+  onOpen: () => {},
   transformOrigin: {
     vertical: 'top',
     horizontal: 'right'

--- a/src/components/Dropdown/test.tsx
+++ b/src/components/Dropdown/test.tsx
@@ -9,10 +9,17 @@ import Dropdown, { Props } from './Dropdown'
 const TestDropdown: FunctionComponent<OmitInternalProps<Props>> = ({
   content,
   disableAutoFocus,
-  children
+  children,
+  onOpen,
+  onClose
 }) => (
   <Picasso loadFonts={false}>
-    <Dropdown content={content} disableAutoFocus={disableAutoFocus}>
+    <Dropdown
+      content={content}
+      disableAutoFocus={disableAutoFocus}
+      onOpen={onOpen}
+      onClose={onClose}
+    >
       {children}
     </Dropdown>
   </Picasso>
@@ -88,6 +95,42 @@ describe('Dropdown', () => {
     expect(document.activeElement === item).toBeFalsy()
 
     expect(container).toMatchSnapshot()
+
+    unmount()
+  })
+
+  test('should trigger `onOpen`, `onClose` callbacks', () => {
+    const onOpen = jest.fn()
+    const onClose = jest.fn()
+    const { getByText, unmount } = render(
+      <TestDropdown
+        content={
+          <Menu>
+            <Menu.Item>Item1</Menu.Item>
+            <Menu.Item>Item2</Menu.Item>
+            <Menu.Item>Item3</Menu.Item>
+          </Menu>
+        }
+        onOpen={onOpen}
+        onClose={onClose}
+      >
+        Open Dropdown <Dropdown.Arrow />
+      </TestDropdown>,
+      // We need to take snapshot of overlay rendered with Portal
+      { container: document.body }
+    )
+
+    const trigger = getByText('Open Dropdown')
+
+    fireEvent.click(trigger)
+
+    expect(onOpen).toHaveBeenCalledTimes(1)
+    expect(onOpen).toHaveBeenCalledWith()
+
+    fireEvent.click(getByText('Item1'))
+
+    expect(onClose).toHaveBeenCalledTimes(1)
+    expect(onClose).toHaveBeenCalledWith()
 
     unmount()
   })


### PR DESCRIPTION
### Description

We need to know when exactly the Dropdown is opened/closed.

### Review

- [ ] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that visuals specs are green [See the documentation](https://github.com/toptal/picasso/blob/master/README.md#fixing-broken-visual-tests-inside-a-pr)
