### PR TITLE
remove spacing on the left from an iconless sidebar menu item

### DIFF
--- a/src/components/lab/SidebarItem/styles.ts
+++ b/src/components/lab/SidebarItem/styles.ts
@@ -30,7 +30,7 @@ export default ({ palette }: Theme) =>
     },
     selected: {},
     label: {
-      marginLeft: '1.875em'
+      marginLeft: 0
     },
     withIcon: {
       marginLeft: '0.875em'


### PR DESCRIPTION
[FX-375](https://toptal-core.atlassian.net/browse/FX-375)
### How to test

1. try adding SidebarItem without icon prop inside Sidebar
2. notice there's no spacing on the left of it 

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
|![before](https://user-images.githubusercontent.com/54671509/64003892-efd55c80-cb15-11e9-8fc2-277d733dd9f7.png)| ![after](https://user-images.githubusercontent.com/54671509/64003913-f7950100-cb15-11e9-84c3-28d601a4b0d4.png)|

### Review

- [ ] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that visuals specs are green [See the documentation](https://github.com/toptal/picasso/blob/master/README.md#fixing-broken-visual-tests-inside-a-pr)
