### PR TITLE
chore: add toptal.yml file docs link

### DIFF
--- a/toptal.yml
+++ b/toptal.yml
@@ -1,3 +1,9 @@
+# This file stores the project specific information
+#
+# Docs about the format of total.yml file:
+# https://github.com/toptal/cataloger#toptalyml
+# 
+
 owner:
   name: Frontend Experience
   url: https://team.toptal.net/users?team_id=109


### PR DESCRIPTION
### Description

Add docs comments in toptal.yml file and link to the documentation.
Because this file probably will be copied from project to project - it's good to have a link to docs there