### PR TITLE
fix(breakpoints): fix useScreenSize hook

### DIFF
--- a/src/components/Picasso/config/breakpoints.ts
+++ b/src/components/Picasso/config/breakpoints.ts
@@ -40,10 +40,10 @@ export const useScreenSize = () => {
   const updateSize = () => setSize(window.innerWidth)
 
   useEffect(() => {
-    window.onresize = updateSize
+    window.addEventListener('resize', updateSize)
 
     return () => {
-      window.onresize = null
+      window.removeEventListener('resize', updateSize)
     }
   }, [])
 


### PR DESCRIPTION
### Description
Current implementation of useScreenSize hook doesn't work if you're using it on more then one place. Reason for this is how we attach handler to `resize` event.

To fix it I switched to using `addEventListener` and `removeEventListener` for attaching  handler to `resize` event.

### How to test

- Build project locally and link it with React app
- Try to use `useScreenSize` hook at two or more components to see if both of them got updated when you change screen size

### Review

- [ ] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that visuals specs are green [See the documentation](https://github.com/toptal/picasso/blob/master/README.md#fixing-broken-visual-tests-inside-a-pr)
