### PR TITLE
fix: fix branch name in release ci build

### DIFF
--- a/ci/jobs/picasso-master-release/Jenkinsfile
+++ b/ci/jobs/picasso-master-release/Jenkinsfile
@@ -90,7 +90,9 @@ pipeline {
           //
           // -v ${PWD}:/artifacts - needs to pass .versions file
           //
-          // -e JENKINS_URL=${JENKINS_URL} - needs to make semantic-release to think
+          // -e JENKINS_URL=${JENKINS_URL} \
+          // -e GIT_BRANCH=${GIT_BRANCH} \
+          // - need to make semantic-release to think
           //   that we are running it inside CI environment
           sh """
             docker run \
@@ -101,6 +103,7 @@ pipeline {
             -e RELEASE_AND_PUBLISH=${RELEASE_AND_PUBLISH} \
             -e NPM_TOKEN=${NPM_TOKEN} \
             -e JENKINS_URL=${JENKINS_URL} \
+            -e GIT_BRANCH=${GIT_BRANCH} \
             -v ${PWD}:/artifacts \
             -v /etc/passwd:/etc/passwd \
             -v /home/jenkins/.ssh:/home/jenkins/.ssh \


### PR DESCRIPTION
Add GIT_BRANCH env variable to show Jenkins that we are building from `master` branch