### PR TITLE
chore: fix picasso-master-release job

### DIFF
--- a/ci/jobs/picasso-master-release/Jenkinsfile
+++ b/ci/jobs/picasso-master-release/Jenkinsfile
@@ -128,8 +128,8 @@ pipeline {
       steps {
         info "== Deploying docs"
         script {
-          downStreamBuilds[1] = buildWithParameters(
-            jobName: "picasso-docs",
+          downStreamBuilds[1] = build(
+            job: "picasso-docs",
             propagate: false,
             wait: true
           )


### PR DESCRIPTION
### Description

`buildWithParameters` is our helper script and should not be used when job is triggered without any parameters.

### How to test

- Try releasing from this branch
- Green build: https://jenkins.toptal.net/job/picasso-master-release/786/console