### PR TITLE
fix(Autocomplete): not show other option when matches any option

### DIFF
--- a/src/components/lab/Autocomplete/Autocomplete.tsx
+++ b/src/components/lab/Autocomplete/Autocomplete.tsx
@@ -219,7 +219,10 @@ export const Autocomplete = forwardRef<HTMLInputElement, Props>(
           const otherOption = {
             text: value
           }
-          const shouldShowOtherOption = showOtherOption && value
+          const shouldShowOtherOption =
+            showOtherOption &&
+            value &&
+            options!.every(option => getDisplayValue!(option) !== value)
 
           const optionsMenu = (
             <ScrollMenu selectedIndex={highlightedIndex}>


### PR DESCRIPTION
### Description

Hide option when the value matches one of the options from the options list