### PR TITLE
fix(autocomplete): fix onchange event firing too often

### DIFF
--- a/src/components/Autocomplete/Autocomplete.tsx
+++ b/src/components/Autocomplete/Autocomplete.tsx
@@ -44,7 +44,7 @@ export interface Props
     Omit<HTMLInputProps, 'onChange' | 'onSelect'> {
   /** Placeholder for value */
   placeholder?: string
-  /** Debounce time for onChange event handler */
+  /** Debounce time in ms for onChange event handler */
   debounceTime?: number
   /** Width of the component which will apply `min-width` to the `input` */
   width?: 'full' | 'shrink' | 'auto'
@@ -100,7 +100,10 @@ export const Autocomplete: FunctionComponent<Props> = ({
   const [filter, setFilter] = useState(EMPTY_VALUE)
   const [placeholder, setPlaceholder] = useState(initialPlaceholder)
   const [selectedItem, setSelectedItem] = useState<Maybe<Item>>(null)
-  const onChangeDebounced = debounce(onChange!, debounceTime)
+  const onChangeDebounced = React.useCallback(
+    debounce(onChange!, debounceTime),
+    [onChange, debounceTime]
+  )
 
   const selectItem = (item: Maybe<Item>) => {
     if (item === undefined) return


### PR DESCRIPTION
[FX-376](https://toptal-core.atlassian.net/browse/FX-376)

### Description

Fixes [FX-376](https://toptal-core.atlassian.net/browse/FX-376)

### How to test

1. Run `yarn: storybook`
2. Go to `Autocomplete` page, `Default` example
3. Set some long `debounceTime`, like `1000`
4. Type fast. You should see just 1 `onChange` event on console

### Review

- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that visuals specs are green [See the documentation](https://github.com/toptal/picasso/blob/master/README.md#fixing-broken-visual-tests-inside-a-pr)
