### PR TITLE
feat(NotificationProvider): [BIL-789] extend NotificationProvider

### DIFF
--- a/packages/picasso/package.json
+++ b/packages/picasso/package.json
@@ -30,7 +30,7 @@
     "@material-ui/icons": "4.5.1",
     "@toptal/picasso-shared": "^1.0.1",
     "classnames": "^2.2.6",
-    "notistack": "^0.8.9",
+    "notistack": "^0.9.7",
     "react-modal-hook": "^2.0.0",
     "react-router-dom": "^5.0.1",
     "react-truncate": "^2.4.0"

--- a/packages/picasso/src/utils/Notifications/NotificationsProvider.tsx
+++ b/packages/picasso/src/utils/Notifications/NotificationsProvider.tsx
@@ -6,11 +6,20 @@ import { headerHeight } from '../../PageHeader/styles'
 
 const MAX_NOTIFICATION_MESSAGES = 5
 
-const NotificationsProvider: FunctionComponent = ({ children }) => {
+interface Props {
+  /** Notification DOMNode for createPortal */
+  container?: HTMLElement
+}
+
+const NotificationsProvider: FunctionComponent<Props> = ({
+  children,
+  container
+}) => {
   const { hasPageHeader } = usePageHeader()
 
   return (
     <SnackbarProvider
+      domRoot={container}
       maxSnack={MAX_NOTIFICATION_MESSAGES}
       style={hasPageHeader ? { marginTop: headerHeight.default } : undefined}
     >

--- a/packages/picasso/src/utils/Notifications/__snapshots__/test.tsx.snap
+++ b/packages/picasso/src/utils/Notifications/__snapshots__/test.tsx.snap
@@ -42,58 +42,73 @@ exports[`useNotifications error notification render 1`] = `
       </span>
     </button>
     <div
-      class="MuiSnackbar-root SnackbarItem-root MuiSnackbar-anchorOriginTopRight SnackbarItem-anchorOriginTopRight"
-      height="0"
-      style="top: 20px; transition: all 200ms; transition-delay: 150ms;"
+      class="makeStyles-root makeStyles-top makeStyles-right makeStyles-top makeStyles-right"
     >
       <div
-        class="MuiTypography-root MuiPaper-root MuiPaper-elevation6 MuiSnackbarContent-root Notification-notificationRed Notification-notificationShadow Notification-notification ForwardRef(Notification)-formNotification MuiTypography-body2"
-        role="alertdialog"
-        style="webkit-transform: none; transform: none; webkit-transition: -webkit-transform 225ms cubic-bezier(0.0, 0, 0.2, 1) 0ms; transition: transform 225ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;"
+        class="MuiCollapse-container SnackbarItem-collapseContainer MuiCollapse-entered"
+        style="min-height: 0px;"
       >
         <div
-          class="MuiSnackbarContent-message"
+          class="MuiCollapse-wrapper SnackbarItem-collapseWrapper"
         >
           <div
-            class="Container-flex Notification-iconWrapper"
-            style="align-items: center;"
+            class="MuiCollapse-wrapperInner"
           >
-            <svg
-              class="SvgExclamation16-root SvgExclamation16-red"
-              style="min-width: 16px; min-height: 16px;"
-              viewBox="0 0 16 16"
+            <div
+              class="MuiSnackbar-root SnackbarItem-root SnackbarItem-wrappedRoot MuiSnackbar-anchorOriginTopRight SnackbarItem-anchorOriginTopRight"
             >
-              <path
-                d="M7.5 15a7.5 7.5 0 1 1 0-15 7.5 7.5 0 0 1 0 15zm0-1a6.5 6.5 0 1 0 0-13 6.5 6.5 0 0 0 0 13zM7 3h1v6H7V3zm0 8h1v1H7v-1z"
-              />
-            </svg>
-          </div>
-          <div
-            class="MuiTypography-root Typography-bodyMedium Notification-content Notification-contentCloseButton MuiTypography-body1"
-          >
-            Error message
-          </div>
-          <button
-            class="MuiButtonBase-root makeStyles-circular makeStyles-medium makeStyles-primaryBlue makeStyles-root Notification-close"
-            tabindex="0"
-            title="Close Notification"
-            type="button"
-          >
-            <span
-              class="Container-flex Container-inline makeStyles-content"
-              style="align-items: center;"
-            >
-              <svg
-                class="SvgCloseMinor16-root makeStyles-icon Notification-closeIcon"
-                style="min-width: 16px; min-height: 16px;"
-                viewBox="0 0 16 16"
+              <div
+                class="MuiTypography-root MuiPaper-root MuiPaper-elevation6 MuiSnackbarContent-root Notification-notificationRed Notification-notificationShadow Notification-notification ForwardRef(Notification)-formNotification MuiTypography-body2"
+                role="alertdialog"
+                style="webkit-transform: none; transform: none; webkit-transition: -webkit-transform 225ms cubic-bezier(0.0, 0, 0.2, 1) 0ms; transition: transform 225ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;"
               >
-                <path
-                  d="M8.707 8l3.5 3.5-.707.707-3.5-3.5-3.5 3.5-.707-.707 3.5-3.5-3.5-3.5.707-.707 3.5 3.5 3.5-3.5.707.707-3.5 3.5z"
-                />
-              </svg>
-            </span>
-          </button>
+                <div
+                  class="MuiSnackbarContent-message"
+                >
+                  <div
+                    class="Container-flex Notification-iconWrapper"
+                    style="align-items: center;"
+                  >
+                    <svg
+                      class="SvgExclamation16-root SvgExclamation16-red"
+                      style="min-width: 16px; min-height: 16px;"
+                      viewBox="0 0 16 16"
+                    >
+                      <path
+                        d="M7.5 15a7.5 7.5 0 1 1 0-15 7.5 7.5 0 0 1 0 15zm0-1a6.5 6.5 0 1 0 0-13 6.5 6.5 0 0 0 0 13zM7 3h1v6H7V3zm0 8h1v1H7v-1z"
+                      />
+                    </svg>
+                  </div>
+                  <div
+                    class="MuiTypography-root Typography-bodyMedium Notification-content Notification-contentCloseButton MuiTypography-body1"
+                  >
+                    Error message
+                  </div>
+                  <button
+                    class="MuiButtonBase-root makeStyles-circular makeStyles-medium makeStyles-primaryBlue makeStyles-root Notification-close"
+                    tabindex="0"
+                    title="Close Notification"
+                    type="button"
+                  >
+                    <span
+                      class="Container-flex Container-inline makeStyles-content"
+                      style="align-items: center;"
+                    >
+                      <svg
+                        class="SvgCloseMinor16-root makeStyles-icon Notification-closeIcon"
+                        style="min-width: 16px; min-height: 16px;"
+                        viewBox="0 0 16 16"
+                      >
+                        <path
+                          d="M8.707 8l3.5 3.5-.707.707-3.5-3.5-3.5 3.5-.707-.707 3.5-3.5-3.5-3.5.707-.707 3.5 3.5 3.5-3.5.707.707-3.5 3.5z"
+                        />
+                      </svg>
+                    </span>
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
         </div>
       </div>
     </div>
@@ -143,58 +158,73 @@ exports[`useNotifications info notification render 1`] = `
       </span>
     </button>
     <div
-      class="MuiSnackbar-root SnackbarItem-root MuiSnackbar-anchorOriginTopRight SnackbarItem-anchorOriginTopRight"
-      height="0"
-      style="top: 20px; transition: all 200ms; transition-delay: 150ms;"
+      class="makeStyles-root makeStyles-top makeStyles-right makeStyles-top makeStyles-right"
     >
       <div
-        class="MuiTypography-root MuiPaper-root MuiPaper-elevation6 MuiSnackbarContent-root Notification-notificationWhite Notification-notificationShadow Notification-notification ForwardRef(Notification)-generalNotification MuiTypography-body2"
-        role="alertdialog"
-        style="webkit-transform: none; transform: none; webkit-transition: -webkit-transform 225ms cubic-bezier(0.0, 0, 0.2, 1) 0ms; transition: transform 225ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;"
+        class="MuiCollapse-container SnackbarItem-collapseContainer MuiCollapse-entered"
+        style="min-height: 0px;"
       >
         <div
-          class="MuiSnackbarContent-message"
+          class="MuiCollapse-wrapper SnackbarItem-collapseWrapper"
         >
           <div
-            class="Container-flex Notification-iconWrapper"
-            style="align-items: center;"
+            class="MuiCollapse-wrapperInner"
           >
-            <svg
-              class="SvgInfo16-root SvgInfo16-grey"
-              style="min-width: 16px; min-height: 16px;"
-              viewBox="0 0 16 16"
+            <div
+              class="MuiSnackbar-root SnackbarItem-root SnackbarItem-wrappedRoot MuiSnackbar-anchorOriginTopRight SnackbarItem-anchorOriginTopRight"
             >
-              <path
-                d="M7.5 15a7.5 7.5 0 1 1 0-15 7.5 7.5 0 0 1 0 15zm0-1a6.5 6.5 0 1 0 0-13 6.5 6.5 0 0 0 0 13zM7 6h1v6H7V6zm0-3h1v1H7V3z"
-              />
-            </svg>
-          </div>
-          <div
-            class="MuiTypography-root Typography-bodyMedium Notification-content Notification-contentCloseButton MuiTypography-body1"
-          >
-            Info message
-          </div>
-          <button
-            class="MuiButtonBase-root makeStyles-circular makeStyles-medium makeStyles-primaryBlue makeStyles-root Notification-close"
-            tabindex="0"
-            title="Close Notification"
-            type="button"
-          >
-            <span
-              class="Container-flex Container-inline makeStyles-content"
-              style="align-items: center;"
-            >
-              <svg
-                class="SvgCloseMinor16-root makeStyles-icon Notification-closeIcon"
-                style="min-width: 16px; min-height: 16px;"
-                viewBox="0 0 16 16"
+              <div
+                class="MuiTypography-root MuiPaper-root MuiPaper-elevation6 MuiSnackbarContent-root Notification-notificationWhite Notification-notificationShadow Notification-notification ForwardRef(Notification)-generalNotification MuiTypography-body2"
+                role="alertdialog"
+                style="webkit-transform: none; transform: none; webkit-transition: -webkit-transform 225ms cubic-bezier(0.0, 0, 0.2, 1) 0ms; transition: transform 225ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;"
               >
-                <path
-                  d="M8.707 8l3.5 3.5-.707.707-3.5-3.5-3.5 3.5-.707-.707 3.5-3.5-3.5-3.5.707-.707 3.5 3.5 3.5-3.5.707.707-3.5 3.5z"
-                />
-              </svg>
-            </span>
-          </button>
+                <div
+                  class="MuiSnackbarContent-message"
+                >
+                  <div
+                    class="Container-flex Notification-iconWrapper"
+                    style="align-items: center;"
+                  >
+                    <svg
+                      class="SvgInfo16-root SvgInfo16-grey"
+                      style="min-width: 16px; min-height: 16px;"
+                      viewBox="0 0 16 16"
+                    >
+                      <path
+                        d="M7.5 15a7.5 7.5 0 1 1 0-15 7.5 7.5 0 0 1 0 15zm0-1a6.5 6.5 0 1 0 0-13 6.5 6.5 0 0 0 0 13zM7 6h1v6H7V6zm0-3h1v1H7V3z"
+                      />
+                    </svg>
+                  </div>
+                  <div
+                    class="MuiTypography-root Typography-bodyMedium Notification-content Notification-contentCloseButton MuiTypography-body1"
+                  >
+                    Info message
+                  </div>
+                  <button
+                    class="MuiButtonBase-root makeStyles-circular makeStyles-medium makeStyles-primaryBlue makeStyles-root Notification-close"
+                    tabindex="0"
+                    title="Close Notification"
+                    type="button"
+                  >
+                    <span
+                      class="Container-flex Container-inline makeStyles-content"
+                      style="align-items: center;"
+                    >
+                      <svg
+                        class="SvgCloseMinor16-root makeStyles-icon Notification-closeIcon"
+                        style="min-width: 16px; min-height: 16px;"
+                        viewBox="0 0 16 16"
+                      >
+                        <path
+                          d="M8.707 8l3.5 3.5-.707.707-3.5-3.5-3.5 3.5-.707-.707 3.5-3.5-3.5-3.5.707-.707 3.5 3.5 3.5-3.5.707.707-3.5 3.5z"
+                        />
+                      </svg>
+                    </span>
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
         </div>
       </div>
     </div>
@@ -244,58 +274,73 @@ exports[`useNotifications success notification render 1`] = `
       </span>
     </button>
     <div
-      class="MuiSnackbar-root SnackbarItem-root MuiSnackbar-anchorOriginTopRight SnackbarItem-anchorOriginTopRight"
-      height="0"
-      style="top: 20px; transition: all 200ms; transition-delay: 150ms;"
+      class="makeStyles-root makeStyles-top makeStyles-right makeStyles-top makeStyles-right"
     >
       <div
-        class="MuiTypography-root MuiPaper-root MuiPaper-elevation6 MuiSnackbarContent-root Notification-notificationGreen Notification-notificationShadow Notification-notification ForwardRef(Notification)-formNotification MuiTypography-body2"
-        role="alertdialog"
-        style="webkit-transform: none; transform: none; webkit-transition: -webkit-transform 225ms cubic-bezier(0.0, 0, 0.2, 1) 0ms; transition: transform 225ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;"
+        class="MuiCollapse-container SnackbarItem-collapseContainer MuiCollapse-entered"
+        style="min-height: 0px;"
       >
         <div
-          class="MuiSnackbarContent-message"
+          class="MuiCollapse-wrapper SnackbarItem-collapseWrapper"
         >
           <div
-            class="Container-flex Notification-iconWrapper"
-            style="align-items: center;"
+            class="MuiCollapse-wrapperInner"
           >
-            <svg
-              class="SvgCheckMinor16-root SvgCheckMinor16-green"
-              style="min-width: 16px; min-height: 16px;"
-              viewBox="0 0 16 16"
+            <div
+              class="MuiSnackbar-root SnackbarItem-root SnackbarItem-wrappedRoot MuiSnackbar-anchorOriginTopRight SnackbarItem-anchorOriginTopRight"
             >
-              <path
-                d="M6.5 9.793l4-4 .707.707-4 4-.707.707L3.793 8.5l.707-.707 2 2z"
-              />
-            </svg>
-          </div>
-          <div
-            class="MuiTypography-root Typography-bodyMedium Notification-content Notification-contentCloseButton MuiTypography-body1"
-          >
-            Success message
-          </div>
-          <button
-            class="MuiButtonBase-root makeStyles-circular makeStyles-medium makeStyles-primaryBlue makeStyles-root Notification-close"
-            tabindex="0"
-            title="Close Notification"
-            type="button"
-          >
-            <span
-              class="Container-flex Container-inline makeStyles-content"
-              style="align-items: center;"
-            >
-              <svg
-                class="SvgCloseMinor16-root makeStyles-icon Notification-closeIcon"
-                style="min-width: 16px; min-height: 16px;"
-                viewBox="0 0 16 16"
+              <div
+                class="MuiTypography-root MuiPaper-root MuiPaper-elevation6 MuiSnackbarContent-root Notification-notificationGreen Notification-notificationShadow Notification-notification ForwardRef(Notification)-formNotification MuiTypography-body2"
+                role="alertdialog"
+                style="webkit-transform: none; transform: none; webkit-transition: -webkit-transform 225ms cubic-bezier(0.0, 0, 0.2, 1) 0ms; transition: transform 225ms cubic-bezier(0.0, 0, 0.2, 1) 0ms;"
               >
-                <path
-                  d="M8.707 8l3.5 3.5-.707.707-3.5-3.5-3.5 3.5-.707-.707 3.5-3.5-3.5-3.5.707-.707 3.5 3.5 3.5-3.5.707.707-3.5 3.5z"
-                />
-              </svg>
-            </span>
-          </button>
+                <div
+                  class="MuiSnackbarContent-message"
+                >
+                  <div
+                    class="Container-flex Notification-iconWrapper"
+                    style="align-items: center;"
+                  >
+                    <svg
+                      class="SvgCheckMinor16-root SvgCheckMinor16-green"
+                      style="min-width: 16px; min-height: 16px;"
+                      viewBox="0 0 16 16"
+                    >
+                      <path
+                        d="M6.5 9.793l4-4 .707.707-4 4-.707.707L3.793 8.5l.707-.707 2 2z"
+                      />
+                    </svg>
+                  </div>
+                  <div
+                    class="MuiTypography-root Typography-bodyMedium Notification-content Notification-contentCloseButton MuiTypography-body1"
+                  >
+                    Success message
+                  </div>
+                  <button
+                    class="MuiButtonBase-root makeStyles-circular makeStyles-medium makeStyles-primaryBlue makeStyles-root Notification-close"
+                    tabindex="0"
+                    title="Close Notification"
+                    type="button"
+                  >
+                    <span
+                      class="Container-flex Container-inline makeStyles-content"
+                      style="align-items: center;"
+                    >
+                      <svg
+                        class="SvgCloseMinor16-root makeStyles-icon Notification-closeIcon"
+                        style="min-width: 16px; min-height: 16px;"
+                        viewBox="0 0 16 16"
+                      >
+                        <path
+                          d="M8.707 8l3.5 3.5-.707.707-3.5-3.5-3.5 3.5-.707-.707 3.5-3.5-3.5-3.5.707-.707 3.5 3.5 3.5-3.5.707.707-3.5 3.5z"
+                        />
+                      </svg>
+                    </span>
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
         </div>
       </div>
     </div>

--- a/packages/picasso/src/utils/Notifications/use-notifications.tsx
+++ b/packages/picasso/src/utils/Notifications/use-notifications.tsx
@@ -65,7 +65,7 @@ export const useNotifications = () => {
     const notificationId = enqueueSnackbar('', {
       anchorOrigin: defaultPosition,
       // eslint-disable-next-line react/display-name
-      children: (key: string) => (
+      content: (key: string) => (
         <StyledNotification
           content={content}
           icon={icon}

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "classnames": "^2.2.6",
     "color": "^3.1.1",
-    "notistack": "^0.8.9",
+    "notistack": "^0.9.7",
     "react-modal-hook": "^2.0.0"
   },
   "devDependencies": {

--- a/packages/shared/src/Picasso/NotificationsProvider.tsx
+++ b/packages/shared/src/Picasso/NotificationsProvider.tsx
@@ -1,5 +1,5 @@
-import React, { FunctionComponent } from 'react'
 import { SnackbarProvider } from 'notistack'
+import React, { FunctionComponent } from 'react'
 
 import { usePageHeader } from '../Picasso'
 
@@ -8,12 +8,21 @@ export const headerHeight = { default: '4.5em', smallAndMedium: '3em' }
 
 const MAX_NOTIFICATION_MESSAGES = 5
 
-const NotificationsProvider: FunctionComponent = ({ children }) => {
+interface Props {
+  /** Notification DOMNode for createPortal */
+  container?: HTMLElement
+}
+
+const NotificationsProvider: FunctionComponent<Props> = ({
+  children,
+  container
+}) => {
   const { hasPageHeader } = usePageHeader()
 
   return (
     <SnackbarProvider
       maxSnack={MAX_NOTIFICATION_MESSAGES}
+      domRoot={container}
       style={hasPageHeader ? { marginTop: headerHeight.default } : undefined}
     >
       {children}

--- a/packages/shared/src/Picasso/Picasso.tsx
+++ b/packages/shared/src/Picasso/Picasso.tsx
@@ -117,19 +117,24 @@ interface PicassoProps {
   loadFonts?: boolean
   /** Whether to apply Picasso CSS reset */
   reset?: boolean
+  /** Notification DOMNode for createPortal */
+  notificationContainer?: HTMLElement
 }
 
 const Picasso: FunctionComponent<PicassoProps> = ({
   loadFonts,
   reset,
-  children
+  children,
+  notificationContainer
 }) => (
   <MuiThemeProvider theme={PicassoProvider.theme}>
     {loadFonts && <FontsLoader />}
     {reset && <CssBaseline />}
     <PicassoGlobalStylesProvider>
       <ModalProvider>
-        <NotificationsProvider>{children}</NotificationsProvider>
+        <NotificationsProvider container={notificationContainer}>
+          {children}
+        </NotificationsProvider>
       </ModalProvider>
     </PicassoGlobalStylesProvider>
   </MuiThemeProvider>

--- a/yarn.lock
+++ b/yarn.lock
@@ -12768,10 +12768,10 @@ normalize-url@^4.0.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-4.3.0.tgz#9c49e10fc1876aeb76dba88bf1b2b5d9fa57b2ee"
 
-notistack@^0.8.9:
-  version "0.8.9"
-  resolved "https://registry.yarnpkg.com/notistack/-/notistack-0.8.9.tgz#8c6211a9260f4f1b41b0ebdc8dc43d7bcbf35b97"
-  integrity sha512-nRHQVWUfgHnvnKrjRbRX9f+YAnbyh96yRyO5bEP/FCLVLuTZcJOwUr0GZ7Xr/8wK3+hXa9JYpXUkUhSxj1K8NQ==
+notistack@^0.9.7:
+  version "0.9.7"
+  resolved "https://registry.yarnpkg.com/notistack/-/notistack-0.9.7.tgz#4475db65ec365c1d38244c66285e81f525ea0abb"
+  integrity sha512-OztbtaIiCMR7QdcDGXTcYu96Uuvu26k41d7cnMGdf4NaKkAX06fsLPAlodGPj4HrMjMBUl8nvUQ3LmQOS6kHWQ==
   dependencies:
     classnames "^2.2.6"
     hoist-non-react-statics "^3.3.0"
@@ -12997,7 +12997,6 @@ npm@5.1.0, npm@^5.7.1:
     cmd-shim "~2.0.2"
     columnify "~1.5.4"
     config-chain "~1.1.11"
-    debuglog "*"
     detect-indent "~5.0.0"
     detect-newline "^2.1.0"
     dezalgo "~1.0.3"
@@ -13011,7 +13010,6 @@ npm@5.1.0, npm@^5.7.1:
     has-unicode "~2.0.1"
     hosted-git-info "^2.6.0"
     iferr "~0.1.5"
-    imurmurhash "*"
     inflight "~1.0.6"
     inherits "~2.0.3"
     ini "^1.3.5"
@@ -13023,14 +13021,8 @@ npm@5.1.0, npm@^5.7.1:
     libnpx "^10.2.0"
     lock-verify "^2.0.2"
     lockfile "^1.0.4"
-    lodash._baseindexof "*"
     lodash._baseuniq "~4.6.0"
-    lodash._bindcallback "*"
-    lodash._cacheindexof "*"
-    lodash._createcache "*"
-    lodash._getnative "*"
     lodash.clonedeep "~4.5.0"
-    lodash.restparam "*"
     lodash.union "~4.6.0"
     lodash.uniq "~4.5.0"
     lodash.without "~4.4.0"
@@ -13068,7 +13060,6 @@ npm@5.1.0, npm@^5.7.1:
     read-package-json "^2.0.13"
     read-package-tree "^5.2.1"
     readable-stream "^2.3.6"
-    readdir-scoped-modules "*"
     request "^2.85.0"
     retry "^0.12.0"
     rimraf "~2.6.2"


### PR DESCRIPTION
[BIL-798](https://toptal-core.atlassian.net/browse/BIL-798)

### Description

`NotificationProvider` extend functionality to be able to render into a different `domNode`

### Review

- [x] Annotate all `props` in component with documentation
- n/a ~[ ]~ Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure that visuals specs are green [See the documentation](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
