### PR TITLE
fix(Modal): fix scrollbar settings and spacing

### DIFF
--- a/src/components/ModalActions/styles.ts
+++ b/src/components/ModalActions/styles.ts
@@ -3,7 +3,7 @@ import { createStyles } from '@material-ui/core'
 export default () =>
   createStyles({
     root: {
-      margin: '0 2rem 2rem',
+      margin: '1rem 2rem 2rem',
       textAlign: 'right'
     }
   })

--- a/src/components/ModalContent/styles.ts
+++ b/src/components/ModalContent/styles.ts
@@ -3,8 +3,8 @@ import { createStyles } from '@material-ui/core'
 export default () =>
   createStyles({
     root: {
-      margin: '2rem',
-      overflow: 'scroll',
+      padding: '1rem 2rem',
+      overflow: 'auto',
       flex: '1 1 auto'
     }
   })

--- a/src/components/ModalTitle/styles.ts
+++ b/src/components/ModalTitle/styles.ts
@@ -3,6 +3,6 @@ import { createStyles } from '@material-ui/core/styles'
 export default () =>
   createStyles({
     root: {
-      margin: '1.625rem 2rem 0'
+      margin: '1.625rem 2rem 1rem'
     }
   })


### PR DESCRIPTION
[FX-534](https://toptal-core.atlassian.net/browse/FX-534)

### Description

Resolves #738

Fixed overflow for scrollbars but also overall ModalContent spacing regarding scrollbars and relative to ModalTitle and ModalActions. When scrolling it is better to have some spacing in Actions and Title to get distance from scrolled content.

### How to test

Go to Modal and decrease size of your window. Content should become scrollable. Scrollbars shouldn't be visible if there is no overflow. You can check that on mac by going to System Preferences > General > Show scrollbars: Always