### PR TITLE
docs(readme): remove depfu badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 
 [![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release)
 [![](https://img.shields.io/badge/npm-3.3.0-brightgreen.svg)](https://www.npmjs.com/package/@toptal/picasso)
-[![Depfu](https://badges.depfu.com/badges/5334b0c5b6255a3e8b0199b2a5411667/count.svg)](https://depfu.com/repos/toptal/picasso?project_id=7646)
 [![#-frontend-exp-core](https://img.shields.io/badge/slack-%23--frontend--exp--core-green.svg)](https://toptal-core.slack.com/app_redirect?channel=CERF5NHT3)
 
 ## Installation instructions


### PR DESCRIPTION
No ticket

### Description

We don't use depfu anymore, if we need, we can add a dependabot badge

### How to test

- check demo

### Review

- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure that visuals specs are green [See the documentation](https://github.com/toptal/picasso/blob/master/README.md#fixing-broken-visual-tests-inside-a-pr)
