### PR TITLE
chore: rename `justifyContent` prop in `Grid` to match `Container`

### DIFF
--- a/.storybook/stories/tutorials/Forms/story/Forms.1.example.jsx
+++ b/.storybook/stories/tutorials/Forms/story/Forms.1.example.jsx
@@ -3,7 +3,7 @@ import { Grid, Form, TextField } from '@toptal/picasso'
 
 const FormsExample = () => (
   <div>
-    <Grid justify='center' alignItems='center'>
+    <Grid justifyContent='center' alignItems='center'>
       <Grid.Item small={12} medium={8} large={6}>
         <Form>
           <Form.Field>

--- a/.storybook/stories/tutorials/Forms/story/Forms.2.example.jsx
+++ b/.storybook/stories/tutorials/Forms/story/Forms.2.example.jsx
@@ -3,7 +3,7 @@ import { Grid, Checkbox, Select, TextField, Form } from '@toptal/picasso'
 
 const FormsExample = () => (
   <div>
-    <Grid justify='center' alignItems='center'>
+    <Grid justifyContent='center' alignItems='center'>
       <Grid.Item small={12} medium={8} large={6}>
         <Form>
           <Form.Field>

--- a/.storybook/stories/tutorials/Forms/story/Forms.3.example.jsx
+++ b/.storybook/stories/tutorials/Forms/story/Forms.3.example.jsx
@@ -3,7 +3,7 @@ import { Grid, Checkbox, Select, TextField, Form } from '@toptal/picasso'
 
 const FormsExample = () => (
   <div>
-    <Grid justify='center' alignItems='center'>
+    <Grid justifyContent='center' alignItems='center'>
       <Grid.Item small={12} medium={8} large={6}>
         <Form>
           <Form.Field>

--- a/.storybook/stories/tutorials/Forms/story/Forms.4.example.jsx
+++ b/.storybook/stories/tutorials/Forms/story/Forms.4.example.jsx
@@ -3,7 +3,7 @@ import { Grid, Checkbox, Select, TextField, Form } from '@toptal/picasso'
 
 const FormsExample = () => (
   <div>
-    <Grid justify='center' alignItems='center'>
+    <Grid justifyContent='center' alignItems='center'>
       <Grid.Item small={12} medium={8} large={6}>
         <Form>
           <Form.Field>

--- a/.storybook/stories/tutorials/Forms/story/Forms.final.example.jsx
+++ b/.storybook/stories/tutorials/Forms/story/Forms.final.example.jsx
@@ -13,7 +13,7 @@ import {
 
 const FormsExample = () => (
   <div>
-    <Grid justify='center' alignItems='center'>
+    <Grid justifyContent='center' alignItems='center'>
       <Grid.Item small={12} medium={8} large={6}>
         <Form>
           <Form.Field>

--- a/.storybook/stories/tutorials/Forms/story/index.jsx
+++ b/.storybook/stories/tutorials/Forms/story/index.jsx
@@ -36,7 +36,7 @@ tutorialChapter
   .addTextSection(
     `
 For this example we will use \`Grid\` component to make form responsive and adequate size for different
-screen sizes. It can easily be centered using \`justify\` prop. Each form should have
+screen sizes. It can easily be centered using \`justifyContent\` prop. Each form should have
 [\`Form\`](..?path=/story/forms-folder--form) component as root element to handle form interaction like
 \`onSubmit\` events.
 

--- a/src/components/AccountSelect/story/Page.example.jsx
+++ b/src/components/AccountSelect/story/Page.example.jsx
@@ -32,7 +32,7 @@ const accounts = [
 const AccountSelectPageExample = () => (
   <Page>
     <Page.Content>
-      <Grid justify='center'>
+      <Grid justifyContent='center'>
         <Grid.Item small={5}>
           <Container flex direction='column' alignItems='center'>
             <Logo emblem />

--- a/src/components/Grid/Grid.tsx
+++ b/src/components/Grid/Grid.tsx
@@ -22,7 +22,7 @@ interface Props extends StandardProps, HTMLAttributes<HTMLElement> {
   /** Defines the align-items style property based on the direction */
   alignItems?: GridItemsAlignment
   /** Defines the justify-content style property based on the direction */
-  justify?: GridJustification
+  justifyContent?: GridJustification
   /** Defines the flex-wrap style property based on the direction */
   wrap?: GridWrap
 }
@@ -41,7 +41,7 @@ export const Grid: FunctionComponent<Props> & StaticProps = ({
   spacing,
   direction,
   alignItems,
-  justify,
+  justifyContent,
   wrap,
   classes,
   className,
@@ -55,7 +55,7 @@ export const Grid: FunctionComponent<Props> & StaticProps = ({
     spacing={humanToMUISpacing(spacing!)}
     direction={direction}
     alignItems={alignItems}
-    justify={justify}
+    justify={justifyContent}
     wrap={wrap}
     classes={classes}
     className={className}
@@ -68,7 +68,7 @@ export const Grid: FunctionComponent<Props> & StaticProps = ({
 Grid.defaultProps = {
   alignItems: 'flex-start',
   direction: 'row',
-  justify: 'flex-start',
+  justifyContent: 'flex-start',
   spacing: 32,
   wrap: 'wrap'
 }

--- a/src/components/Grid/story/Alignment.example.jsx
+++ b/src/components/Grid/story/Alignment.example.jsx
@@ -3,19 +3,19 @@ import { Grid, Button } from '@toptal/picasso'
 
 const GridAlignmentExample = () => (
   <div>
-    <Grid justify='flex-start'>
+    <Grid justifyContent='flex-start'>
       <Grid.Item>
         <Button>Left</Button>
       </Grid.Item>
     </Grid>
 
-    <Grid justify='center'>
+    <Grid justifyContent='center'>
       <Grid.Item>
         <Button>Center</Button>
       </Grid.Item>
     </Grid>
 
-    <Grid justify='flex-end'>
+    <Grid justifyContent='flex-end'>
       <Grid.Item>
         <Button>Right</Button>
       </Grid.Item>

--- a/src/components/GridItem/story/CenteredLayout.example.jsx
+++ b/src/components/GridItem/story/CenteredLayout.example.jsx
@@ -5,7 +5,7 @@ const GridCenteredLayoutExample = () => (
   <Page>
     <Page.Header title='Onboarding' />
     <Page.Content>
-      <Grid justify='center'>
+      <Grid justifyContent='center'>
         <Grid.Item small={8}>
           <SampleContainer>Content</SampleContainer>
         </Grid.Item>


### PR DESCRIPTION
BREAKING CHANGE: rename `justify` prop in `Grid`  to `justifyContent`

[FX-208](https://toptal-core.atlassian.net/browse/FX-208)