### PR TITLE
fix(Modal): fix close icon with content

### DIFF
--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -82,12 +82,12 @@ export const Modal = forwardRef<HTMLElement, Props>(function Modal(
       open={open}
       transitionDuration={transitionDuration}
     >
+      {children}
       {onClose && (
         <span onClick={onClose}>
           <CloseMinor16 className={closeButton} />
         </span>
       )}
-      {children}
     </Dialog>
   )
 }) as CompoundedComponentWithRef<Props, HTMLElement, StaticProps>


### PR DESCRIPTION
[bil-706](https://toptal-core.atlassian.net/browse/BIL-706)

### Description

Further improvements ideas:
+ replace `span` to `button` (to make it fully ARIA compatible)

### How to test

- Close icon still clickable when something overlaps it (for ex in the title use full width block element)

### Review

-  ~[ ]~ n/a Annotate all `props` in component with documentation
-  ~[ ]~ n/a Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- ~[ ]~ n/a Ensure that visuals specs are green [See the documentation](https://github.com/toptal/picasso/blob/master/README.md#fixing-broken-visual-tests-inside-a-pr)
