### PR TITLE
chore(release): disable concurrent builds

### DIFF
--- a/ci/jobs/picasso-master-release/Jenkinsfile
+++ b/ci/jobs/picasso-master-release/Jenkinsfile
@@ -24,6 +24,7 @@ pipeline {
     timestamps()
     timeout(time: 15, unit: 'MINUTES')
     skipDefaultCheckout()
+    disableConcurrentBuilds()
   }
 
   environment {


### PR DESCRIPTION
No ticket

### Description

An attempt to prevent errors like this https://jenkins.toptal.net/job/picasso-master-release/513//consoleFull

### How to test

- merge two PRs one by one and check how much jobs are executed

### Review

- [ ] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that visuals specs are green [See the documentation](https://github.com/toptal/picasso/blob/master/README.md#fixing-broken-visual-tests-inside-a-pr)
