### PR TITLE
chore: remove unused parameter CI_NODE_INDEX

### DIFF
--- a/ci/jobs/picasso-master-release/Jenkinsfile
+++ b/ci/jobs/picasso-master-release/Jenkinsfile
@@ -131,10 +131,7 @@ pipeline {
           downStreamBuilds[1] = buildWithParameters(
             jobName: "picasso-docs",
             propagate: false,
-            wait: true,
-            parameters: [
-              CI_NODE_INDEX: "0"
-            ]
+            wait: true
           )
         }
       }


### PR DESCRIPTION
[INF-844](https://toptal-core.atlassian.net/browse/INF-844)

### Description
The parameter is unused in the `picasso-docs`, other parameters should be sent as their default values, so we can just drop this one.
This removes a warning from Jenkins logs. 
### How to test
- Just run the job