### PR TITLE
fix: fix useLayoutEffect warnings

### DIFF
--- a/.storybook/components/CodeExample/CodeExample.tsx
+++ b/.storybook/components/CodeExample/CodeExample.tsx
@@ -1,10 +1,9 @@
 declare var TEST_ENV: string // defined by ENV
 
 import _ from 'lodash'
-import React, { ReactNode, Component } from 'react'
+import React, { ReactNode, Component, useState, useEffect } from 'react'
 import styled from 'styled-components'
 import { withStyles } from '@material-ui/core/styles'
-import IconCode from '@material-ui/icons/Code'
 import IconLink from '@material-ui/icons/Link'
 import SourceRender from 'react-source-render'
 import copy from 'copy-to-clipboard'
@@ -148,7 +147,20 @@ class CodeExample extends Component<Props> {
       </div>
     )
 
-    const renderInPicasso = (element: ReactNode) => <Picasso>{element}</Picasso>
+    const renderInPicasso = (element: ReactNode) => {
+      const [showThemeProvider, setShowThemeProvider] = useState(false)
+
+      // Wait until after client-side hydration to show
+      useEffect(() => {
+        setShowThemeProvider(true)
+      }, [])
+
+      if (!showThemeProvider) {
+        return null
+      }
+
+      return <Picasso>{element}</Picasso>
+    }
 
     return (
       <div ref={this.sourceRendererRef}>

--- a/src/components/Picasso/Picasso.tsx
+++ b/src/components/Picasso/Picasso.tsx
@@ -9,8 +9,7 @@ import React, {
   createRef,
   RefObject,
   useContext,
-  useState,
-  useEffect
+  useState
 } from 'react'
 
 import CssBaseline from '../CssBaseline'
@@ -124,28 +123,15 @@ const Picasso: FunctionComponent<PicassoProps> = ({
   loadFonts,
   reset,
   children
-}) => {
-  const [showThemeProvider, setShowThemeProvider] = useState(false)
-
-  // Wait until after client-side hydration to show
-  useEffect(() => {
-    setShowThemeProvider(true)
-  }, [])
-
-  if (!showThemeProvider) {
-    return null
-  }
-
-  return (
-    <MuiThemeProvider theme={PicassoProvider.theme}>
-      {loadFonts && <FontsLoader />}
-      {reset && <CssBaseline />}
-      <PicassoGlobalStylesProvider>
-        <NotificationsProvider>{children}</NotificationsProvider>
-      </PicassoGlobalStylesProvider>
-    </MuiThemeProvider>
-  )
-}
+}) => (
+  <MuiThemeProvider theme={PicassoProvider.theme}>
+    {loadFonts && <FontsLoader />}
+    {reset && <CssBaseline />}
+    <PicassoGlobalStylesProvider>
+      <NotificationsProvider>{children}</NotificationsProvider>
+    </PicassoGlobalStylesProvider>
+  </MuiThemeProvider>
+)
 
 Picasso.defaultProps = {
   loadFonts: true,


### PR DESCRIPTION
### Description

We had a huge number of warnings for each `ThemeProvider` component in Picasso:

<img width="1266" alt="Screenshot 2019-08-20 at 12 21 40" src="https://user-images.githubusercontent.com/2836281/63334912-1987ca00-c345-11e9-869b-e2c0737dcb1c.png">

It looks like the reason is that MUI `ThemeProvider` is using `useLayoutEffect` inside and the fix is suggested by Dan Abramov - https://gist.github.com/gaearon/e7d97cdf38a2907924ea12e4ebdf3c85#option-2-lazily-show-component-with-uselayouteffect

So basically applying this fix inside `Picasso` root component

IMPORTANT! You can't see those warnings in Preview of Picasso, only visible in dev mode