### PR TITLE
fix(ShowMore): add props spreading to ShowMore component

### DIFF
--- a/src/components/ShowMore/ShowMore.tsx
+++ b/src/components/ShowMore/ShowMore.tsx
@@ -36,6 +36,8 @@ export const ShowMore = forwardRef<HTMLSpanElement, Props>(function ShowMore(
     moreText = 'Show more',
     lessText = 'Show less',
     onToggle = () => {},
+    className,
+    style,
     ...rest
   },
   ref
@@ -44,8 +46,15 @@ export const ShowMore = forwardRef<HTMLSpanElement, Props>(function ShowMore(
 
   return (
     <React.Fragment>
-      {/* eslint-disable-next-line react/jsx-props-no-spreading */}
-      <Typography ref={ref} size='medium' color='dark-grey' {...rest}>
+      <Typography
+        // eslint-disable-next-line react/jsx-props-no-spreading
+        {...rest}
+        ref={ref}
+        size='medium'
+        color='dark-grey'
+        className={className}
+        style={style}
+      >
         <Truncate lines={!shownMore && rows}>{children}</Truncate>
       </Typography>
       {!disableToggle && (


### PR DESCRIPTION
### Description

We don't spread props for ShowMore and there is a case when we need to change the text color and we simply couldn't, so this PR fixes it.