### PR TITLE
fix(components): reduce deprecation noise

### DIFF
--- a/src/components/Icon/_withDeprecationWarning.tsx
+++ b/src/components/Icon/_withDeprecationWarning.tsx
@@ -5,17 +5,21 @@ const withDeprecationWarning = (oldName: string, newName?: string) => <
 >(
   NewIcon: React.ComponentType<T>
 ): React.ComponentType<T> => {
-  if (!newName) {
-    window.console.warn(
-      `'${oldName}' icon is deprecated and will be removed in the next major release of Picasso. Please contact your designer to provide you a correct icon.`
-    )
-  } else {
-    window.console.warn(
-      `'${oldName}' icon is deprecated and will be removed in the next major release of Picasso. Please use '${newName}' directly to maintain pixel perfect icons.`
-    )
+  const newIconComponent = (props: T) => {
+    React.useEffect(() => {
+      if (!newName) {
+        window.console.warn(
+          `'${oldName}' icon is deprecated and will be removed in the next major release of Picasso. Please contact your designer to provide you a correct icon.`
+        )
+      } else {
+        window.console.warn(
+          `'${oldName}' icon is deprecated and will be removed in the next major release of Picasso. Please use '${newName}' directly to maintain pixel perfect icons.`
+        )
+      }
+    }, [])
+    // eslint-disable-next-line react/jsx-props-no-spreading
+    return <NewIcon {...props} />
   }
-  // eslint-disable-next-line react/jsx-props-no-spreading
-  const newIconComponent = (props: T) => <NewIcon {...props} />
 
   return newIconComponent
 }


### PR DESCRIPTION
[FX-343](https://toptal-core.atlassian.net/browse/FX-343)

### Description

Reduce noise of deprecation warnings by only triggering them if and when the deprecated component is mounted.

### How to test

- Perform `yarn storybook` or `yarn test` and enjoy the almost complete absence of warnings. 

### Review

- [ ] Ensure that visuals specs are green [See the documentation](https://github.com/toptal/picasso/blob/master/README.md#fixing-broken-visual-tests-inside-a-pr)
