### PR TITLE
chore(Autocomplete): fix warning about RootRef

### DIFF
--- a/src/components/ScrollMenu/ScrollMenu.tsx
+++ b/src/components/ScrollMenu/ScrollMenu.tsx
@@ -32,10 +32,7 @@ const ScrollMenu: FunctionComponent<Props> = ({
   const [prevSelectedIndex, setPrevSelectedIndex] = useState(selectedIndex)
 
   const renderChildren = React.Children.map(children, (child, index) => {
-    if (index === 0) {
-      // hack to be able to set ref for Menu.Item
-      // when we will move to MUI v4 we will be able
-      // just set ref={firstItemRef} to the child
+    if (index === 0 && child) {
       return <RootRef rootRef={firstItemRef}>{child}</RootRef>
     }
 


### PR DESCRIPTION
### Description

In tests and in dev console we can see the warning about `RootRef` accepting `null` as a child element. So this should fix it.

<img width="630" alt="Screenshot 2019-11-11 at 15 35 22" src="https://user-images.githubusercontent.com/2836281/68591234-e57dfa00-0498-11ea-83e8-7564819b7749.png">
