### PR TITLE
feat(DatePicker): add possibility to use input props

### DIFF
--- a/src/components/lab/DatePicker/DatePicker.tsx
+++ b/src/components/lab/DatePicker/DatePicker.tsx
@@ -2,11 +2,24 @@ import React, { useState } from 'react'
 import format from 'date-fns/format'
 
 import { ClickAwayListener } from '../../utils'
-import { Input, Container } from '../..'
 import { BaseProps } from '../../Picasso'
+import Container from '../../Container'
+import Input, { Props as InputProps } from '../../Input'
 import Calendar, { DateOrDateRangeType, DateRangeType } from '../Calendar'
 
-export interface Props extends BaseProps {
+export interface Props
+  extends BaseProps,
+    Omit<
+      InputProps,
+      | 'value'
+      | 'onSelect'
+      | 'type'
+      | 'autoComplete'
+      | 'multiline'
+      | 'rows'
+      | 'defaultValue'
+      | 'onChange'
+    > {
   /** Method that will be invoked with selected values */
   onSelect: (value: DateOrDateRangeType) => void
   /** Whether calendar supports single date selection or range */
@@ -31,7 +44,13 @@ const formatValue = (value: DateOrDateRangeType) => {
   }
 }
 
-export const DatePicker = ({ onSelect, range, value: initialValue }: Props) => {
+export const DatePicker = ({
+  onSelect,
+  range,
+  value: initialValue,
+  width,
+  ...rest
+}: Props) => {
   const [calendarOpened, setCalendarOpened] = useState(false)
   const [inputValue, setInputValue] = useState<string | undefined>(
     initialValue ? formatValue(initialValue) : undefined
@@ -47,9 +66,14 @@ export const DatePicker = ({ onSelect, range, value: initialValue }: Props) => {
 
   return (
     <ClickAwayListener onClickAway={closeCalendar}>
-      <Container inline>
-        <Input value={inputValue} onFocus={openCalendar} />
-
+      <Container inline={width !== 'full'}>
+        <Input
+          // eslint-disable-next-line react/jsx-props-no-spreading
+          {...rest}
+          value={inputValue}
+          onFocus={openCalendar}
+          width={width}
+        />
         <Calendar
           activeMonth={initialValue}
           value={initialValue}

--- a/src/components/lab/DatePicker/story/WithInputProps.example.tsx
+++ b/src/components/lab/DatePicker/story/WithInputProps.example.tsx
@@ -1,0 +1,22 @@
+import React from 'react'
+import { DatePicker } from '@toptal/picasso/lab'
+import { Search16 } from '@toptal/picasso'
+
+const WithInputPropsExample = () => {
+  return (
+    <div style={{ height: '50vh', width: '100%' }}>
+      <DatePicker
+        icon={<Search16 />}
+        iconPosition='end'
+        width='full'
+        placeholder='Please select date...'
+        onSelect={(date: Date | [Date, Date]) => {
+          /* eslint-disable-next-line no-console */
+          console.log('selected date is: ', date)
+        }}
+      />
+    </div>
+  )
+}
+
+export default WithInputPropsExample

--- a/src/components/lab/DatePicker/story/index.jsx
+++ b/src/components/lab/DatePicker/story/index.jsx
@@ -20,3 +20,7 @@ page
     'lab/DatePicker/story/InitialValue.example.tsx',
     'With initial value specified'
   ) // picasso-skip-visuals
+  .addExample(
+    'lab/DatePicker/story/WithInputProps.example.tsx',
+    'With Input Props'
+  ) // picasso-skip-visuals


### PR DESCRIPTION
[FX-521](https://toptal-core.atlassian.net/browse/FX-521)

### How to test

 - Navigate to `DatePicker` section
 - Observe and test new example `With Input Props`

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| N/A | ![image](https://user-images.githubusercontent.com/9822091/66645064-c6cede00-ec22-11e9-9606-d9123b764597.png) |

### Review

- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that visuals specs are green [See the documentation](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
