### PR TITLE
fix: [FX-173] Fix infinite loop of loading font in IE11 and Edge

### DIFF
--- a/src/components/Picasso/FontsLoader.tsx
+++ b/src/components/Picasso/FontsLoader.tsx
@@ -27,6 +27,10 @@ const DOMTokenListSupports = function (tokenList: DOMTokenList, token: string) {
 const applyLoadedFont = (e: Event) => {
   const target = e.target as HTMLLinkElement
 
+  // this handler needs to be removed from the link tag
+  // because of the issue with the infinite loop of
+  // loading fonts in IE11 and Edge
+  target.removeEventListener('load', applyLoadedFont)
   target.rel = 'stylesheet'
 }
 


### PR DESCRIPTION
[FX-173](https://toptal-core.atlassian.net/browse/FX-173)

### Description

When Picasso page is loaded there is an infinite loop of loading fonts in IE11 and Edge. This should fix it.