### PR TITLE
fix(sidebar & page header menu): dropdown offsets

### DIFF
--- a/src/components/PageHeaderMenu/PageHeaderMenu.tsx
+++ b/src/components/PageHeaderMenu/PageHeaderMenu.tsx
@@ -92,7 +92,7 @@ export const PageHeaderMenu = forwardRef<HTMLDivElement, Props>(
         classes={{ content: classes.content }}
         style={style}
         content={content}
-        offset={{ top: isSmallScreen ? 'small' : 'xsmall' }}
+        offset={{ top: isSmallScreen ? 0.8 : 'xsmall' }}
       >
         {trigger}
         <Dropdown.Arrow className={classes.arrow} />

--- a/src/components/lab/Sidebar/Sidebar.tsx
+++ b/src/components/lab/Sidebar/Sidebar.tsx
@@ -39,7 +39,7 @@ const SmallScreenSidebarWrapper: FunctionComponent<
     <Dropdown
       content={children}
       className={classes.responsiveWrapper}
-      offset={{ top: 'xsmall' }}
+      offset={{ top: 0.4 }}
       onOpen={handleShowSidebar}
       onClose={handleHideSidebar}
     >


### PR DESCRIPTION
[FX-458](https://toptal-core.atlassian.net/browse/FX-458)

### Description

Sidebar and page header menu did not match designs. Dropdown offsets were too large for small screens. In this PR I am trying to fix that.

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| ![image](https://user-images.githubusercontent.com/14070311/65515941-c3301d00-dee8-11e9-8533-70021ff653ff.png) | ![image](https://user-images.githubusercontent.com/14070311/65515504-148bdc80-dee8-11e9-8ee6-479c7bf909d0.png)
 |

### Review

- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure that visuals specs are green [See the documentation](https://github.com/toptal/picasso/blob/master/README.md#fixing-broken-visual-tests-inside-a-pr)