### PR TITLE
fix: master release job timeout

### DIFF
--- a/ci/jobs/picasso-master-release/Jenkinsfile
+++ b/ci/jobs/picasso-master-release/Jenkinsfile
@@ -22,7 +22,7 @@ pipeline {
   options {
     ansiColor('xterm')
     timestamps()
-    timeout(time: 15, unit: 'MINUTES')
+    timeout(time: 25, unit: 'MINUTES')
     skipDefaultCheckout()
     disableConcurrentBuilds()
   }


### PR DESCRIPTION
### Description

It's sad to tell, but looks like the majority of our builds of master release job are failing because of timeout :(

<img width="1160" alt="Screenshot 2019-08-28 at 14 49 28" src="https://user-images.githubusercontent.com/2836281/63853354-28085e00-c9a3-11e9-98f8-e27f24a69254.png">
