### PR TITLE
fix(Menu): fix arrow navigation

### DIFF
--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -28,7 +28,6 @@ export interface Props extends StandardProps, ListNativeProps {
   allowNestedNavigation?: boolean
 }
 
-
 export interface StaticProps {
   Item: typeof MenuItem
 }
@@ -84,7 +83,7 @@ export const Menu = forwardRef<HTMLUListElement, Props>(function Menu(
 
   return (
     <MenuContext.Provider value={menuContext}>
-      {menus[menus.length - 1]}
+      {menus.length === 1 ? menu : menus[menus.length - 1]}
     </MenuContext.Provider>
   )
 }) as CompoundedComponentWithRef<Props, HTMLUListElement, StaticProps>


### PR DESCRIPTION
[FX-447](https://toptal-core.atlassian.net/browse/FX-NNNN)

### Description

Arrow navigation inside Menu was broken in this commit https://github.com/toptal/picasso/commit/32195792fdba43c0b16122acacbeb70a75f87107

Created also a follow up ticket: https://toptal-core.atlassian.net/browse/SP-55
### How to test

You can test it by either:
- running this test `jest src/components/lab/Autocomplete/test.tsx`
- testing the Autocompleter Menu storybook and trying to use arrow navigation after focusing on the input
