### PR TITLE
feat(Autocomplete): add enableAutofill option

### DIFF
--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -34,10 +34,6 @@ export interface Props
   disabled?: boolean
   /** Width of the component */
   width?: 'full' | 'shrink' | 'auto'
-  /** Focus during first mount */
-  autoFocus?: boolean
-  /** Helps users to fill forms faster */
-  autoComplete?: string
   /** Whether icon should be placed at the beginning or end of the `Input` */
   iconPosition?: IconPosition
   /** Specify icon which should be rendered inside Input */
@@ -71,8 +67,6 @@ export const Input = forwardRef<HTMLInputElement, Props>(function Input(
     placeholder,
     error,
     disabled,
-    autoFocus,
-    autoComplete,
     icon,
     iconPosition,
     classes,
@@ -128,10 +122,6 @@ export const Input = forwardRef<HTMLInputElement, Props>(function Input(
       placeholder={placeholder}
       error={error}
       disabled={disabled}
-      autoFocus={autoFocus}
-      // https://developers.google.com/web/updates/2015/06/checkout-faster-with-autofill
-      // according to chrome specification
-      autoComplete={autoComplete}
       multiline={multiline}
       rows={rows}
       rowsMax={rowsMax}

--- a/src/components/OutlinedInput/OutlinedInput.tsx
+++ b/src/components/OutlinedInput/OutlinedInput.tsx
@@ -24,19 +24,8 @@ type ValueType =
 export interface Props
   extends StandardProps,
     Omit<InputHTMLAttributes<HTMLInputElement>, 'value' | 'defaultValue'> {
-  /** The id of the `input` element. */
-  id?: string
-  /** Name attribute of the input element */
-  name?: string
-  /** Placeholder for value */
-  placeholder?: string
-  /** Focus during first mount */
-  autoFocus?: boolean
-  /** Helps users to fill forms faster */
-  autoComplete?: string
   /** Width of the component */
   width?: 'full' | 'shrink' | 'auto'
-  disabled?: boolean
   inputComponent?: ReactType<InputBaseComponentProps>
   inputProps?: InputBaseComponentProps
   defaultValue?: ValueType
@@ -62,16 +51,10 @@ const OutlinedInput = forwardRef<HTMLInputElement, Props>(
       classes,
       className,
       style,
-      id,
-      name,
-      placeholder,
-      autoFocus,
-      autoComplete,
       multiline,
       rows,
       rowsMax,
       width,
-      disabled,
       inputComponent,
       inputProps,
       defaultValue,
@@ -98,7 +81,6 @@ const OutlinedInput = forwardRef<HTMLInputElement, Props>(
         style={style}
         labelWidth={0}
         fullWidth={width === 'full'}
-        disabled={disabled}
         error={error}
         inputComponent={inputComponent}
         inputProps={inputProps}
@@ -108,11 +90,6 @@ const OutlinedInput = forwardRef<HTMLInputElement, Props>(
         type={type}
         startAdornment={startAdornment}
         endAdornment={endAdornment}
-        id={id}
-        name={name}
-        placeholder={placeholder}
-        autoFocus={autoFocus}
-        autoComplete={autoComplete}
         multiline={multiline}
         rows={rows}
         rowsMax={rowsMax}

--- a/src/components/lab/Autocomplete/__snapshots__/test.tsx.snap
+++ b/src/components/lab/Autocomplete/__snapshots__/test.tsx.snap
@@ -39,7 +39,7 @@ exports[`Autocomplete dynamic behavior render options when start typing 1`] = `
               aria-autocomplete="list"
               aria-controls="downshift-3-menu"
               aria-labelledby="downshift-3-label"
-              autocomplete="off"
+              autocomplete="none"
               class="MuiInputBase-input MuiOutlinedInput-input OutlinedInput-input Input-input"
               id="downshift-3-input"
               placeholder="Placeholder text"
@@ -139,7 +139,7 @@ exports[`Autocomplete static behavior default render 1`] = `
           <input
             aria-autocomplete="list"
             aria-labelledby="downshift-0-label"
-            autocomplete="off"
+            autocomplete="none"
             class="MuiInputBase-input MuiOutlinedInput-input OutlinedInput-input Input-input"
             id="downshift-0-input"
             placeholder="Start typing here..."

--- a/src/components/lab/Autocomplete/story/Autofill.example.tsx
+++ b/src/components/lab/Autocomplete/story/Autofill.example.tsx
@@ -1,0 +1,110 @@
+import React from 'react'
+import { Form, Grid, Input, Typography } from '@toptal/picasso'
+import { Autocomplete } from '@toptal/picasso/lab'
+
+const options = [
+  { text: 'Belarus', value: 'BY' },
+  { text: 'Croatia', value: 'HR' },
+  { text: 'Lithuania', value: 'LU' },
+  { text: 'Slovakia', value: 'SK' },
+  { text: 'Ukraine', value: 'UA' }
+]
+
+const AutofillExample = () => (
+  <Grid>
+    <Grid.Item small={5}>
+      <Typography variant='heading'>Autofill enabled for country</Typography>
+      <Form>
+        <Form.Field>
+          <Form.Label>Address</Form.Label>
+          <Input
+            name='ship-address'
+            width='full'
+            autoComplete='shipping street-address'
+            placeholder='123 Any Street'
+          />
+        </Form.Field>
+
+        <Form.Field>
+          <Form.Label>City</Form.Label>
+          <Input
+            placeholder='New York'
+            name='ship-city'
+            autoComplete='shipping locality'
+            width='full'
+          />
+        </Form.Field>
+
+        <Form.Field>
+          <Form.Label>Zip</Form.Label>
+          <Input
+            name='ship-zip'
+            autoComplete='shipping postal-code'
+            width='full'
+            placeholder='10011'
+          />
+        </Form.Field>
+
+        <Form.Field>
+          <Form.Label>Country</Form.Label>
+          <Autocomplete
+            options={options}
+            width='full'
+            name='country'
+            autoComplete='shipping country-name'
+            placeholder='USA'
+            enableAutofill
+          />
+        </Form.Field>
+      </Form>
+    </Grid.Item>
+
+    <Grid.Item small={5}>
+      <Typography variant='heading'>Autofill disabled for country</Typography>
+      <Form>
+        <Form.Field>
+          <Form.Label>Address</Form.Label>
+          <Input
+            name='ship-address'
+            width='full'
+            autoComplete='shipping street-address'
+            placeholder='123 Any Street'
+          />
+        </Form.Field>
+
+        <Form.Field>
+          <Form.Label>City</Form.Label>
+          <Input
+            placeholder='New York'
+            name='ship-city'
+            autoComplete='shipping locality'
+            width='full'
+          />
+        </Form.Field>
+
+        <Form.Field>
+          <Form.Label>Zip</Form.Label>
+          <Input
+            name='ship-zip'
+            autoComplete='shipping postal-code'
+            width='full'
+            placeholder='10011'
+          />
+        </Form.Field>
+
+        <Form.Field>
+          <Form.Label>Country</Form.Label>
+          <Autocomplete
+            options={options}
+            width='full'
+            name='country'
+            autoComplete='shipping country-name'
+            placeholder='USA'
+          />
+        </Form.Field>
+      </Form>
+    </Grid.Item>
+  </Grid>
+)
+
+export default AutofillExample

--- a/src/components/lab/Autocomplete/story/index.jsx
+++ b/src/components/lab/Autocomplete/story/index.jsx
@@ -33,8 +33,8 @@ page
 Autocomplete supports all the default HTML native props, as Input supports.
 
 You also may want to disable standard browser autofill and autocomplete
-for this component. This you can achieve by adding corresponding attributes:
-\`autoComplete='none' and/or autofill='off'\`
+for this component. This you can achieve by adding this attribute:
+\`autoComplete='none'
     `
   )
   .addExample('lab/Autocomplete/story/Default.example.jsx', 'Default')
@@ -71,4 +71,10 @@ for this component. This you can achieve by adding corresponding attributes:
     description: `If you need to obtain the list of options dynamically from a server.
 It is good practice to set debouncing and a minimum number of chars to limit the number of requests you send to the server.
 Start typing "Mongolia" letter by letter to see this example in action.`
+  }) // picasso-skip-visuals
+  .addExample('lab/Autocomplete/story/Autofill.example.tsx', {
+    title: 'Form auto filling',
+    description: `This example shows how to use component inside the form with several fields
+      when it makes sense to have autofill enabled.
+    `
   }) // picasso-skip-visuals

--- a/src/components/lab/Autocomplete/test.tsx
+++ b/src/components/lab/Autocomplete/test.tsx
@@ -28,7 +28,9 @@ const renderAutocomplete = (props: OmitInternalProps<Props>) => {
     minLength,
     inputComponent,
     noOptionsText,
-    renderOption
+    renderOption,
+    enableAutofill,
+    autoComplete
   } = props
 
   return render(
@@ -44,6 +46,8 @@ const renderAutocomplete = (props: OmitInternalProps<Props>) => {
         inputComponent={inputComponent}
         noOptionsText={noOptionsText}
         renderOption={renderOption}
+        enableAutofill={enableAutofill}
+        autoComplete={autoComplete}
       />
     </Picasso>
   )
@@ -454,5 +458,48 @@ describe('Autocomplete', () => {
 
     fireEvent.change(input, { target: { value: 't' } })
     expect(api.baseElement.textContent).toContain('Custom renderer')
+  })
+
+  describe('Autofill', () => {
+    test('when autoComplete value is not passed and autofill is not enabled', () => {
+      const { getByPlaceholderText } = renderAutocomplete({
+        placeholder: 'Start typing here...'
+      })
+      const input = getByPlaceholderText('Start typing here...')
+
+      expect(input.getAttribute('autocomplete')).toBe('none')
+    })
+
+    test('when autoComplete value is not passed and autofill is enabled', () => {
+      const { getByPlaceholderText } = renderAutocomplete({
+        placeholder: 'Start typing here...',
+        enableAutofill: true
+      })
+      const input = getByPlaceholderText('Start typing here...')
+
+      // disabled because of default value in Input
+      expect(input.getAttribute('autocomplete')).toBe('none')
+    })
+
+    test('when autoComplete value is passed and autofill is not enabled', () => {
+      const { getByPlaceholderText } = renderAutocomplete({
+        placeholder: 'Start typing here...',
+        autoComplete: 'country-name'
+      })
+      const input = getByPlaceholderText('Start typing here...')
+
+      expect(input.getAttribute('autocomplete')).toBe('none')
+    })
+
+    test('when autoComplete value is passed and autofill is enabled', () => {
+      const { getByPlaceholderText } = renderAutocomplete({
+        placeholder: 'Start typing here...',
+        enableAutofill: true,
+        autoComplete: 'country-name'
+      })
+      const input = getByPlaceholderText('Start typing here...')
+
+      expect(input.getAttribute('autocomplete')).toBe('country-name')
+    })
   })
 })

--- a/src/components/lab/TagSelector/TagSelector.tsx
+++ b/src/components/lab/TagSelector/TagSelector.tsx
@@ -50,6 +50,8 @@ export interface Props
   onInputChange?: (inputValue: string) => void
   /** Width of the component */
   width?: 'full' | 'shrink' | 'auto'
+  /** Specifies whether the autofill enabled or not, disabled by default */
+  enableAutofill?: boolean
 }
 
 export const TagSelector = forwardRef<HTMLInputElement, Props>(
@@ -66,6 +68,7 @@ export const TagSelector = forwardRef<HTMLInputElement, Props>(
       inputValue: inputValueProp,
       onInputChange,
       width,
+      enableAutofill,
       ...rest
     },
     ref
@@ -202,6 +205,7 @@ export const TagSelector = forwardRef<HTMLInputElement, Props>(
         width={width}
         showOtherOption
         otherOptionText={newOptionLabel}
+        enableAutofill={enableAutofill}
       />
     )
   }
@@ -209,6 +213,7 @@ export const TagSelector = forwardRef<HTMLInputElement, Props>(
 
 TagSelector.defaultProps = {
   defaultValue: [],
+  enableAutofill: false,
   loading: false,
   newOptionLabel: 'Add new option: ',
   onChange: () => {},

--- a/src/components/lab/TagSelector/__snapshots__/test.tsx.snap
+++ b/src/components/lab/TagSelector/__snapshots__/test.tsx.snap
@@ -39,7 +39,7 @@ exports[`TagSelector available options when start typing 1`] = `
               aria-autocomplete="list"
               aria-controls="downshift-1-menu"
               aria-labelledby="downshift-1-label"
-              autocomplete="off"
+              autocomplete="none"
               class="MuiInputBase-input MuiOutlinedInput-input OutlinedInput-input MuiInputBase-inputAdornedStart MuiOutlinedInput-inputAdornedStart"
               id="downshift-1-input"
               placeholder="Please select..."
@@ -173,7 +173,7 @@ exports[`TagSelector default render 1`] = `
           <input
             aria-autocomplete="list"
             aria-labelledby="downshift-0-label"
-            autocomplete="off"
+            autocomplete="none"
             class="MuiInputBase-input MuiOutlinedInput-input OutlinedInput-input MuiInputBase-inputAdornedStart MuiOutlinedInput-inputAdornedStart"
             id="downshift-0-input"
             placeholder="Please select..."
@@ -259,7 +259,7 @@ exports[`TagSelector newly added option selected 1`] = `
             <input
               aria-autocomplete="list"
               aria-labelledby="downshift-4-label"
-              autocomplete="off"
+              autocomplete="none"
               class="MuiInputBase-input MuiOutlinedInput-input OutlinedInput-input MuiInputBase-inputAdornedStart MuiOutlinedInput-inputAdornedStart"
               id="downshift-4-input"
               style="width: auto;"
@@ -375,7 +375,7 @@ exports[`TagSelector options selected and then unselected 1`] = `
             <input
               aria-autocomplete="list"
               aria-labelledby="downshift-5-label"
-              autocomplete="off"
+              autocomplete="none"
               class="MuiInputBase-input MuiOutlinedInput-input OutlinedInput-input MuiInputBase-inputAdornedStart MuiOutlinedInput-inputAdornedStart"
               id="downshift-5-input"
               style="width: auto;"
@@ -461,7 +461,7 @@ exports[`TagSelector preselected value 1`] = `
             <input
               aria-autocomplete="list"
               aria-labelledby="downshift-2-label"
-              autocomplete="off"
+              autocomplete="none"
               class="MuiInputBase-input MuiOutlinedInput-input OutlinedInput-input MuiInputBase-inputAdornedStart MuiOutlinedInput-inputAdornedStart"
               id="downshift-2-input"
               type="text"
@@ -546,7 +546,7 @@ exports[`TagSelector selected option 1`] = `
             <input
               aria-autocomplete="list"
               aria-labelledby="downshift-3-label"
-              autocomplete="off"
+              autocomplete="none"
               class="MuiInputBase-input MuiOutlinedInput-input OutlinedInput-input MuiInputBase-inputAdornedStart MuiOutlinedInput-inputAdornedStart"
               id="downshift-3-input"
               style="width: auto;"


### PR DESCRIPTION
[FX-503](https://toptal-core.atlassian.net/browse/FX-503)

### Description

Provide better option to disable autofill for `Autocomplete` and `TagSelector`

### How to test

- check demo

### Screenshots

![autofill](https://user-images.githubusercontent.com/1291032/66823046-14628800-ef4e-11e9-9941-efc52a7fa7bb.gif)


### Review

- [ ] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that visuals specs are green [See the documentation](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
