### PR TITLE
fix(Sidebar): fix auto-closing on small screens

### DIFF
--- a/src/components/lab/SidebarItem/SidebarItem.tsx
+++ b/src/components/lab/SidebarItem/SidebarItem.tsx
@@ -124,7 +124,6 @@ export const SidebarItem = forwardRef<HTMLElement, Props>(function SidebarItem(
 
     return (
       <Accordion
-        onClick={event => event.stopPropagation()}
         onChange={event => event.stopPropagation()}
         classes={{
           summary: classes.summary,


### PR DESCRIPTION
[FX-NNNN](https://toptal-core.atlassian.net/browse/FX-NNNN)

### Description

Disables auto-closing of Sidebar dropdown on small screens when we click on Item with menu. 

### How to test

Go to Sidebar example, and choose small screen. Click on trigger to open Sidebar and try clicking on items with submenu. Sidebar needs to stay open.

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| Insert screenshots or screen recordings | Insert screenshots or screen recordings |

### Review

- [ ] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that visuals specs are green [See the documentation](https://github.com/toptal/picasso/blob/master/README.md#fixing-broken-visual-tests-inside-a-pr)
