### PR TITLE
fix(EnvironmentBanner): banner no longer steals clicks

### DIFF
--- a/src/components/EnvironmentBanner/styles.ts
+++ b/src/components/EnvironmentBanner/styles.ts
@@ -11,7 +11,8 @@ export default ({ palette, zIndex }: Theme) =>
       textAlign: 'center',
       top: 0,
       width: '100%',
-      zIndex: zIndex.snackbar
+      zIndex: zIndex.snackbar,
+      pointerEvents: 'none'
     },
     rootDevelopment: {
       borderTop: `0.4rem solid ${palette.green.main}`
@@ -30,7 +31,8 @@ export default ({ palette, zIndex }: Theme) =>
       letterSpacing: '.01em',
       padding: '0.25rem 0.7rem 0.5rem',
       textTransform: 'uppercase',
-      userSelect: 'none'
+      userSelect: 'none',
+      pointerEvents: 'initial'
     },
     labelDevelopment: {
       backgroundColor: palette.green.main


### PR DESCRIPTION
re #725

### Description

When the banner is rendered over the header, 
it blocks underlying elements from receiving a click. 
Sidebar or Menu buttons are not accessible.

### How to test

- Put banner over a header
- Try to use header actions

or check out https://github.com/toptal/talent-portal-frontend/pull/130

### Review

- n/a Annotate all `props` in component with documentation
- n/a Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure that visuals specs are green [See the documentation](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)

### Screenshots

#### Before
![screencast 2019-09-27 16-45-31 2019-09-27 16_46_05](https://user-images.githubusercontent.com/2437969/65778529-5f0a9480-e146-11e9-82c0-92ffb15eed05.gif)


#### After
![screencast 2019-09-27 16-42-07 2019-09-27 16_42_56](https://user-images.githubusercontent.com/2437969/65778260-e6a3d380-e145-11e9-9714-a4b612664487.gif)
