### PR TITLE
fix: modal overlay for autocomplete and dropdown

### DIFF
--- a/src/components/Dropdown/Dropdown.tsx
+++ b/src/components/Dropdown/Dropdown.tsx
@@ -48,6 +48,8 @@ export interface Props extends StandardProps, HTMLAttributes<HTMLDivElement> {
   disableAutoFocus?: boolean
   /** Disable close on generic close events */
   disableAutoClose?: boolean
+  /** Disable the portal behavior. The children stay within it's parent DOM hierarchy. */
+  disablePortal?: boolean
   /** Callback invoked when component is opened */
   onOpen?(): void
   /** Callback invoked when component is closed */
@@ -90,6 +92,7 @@ export const Dropdown = forwardRef<HTMLDivElement, Props>(function Dropdown(
     placement,
     disableAutoClose,
     disableAutoFocus,
+    disablePortal,
     onOpen,
     onClose,
     ...rest
@@ -226,11 +229,7 @@ export const Dropdown = forwardRef<HTMLDivElement, Props>(function Dropdown(
           }}
           placement={placement}
           style={paperMargins}
-          // RATIONALE: If portal is enabled, and dropdown's popper contains
-          // for example <Input autoFocus/>, popper will mount to the portal and
-          // before it finishes posotioning itself, autoFocus will force scrolling
-          // to the bottom of the portal.
-          disablePortal
+          disablePortal={disablePortal}
         >
           <ClickAwayListener onClickAway={() => forceClose()}>
             <Grow in={isOpen} appear>
@@ -255,6 +254,7 @@ export const Dropdown = forwardRef<HTMLDivElement, Props>(function Dropdown(
 Dropdown.defaultProps = {
   disableAutoClose: false,
   disableAutoFocus: true,
+  disablePortal: false,
   offset: {},
   onClose: () => {},
   onOpen: () => {},

--- a/src/components/Dropdown/__snapshots__/test.tsx.snap
+++ b/src/components/Dropdown/__snapshots__/test.tsx.snap
@@ -22,151 +22,159 @@ exports[`Dropdown default render 1`] = `
 `;
 
 exports[`Dropdown should render menu 1`] = `
-<div>
-  <div
-    class="Picasso-root"
-  >
+<body>
+  <div>
     <div
-      class="Dropdown-root"
+      class="Picasso-root"
     >
       <div
-        class="Dropdown-anchor"
-      >
-        Open Dropdown 
-        <span
-          class="DropdownArrow-root DropdownArrow-medium"
-        />
-      </div>
-      <div
-        class="Dropdown-popper"
-        role="tooltip"
-        style="position: absolute;"
-        x-placement="bottom-end"
+        class="Dropdown-root"
       >
         <div
-          class="MuiPaper-root MuiPaper-elevation2 Dropdown-content"
-          style="opacity: 1; transform: scale(1, 1); transition: opacity 0ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,transform 0ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;"
+          class="Dropdown-anchor"
         >
-          <ul
-            class="MuiList-root"
-            role="menu"
-            tabindex="-1"
-          >
-            <li
-              aria-disabled="false"
-              class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MenuItem-light MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
-              role="menuitem"
-              tabindex="-1"
-            >
-              <span
-                class="MenuItem-stringContent"
-              >
-                Item1
-              </span>
-            </li>
-            <li
-              aria-disabled="false"
-              class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MenuItem-light MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
-              role="menuitem"
-              tabindex="-1"
-            >
-              <span
-                class="MenuItem-stringContent"
-              >
-                Item2
-              </span>
-            </li>
-            <li
-              aria-disabled="false"
-              class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MenuItem-light MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
-              role="menuitem"
-              tabindex="-1"
-            >
-              <span
-                class="MenuItem-stringContent"
-              >
-                Item3
-              </span>
-            </li>
-          </ul>
+          Open Dropdown 
+          <span
+            class="DropdownArrow-root DropdownArrow-medium"
+          />
         </div>
       </div>
     </div>
   </div>
-</div>
+  <div
+    class="Dropdown-popper"
+    role="tooltip"
+    style="position: absolute;"
+    x-placement="bottom-end"
+  >
+    <div
+      class="MuiPaper-root MuiPaper-elevation2 Dropdown-content"
+      style="opacity: 1; transform: scale(1, 1); transition: opacity 0ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,transform 0ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;"
+    >
+      <ul
+        class="MuiList-root"
+        role="menu"
+        tabindex="-1"
+      >
+        <li
+          aria-disabled="false"
+          class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MenuItem-light MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+          role="menuitem"
+          tabindex="-1"
+        >
+          <span
+            class="MenuItem-stringContent"
+          >
+            Item1
+          </span>
+        </li>
+        <li
+          aria-disabled="false"
+          class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MenuItem-light MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+          role="menuitem"
+          tabindex="-1"
+        >
+          <span
+            class="MenuItem-stringContent"
+          >
+            Item2
+          </span>
+        </li>
+        <li
+          aria-disabled="false"
+          class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MenuItem-light MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+          role="menuitem"
+          tabindex="-1"
+        >
+          <span
+            class="MenuItem-stringContent"
+          >
+            Item3
+          </span>
+        </li>
+      </ul>
+    </div>
+  </div>
+</body>
 `;
 
 exports[`Dropdown should render menu with focus 1`] = `
-<div>
-  <div
-    class="Picasso-root"
-  >
+<body>
+  <div>
     <div
-      class="Dropdown-root"
+      class="Picasso-root"
     >
       <div
-        class="Dropdown-anchor"
-      >
-        Open Dropdown 
-        <span
-          class="DropdownArrow-root DropdownArrow-medium"
-        />
-      </div>
-      <div
-        class="Dropdown-popper"
-        role="tooltip"
-        style="position: absolute; transform: translate3d(NaNpx, NaNpx, 0); top: 0px; left: 0px; will-change: transform;"
-        x-placement="bottom-end"
+        class=""
       >
         <div
-          class="MuiPaper-root MuiPaper-elevation2 Dropdown-content"
-          style="opacity: 1; transform: none; transition: opacity 0ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,transform 0ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;"
+          class="Dropdown-root"
         >
-          <ul
-            class="MuiList-root"
-            role="menu"
-            tabindex="-1"
+          <div
+            class="Dropdown-anchor"
           >
-            <li
-              aria-disabled="false"
-              class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MenuItem-light MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button Mui-focusVisible Mui-focusVisible"
-              role="menuitem"
-              tabindex="-1"
-            >
-              <span
-                class="MenuItem-stringContent"
-              >
-                Item1
-              </span>
-            </li>
-            <li
-              aria-disabled="false"
-              class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MenuItem-light MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
-              role="menuitem"
-              tabindex="-1"
-            >
-              <span
-                class="MenuItem-stringContent"
-              >
-                Item2
-              </span>
-            </li>
-            <li
-              aria-disabled="false"
-              class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MenuItem-light MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
-              role="menuitem"
-              tabindex="-1"
-            >
-              <span
-                class="MenuItem-stringContent"
-              >
-                Item3
-              </span>
-            </li>
-          </ul>
+            Open Dropdown 
+            <span
+              class="DropdownArrow-root DropdownArrow-medium"
+            />
+          </div>
         </div>
       </div>
     </div>
   </div>
-</div>
+  <div
+    class="Dropdown-popper"
+    role="tooltip"
+    style="position: absolute; transform: translate3d(NaNpx, NaNpx, 0); top: 0px; left: 0px; will-change: transform;"
+    x-placement="bottom-end"
+  >
+    <div
+      class="MuiPaper-root MuiPaper-elevation2 Dropdown-content"
+      style="opacity: 1; transform: none; transition: opacity 0ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,transform 0ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;"
+    >
+      <ul
+        class="MuiList-root"
+        role="menu"
+        tabindex="-1"
+      >
+        <li
+          aria-disabled="false"
+          class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MenuItem-light MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button Mui-focusVisible Mui-focusVisible"
+          role="menuitem"
+          tabindex="-1"
+        >
+          <span
+            class="MenuItem-stringContent"
+          >
+            Item1
+          </span>
+        </li>
+        <li
+          aria-disabled="false"
+          class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MenuItem-light MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+          role="menuitem"
+          tabindex="-1"
+        >
+          <span
+            class="MenuItem-stringContent"
+          >
+            Item2
+          </span>
+        </li>
+        <li
+          aria-disabled="false"
+          class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MenuItem-light MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+          role="menuitem"
+          tabindex="-1"
+        >
+          <span
+            class="MenuItem-stringContent"
+          >
+            Item3
+          </span>
+        </li>
+      </ul>
+    </div>
+  </div>
+</body>
 `;

--- a/src/components/Dropdown/story/CustomContent.example.jsx
+++ b/src/components/Dropdown/story/CustomContent.example.jsx
@@ -9,9 +9,10 @@ import {
   Typography
 } from '@toptal/picasso'
 
+// Autofocus will force scrolling to the bottom of the portal, so we disable portal
 const ComplexDefaultExample = () => (
   <div>
-    <Dropdown content={<ComplexContent />} disableAutoClose>
+    <Dropdown content={<ComplexContent />} disableAutoClose disablePortal>
       Open Dropdown
       <Dropdown.Arrow />
     </Dropdown>

--- a/src/components/Dropdown/test.tsx
+++ b/src/components/Dropdown/test.tsx
@@ -4,6 +4,7 @@ import React from 'react'
 import Menu from '../Menu'
 import Picasso from '../Picasso'
 import Dropdown from './Dropdown'
+import Container from '../Container'
 
 afterEach(cleanup)
 
@@ -21,7 +22,7 @@ describe('Dropdown', () => {
   })
 
   test('should render menu', () => {
-    const { container, getByText, unmount } = render(
+    const { getByText, unmount, baseElement } = render(
       <Picasso loadFonts={false}>
         <Dropdown
           content={
@@ -41,38 +42,39 @@ describe('Dropdown', () => {
 
     fireEvent.click(trigger)
 
-    expect(container).toMatchSnapshot()
+    expect(baseElement).toMatchSnapshot()
 
     unmount()
   })
 
   test('should render menu with focus', async () => {
-    const { container, getByText, unmount } = render(
+    const { baseElement, getByText, unmount } = render(
       <Picasso loadFonts={false}>
-        <Dropdown
-          content={
-            <Menu>
-              <Menu.Item>Item1</Menu.Item>
-              <Menu.Item>Item2</Menu.Item>
-              <Menu.Item>Item3</Menu.Item>
-            </Menu>
-          }
-          disableAutoFocus={false}
-        >
-          Open Dropdown <Dropdown.Arrow />
-        </Dropdown>
+        <Container>
+          <Dropdown
+            content={
+              <Menu>
+                <Menu.Item>Item1</Menu.Item>
+                <Menu.Item>Item2</Menu.Item>
+                <Menu.Item>Item3</Menu.Item>
+              </Menu>
+            }
+            disableAutoFocus={false}
+          >
+            Open Dropdown <Dropdown.Arrow />
+          </Dropdown>
+        </Container>
       </Picasso>
     )
 
     const trigger = getByText('Open Dropdown')
 
     fireEvent.click(trigger)
-
     await wait(() => {
-      expect(document.activeElement).toBe(container.querySelector('li'))
+      expect(document.activeElement).toBe(baseElement.querySelector('li'))
     })
 
-    expect(container).toMatchSnapshot()
+    expect(baseElement).toMatchSnapshot()
 
     unmount()
   })

--- a/src/components/lab/Autocomplete/__snapshots__/test.tsx.snap
+++ b/src/components/lab/Autocomplete/__snapshots__/test.tsx.snap
@@ -1,95 +1,107 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Autocomplete dynamic behavior render options when start typing 1`] = `
-<div>
-  <div
-    class="Picasso-root"
-  >
+<body>
+  <div>
     <div
-      aria-expanded="true"
-      aria-haspopup="listbox"
-      aria-labelledby="downshift-3-label"
-      aria-owns="downshift-3-menu"
-      class="Autocomplete-root Autocomplete-rootAuto"
-      role="combobox"
+      class="Picasso-root"
     >
       <div
-        class="MuiInputBase-root MuiOutlinedInput-root OutlinedInput-root Input-root OutlinedInput-rootAuto"
-      >
-        <fieldset
-          aria-hidden="true"
-          class="PrivateNotchedOutline-root MuiOutlinedInput-notchedOutline"
-          style="padding-left: 8px;"
-        >
-          <legend
-            class="PrivateNotchedOutline-legend"
-            style="width: 0.01px;"
-          >
-            <span>
-              ​
-            </span>
-          </legend>
-        </fieldset>
-        <input
-          aria-activedescendant="downshift-3-item-0"
-          aria-autocomplete="list"
-          aria-controls="downshift-3-menu"
-          aria-labelledby="downshift-3-label"
-          autocomplete="off"
-          class="MuiInputBase-input MuiOutlinedInput-input OutlinedInput-input Input-input"
-          id="downshift-3-input"
-          placeholder="Placeholder text"
-          type="text"
-          value="t"
-        />
-      </div>
-      <div
+        aria-expanded="true"
+        aria-haspopup="listbox"
         aria-labelledby="downshift-3-label"
-        id="downshift-3-menu"
-        role="listbox"
+        aria-owns="downshift-3-menu"
+        class="Autocomplete-root Autocomplete-rootAuto"
+        role="combobox"
       >
-        <ul
-          class="MuiList-root ScrollMenu-menu"
-          role="menu"
-          tabindex="-1"
+        <div
+          class="Container-flex"
         >
           <div
-            class="ScrollMenu-scrollView"
+            class="MuiInputBase-root MuiOutlinedInput-root OutlinedInput-root Input-root OutlinedInput-rootAuto"
           >
-            <li
-              aria-disabled="false"
-              aria-selected="true"
-              class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MenuItem-light Mui-selected MenuItem-selected MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button Mui-selected"
-              id="downshift-3-item-0"
-              role="option"
-              tabindex="-1"
+            <fieldset
+              aria-hidden="true"
+              class="PrivateNotchedOutline-root MuiOutlinedInput-notchedOutline"
+              style="padding-left: 8px;"
             >
-              <span
-                class="MenuItem-stringContent"
+              <legend
+                class="PrivateNotchedOutline-legend"
+                style="width: 0.01px;"
               >
-                Croatia
-              </span>
-            </li>
-            <li
-              aria-disabled="false"
-              aria-selected="false"
-              class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MenuItem-light MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
-              id="downshift-3-item-1"
-              role="option"
-              tabindex="-1"
-            >
-              <span
-                class="MenuItem-stringContent"
-              >
-                Lithuania
-              </span>
-            </li>
+                <span>
+                  ​
+                </span>
+              </legend>
+            </fieldset>
+            <input
+              aria-activedescendant="downshift-3-item-0"
+              aria-autocomplete="list"
+              aria-controls="downshift-3-menu"
+              aria-labelledby="downshift-3-label"
+              autocomplete="off"
+              class="MuiInputBase-input MuiOutlinedInput-input OutlinedInput-input Input-input"
+              id="downshift-3-input"
+              placeholder="Placeholder text"
+              type="text"
+              value="t"
+            />
           </div>
-        </ul>
+        </div>
+        <div
+          aria-labelledby="downshift-3-label"
+          id="downshift-3-menu"
+          role="listbox"
+        />
       </div>
     </div>
   </div>
-</div>
+  <div
+    class="Autocomplete-popper"
+    role="tooltip"
+    style="position: absolute;"
+    x-placement="bottom"
+  >
+    <ul
+      class="MuiList-root ScrollMenu-menu"
+      role="menu"
+      tabindex="-1"
+    >
+      <div
+        class="ScrollMenu-scrollView"
+      >
+        <li
+          aria-disabled="false"
+          aria-selected="true"
+          class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MenuItem-light Mui-selected MenuItem-selected MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button Mui-selected"
+          id="downshift-3-item-0"
+          role="option"
+          tabindex="-1"
+        >
+          <span
+            class="MenuItem-stringContent"
+          >
+            Croatia
+          </span>
+        </li>
+        <li
+          aria-disabled="false"
+          aria-selected="false"
+          class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MenuItem-light MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+          id="downshift-3-item-1"
+          role="option"
+          tabindex="-1"
+        >
+          <span
+            class="MenuItem-stringContent"
+          >
+            Lithuania
+          </span>
+        </li>
+      </div>
+    </ul>
+  </div>
+</body>
 `;
 
 exports[`Autocomplete static behavior default render 1`] = `
@@ -105,32 +117,36 @@ exports[`Autocomplete static behavior default render 1`] = `
       role="combobox"
     >
       <div
-        class="MuiInputBase-root MuiOutlinedInput-root OutlinedInput-root Input-root OutlinedInput-rootAuto"
+        class="Container-flex"
       >
-        <fieldset
-          aria-hidden="true"
-          class="PrivateNotchedOutline-root MuiOutlinedInput-notchedOutline"
-          style="padding-left: 8px;"
+        <div
+          class="MuiInputBase-root MuiOutlinedInput-root OutlinedInput-root Input-root OutlinedInput-rootAuto"
         >
-          <legend
-            class="PrivateNotchedOutline-legend"
-            style="width: 0.01px;"
+          <fieldset
+            aria-hidden="true"
+            class="PrivateNotchedOutline-root MuiOutlinedInput-notchedOutline"
+            style="padding-left: 8px;"
           >
-            <span>
-              ​
-            </span>
-          </legend>
-        </fieldset>
-        <input
-          aria-autocomplete="list"
-          aria-labelledby="downshift-0-label"
-          autocomplete="off"
-          class="MuiInputBase-input MuiOutlinedInput-input OutlinedInput-input Input-input"
-          id="downshift-0-input"
-          placeholder="Start typing here..."
-          type="text"
-          value=""
-        />
+            <legend
+              class="PrivateNotchedOutline-legend"
+              style="width: 0.01px;"
+            >
+              <span>
+                ​
+              </span>
+            </legend>
+          </fieldset>
+          <input
+            aria-autocomplete="list"
+            aria-labelledby="downshift-0-label"
+            autocomplete="off"
+            class="MuiInputBase-input MuiOutlinedInput-input OutlinedInput-input Input-input"
+            id="downshift-0-input"
+            placeholder="Start typing here..."
+            type="text"
+            value=""
+          />
+        </div>
       </div>
       <div
         aria-labelledby="downshift-0-label"

--- a/src/components/lab/Autocomplete/styles.ts
+++ b/src/components/lab/Autocomplete/styles.ts
@@ -1,4 +1,5 @@
 import { Theme, createStyles } from '@material-ui/core/styles'
+import zIndex from '@material-ui/core/styles/zIndex'
 
 export default ({ sizes: { input, borderWidth }, palette }: Theme) =>
   createStyles({
@@ -18,5 +19,6 @@ export default ({ sizes: { input, borderWidth }, palette }: Theme) =>
     },
     stringContent: {
       fontSize: '0.8125em'
-    }
+    },
+    popper: { zIndex: zIndex.modal }
   })

--- a/src/components/lab/Autocomplete/test.tsx
+++ b/src/components/lab/Autocomplete/test.tsx
@@ -95,7 +95,7 @@ describe('Autocomplete', () => {
     test('render options when start typing', () => {
       const {
         getByPlaceholderText,
-        container,
+        baseElement,
         getAllByRole
       } = renderAutocomplete({
         placeholder,
@@ -109,7 +109,7 @@ describe('Autocomplete', () => {
       const filteredOptions = getAllByRole('option').map(li => li.textContent)
 
       expect(filteredOptions).toEqual(['Croatia', 'Lithuania'])
-      expect(container).toMatchSnapshot()
+      expect(baseElement).toMatchSnapshot()
     })
 
     describe('on focus', () => {
@@ -453,6 +453,6 @@ describe('Autocomplete', () => {
     const input = api.getByPlaceholderText('Start typing here...')
 
     fireEvent.change(input, { target: { value: 't' } })
-    expect(api.container.textContent).toContain('Custom renderer')
+    expect(api.baseElement.textContent).toContain('Custom renderer')
   })
 })

--- a/src/components/lab/TagSelector/__snapshots__/test.tsx.snap
+++ b/src/components/lab/TagSelector/__snapshots__/test.tsx.snap
@@ -1,129 +1,141 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`TagSelector available options when start typing 1`] = `
-<div>
-  <div
-    class="Picasso-root"
-  >
+<body>
+  <div>
     <div
-      aria-expanded="true"
-      aria-haspopup="listbox"
-      aria-labelledby="downshift-1-label"
-      aria-owns="downshift-1-menu"
-      class="Autocomplete-root Autocomplete-rootAuto"
-      role="combobox"
+      class="Picasso-root"
     >
       <div
-        class="MuiInputBase-root MuiOutlinedInput-root OutlinedInput-root OutlinedInput-rootAuto TagSelectorInput-inputBase MuiInputBase-adornedStart MuiOutlinedInput-adornedStart"
-      >
-        <fieldset
-          aria-hidden="true"
-          class="PrivateNotchedOutline-root MuiOutlinedInput-notchedOutline"
-          style="padding-left: 8px;"
-        >
-          <legend
-            class="PrivateNotchedOutline-legend"
-            style="width: 0.01px;"
-          >
-            <span>
-              ​
-            </span>
-          </legend>
-        </fieldset>
-        <input
-          aria-activedescendant="downshift-1-item-0"
-          aria-autocomplete="list"
-          aria-controls="downshift-1-menu"
-          aria-labelledby="downshift-1-label"
-          autocomplete="off"
-          class="MuiInputBase-input MuiOutlinedInput-input OutlinedInput-input MuiInputBase-inputAdornedStart MuiOutlinedInput-inputAdornedStart"
-          id="downshift-1-input"
-          placeholder="Please select..."
-          style="width: auto;"
-          type="text"
-          value="Al"
-        />
-      </div>
-      <div
+        aria-expanded="true"
+        aria-haspopup="listbox"
         aria-labelledby="downshift-1-label"
-        id="downshift-1-menu"
-        role="listbox"
+        aria-owns="downshift-1-menu"
+        class="Autocomplete-root Autocomplete-rootAuto"
+        role="combobox"
       >
-        <ul
-          class="MuiList-root ScrollMenu-menu"
-          role="menu"
-          tabindex="-1"
+        <div
+          class="Container-flex"
         >
           <div
-            class="ScrollMenu-scrollView"
+            class="MuiInputBase-root MuiOutlinedInput-root OutlinedInput-root OutlinedInput-rootAuto TagSelectorInput-inputBase MuiInputBase-adornedStart MuiOutlinedInput-adornedStart"
           >
-            <li
-              aria-disabled="false"
-              aria-selected="true"
-              class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MenuItem-light Mui-selected MenuItem-selected MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button Mui-selected"
-              id="downshift-1-item-0"
-              role="option"
-              tabindex="-1"
+            <fieldset
+              aria-hidden="true"
+              class="PrivateNotchedOutline-root MuiOutlinedInput-notchedOutline"
+              style="padding-left: 8px;"
             >
-              <span
-                class="MenuItem-stringContent"
+              <legend
+                class="PrivateNotchedOutline-legend"
+                style="width: 0.01px;"
               >
-                Aland Islands
-              </span>
-            </li>
-            <li
-              aria-disabled="false"
-              aria-selected="false"
-              class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MenuItem-light MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
-              id="downshift-1-item-1"
-              role="option"
-              tabindex="-1"
-            >
-              <span
-                class="MenuItem-stringContent"
-              >
-                Albania
-              </span>
-            </li>
-            <li
-              aria-disabled="false"
-              aria-selected="false"
-              class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MenuItem-light MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
-              id="downshift-1-item-2"
-              role="option"
-              tabindex="-1"
-            >
-              <span
-                class="MenuItem-stringContent"
-              >
-                Algeria
-              </span>
-            </li>
-            <li
-              aria-disabled="false"
-              aria-selected="false"
-              class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MenuItem-light Autocomplete-otherOption MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
-              id="downshift-1-item-3"
-              role="option"
-              tabindex="-1"
-            >
-              <span
-                class="Autocomplete-stringContent"
-              >
-                <span
-                  class="MuiTypography-root Typography-bodyInherit Typography-darkGrey MuiTypography-body1"
-                >
-                  Add new option: 
+                <span>
+                  ​
                 </span>
-                Al
-              </span>
-            </li>
+              </legend>
+            </fieldset>
+            <input
+              aria-activedescendant="downshift-1-item-0"
+              aria-autocomplete="list"
+              aria-controls="downshift-1-menu"
+              aria-labelledby="downshift-1-label"
+              autocomplete="off"
+              class="MuiInputBase-input MuiOutlinedInput-input OutlinedInput-input MuiInputBase-inputAdornedStart MuiOutlinedInput-inputAdornedStart"
+              id="downshift-1-input"
+              placeholder="Please select..."
+              style="width: auto;"
+              type="text"
+              value="Al"
+            />
           </div>
-        </ul>
+        </div>
+        <div
+          aria-labelledby="downshift-1-label"
+          id="downshift-1-menu"
+          role="listbox"
+        />
       </div>
     </div>
   </div>
-</div>
+  <div
+    class="Autocomplete-popper"
+    role="tooltip"
+    style="position: absolute;"
+    x-placement="bottom"
+  >
+    <ul
+      class="MuiList-root ScrollMenu-menu"
+      role="menu"
+      tabindex="-1"
+    >
+      <div
+        class="ScrollMenu-scrollView"
+      >
+        <li
+          aria-disabled="false"
+          aria-selected="true"
+          class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MenuItem-light Mui-selected MenuItem-selected MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button Mui-selected"
+          id="downshift-1-item-0"
+          role="option"
+          tabindex="-1"
+        >
+          <span
+            class="MenuItem-stringContent"
+          >
+            Aland Islands
+          </span>
+        </li>
+        <li
+          aria-disabled="false"
+          aria-selected="false"
+          class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MenuItem-light MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+          id="downshift-1-item-1"
+          role="option"
+          tabindex="-1"
+        >
+          <span
+            class="MenuItem-stringContent"
+          >
+            Albania
+          </span>
+        </li>
+        <li
+          aria-disabled="false"
+          aria-selected="false"
+          class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MenuItem-light MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+          id="downshift-1-item-2"
+          role="option"
+          tabindex="-1"
+        >
+          <span
+            class="MenuItem-stringContent"
+          >
+            Algeria
+          </span>
+        </li>
+        <li
+          aria-disabled="false"
+          aria-selected="false"
+          class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MenuItem-light Autocomplete-otherOption MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+          id="downshift-1-item-3"
+          role="option"
+          tabindex="-1"
+        >
+          <span
+            class="Autocomplete-stringContent"
+          >
+            <span
+              class="MuiTypography-root Typography-bodyInherit Typography-darkGrey MuiTypography-body1"
+            >
+              Add new option: 
+            </span>
+            Al
+          </span>
+        </li>
+      </div>
+    </ul>
+  </div>
+</body>
 `;
 
 exports[`TagSelector default render 1`] = `
@@ -139,33 +151,37 @@ exports[`TagSelector default render 1`] = `
       role="combobox"
     >
       <div
-        class="MuiInputBase-root MuiOutlinedInput-root OutlinedInput-root OutlinedInput-rootAuto TagSelectorInput-inputBase MuiInputBase-adornedStart MuiOutlinedInput-adornedStart"
+        class="Container-flex"
       >
-        <fieldset
-          aria-hidden="true"
-          class="PrivateNotchedOutline-root MuiOutlinedInput-notchedOutline"
-          style="padding-left: 8px;"
+        <div
+          class="MuiInputBase-root MuiOutlinedInput-root OutlinedInput-root OutlinedInput-rootAuto TagSelectorInput-inputBase MuiInputBase-adornedStart MuiOutlinedInput-adornedStart"
         >
-          <legend
-            class="PrivateNotchedOutline-legend"
-            style="width: 0.01px;"
+          <fieldset
+            aria-hidden="true"
+            class="PrivateNotchedOutline-root MuiOutlinedInput-notchedOutline"
+            style="padding-left: 8px;"
           >
-            <span>
-              ​
-            </span>
-          </legend>
-        </fieldset>
-        <input
-          aria-autocomplete="list"
-          aria-labelledby="downshift-0-label"
-          autocomplete="off"
-          class="MuiInputBase-input MuiOutlinedInput-input OutlinedInput-input MuiInputBase-inputAdornedStart MuiOutlinedInput-inputAdornedStart"
-          id="downshift-0-input"
-          placeholder="Please select..."
-          style="width: auto;"
-          type="text"
-          value=""
-        />
+            <legend
+              class="PrivateNotchedOutline-legend"
+              style="width: 0.01px;"
+            >
+              <span>
+                ​
+              </span>
+            </legend>
+          </fieldset>
+          <input
+            aria-autocomplete="list"
+            aria-labelledby="downshift-0-label"
+            autocomplete="off"
+            class="MuiInputBase-input MuiOutlinedInput-input OutlinedInput-input MuiInputBase-inputAdornedStart MuiOutlinedInput-inputAdornedStart"
+            id="downshift-0-input"
+            placeholder="Please select..."
+            style="width: auto;"
+            type="text"
+            value=""
+          />
+        </div>
       </div>
       <div
         aria-labelledby="downshift-0-label"
@@ -178,475 +194,499 @@ exports[`TagSelector default render 1`] = `
 `;
 
 exports[`TagSelector newly added option selected 1`] = `
-<div>
-  <div
-    class="Picasso-root"
-  >
+<body>
+  <div>
     <div
-      aria-expanded="false"
-      aria-haspopup="listbox"
-      aria-labelledby="downshift-4-label"
-      class="Autocomplete-root Autocomplete-rootAuto"
-      role="combobox"
+      class="Picasso-root"
     >
       <div
-        class="MuiInputBase-root MuiOutlinedInput-root OutlinedInput-root OutlinedInput-rootAuto TagSelectorInput-inputBase MuiInputBase-adornedStart MuiOutlinedInput-adornedStart"
+        aria-expanded="false"
+        aria-haspopup="listbox"
+        aria-labelledby="downshift-4-label"
+        class="Autocomplete-root Autocomplete-rootAuto"
+        role="combobox"
       >
-        <fieldset
-          aria-hidden="true"
-          class="PrivateNotchedOutline-root MuiOutlinedInput-notchedOutline"
-          style="padding-left: 8px;"
-        >
-          <legend
-            class="PrivateNotchedOutline-legend"
-            style="width: 0.01px;"
-          >
-            <span>
-              ​
-            </span>
-          </legend>
-        </fieldset>
         <div
-          class="MuiChip-root Label-root MuiChip-deletable"
-          role="button"
-          tabindex="0"
+          class="Container-flex"
         >
-          <span
-            class="MuiChip-label"
+          <div
+            class="MuiInputBase-root MuiOutlinedInput-root OutlinedInput-root OutlinedInput-rootAuto TagSelectorInput-inputBase MuiInputBase-adornedStart MuiOutlinedInput-adornedStart"
           >
-            <span
-              class="Label-innerLabel"
+            <fieldset
+              aria-hidden="true"
+              class="PrivateNotchedOutline-root MuiOutlinedInput-notchedOutline"
+              style="padding-left: 8px;"
             >
-              xxxx
-            </span>
-          </span>
-          <span
-            aria-label="delete icon"
-            class="MuiChip-deleteIcon"
-            role="button"
-          >
-            <svg
-              class="SvgCloseMinor16-root"
-              style="min-width: 16px; min-height: 16px;"
-              viewBox="0 0 16 16"
-            >
-              <defs>
-                <path
-                  d="M8.707 8l3.5 3.5-.707.707-3.5-3.5-3.5 3.5-.707-.707 3.5-3.5-3.5-3.5.707-.707 3.5 3.5 3.5-3.5.707.707-3.5 3.5z"
-                  id="closeMinor16_svg__a"
-                />
-              </defs>
-              <g
-                fill-rule="evenodd"
+              <legend
+                class="PrivateNotchedOutline-legend"
+                style="width: 0.01px;"
               >
-                <mask
-                  id="closeMinor16_svg__b"
+                <span>
+                  ​
+                </span>
+              </legend>
+            </fieldset>
+            <div
+              class="MuiChip-root Label-root MuiChip-deletable"
+              role="button"
+              tabindex="0"
+            >
+              <span
+                class="MuiChip-label"
+              >
+                <span
+                  class="Label-innerLabel"
                 >
-                  <use
-                    xlink:href="#closeMinor16_svg__a"
-                  />
-                </mask>
-                <use
-                  fill-rule="nonzero"
-                  xlink:href="#closeMinor16_svg__a"
-                />
-                <g
-                  mask="url(#closeMinor16_svg__b)"
+                  xxxx
+                </span>
+              </span>
+              <span
+                aria-label="delete icon"
+                class="MuiChip-deleteIcon"
+                role="button"
+              >
+                <svg
+                  class="SvgCloseMinor16-root"
+                  style="min-width: 16px; min-height: 16px;"
+                  viewBox="0 0 16 16"
                 >
-                  <path
-                    d="M0 0h16v16H0z"
-                  />
-                </g>
-              </g>
-            </svg>
-          </span>
+                  <defs>
+                    <path
+                      d="M8.707 8l3.5 3.5-.707.707-3.5-3.5-3.5 3.5-.707-.707 3.5-3.5-3.5-3.5.707-.707 3.5 3.5 3.5-3.5.707.707-3.5 3.5z"
+                      id="closeMinor16_svg__a"
+                    />
+                  </defs>
+                  <g
+                    fill-rule="evenodd"
+                  >
+                    <mask
+                      id="closeMinor16_svg__b"
+                    >
+                      <use
+                        xlink:href="#closeMinor16_svg__a"
+                      />
+                    </mask>
+                    <use
+                      fill-rule="nonzero"
+                      xlink:href="#closeMinor16_svg__a"
+                    />
+                    <g
+                      mask="url(#closeMinor16_svg__b)"
+                    >
+                      <path
+                        d="M0 0h16v16H0z"
+                      />
+                    </g>
+                  </g>
+                </svg>
+              </span>
+            </div>
+            <input
+              aria-autocomplete="list"
+              aria-labelledby="downshift-4-label"
+              autocomplete="off"
+              class="MuiInputBase-input MuiOutlinedInput-input OutlinedInput-input MuiInputBase-inputAdornedStart MuiOutlinedInput-inputAdornedStart"
+              id="downshift-4-input"
+              style="width: auto;"
+              type="text"
+              value=""
+            />
+          </div>
         </div>
-        <input
-          aria-autocomplete="list"
+        <div
           aria-labelledby="downshift-4-label"
-          autocomplete="off"
-          class="MuiInputBase-input MuiOutlinedInput-input OutlinedInput-input MuiInputBase-inputAdornedStart MuiOutlinedInput-inputAdornedStart"
-          id="downshift-4-input"
-          style="width: auto;"
-          type="text"
-          value=""
+          id="downshift-4-menu"
+          role="listbox"
         />
       </div>
-      <div
-        aria-labelledby="downshift-4-label"
-        id="downshift-4-menu"
-        role="listbox"
-      />
     </div>
   </div>
-</div>
+</body>
 `;
 
 exports[`TagSelector options selected and then unselected 1`] = `
-<div>
-  <div
-    class="Picasso-root"
-  >
+<body>
+  <div>
     <div
-      aria-expanded="false"
-      aria-haspopup="listbox"
-      aria-labelledby="downshift-5-label"
-      class="Autocomplete-root Autocomplete-rootAuto"
-      role="combobox"
+      class="Picasso-root"
     >
       <div
-        class="MuiInputBase-root MuiOutlinedInput-root OutlinedInput-root OutlinedInput-rootAuto TagSelectorInput-inputBase MuiInputBase-adornedStart MuiOutlinedInput-adornedStart"
+        aria-expanded="false"
+        aria-haspopup="listbox"
+        aria-labelledby="downshift-5-label"
+        class="Autocomplete-root Autocomplete-rootAuto"
+        role="combobox"
       >
-        <fieldset
-          aria-hidden="true"
-          class="PrivateNotchedOutline-root MuiOutlinedInput-notchedOutline"
-          style="padding-left: 8px;"
-        >
-          <legend
-            class="PrivateNotchedOutline-legend"
-            style="width: 0.01px;"
-          >
-            <span>
-              ​
-            </span>
-          </legend>
-        </fieldset>
         <div
-          class="MuiChip-root Label-root MuiChip-deletable"
-          role="button"
-          tabindex="0"
+          class="Container-flex"
         >
-          <span
-            class="MuiChip-label"
+          <div
+            class="MuiInputBase-root MuiOutlinedInput-root OutlinedInput-root OutlinedInput-rootAuto TagSelectorInput-inputBase MuiInputBase-adornedStart MuiOutlinedInput-adornedStart"
           >
-            <span
-              class="Label-innerLabel"
+            <fieldset
+              aria-hidden="true"
+              class="PrivateNotchedOutline-root MuiOutlinedInput-notchedOutline"
+              style="padding-left: 8px;"
             >
-              Afghanistan
-            </span>
-          </span>
-          <span
-            aria-label="delete icon"
-            class="MuiChip-deleteIcon"
-            role="button"
-          >
-            <svg
-              class="SvgCloseMinor16-root"
-              style="min-width: 16px; min-height: 16px;"
-              viewBox="0 0 16 16"
-            >
-              <defs>
-                <path
-                  d="M8.707 8l3.5 3.5-.707.707-3.5-3.5-3.5 3.5-.707-.707 3.5-3.5-3.5-3.5.707-.707 3.5 3.5 3.5-3.5.707.707-3.5 3.5z"
-                  id="closeMinor16_svg__a"
-                />
-              </defs>
-              <g
-                fill-rule="evenodd"
+              <legend
+                class="PrivateNotchedOutline-legend"
+                style="width: 0.01px;"
               >
-                <mask
-                  id="closeMinor16_svg__b"
+                <span>
+                  ​
+                </span>
+              </legend>
+            </fieldset>
+            <div
+              class="MuiChip-root Label-root MuiChip-deletable"
+              role="button"
+              tabindex="0"
+            >
+              <span
+                class="MuiChip-label"
+              >
+                <span
+                  class="Label-innerLabel"
                 >
-                  <use
-                    xlink:href="#closeMinor16_svg__a"
-                  />
-                </mask>
-                <use
-                  fill-rule="nonzero"
-                  xlink:href="#closeMinor16_svg__a"
-                />
-                <g
-                  mask="url(#closeMinor16_svg__b)"
+                  Afghanistan
+                </span>
+              </span>
+              <span
+                aria-label="delete icon"
+                class="MuiChip-deleteIcon"
+                role="button"
+              >
+                <svg
+                  class="SvgCloseMinor16-root"
+                  style="min-width: 16px; min-height: 16px;"
+                  viewBox="0 0 16 16"
                 >
-                  <path
-                    d="M0 0h16v16H0z"
-                  />
-                </g>
-              </g>
-            </svg>
-          </span>
+                  <defs>
+                    <path
+                      d="M8.707 8l3.5 3.5-.707.707-3.5-3.5-3.5 3.5-.707-.707 3.5-3.5-3.5-3.5.707-.707 3.5 3.5 3.5-3.5.707.707-3.5 3.5z"
+                      id="closeMinor16_svg__a"
+                    />
+                  </defs>
+                  <g
+                    fill-rule="evenodd"
+                  >
+                    <mask
+                      id="closeMinor16_svg__b"
+                    >
+                      <use
+                        xlink:href="#closeMinor16_svg__a"
+                      />
+                    </mask>
+                    <use
+                      fill-rule="nonzero"
+                      xlink:href="#closeMinor16_svg__a"
+                    />
+                    <g
+                      mask="url(#closeMinor16_svg__b)"
+                    >
+                      <path
+                        d="M0 0h16v16H0z"
+                      />
+                    </g>
+                  </g>
+                </svg>
+              </span>
+            </div>
+            <div
+              class="MuiChip-root Label-root MuiChip-deletable"
+              role="button"
+              tabindex="0"
+            >
+              <span
+                class="MuiChip-label"
+              >
+                <span
+                  class="Label-innerLabel"
+                >
+                  Albania
+                </span>
+              </span>
+              <span
+                aria-label="delete icon"
+                class="MuiChip-deleteIcon"
+                role="button"
+              >
+                <svg
+                  class="SvgCloseMinor16-root"
+                  style="min-width: 16px; min-height: 16px;"
+                  viewBox="0 0 16 16"
+                >
+                  <defs>
+                    <path
+                      d="M8.707 8l3.5 3.5-.707.707-3.5-3.5-3.5 3.5-.707-.707 3.5-3.5-3.5-3.5.707-.707 3.5 3.5 3.5-3.5.707.707-3.5 3.5z"
+                      id="closeMinor16_svg__a"
+                    />
+                  </defs>
+                  <g
+                    fill-rule="evenodd"
+                  >
+                    <mask
+                      id="closeMinor16_svg__b"
+                    >
+                      <use
+                        xlink:href="#closeMinor16_svg__a"
+                      />
+                    </mask>
+                    <use
+                      fill-rule="nonzero"
+                      xlink:href="#closeMinor16_svg__a"
+                    />
+                    <g
+                      mask="url(#closeMinor16_svg__b)"
+                    >
+                      <path
+                        d="M0 0h16v16H0z"
+                      />
+                    </g>
+                  </g>
+                </svg>
+              </span>
+            </div>
+            <input
+              aria-autocomplete="list"
+              aria-labelledby="downshift-5-label"
+              autocomplete="off"
+              class="MuiInputBase-input MuiOutlinedInput-input OutlinedInput-input MuiInputBase-inputAdornedStart MuiOutlinedInput-inputAdornedStart"
+              id="downshift-5-input"
+              style="width: auto;"
+              type="text"
+              value=""
+            />
+          </div>
         </div>
         <div
-          class="MuiChip-root Label-root MuiChip-deletable"
-          role="button"
-          tabindex="0"
-        >
-          <span
-            class="MuiChip-label"
-          >
-            <span
-              class="Label-innerLabel"
-            >
-              Albania
-            </span>
-          </span>
-          <span
-            aria-label="delete icon"
-            class="MuiChip-deleteIcon"
-            role="button"
-          >
-            <svg
-              class="SvgCloseMinor16-root"
-              style="min-width: 16px; min-height: 16px;"
-              viewBox="0 0 16 16"
-            >
-              <defs>
-                <path
-                  d="M8.707 8l3.5 3.5-.707.707-3.5-3.5-3.5 3.5-.707-.707 3.5-3.5-3.5-3.5.707-.707 3.5 3.5 3.5-3.5.707.707-3.5 3.5z"
-                  id="closeMinor16_svg__a"
-                />
-              </defs>
-              <g
-                fill-rule="evenodd"
-              >
-                <mask
-                  id="closeMinor16_svg__b"
-                >
-                  <use
-                    xlink:href="#closeMinor16_svg__a"
-                  />
-                </mask>
-                <use
-                  fill-rule="nonzero"
-                  xlink:href="#closeMinor16_svg__a"
-                />
-                <g
-                  mask="url(#closeMinor16_svg__b)"
-                >
-                  <path
-                    d="M0 0h16v16H0z"
-                  />
-                </g>
-              </g>
-            </svg>
-          </span>
-        </div>
-        <input
-          aria-autocomplete="list"
           aria-labelledby="downshift-5-label"
-          autocomplete="off"
-          class="MuiInputBase-input MuiOutlinedInput-input OutlinedInput-input MuiInputBase-inputAdornedStart MuiOutlinedInput-inputAdornedStart"
-          id="downshift-5-input"
-          style="width: auto;"
-          type="text"
-          value=""
+          id="downshift-5-menu"
+          role="listbox"
         />
       </div>
-      <div
-        aria-labelledby="downshift-5-label"
-        id="downshift-5-menu"
-        role="listbox"
-      />
     </div>
   </div>
-</div>
+</body>
 `;
 
 exports[`TagSelector preselected value 1`] = `
-<div>
-  <div
-    class="Picasso-root"
-  >
+<body>
+  <div>
     <div
-      aria-expanded="false"
-      aria-haspopup="listbox"
-      aria-labelledby="downshift-2-label"
-      class="Autocomplete-root Autocomplete-rootAuto"
-      role="combobox"
+      class="Picasso-root"
     >
       <div
-        class="MuiInputBase-root MuiOutlinedInput-root OutlinedInput-root OutlinedInput-rootAuto TagSelectorInput-inputBase MuiInputBase-adornedStart MuiOutlinedInput-adornedStart"
+        aria-expanded="false"
+        aria-haspopup="listbox"
+        aria-labelledby="downshift-2-label"
+        class="Autocomplete-root Autocomplete-rootAuto"
+        role="combobox"
       >
-        <fieldset
-          aria-hidden="true"
-          class="PrivateNotchedOutline-root MuiOutlinedInput-notchedOutline"
-          style="padding-left: 8px;"
-        >
-          <legend
-            class="PrivateNotchedOutline-legend"
-            style="width: 0.01px;"
-          >
-            <span>
-              ​
-            </span>
-          </legend>
-        </fieldset>
         <div
-          class="MuiChip-root Label-root MuiChip-deletable"
-          role="button"
-          tabindex="0"
+          class="Container-flex"
         >
-          <span
-            class="MuiChip-label"
+          <div
+            class="MuiInputBase-root MuiOutlinedInput-root OutlinedInput-root OutlinedInput-rootAuto TagSelectorInput-inputBase MuiInputBase-adornedStart MuiOutlinedInput-adornedStart"
           >
-            <span
-              class="Label-innerLabel"
+            <fieldset
+              aria-hidden="true"
+              class="PrivateNotchedOutline-root MuiOutlinedInput-notchedOutline"
+              style="padding-left: 8px;"
             >
-              Afghanistan
-            </span>
-          </span>
-          <span
-            aria-label="delete icon"
-            class="MuiChip-deleteIcon"
-            role="button"
-          >
-            <svg
-              class="SvgCloseMinor16-root"
-              style="min-width: 16px; min-height: 16px;"
-              viewBox="0 0 16 16"
-            >
-              <defs>
-                <path
-                  d="M8.707 8l3.5 3.5-.707.707-3.5-3.5-3.5 3.5-.707-.707 3.5-3.5-3.5-3.5.707-.707 3.5 3.5 3.5-3.5.707.707-3.5 3.5z"
-                  id="closeMinor16_svg__a"
-                />
-              </defs>
-              <g
-                fill-rule="evenodd"
+              <legend
+                class="PrivateNotchedOutline-legend"
+                style="width: 0.01px;"
               >
-                <mask
-                  id="closeMinor16_svg__b"
+                <span>
+                  ​
+                </span>
+              </legend>
+            </fieldset>
+            <div
+              class="MuiChip-root Label-root MuiChip-deletable"
+              role="button"
+              tabindex="0"
+            >
+              <span
+                class="MuiChip-label"
+              >
+                <span
+                  class="Label-innerLabel"
                 >
-                  <use
-                    xlink:href="#closeMinor16_svg__a"
-                  />
-                </mask>
-                <use
-                  fill-rule="nonzero"
-                  xlink:href="#closeMinor16_svg__a"
-                />
-                <g
-                  mask="url(#closeMinor16_svg__b)"
+                  Afghanistan
+                </span>
+              </span>
+              <span
+                aria-label="delete icon"
+                class="MuiChip-deleteIcon"
+                role="button"
+              >
+                <svg
+                  class="SvgCloseMinor16-root"
+                  style="min-width: 16px; min-height: 16px;"
+                  viewBox="0 0 16 16"
                 >
-                  <path
-                    d="M0 0h16v16H0z"
-                  />
-                </g>
-              </g>
-            </svg>
-          </span>
+                  <defs>
+                    <path
+                      d="M8.707 8l3.5 3.5-.707.707-3.5-3.5-3.5 3.5-.707-.707 3.5-3.5-3.5-3.5.707-.707 3.5 3.5 3.5-3.5.707.707-3.5 3.5z"
+                      id="closeMinor16_svg__a"
+                    />
+                  </defs>
+                  <g
+                    fill-rule="evenodd"
+                  >
+                    <mask
+                      id="closeMinor16_svg__b"
+                    >
+                      <use
+                        xlink:href="#closeMinor16_svg__a"
+                      />
+                    </mask>
+                    <use
+                      fill-rule="nonzero"
+                      xlink:href="#closeMinor16_svg__a"
+                    />
+                    <g
+                      mask="url(#closeMinor16_svg__b)"
+                    >
+                      <path
+                        d="M0 0h16v16H0z"
+                      />
+                    </g>
+                  </g>
+                </svg>
+              </span>
+            </div>
+            <input
+              aria-autocomplete="list"
+              aria-labelledby="downshift-2-label"
+              autocomplete="off"
+              class="MuiInputBase-input MuiOutlinedInput-input OutlinedInput-input MuiInputBase-inputAdornedStart MuiOutlinedInput-inputAdornedStart"
+              id="downshift-2-input"
+              type="text"
+              value=""
+            />
+          </div>
         </div>
-        <input
-          aria-autocomplete="list"
+        <div
           aria-labelledby="downshift-2-label"
-          autocomplete="off"
-          class="MuiInputBase-input MuiOutlinedInput-input OutlinedInput-input MuiInputBase-inputAdornedStart MuiOutlinedInput-inputAdornedStart"
-          id="downshift-2-input"
-          type="text"
-          value=""
+          id="downshift-2-menu"
+          role="listbox"
         />
       </div>
-      <div
-        aria-labelledby="downshift-2-label"
-        id="downshift-2-menu"
-        role="listbox"
-      />
     </div>
   </div>
-</div>
+</body>
 `;
 
 exports[`TagSelector selected option 1`] = `
-<div>
-  <div
-    class="Picasso-root"
-  >
+<body>
+  <div>
     <div
-      aria-expanded="false"
-      aria-haspopup="listbox"
-      aria-labelledby="downshift-3-label"
-      class="Autocomplete-root Autocomplete-rootAuto"
-      role="combobox"
+      class="Picasso-root"
     >
       <div
-        class="MuiInputBase-root MuiOutlinedInput-root OutlinedInput-root OutlinedInput-rootAuto TagSelectorInput-inputBase MuiInputBase-adornedStart MuiOutlinedInput-adornedStart"
+        aria-expanded="false"
+        aria-haspopup="listbox"
+        aria-labelledby="downshift-3-label"
+        class="Autocomplete-root Autocomplete-rootAuto"
+        role="combobox"
       >
-        <fieldset
-          aria-hidden="true"
-          class="PrivateNotchedOutline-root MuiOutlinedInput-notchedOutline"
-          style="padding-left: 8px;"
-        >
-          <legend
-            class="PrivateNotchedOutline-legend"
-            style="width: 0.01px;"
-          >
-            <span>
-              ​
-            </span>
-          </legend>
-        </fieldset>
         <div
-          class="MuiChip-root Label-root MuiChip-deletable"
-          role="button"
-          tabindex="0"
+          class="Container-flex"
         >
-          <span
-            class="MuiChip-label"
+          <div
+            class="MuiInputBase-root MuiOutlinedInput-root OutlinedInput-root OutlinedInput-rootAuto TagSelectorInput-inputBase MuiInputBase-adornedStart MuiOutlinedInput-adornedStart"
           >
-            <span
-              class="Label-innerLabel"
+            <fieldset
+              aria-hidden="true"
+              class="PrivateNotchedOutline-root MuiOutlinedInput-notchedOutline"
+              style="padding-left: 8px;"
             >
-              Afghanistan
-            </span>
-          </span>
-          <span
-            aria-label="delete icon"
-            class="MuiChip-deleteIcon"
-            role="button"
-          >
-            <svg
-              class="SvgCloseMinor16-root"
-              style="min-width: 16px; min-height: 16px;"
-              viewBox="0 0 16 16"
-            >
-              <defs>
-                <path
-                  d="M8.707 8l3.5 3.5-.707.707-3.5-3.5-3.5 3.5-.707-.707 3.5-3.5-3.5-3.5.707-.707 3.5 3.5 3.5-3.5.707.707-3.5 3.5z"
-                  id="closeMinor16_svg__a"
-                />
-              </defs>
-              <g
-                fill-rule="evenodd"
+              <legend
+                class="PrivateNotchedOutline-legend"
+                style="width: 0.01px;"
               >
-                <mask
-                  id="closeMinor16_svg__b"
+                <span>
+                  ​
+                </span>
+              </legend>
+            </fieldset>
+            <div
+              class="MuiChip-root Label-root MuiChip-deletable"
+              role="button"
+              tabindex="0"
+            >
+              <span
+                class="MuiChip-label"
+              >
+                <span
+                  class="Label-innerLabel"
                 >
-                  <use
-                    xlink:href="#closeMinor16_svg__a"
-                  />
-                </mask>
-                <use
-                  fill-rule="nonzero"
-                  xlink:href="#closeMinor16_svg__a"
-                />
-                <g
-                  mask="url(#closeMinor16_svg__b)"
+                  Afghanistan
+                </span>
+              </span>
+              <span
+                aria-label="delete icon"
+                class="MuiChip-deleteIcon"
+                role="button"
+              >
+                <svg
+                  class="SvgCloseMinor16-root"
+                  style="min-width: 16px; min-height: 16px;"
+                  viewBox="0 0 16 16"
                 >
-                  <path
-                    d="M0 0h16v16H0z"
-                  />
-                </g>
-              </g>
-            </svg>
-          </span>
+                  <defs>
+                    <path
+                      d="M8.707 8l3.5 3.5-.707.707-3.5-3.5-3.5 3.5-.707-.707 3.5-3.5-3.5-3.5.707-.707 3.5 3.5 3.5-3.5.707.707-3.5 3.5z"
+                      id="closeMinor16_svg__a"
+                    />
+                  </defs>
+                  <g
+                    fill-rule="evenodd"
+                  >
+                    <mask
+                      id="closeMinor16_svg__b"
+                    >
+                      <use
+                        xlink:href="#closeMinor16_svg__a"
+                      />
+                    </mask>
+                    <use
+                      fill-rule="nonzero"
+                      xlink:href="#closeMinor16_svg__a"
+                    />
+                    <g
+                      mask="url(#closeMinor16_svg__b)"
+                    >
+                      <path
+                        d="M0 0h16v16H0z"
+                      />
+                    </g>
+                  </g>
+                </svg>
+              </span>
+            </div>
+            <input
+              aria-autocomplete="list"
+              aria-labelledby="downshift-3-label"
+              autocomplete="off"
+              class="MuiInputBase-input MuiOutlinedInput-input OutlinedInput-input MuiInputBase-inputAdornedStart MuiOutlinedInput-inputAdornedStart"
+              id="downshift-3-input"
+              style="width: auto;"
+              type="text"
+              value=""
+            />
+          </div>
         </div>
-        <input
-          aria-autocomplete="list"
+        <div
           aria-labelledby="downshift-3-label"
-          autocomplete="off"
-          class="MuiInputBase-input MuiOutlinedInput-input OutlinedInput-input MuiInputBase-inputAdornedStart MuiOutlinedInput-inputAdornedStart"
-          id="downshift-3-input"
-          style="width: auto;"
-          type="text"
-          value=""
+          id="downshift-3-menu"
+          role="listbox"
         />
       </div>
-      <div
-        aria-labelledby="downshift-3-label"
-        id="downshift-3-menu"
-        role="listbox"
-      />
     </div>
   </div>
-</div>
+</body>
 `;

--- a/src/components/lab/TagSelector/test.tsx
+++ b/src/components/lab/TagSelector/test.tsx
@@ -68,16 +68,16 @@ describe('TagSelector', () => {
   })
 
   test('available options when start typing', () => {
-    const { container, getByPlaceholderText } = renderTagSelector(testProps)
+    const { baseElement, getByPlaceholderText } = renderTagSelector(testProps)
     const input = getByPlaceholderText(testProps.placeholder)
 
     fireEvent.change(input, { target: { value: 'Al' } })
 
-    expect(container).toMatchSnapshot()
+    expect(baseElement).toMatchSnapshot()
   })
 
   test('preselected value', () => {
-    const { container } = renderTagSelector({
+    const { baseElement } = renderTagSelector({
       loading: false,
       newOptionLabel: 'Add: ',
       options,
@@ -85,24 +85,27 @@ describe('TagSelector', () => {
       defaultValue: [options[0].value]
     })
 
-    expect(container).toMatchSnapshot()
+    expect(baseElement).toMatchSnapshot()
   })
 
   test('selected option', async () => {
     const renderResult = renderTagSelector(testProps)
-    const { container, getByPlaceholderText } = renderResult
+    const { baseElement, getByPlaceholderText } = renderResult
 
     const input = getByPlaceholderText(testProps.placeholder)
 
     await selectOption(renderResult, input, options[0].text)
 
-    expect(container).toMatchSnapshot()
+    expect(baseElement).toMatchSnapshot()
   })
 
   test('newly added option selected', async () => {
-    const { container, getByPlaceholderText, getByText } = renderTagSelector(
-      testProps
-    )
+    const {
+      baseElement,
+      container,
+      getByPlaceholderText,
+      getByText
+    } = renderTagSelector(testProps)
     const newOptionText = 'xxxx'
 
     const input = getByPlaceholderText(testProps.placeholder)
@@ -116,12 +119,16 @@ describe('TagSelector', () => {
 
     fireEvent.click(newOptionElement)
 
-    expect(container).toMatchSnapshot()
+    expect(baseElement).toMatchSnapshot()
   })
 
   test('options selected and then unselected', async () => {
     const renderResult = renderTagSelector(testProps)
-    const { container, getByPlaceholderText, getAllByLabelText } = renderResult
+    const {
+      baseElement,
+      getByPlaceholderText,
+      getAllByLabelText
+    } = renderResult
     const input = getByPlaceholderText(testProps.placeholder)
 
     await selectOption(renderResult, input, options[0].text)
@@ -134,6 +141,6 @@ describe('TagSelector', () => {
 
     fireEvent.click(optionDeleteElements[1])
 
-    expect(container).toMatchSnapshot()
+    expect(baseElement).toMatchSnapshot()
   })
 })


### PR DESCRIPTION
[FX-519](https://toptal-core.atlassian.net/browse/FX-519)

### Description

Introduced portal to autocomplete and dropdown so they can overlay modals when placed in them.

 RATIONALE TO DISABLE PORTAL: If portal is enabled, and dropdown's popper contains
 for example <Input autoFocus/> like it does in this example, popper will mount to the portal and
 before it finishes posotioning itself, autoFocus will force scrolling
 to the bottom of the portal.

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| ![image](https://user-images.githubusercontent.com/14070311/66459672-293aa980-ea7e-11e9-9bcb-a51637b0450e.png) | ![image](https://user-images.githubusercontent.com/14070311/66459602-0a3c1780-ea7e-11e9-97a4-febf491640da.png)
 |

### Review

- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure that visuals specs are green [See the documentation](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)