### PR TITLE
chore(yarn test:watch): run what changed only, no parallelism

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "module": "./build/index.js",
   "scripts": {
     "test": "jest",
-    "test:watch": "jest --watchAll",
+    "test:watch": "jest --watch --runInBand",
     "test:visual": "./bin/run-in-docker ./bin/test-visual",
     "lint": "davinci syntax lint code .",
     "start": "start-storybook -p 9001 -s ./.storybook/public -c .storybook",


### PR DESCRIPTION
When I tried to use test:watch to monitor my work, after each file save I had to wait for all tests
to run while I cared only about my changes and fast feedback. So I suggest that we change test:watch
so it runs without parallelism and not spend time on spinning up workers and also test only code
that has been changed
