### PR TITLE
chore: setup trigger jenkins job stage by name

### DIFF
--- a/ci/jobs/picasso-pr-specs/Jenkinsfile
+++ b/ci/jobs/picasso-pr-specs/Jenkinsfile
@@ -1,4 +1,4 @@
-@Library('globalLibrary@inf-add-function-to-match-pr-comment') _
+@Library('globalLibrary@master') _
 
 ghHelper = new helpers.GithubNotifyHelper()
 helper = new helpers.Helpers()
@@ -69,7 +69,7 @@ pipeline {
     stage('Danger checks') {
       when {
         expression {
-          ghprbMatchesComment(/danger/)
+          ghprbMatchesComment(/danger|all/)
         }
       }
       steps {
@@ -92,7 +92,7 @@ pipeline {
     stage('Deploy documentation') {
       when {
         expression {
-          ghprbMatchesComment(/deploy:documentation/)
+          ghprbMatchesComment(/deploy:documentation|all/)
         }
       }
       steps {
@@ -117,7 +117,7 @@ pipeline {
         stage('Run linter') {
           when {
             expression {
-              ghprbMatchesComment(/lint/)
+              ghprbMatchesComment(/lint|all/)
             }
           }
 
@@ -148,7 +148,7 @@ pipeline {
         stage('Run jest') {
           when {
             expression {
-              ghprbMatchesComment(/test/)
+              ghprbMatchesComment(/test|all/)
             }
           }
 
@@ -179,7 +179,7 @@ pipeline {
         stage('Check build') {
           when {
             expression {
-              ghprbMatchesComment(/build/)
+              ghprbMatchesComment(/build|all/)
             }
           }
 
@@ -213,7 +213,7 @@ pipeline {
     stage('Run visual tests') {
       when {
         expression {
-          ghprbMatchesComment(/test:visual/)
+          ghprbMatchesComment(/test:visual|all/)
         }
       }
 


### PR DESCRIPTION
[INF-746](https://toptal-core.atlassian.net/browse/INF-746)

### Description

This PR and https://github.com/toptal/jenkins-scripts/pull/147 + manual work of @conf together add support of re-running specific stages of the `picasso-pr-specs` job.

E.g. `@toptal-bot run test:visual` - to re-run visual tests. 

Whole list of commands:

- `all` - to run the whole pipeline
- `danger` - Danger checks
- `lint` - Run linter
- `test` - Run jest
- `build` - Check build
- `test:visual` - Run visual tests
- `deploy:documentation` - Deploy documentation

### How to test

- write `@toptal-bot run danger`  inside PR comment and check that build is started and only danger check was invoked

### Review

- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure that visuals specs are green [See the documentation](https://github.com/toptal/picasso/blob/master/README.md#fixing-broken-visual-tests-inside-a-pr)
