### PR TITLE
fix(Autocomplete): disable default chrome autocomplete

### DIFF
--- a/src/components/lab/Autocomplete/Autocomplete.tsx
+++ b/src/components/lab/Autocomplete/Autocomplete.tsx
@@ -270,7 +270,9 @@ export const Autocomplete = forwardRef<HTMLInputElement, Props>(
                 selectItem(null)
               }
               onKeyDown!(event, inputValue)
-            }
+            },
+            // here we override the value returned from downshift, `off` by default
+            autoComplete: rest.autoComplete || 'off'
           })
 
           return (

--- a/src/components/lab/Autocomplete/story/index.jsx
+++ b/src/components/lab/Autocomplete/story/index.jsx
@@ -34,7 +34,7 @@ Autocomplete supports all the default HTML native props, as Input supports.
 
 You also may want to disable standard browser autofill and autocomplete
 for this component. This you can achieve by adding corresponding attributes:
-\`autocomplete='nope' autofill='off'\`
+\`autoComplete='none' and/or autofill='off'\`
     `
   )
   .addExample('lab/Autocomplete/story/Default.example.jsx', 'Default')


### PR DESCRIPTION
No ticket

### Description

Seems downshift overrides autoComplete value to 'off' by defalut

### How to test

- set `autoComplete='none'` for Autocomplete component and check the result

### Review

- [x] Test manually
