### PR TITLE
chore(deps-dev): bump js-yaml to 3.13.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -153,6 +153,7 @@
     }
   },
   "resolutions": {
+    "js-yaml": "^3.13.1",
     "lodash": "^4.17.12",
     "**/marksy/marked": "^0.6.0",
     "**/npx/npm": "^5.7.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9453,14 +9453,7 @@ js-tokens@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
 
-js-yaml@^3.10.0, js-yaml@^3.12.0, js-yaml@^3.9.0:
-  version "3.12.2"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.12.2.tgz#ef1d067c5a9d9cb65bd72f285b5d8105c77f14fc"
-  dependencies:
-    argparse "^1.0.7"
-    esprima "^4.0.0"
-
-js-yaml@^3.13.0, js-yaml@^3.13.1:
+js-yaml@^3.10.0, js-yaml@^3.12.0, js-yaml@^3.13.0, js-yaml@^3.13.1, js-yaml@^3.9.0:
   version "3.13.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.13.1.tgz#aff151b30bfdfa8e49e05da22e7415e9dfa37847"
   dependencies:


### PR DESCRIPTION
No ticket.

### Description

In order to address the following vulnerabilities:

| Severity | Vulnerability type | Affected package | Introduced through | More info |
| --- | --- | --- | --- | --- | 
| High | Arbitrary Code Execution | js-yaml <3.13.1 | css-loader@0.28.11 | [snyk.io](https://snyk.io/vuln/SNYK-JS-JSYAML-174129) |
| Medium | Denial of Service (DoS) | js-yaml <3.13.0 | css-loader@0.28.11 | [snyk.io](https://snyk.io/vuln/SNYK-JS-JSYAML-173999) |

According to [js-yaml's changelog](https://github.com/nodeca/js-yaml/blob/master/CHANGELOG.md), there are no breaking changes between `3.9.0` and `3.13.1`.


### Review

- [n/a] Annotate all `props` in component with documentation
- [n/a] Create `examples` for component
- [n/a] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that visuals specs are green [See the documentation](https://github.com/toptal/picasso/blob/master/README.md#fixing-broken-visual-tests-inside-a-pr)