### PR TITLE
fix(Button): accept all props of the component passed in the as property

### DIFF
--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -6,7 +6,7 @@ import React, {
   ElementType
 } from 'react'
 import cx from 'classnames'
-import { withStyles } from '@material-ui/core/styles'
+import { makeStyles, Theme } from '@material-ui/core/styles'
 import ButtonBase, { ButtonBaseProps } from '@material-ui/core/ButtonBase'
 
 import Loader from '../Loader'
@@ -14,11 +14,11 @@ import Container from '../Container'
 import Group from '../ButtonGroup'
 import kebabToCamelCase from '../utils/kebab-to-camel-case'
 import {
-  StandardProps,
-  PicassoComponentWithRef,
+  BaseProps,
   SizeType,
   ButtonOrAnchorProps,
-  CompoundedComponentWithRef
+  CompoundedComponentWithRef,
+  OverridableComponent
 } from '../Picasso'
 import styles from './styles'
 
@@ -37,7 +37,7 @@ export type VariantType =
 
 type IconPositionType = 'left' | 'right'
 
-export interface Props extends StandardProps, ButtonOrAnchorProps {
+export interface Props extends BaseProps, ButtonOrAnchorProps {
   /** Show button in the active state (left mouse button down) */
   active?: boolean
   /** The component used for the root node. Either a string to use a DOM element or a component. */
@@ -70,7 +70,7 @@ export interface Props extends StandardProps, ButtonOrAnchorProps {
   circular?: boolean
   /** HTML title of Button component */
   title?: string
-  /** HTML type of Button component **/
+  /** HTML type of Button component */
   type?: 'button' | 'reset' | 'submit'
 }
 
@@ -84,13 +84,17 @@ const getVariantType = (variant: VariantType) => {
   return type
 }
 
+const useStyles = makeStyles<Theme, Props>(styles)
+
 export const Button = forwardRef<HTMLButtonElement, Props>(function Button(
-  {
+  props,
+  ref
+) {
+  const {
     icon,
     iconPosition,
     loading,
     children,
-    classes,
     className,
     style,
     fullWidth,
@@ -107,9 +111,9 @@ export const Button = forwardRef<HTMLButtonElement, Props>(function Button(
     type,
     as,
     ...rest
-  },
-  ref
-) {
+  } = props
+  const classes = useStyles(props)
+
   const {
     icon: iconClass,
     iconLeft: iconLeftClass,
@@ -216,8 +220,4 @@ Button.displayName = 'Button'
 
 Button.Group = Group
 
-export default withStyles(styles)(Button) as PicassoComponentWithRef<
-  Props,
-  HTMLButtonElement,
-  StaticProps
->
+export default Button as OverridableComponent<Props> & StaticProps

--- a/src/components/Button/__snapshots__/test.tsx.snap
+++ b/src/components/Button/__snapshots__/test.tsx.snap
@@ -6,13 +6,13 @@ exports[`disabled button renders disabled version 1`] = `
     class="Picasso-root"
   >
     <button
-      class="MuiButtonBase-root Button-medium Button-primaryDisabled Button-root Mui-disabled"
+      class="MuiButtonBase-root makeStyles-medium makeStyles-primaryDisabled makeStyles-root Mui-disabled"
       disabled=""
       tabindex="-1"
       type="button"
     >
       <span
-        class="Container-flex Container-inline Button-content"
+        class="Container-flex Container-inline makeStyles-content"
         style="align-items: center;"
       >
         Click me!

--- a/src/components/Button/story/index.jsx
+++ b/src/components/Button/story/index.jsx
@@ -14,8 +14,165 @@ page
   .addComponentDocs({
     component: Button,
     additionalDocs: {
+      children: {
+        name: 'children',
+        type: 'ReactNode',
+        description: 'Content of Button component',
+        defaultValue: 'null'
+      },
+      className: {
+        name: 'className',
+        type: 'string',
+        description: 'Classnames applied to root element'
+      },
+      style: {
+        name: 'style',
+        type: 'CSSProperties',
+        description: 'Style applied to root element'
+      },
+      title: {
+        name: 'title',
+        type: 'string',
+        description: 'HTML title of Button component'
+      },
+      onClick: {
+        name: 'onClick',
+        type: {
+          name: 'function',
+          description:
+            '(event: React.MouseEvent<HTMLButtonElement & HTMLAnchorElement>) => void'
+        },
+        description: 'Callback invoked when component is clicked'
+      },
+      size: {
+        name: 'size',
+        type: {
+          name: 'enum',
+          enums: ['medium', 'large', 'small']
+        },
+        defaultValue: 'medium',
+        description: 'A button can have different sizes'
+      },
       icon: {
-        type: 'ReactElement'
+        name: 'icon',
+        type: 'ReactElement',
+        description: "Add an `<Icon />` along Button's children"
+      },
+      active: {
+        name: 'active',
+        type: 'boolean',
+        description: 'Show button in the active state (left mouse button down)',
+        defaultValue: 'false'
+      },
+      disabled: {
+        name: 'disabled',
+        type: 'boolean',
+        description: 'Disables button',
+        defaultValue: 'false'
+      },
+
+      fullWidth: {
+        name: 'fullWidth',
+        type: 'boolean',
+        description: 'Take the full width of a container',
+        defaultValue: 'false'
+      },
+      hovered: {
+        name: 'hovered',
+        type: 'boolean',
+        description: 'Set hovered style for the button',
+        defaultValue: 'false'
+      },
+      circular: {
+        name: 'circular',
+        type: 'boolean',
+        description: 'Circular style of Button component',
+        defaultValue: 'false'
+      },
+      as: {
+        name: 'as',
+        type: {
+          name: 'enum',
+          enums: [
+            '"symbol"',
+            '"abbr"',
+            '"address"',
+            '"article"',
+            '"aside"',
+            '"b"',
+            '"bdi"',
+            '"bdo"',
+            '"big"',
+            '"blockquote"',
+            '"caption"',
+            '"cite"',
+            '"code"',
+            '"dd"',
+            '"del"',
+            '"details"',
+            '"dfn"',
+            '"dt"',
+            '"em"',
+            '"figcaption"',
+            '... 95 more ...'
+          ]
+        },
+        description:
+          'The component used for the root node. Either a string to use a DOM element or a component.',
+        defaultValue: 'button'
+      },
+      iconPosition: {
+        name: 'iconPosition',
+        description: 'Icon can be positioned on the left or right',
+        type: {
+          name: 'enum',
+          enums: ['left', 'right']
+        },
+        defaultValue: 'left'
+      },
+      loading: {
+        name: 'loading',
+        type: 'boolean',
+        description: 'A button can show a loading indicator',
+        defaultValue: 'false'
+      },
+      variant: {
+        name: 'variant',
+        defaultValue: 'primary-blue',
+        description: 'The variant to use',
+        type: {
+          name: 'enum',
+          enums: [
+            'transparent',
+            'flat',
+            'primary-blue',
+            'secondary-blue',
+            'primary-red',
+            'secondary-red',
+            'primary-green',
+            'flat-white',
+            'secondary-white',
+            'transparent-white',
+            'transparent-blue'
+          ]
+        }
+      },
+      value: {
+        name: 'value',
+        description: 'HTML Value of Button component',
+        type: {
+          name: 'enum',
+          enums: ['string', 'number']
+        }
+      },
+      type: {
+        name: 'type',
+        description: 'HTML type of Button component',
+        type: {
+          name: 'enum',
+          enums: ['button', 'reset', 'submit']
+        },
+        defaultValue: 'button'
       }
     },
     name: 'Button'

--- a/src/components/ButtonGroup/__snapshots__/test.tsx.snap
+++ b/src/components/ButtonGroup/__snapshots__/test.tsx.snap
@@ -9,32 +9,32 @@ exports[`ButtonGroup render 1`] = `
       class="ButtonGroup-root"
     >
       <button
-        class="MuiButtonBase-root Button-medium Button-primaryBlue Button-root ButtonGroup-button"
+        class="MuiButtonBase-root makeStyles-medium makeStyles-primaryBlue makeStyles-root ButtonGroup-button"
         tabindex="0"
         type="button"
       >
         <span
-          class="Container-flex Container-inline Button-content"
+          class="Container-flex Container-inline makeStyles-content"
           style="align-items: center;"
         />
       </button>
       <button
-        class="MuiButtonBase-root Button-active ButtonGroup-active Button-medium Button-primaryBlue Button-root ButtonGroup-button"
+        class="MuiButtonBase-root makeStyles-active ButtonGroup-active makeStyles-medium makeStyles-primaryBlue makeStyles-root ButtonGroup-button"
         tabindex="0"
         type="button"
       >
         <span
-          class="Container-flex Container-inline Button-content"
+          class="Container-flex Container-inline makeStyles-content"
           style="align-items: center;"
         />
       </button>
       <button
-        class="MuiButtonBase-root Button-medium Button-primaryBlue Button-root ButtonGroup-button"
+        class="MuiButtonBase-root makeStyles-medium makeStyles-primaryBlue makeStyles-root ButtonGroup-button"
         tabindex="0"
         type="button"
       >
         <span
-          class="Container-flex Container-inline Button-content"
+          class="Container-flex Container-inline makeStyles-content"
           style="align-items: center;"
         />
       </button>

--- a/src/components/FileInput/__snapshots__/test.tsx.snap
+++ b/src/components/FileInput/__snapshots__/test.tsx.snap
@@ -46,12 +46,12 @@ exports[`FileInput default render 1`] = `
         class="MuiInputAdornment-root InputAdornment-root MuiInputAdornment-positionEnd"
       >
         <button
-          class="MuiButtonBase-root Button-small Button-primaryBlue Button-root FileInput-button"
+          class="MuiButtonBase-root makeStyles-small makeStyles-primaryBlue makeStyles-root FileInput-button"
           tabindex="0"
           type="button"
         >
           <span
-            class="Container-flex Container-inline Button-content"
+            class="Container-flex Container-inline makeStyles-content"
             style="align-items: center;"
           >
             Choose File

--- a/src/components/Helpbox/__snapshots__/test.tsx.snap
+++ b/src/components/Helpbox/__snapshots__/test.tsx.snap
@@ -28,12 +28,12 @@ exports[`Helpbox default render 1`] = `
         style="align-items: center;"
       >
         <button
-          class="MuiButtonBase-root Button-medium Button-primaryBlue Button-root"
+          class="MuiButtonBase-root makeStyles-medium makeStyles-primaryBlue makeStyles-root"
           tabindex="0"
           type="button"
         >
           <span
-            class="Container-flex Container-inline Button-content"
+            class="Container-flex Container-inline makeStyles-content"
             style="align-items: center;"
           >
             Button

--- a/src/components/Modal/__snapshots__/test.tsx.snap
+++ b/src/components/Modal/__snapshots__/test.tsx.snap
@@ -51,24 +51,24 @@ exports[`renders Modal 1`] = `
           class="ModalActions-root"
         >
           <button
-            class="MuiButtonBase-root Button-medium Button-flat Button-root"
+            class="MuiButtonBase-root makeStyles-medium makeStyles-flat makeStyles-root"
             tabindex="0"
             type="button"
           >
             <span
-              class="Container-flex Container-inline Button-content"
+              class="Container-flex Container-inline makeStyles-content"
               style="align-items: center;"
             >
               Cancel
             </span>
           </button>
           <button
-            class="MuiButtonBase-root Button-medium Button-primaryGreen Button-root"
+            class="MuiButtonBase-root makeStyles-medium makeStyles-primaryGreen makeStyles-root"
             tabindex="0"
             type="button"
           >
             <span
-              class="Container-flex Container-inline Button-content"
+              class="Container-flex Container-inline makeStyles-content"
               style="align-items: center;"
             >
               Update
@@ -94,12 +94,12 @@ exports[`useModal opens and closes modal 1`] = `
     >
       <button
         aria-hidden="true"
-        class="MuiButtonBase-root Button-medium Button-primaryBlue Button-root"
+        class="MuiButtonBase-root makeStyles-medium makeStyles-primaryBlue makeStyles-root"
         tabindex="0"
         type="button"
       >
         <span
-          class="Container-flex Container-inline Button-content"
+          class="Container-flex Container-inline makeStyles-content"
           style="align-items: center;"
         >
           Show
@@ -133,12 +133,12 @@ exports[`useModal opens and closes modal 1`] = `
               Modal content
             </p>
             <button
-              class="MuiButtonBase-root Button-medium Button-primaryBlue Button-root"
+              class="MuiButtonBase-root makeStyles-medium makeStyles-primaryBlue makeStyles-root"
               tabindex="0"
               type="button"
             >
               <span
-                class="Container-flex Container-inline Button-content"
+                class="Container-flex Container-inline makeStyles-content"
                 style="align-items: center;"
               >
                 Hide
@@ -164,12 +164,12 @@ exports[`useModal opens and closes modal 2`] = `
       style=""
     >
       <button
-        class="MuiButtonBase-root Button-medium Button-primaryBlue Button-root"
+        class="MuiButtonBase-root makeStyles-medium makeStyles-primaryBlue makeStyles-root"
         tabindex="0"
         type="button"
       >
         <span
-          class="Container-flex Container-inline Button-content"
+          class="Container-flex Container-inline makeStyles-content"
           style="align-items: center;"
         >
           Show
@@ -189,12 +189,12 @@ exports[`useModal shows multiple modals at the same time 1`] = `
     >
       <button
         aria-hidden="true"
-        class="MuiButtonBase-root Button-medium Button-primaryBlue Button-root"
+        class="MuiButtonBase-root makeStyles-medium makeStyles-primaryBlue makeStyles-root"
         tabindex="0"
         type="button"
       >
         <span
-          class="Container-flex Container-inline Button-content"
+          class="Container-flex Container-inline makeStyles-content"
           style="align-items: center;"
         >
           Show first
@@ -202,12 +202,12 @@ exports[`useModal shows multiple modals at the same time 1`] = `
       </button>
       <button
         aria-hidden="true"
-        class="MuiButtonBase-root Button-medium Button-primaryBlue Button-root"
+        class="MuiButtonBase-root makeStyles-medium makeStyles-primaryBlue makeStyles-root"
         tabindex="0"
         type="button"
       >
         <span
-          class="Container-flex Container-inline Button-content"
+          class="Container-flex Container-inline makeStyles-content"
           style="align-items: center;"
         >
           Show second

--- a/src/components/Pagination/__snapshots__/test.tsx.snap
+++ b/src/components/Pagination/__snapshots__/test.tsx.snap
@@ -10,24 +10,24 @@ exports[`renders default 1`] = `
       style="align-items: center;"
     >
       <button
-        class="MuiButtonBase-root Button-small Button-secondaryBlue Button-root"
+        class="MuiButtonBase-root makeStyles-small makeStyles-secondaryBlue makeStyles-root"
         tabindex="0"
         type="button"
       >
         <span
-          class="Container-flex Container-inline Button-content"
+          class="Container-flex Container-inline makeStyles-content"
           style="align-items: center;"
         >
           Prev
         </span>
       </button>
       <button
-        class="MuiButtonBase-root Button-small Button-secondaryBlue Button-root Pagination-rangeButton"
+        class="MuiButtonBase-root makeStyles-small makeStyles-secondaryBlue makeStyles-root Pagination-rangeButton"
         tabindex="0"
         type="button"
       >
         <span
-          class="Container-flex Container-inline Button-content"
+          class="Container-flex Container-inline makeStyles-content"
           style="align-items: center;"
         >
           1
@@ -43,36 +43,36 @@ exports[`renders default 1`] = `
         </p>
       </div>
       <button
-        class="MuiButtonBase-root Button-small Button-secondaryBlue Button-root Pagination-rangeButton"
+        class="MuiButtonBase-root makeStyles-small makeStyles-secondaryBlue makeStyles-root Pagination-rangeButton"
         tabindex="0"
         type="button"
       >
         <span
-          class="Container-flex Container-inline Button-content"
+          class="Container-flex Container-inline makeStyles-content"
           style="align-items: center;"
         >
           4
         </span>
       </button>
       <button
-        class="MuiButtonBase-root Button-small Button-primaryBlue Button-root Pagination-rangeButton"
+        class="MuiButtonBase-root makeStyles-small makeStyles-primaryBlue makeStyles-root Pagination-rangeButton"
         tabindex="0"
         type="button"
       >
         <span
-          class="Container-flex Container-inline Button-content"
+          class="Container-flex Container-inline makeStyles-content"
           style="align-items: center;"
         >
           5
         </span>
       </button>
       <button
-        class="MuiButtonBase-root Button-small Button-secondaryBlue Button-root Pagination-rangeButton"
+        class="MuiButtonBase-root makeStyles-small makeStyles-secondaryBlue makeStyles-root Pagination-rangeButton"
         tabindex="0"
         type="button"
       >
         <span
-          class="Container-flex Container-inline Button-content"
+          class="Container-flex Container-inline makeStyles-content"
           style="align-items: center;"
         >
           6
@@ -88,24 +88,24 @@ exports[`renders default 1`] = `
         </p>
       </div>
       <button
-        class="MuiButtonBase-root Button-small Button-secondaryBlue Button-root Pagination-rangeButton"
+        class="MuiButtonBase-root makeStyles-small makeStyles-secondaryBlue makeStyles-root Pagination-rangeButton"
         tabindex="0"
         type="button"
       >
         <span
-          class="Container-flex Container-inline Button-content"
+          class="Container-flex Container-inline makeStyles-content"
           style="align-items: center;"
         >
           20
         </span>
       </button>
       <button
-        class="MuiButtonBase-root Button-small Button-secondaryBlue Button-root"
+        class="MuiButtonBase-root makeStyles-small makeStyles-secondaryBlue makeStyles-root"
         tabindex="0"
         type="button"
       >
         <span
-          class="Container-flex Container-inline Button-content"
+          class="Container-flex Container-inline makeStyles-content"
           style="align-items: center;"
         >
           Next
@@ -126,26 +126,26 @@ exports[`renders disabled 1`] = `
       style="align-items: center;"
     >
       <button
-        class="MuiButtonBase-root Button-small Button-secondaryDisabled Button-root Mui-disabled"
+        class="MuiButtonBase-root makeStyles-small makeStyles-secondaryDisabled makeStyles-root Mui-disabled"
         disabled=""
         tabindex="-1"
         type="button"
       >
         <span
-          class="Container-flex Container-inline Button-content"
+          class="Container-flex Container-inline makeStyles-content"
           style="align-items: center;"
         >
           Prev
         </span>
       </button>
       <button
-        class="MuiButtonBase-root Button-small Button-secondaryDisabled Button-root Pagination-rangeButton Mui-disabled"
+        class="MuiButtonBase-root makeStyles-small makeStyles-secondaryDisabled makeStyles-root Pagination-rangeButton Mui-disabled"
         disabled=""
         tabindex="-1"
         type="button"
       >
         <span
-          class="Container-flex Container-inline Button-content"
+          class="Container-flex Container-inline makeStyles-content"
           style="align-items: center;"
         >
           1
@@ -161,39 +161,39 @@ exports[`renders disabled 1`] = `
         </p>
       </div>
       <button
-        class="MuiButtonBase-root Button-small Button-secondaryDisabled Button-root Pagination-rangeButton Mui-disabled"
+        class="MuiButtonBase-root makeStyles-small makeStyles-secondaryDisabled makeStyles-root Pagination-rangeButton Mui-disabled"
         disabled=""
         tabindex="-1"
         type="button"
       >
         <span
-          class="Container-flex Container-inline Button-content"
+          class="Container-flex Container-inline makeStyles-content"
           style="align-items: center;"
         >
           4
         </span>
       </button>
       <button
-        class="MuiButtonBase-root Button-small Button-primaryDisabled Button-root Pagination-rangeButton Mui-disabled"
+        class="MuiButtonBase-root makeStyles-small makeStyles-primaryDisabled makeStyles-root Pagination-rangeButton Mui-disabled"
         disabled=""
         tabindex="-1"
         type="button"
       >
         <span
-          class="Container-flex Container-inline Button-content"
+          class="Container-flex Container-inline makeStyles-content"
           style="align-items: center;"
         >
           5
         </span>
       </button>
       <button
-        class="MuiButtonBase-root Button-small Button-secondaryDisabled Button-root Pagination-rangeButton Mui-disabled"
+        class="MuiButtonBase-root makeStyles-small makeStyles-secondaryDisabled makeStyles-root Pagination-rangeButton Mui-disabled"
         disabled=""
         tabindex="-1"
         type="button"
       >
         <span
-          class="Container-flex Container-inline Button-content"
+          class="Container-flex Container-inline makeStyles-content"
           style="align-items: center;"
         >
           6
@@ -209,26 +209,26 @@ exports[`renders disabled 1`] = `
         </p>
       </div>
       <button
-        class="MuiButtonBase-root Button-small Button-secondaryDisabled Button-root Pagination-rangeButton Mui-disabled"
+        class="MuiButtonBase-root makeStyles-small makeStyles-secondaryDisabled makeStyles-root Pagination-rangeButton Mui-disabled"
         disabled=""
         tabindex="-1"
         type="button"
       >
         <span
-          class="Container-flex Container-inline Button-content"
+          class="Container-flex Container-inline makeStyles-content"
           style="align-items: center;"
         >
           20
         </span>
       </button>
       <button
-        class="MuiButtonBase-root Button-small Button-secondaryDisabled Button-root Mui-disabled"
+        class="MuiButtonBase-root makeStyles-small makeStyles-secondaryDisabled makeStyles-root Mui-disabled"
         disabled=""
         tabindex="-1"
         type="button"
       >
         <span
-          class="Container-flex Container-inline Button-content"
+          class="Container-flex Container-inline makeStyles-content"
           style="align-items: center;"
         >
           Next

--- a/src/components/lab/Calendar/__snapshots__/test.tsx.snap
+++ b/src/components/lab/Calendar/__snapshots__/test.tsx.snap
@@ -12,12 +12,12 @@ exports[`Calendar default render 1`] = `
         class="makeStyles-actions"
       >
         <button
-          class="MuiButtonBase-root Button-small Button-flat Button-root"
+          class="MuiButtonBase-root makeStyles-small makeStyles-flat makeStyles-root"
           tabindex="0"
           type="button"
         >
           <span
-            class="Container-flex Container-inline Button-content"
+            class="Container-flex Container-inline makeStyles-content"
             style="align-items: center;"
           >
             <svg
@@ -37,12 +37,12 @@ exports[`Calendar default render 1`] = `
           February 2019
         </h3>
         <button
-          class="MuiButtonBase-root Button-small Button-flat Button-root"
+          class="MuiButtonBase-root makeStyles-small makeStyles-flat makeStyles-root"
           tabindex="0"
           type="button"
         >
           <span
-            class="Container-flex Container-inline Button-content"
+            class="Container-flex Container-inline makeStyles-content"
             style="align-items: center;"
           >
             <svg

--- a/src/components/lab/PromptModal/__snapshots__/test.tsx.snap
+++ b/src/components/lab/PromptModal/__snapshots__/test.tsx.snap
@@ -57,24 +57,24 @@ exports[`renders PromptModal 1`] = `
           class="ModalActions-root"
         >
           <button
-            class="MuiButtonBase-root Button-medium Button-flat Button-root"
+            class="MuiButtonBase-root makeStyles-medium makeStyles-flat makeStyles-root"
             tabindex="0"
             type="button"
           >
             <span
-              class="Container-flex Container-inline Button-content"
+              class="Container-flex Container-inline makeStyles-content"
               style="align-items: center;"
             >
               Cancel
             </span>
           </button>
           <button
-            class="MuiButtonBase-root Button-medium Button-primaryGreen Button-root"
+            class="MuiButtonBase-root makeStyles-medium makeStyles-primaryGreen makeStyles-root"
             tabindex="0"
             type="button"
           >
             <span
-              class="Container-flex Container-inline Button-content"
+              class="Container-flex Container-inline makeStyles-content"
               style="align-items: center;"
             >
               Submit
@@ -100,12 +100,12 @@ exports[`showPrompt opens and closes modal on Submit action 1`] = `
       class="Picasso-root"
     >
       <button
-        class="MuiButtonBase-root Button-medium Button-primaryBlue Button-root"
+        class="MuiButtonBase-root makeStyles-medium makeStyles-primaryBlue makeStyles-root"
         tabindex="0"
         type="button"
       >
         <span
-          class="Container-flex Container-inline Button-content"
+          class="Container-flex Container-inline makeStyles-content"
           style="align-items: center;"
         >
           Show
@@ -127,12 +127,12 @@ exports[`showPrompt opens and closes modal on Submit action 2`] = `
     >
       <button
         aria-hidden="true"
-        class="MuiButtonBase-root Button-medium Button-primaryBlue Button-root"
+        class="MuiButtonBase-root makeStyles-medium makeStyles-primaryBlue makeStyles-root"
         tabindex="0"
         type="button"
       >
         <span
-          class="Container-flex Container-inline Button-content"
+          class="Container-flex Container-inline makeStyles-content"
           style="align-items: center;"
         >
           Show
@@ -184,24 +184,24 @@ exports[`showPrompt opens and closes modal on Submit action 2`] = `
               class="ModalActions-root"
             >
               <button
-                class="MuiButtonBase-root Button-medium Button-flat Button-root"
+                class="MuiButtonBase-root makeStyles-medium makeStyles-flat makeStyles-root"
                 tabindex="0"
                 type="button"
               >
                 <span
-                  class="Container-flex Container-inline Button-content"
+                  class="Container-flex Container-inline makeStyles-content"
                   style="align-items: center;"
                 >
                   Cancel
                 </span>
               </button>
               <button
-                class="MuiButtonBase-root Button-medium Button-primaryGreen Button-root"
+                class="MuiButtonBase-root makeStyles-medium makeStyles-primaryGreen makeStyles-root"
                 tabindex="0"
                 type="button"
               >
                 <span
-                  class="Container-flex Container-inline Button-content"
+                  class="Container-flex Container-inline makeStyles-content"
                   style="align-items: center;"
                 >
                   Submit
@@ -241,12 +241,12 @@ exports[`showPrompt opens and closes modal on Submit action 3`] = `
       style=""
     >
       <button
-        class="MuiButtonBase-root Button-medium Button-primaryBlue Button-root"
+        class="MuiButtonBase-root makeStyles-medium makeStyles-primaryBlue makeStyles-root"
         tabindex="0"
         type="button"
       >
         <span
-          class="Container-flex Container-inline Button-content"
+          class="Container-flex Container-inline makeStyles-content"
           style="align-items: center;"
         >
           Show
@@ -267,12 +267,12 @@ exports[`showPrompt with input returns result on Submit action  1`] = `
       style=""
     >
       <button
-        class="MuiButtonBase-root Button-medium Button-primaryBlue Button-root"
+        class="MuiButtonBase-root makeStyles-medium makeStyles-primaryBlue makeStyles-root"
         tabindex="0"
         type="button"
       >
         <span
-          class="Container-flex Container-inline Button-content"
+          class="Container-flex Container-inline makeStyles-content"
           style="align-items: center;"
         >
           Show

--- a/src/components/lab/utils/Modal/__snapshots__/test.tsx.snap
+++ b/src/components/lab/utils/Modal/__snapshots__/test.tsx.snap
@@ -12,12 +12,12 @@ exports[`useModal opens and closes modal 1`] = `
     >
       <button
         aria-hidden="true"
-        class="MuiButtonBase-root Button-medium Button-primaryBlue Button-root"
+        class="MuiButtonBase-root makeStyles-medium makeStyles-primaryBlue makeStyles-root"
         tabindex="0"
         type="button"
       >
         <span
-          class="Container-flex Container-inline Button-content"
+          class="Container-flex Container-inline makeStyles-content"
           style="align-items: center;"
         >
           Show
@@ -51,12 +51,12 @@ exports[`useModal opens and closes modal 1`] = `
               Modal content
             </p>
             <button
-              class="MuiButtonBase-root Button-medium Button-primaryBlue Button-root"
+              class="MuiButtonBase-root makeStyles-medium makeStyles-primaryBlue makeStyles-root"
               tabindex="0"
               type="button"
             >
               <span
-                class="Container-flex Container-inline Button-content"
+                class="Container-flex Container-inline makeStyles-content"
                 style="align-items: center;"
               >
                 Hide
@@ -85,12 +85,12 @@ exports[`useModal opens and closes modal 2`] = `
       style=""
     >
       <button
-        class="MuiButtonBase-root Button-medium Button-primaryBlue Button-root"
+        class="MuiButtonBase-root makeStyles-medium makeStyles-primaryBlue makeStyles-root"
         tabindex="0"
         type="button"
       >
         <span
-          class="Container-flex Container-inline Button-content"
+          class="Container-flex Container-inline makeStyles-content"
           style="align-items: center;"
         >
           Show
@@ -113,12 +113,12 @@ exports[`useModal shows multiple modals at the same time 1`] = `
     >
       <button
         aria-hidden="true"
-        class="MuiButtonBase-root Button-medium Button-primaryBlue Button-root"
+        class="MuiButtonBase-root makeStyles-medium makeStyles-primaryBlue makeStyles-root"
         tabindex="0"
         type="button"
       >
         <span
-          class="Container-flex Container-inline Button-content"
+          class="Container-flex Container-inline makeStyles-content"
           style="align-items: center;"
         >
           Show first
@@ -126,12 +126,12 @@ exports[`useModal shows multiple modals at the same time 1`] = `
       </button>
       <button
         aria-hidden="true"
-        class="MuiButtonBase-root Button-medium Button-primaryBlue Button-root"
+        class="MuiButtonBase-root makeStyles-medium makeStyles-primaryBlue makeStyles-root"
         tabindex="0"
         type="button"
       >
         <span
-          class="Container-flex Container-inline Button-content"
+          class="Container-flex Container-inline makeStyles-content"
           style="align-items: center;"
         >
           Show second

--- a/src/components/utils/Notifications/__snapshots__/test.tsx.snap
+++ b/src/components/utils/Notifications/__snapshots__/test.tsx.snap
@@ -6,36 +6,36 @@ exports[`useNotifications error notification render 1`] = `
     class="Picasso-root"
   >
     <button
-      class="MuiButtonBase-root Button-medium Button-primaryBlue Button-root"
+      class="MuiButtonBase-root makeStyles-medium makeStyles-primaryBlue makeStyles-root"
       tabindex="0"
       type="button"
     >
       <span
-        class="Container-flex Container-inline Button-content"
+        class="Container-flex Container-inline makeStyles-content"
         style="align-items: center;"
       >
         Show Error
       </span>
     </button>
     <button
-      class="MuiButtonBase-root Button-medium Button-primaryBlue Button-root"
+      class="MuiButtonBase-root makeStyles-medium makeStyles-primaryBlue makeStyles-root"
       tabindex="0"
       type="button"
     >
       <span
-        class="Container-flex Container-inline Button-content"
+        class="Container-flex Container-inline makeStyles-content"
         style="align-items: center;"
       >
         Show Info
       </span>
     </button>
     <button
-      class="MuiButtonBase-root Button-medium Button-primaryBlue Button-root"
+      class="MuiButtonBase-root makeStyles-medium makeStyles-primaryBlue makeStyles-root"
       tabindex="0"
       type="button"
     >
       <span
-        class="Container-flex Container-inline Button-content"
+        class="Container-flex Container-inline makeStyles-content"
         style="align-items: center;"
       >
         Show Success
@@ -74,17 +74,17 @@ exports[`useNotifications error notification render 1`] = `
             Error message
           </div>
           <button
-            class="MuiButtonBase-root Button-circular Button-medium Button-primaryBlue Button-root Notification-close"
+            class="MuiButtonBase-root makeStyles-circular makeStyles-medium makeStyles-primaryBlue makeStyles-root Notification-close"
             tabindex="0"
             title="Close Notification"
             type="button"
           >
             <span
-              class="Container-flex Container-inline Button-content"
+              class="Container-flex Container-inline makeStyles-content"
               style="align-items: center;"
             >
               <svg
-                class="SvgCloseMinor16-root Button-icon Notification-closeIcon"
+                class="SvgCloseMinor16-root makeStyles-icon Notification-closeIcon"
                 style="min-width: 16px; min-height: 16px;"
                 viewBox="0 0 16 16"
               >
@@ -107,36 +107,36 @@ exports[`useNotifications info notification render 1`] = `
     class="Picasso-root"
   >
     <button
-      class="MuiButtonBase-root Button-medium Button-primaryBlue Button-root"
+      class="MuiButtonBase-root makeStyles-medium makeStyles-primaryBlue makeStyles-root"
       tabindex="0"
       type="button"
     >
       <span
-        class="Container-flex Container-inline Button-content"
+        class="Container-flex Container-inline makeStyles-content"
         style="align-items: center;"
       >
         Show Error
       </span>
     </button>
     <button
-      class="MuiButtonBase-root Button-medium Button-primaryBlue Button-root"
+      class="MuiButtonBase-root makeStyles-medium makeStyles-primaryBlue makeStyles-root"
       tabindex="0"
       type="button"
     >
       <span
-        class="Container-flex Container-inline Button-content"
+        class="Container-flex Container-inline makeStyles-content"
         style="align-items: center;"
       >
         Show Info
       </span>
     </button>
     <button
-      class="MuiButtonBase-root Button-medium Button-primaryBlue Button-root"
+      class="MuiButtonBase-root makeStyles-medium makeStyles-primaryBlue makeStyles-root"
       tabindex="0"
       type="button"
     >
       <span
-        class="Container-flex Container-inline Button-content"
+        class="Container-flex Container-inline makeStyles-content"
         style="align-items: center;"
       >
         Show Success
@@ -175,17 +175,17 @@ exports[`useNotifications info notification render 1`] = `
             Info message
           </div>
           <button
-            class="MuiButtonBase-root Button-circular Button-medium Button-primaryBlue Button-root Notification-close"
+            class="MuiButtonBase-root makeStyles-circular makeStyles-medium makeStyles-primaryBlue makeStyles-root Notification-close"
             tabindex="0"
             title="Close Notification"
             type="button"
           >
             <span
-              class="Container-flex Container-inline Button-content"
+              class="Container-flex Container-inline makeStyles-content"
               style="align-items: center;"
             >
               <svg
-                class="SvgCloseMinor16-root Button-icon Notification-closeIcon"
+                class="SvgCloseMinor16-root makeStyles-icon Notification-closeIcon"
                 style="min-width: 16px; min-height: 16px;"
                 viewBox="0 0 16 16"
               >
@@ -208,36 +208,36 @@ exports[`useNotifications success notification render 1`] = `
     class="Picasso-root"
   >
     <button
-      class="MuiButtonBase-root Button-medium Button-primaryBlue Button-root"
+      class="MuiButtonBase-root makeStyles-medium makeStyles-primaryBlue makeStyles-root"
       tabindex="0"
       type="button"
     >
       <span
-        class="Container-flex Container-inline Button-content"
+        class="Container-flex Container-inline makeStyles-content"
         style="align-items: center;"
       >
         Show Error
       </span>
     </button>
     <button
-      class="MuiButtonBase-root Button-medium Button-primaryBlue Button-root"
+      class="MuiButtonBase-root makeStyles-medium makeStyles-primaryBlue makeStyles-root"
       tabindex="0"
       type="button"
     >
       <span
-        class="Container-flex Container-inline Button-content"
+        class="Container-flex Container-inline makeStyles-content"
         style="align-items: center;"
       >
         Show Info
       </span>
     </button>
     <button
-      class="MuiButtonBase-root Button-medium Button-primaryBlue Button-root"
+      class="MuiButtonBase-root makeStyles-medium makeStyles-primaryBlue makeStyles-root"
       tabindex="0"
       type="button"
     >
       <span
-        class="Container-flex Container-inline Button-content"
+        class="Container-flex Container-inline makeStyles-content"
         style="align-items: center;"
       >
         Show Success
@@ -276,17 +276,17 @@ exports[`useNotifications success notification render 1`] = `
             Success message
           </div>
           <button
-            class="MuiButtonBase-root Button-circular Button-medium Button-primaryBlue Button-root Notification-close"
+            class="MuiButtonBase-root makeStyles-circular makeStyles-medium makeStyles-primaryBlue makeStyles-root Notification-close"
             tabindex="0"
             title="Close Notification"
             type="button"
           >
             <span
-              class="Container-flex Container-inline Button-content"
+              class="Container-flex Container-inline makeStyles-content"
               style="align-items: center;"
             >
               <svg
-                class="SvgCloseMinor16-root Button-icon Notification-closeIcon"
+                class="SvgCloseMinor16-root makeStyles-icon Notification-closeIcon"
                 style="min-width: 16px; min-height: 16px;"
                 viewBox="0 0 16 16"
               >


### PR DESCRIPTION
no-ticket, trying to use Button with a react-router

### Description

Ensure that all the props of the component passed in the `as` property are accepted in the typing.
It allows to use Button as a Link with `<Button as={RouterLink} to='/somewhere'>Go somewhere</Button>`

This is needed to implement the screen below:
![Screenshot 2019-11-04 at 10 01 53](https://user-images.githubusercontent.com/2437969/68109181-2b135380-feea-11e9-80b0-515e18af414a.png)


### How to test

See no compilation errors for 
```
<Button as={RouterLink} to='/somewhere'>Go somewhere</Button>
```



### Review

- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure that visuals specs are green [See the documentation](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
