### PR TITLE
fix(Menu): export static props for Menu to fix ts type check

### DIFF
--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -15,7 +15,7 @@ export type ListNativeProps = HTMLAttributes<HTMLUListElement> &
 
 export interface Props extends StandardProps, ListNativeProps {}
 
-interface StaticProps {
+export interface StaticProps {
   Item: typeof MenuItem
 }
 


### PR DESCRIPTION
Fixing TS type check for external projects which are using `Menu` component.