### PR TITLE
fix: add read/write rights for jenkins user for release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,6 +42,8 @@ COPY . /app
 RUN chmod a+rw /app
 # needs to be +rw for changing the content and use NPM_TOKEN for publish
 RUN chmod a+rw /app/.npmrc
+RUN chmod a+rw /app/CHANGELOG.md
+RUN chmod a+rw /app/package.json
 
 COPY bin/entrypoint.sh /usr/local/bin/entrypoint.sh
 RUN chmod +x /usr/local/bin/entrypoint.sh


### PR DESCRIPTION
Add correct rights for files, which should be touched by semantic-release