### PR TITLE
fix(paper): fix default text color

### DIFF
--- a/src/components/Paper/styles.ts
+++ b/src/components/Paper/styles.ts
@@ -2,6 +2,12 @@ import { createStyles } from '@material-ui/core/styles'
 
 import { PicassoProvider } from '../Picasso'
 
-PicassoProvider.override(() => ({}))
+PicassoProvider.override(() => ({
+  MuiPaper: {
+    root: {
+      color: 'unset'
+    }
+  }
+}))
 
 export default () => createStyles({})


### PR DESCRIPTION
[FX-374](https://toptal-core.atlassian.net/browse/FX-374)

### Description

Change `Paper` component default text color. `Paper` styles in v4 uses `color: theme.palette.text.primary`, and v3 does not set any value.

Here we override the `Paper` component styles with `color: unset`

### How to test

- Run `yarn storybook` and check "Container: Spacing" story.

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| ![Screenshot 2019-08-16 at 09 22 56](https://user-images.githubusercontent.com/16798121/63150612-89c1e300-c007-11e9-937d-af1545df5d54.png) | ![Screenshot 2019-08-16 at 09 22 23](https://user-images.githubusercontent.com/16798121/63150640-a3632a80-c007-11e9-9a69-306d0df84244.png) |

### Review


- [ ] Ensure that visuals specs are green [See the documentation](https://github.com/toptal/picasso/blob/master/README.md#fixing-broken-visual-tests-inside-a-pr)
