### PR TITLE
chore: fix master release build on CI

### DIFF
--- a/ci/jobs/picasso-master-release/Jenkinsfile
+++ b/ci/jobs/picasso-master-release/Jenkinsfile
@@ -18,7 +18,7 @@ pipeline {
   options {
     ansiColor('xterm')
     timestamps()
-    timeout(time: 40, unit: 'MINUTES')
+    timeout(time: 50, unit: 'MINUTES')
     skipDefaultCheckout()
     disableConcurrentBuilds()
   }


### PR DESCRIPTION
### Description

Looks like our deploys are failing because of timeout - https://jenkins.toptal.net/job/picasso-master-release/
I've already created a story to fix the build time properly - https://toptal-core.atlassian.net/browse/FX-528 , but before it's done it makes sense to increase the timeout