### PR TITLE
chore(docs): fix header position in code example

### DIFF
--- a/.storybook/components/CodeExample/CodeExample.tsx
+++ b/.storybook/components/CodeExample/CodeExample.tsx
@@ -57,7 +57,7 @@ const Purifier: FunctionComponent = ({ children }) => {
     }
 
     purifyFixedPosition(sourceRendererRef.current)
-  }, [])
+  }, [sourceRendererRef])
 
   return <div ref={sourceRendererRef}>{children}</div>
 }
@@ -67,7 +67,6 @@ const Purifier: FunctionComponent = ({ children }) => {
 // for SSR rendering.
 // This fix is suggested here
 // https://gist.github.com/gaearon/e7d97cdf38a2907924ea12e4ebdf3c85#option-2-lazily-show-component-with-uselayouteffect
-// @ts-ignore
 const PicassoSSR: FunctionComponent = ({ children }) => {
   const [showPicasso, setShowPicasso] = useState(false)
 


### PR DESCRIPTION
[FX-431](https://toptal-core.atlassian.net/browse/FX-431)

### Description

Added specific component that removes `fixed` and adds `absolute` positioning of header. Current solution was not working due to PicassoSSR delaying initial render, and calling just `purifyHeader` in `useEffect` caused flickering of header because change of styling required additional render.

### How to test

Open Page https://picasso.toptal.net/?path=/story/layout-folder--page


### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| Insert screenshots or screen recordings | Insert screenshots or screen recordings |

### Review

- [ ] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that visuals specs are green [See the documentation](https://github.com/toptal/picasso/blob/master/README.md#fixing-broken-visual-tests-inside-a-pr)
