### PR TITLE
chore: ts-loader warning about not found types

### DIFF
--- a/.storybook/plugins/IgnoreNotFoundExportPlugin.js
+++ b/.storybook/plugins/IgnoreNotFoundExportPlugin.js
@@ -1,0 +1,41 @@
+const ModuleDependencyWarning = require('webpack/lib/ModuleDependencyWarning')
+
+module.exports = class IgnoreNotFoundExportPlugin {
+  constructor(exportsToIgnore = []) {
+    this.exportsToIgnore = exportsToIgnore
+  }
+
+  getMessageRegExp() {
+    if (this.exportsToIgnore.length > 0) {
+      return new RegExp(
+        `export '${this.exportsToIgnore.join(
+          '|'
+        )}'( \\(reexported as '.*'\\))? was not found in`
+      )
+    } else {
+      return /export '.*'( \(reexported as '.*'\))? was not found in/
+    }
+  }
+
+  apply(compiler) {
+    const messageRegExp = this.getMessageRegExp()
+
+    const doneHook = stats => {
+      stats.compilation.warnings = stats.compilation.warnings.filter(warn => {
+        if (
+          warn instanceof ModuleDependencyWarning &&
+          messageRegExp.test(warn.message)
+        ) {
+          return false
+        }
+        return true
+      })
+    }
+
+    if (compiler.hooks) {
+      compiler.hooks.done.tap('IgnoreNotFoundExportPlugin', doneHook)
+    } else {
+      compiler.plugin('done', doneHook)
+    }
+  }
+}

--- a/.storybook/plugins/index.js
+++ b/.storybook/plugins/index.js
@@ -1,0 +1,5 @@
+const IgnoreNotFoundPlugin = require('./IgnoreNotFoundExportPlugin')
+
+module.exports = {
+  IgnoreNotFoundPlugin
+}

--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -2,6 +2,7 @@ const webpack = require('webpack')
 const path = require('path')
 const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin')
 const ForkTsCheckerNotifierWebpackPlugin = require('fork-ts-checker-notifier-webpack-plugin')
+const { IgnoreNotFoundPlugin } = require('./plugins')
 
 // example: /components/Button/Button.tsx
 const COMPONENT_DECLARATION_FILE_REGEXP = /components\/(.*)\/\1.tsx$/
@@ -68,7 +69,9 @@ module.exports = ({ config }) => {
   config.plugins.push(
     new webpack.DefinePlugin({
       TEST_ENV: JSON.stringify(env.TEST_ENV)
-    })
+    }),
+    // https://github.com/TypeStrong/ts-loader/issues/653
+    new IgnoreNotFoundPlugin(['OverridableComponent', 'StandardProps'])
   )
 
   if (isDevelopment) {

--- a/src/components/Container/index.ts
+++ b/src/components/Container/index.ts
@@ -1,1 +1,2 @@
-export { default, VariantType } from './Container'
+export { default } from './Container'
+export * from './Container'

--- a/src/components/Menu/index.ts
+++ b/src/components/Menu/index.ts
@@ -1,1 +1,2 @@
-export { default, Props } from './Menu'
+export { default } from './Menu'
+export * from './Menu'

--- a/src/components/MenuItem/index.ts
+++ b/src/components/MenuItem/index.ts
@@ -1,1 +1,2 @@
-export { default, Props } from './MenuItem'
+export { default } from './MenuItem'
+export * from './MenuItem'

--- a/src/components/Notification/index.ts
+++ b/src/components/Notification/index.ts
@@ -1,1 +1,2 @@
-export { default, VariantType } from './Notification'
+export { default } from './Notification'
+export * from './Notification'

--- a/src/components/Picasso/index.ts
+++ b/src/components/Picasso/index.ts
@@ -5,21 +5,6 @@ export {
   usePageHeader
 } from './Picasso'
 
-export {
-  BaseProps,
-  JssProps,
-  StandardProps,
-  SizeType,
-  OmitInternalProps,
-  SpacingType,
-  spacingToEm,
-  PicassoComponent,
-  PicassoComponentWithRef,
-  SpacingEnum,
-  ButtonOrAnchorProps,
-  CompoundedComponentWithRef,
-  OverridableComponent,
-  ColorType
-} from './types'
+export * from './types'
 
 export { useScreenSize, isScreenSize, useBreakpoint } from './config'


### PR DESCRIPTION
### Description

TypeScript checks all the imports/exports by itself, so we don't need
such warnings from ts-loader or webpack.

Related to https://toptal-core.atlassian.net/browse/SP-54

### How to test

- check terminal

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| ![image](https://user-images.githubusercontent.com/1291032/66161951-07809300-e636-11e9-8f30-549bcd87b613.png)| ![image](https://user-images.githubusercontent.com/1291032/66161978-19facc80-e636-11e9-8878-25674ff7aab5.png)|

### Review

- [ ] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that visuals specs are green [See the documentation](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
