### PR TITLE
chore(button): remove @ts-ignore from the stories

### DIFF
--- a/src/components/Button/story/Augmentation.example.tsx
+++ b/src/components/Button/story/Augmentation.example.tsx
@@ -4,28 +4,22 @@ import { Settings16 } from '@toptal/picasso/Icon'
 
 const ButtonAugmentationExample = () => (
   <div>
-    {/*
-        // @ts-ignore - until we fix as typings */}
     <Button as={Link} href='/#home'>
       Link
     </Button>
-    {/*
-      // @ts-ignore - until we fix as typings */}
+
     <Button as={Link} href='/#home' icon={<Settings16 />}>
       Link
     </Button>
-    {/*
-      // @ts-ignore - until we fix as typings */}
+
     <Button as={Link} href='/#home' variant='secondary-red'>
       Link
     </Button>
-    {/*
-      // @ts-ignore - until we fix as typings */}
+
     <Button as={Link} href='/#home' disabled>
       Link
     </Button>
-    {/*
-      // @ts-ignore - until we fix as typings */}
+
     <Button as={Link} href='/#home' loading>
       Link
     </Button>


### PR DESCRIPTION
[FX-560](https://toptal-core.atlassian.net/browse/FX-560)

This problem seems to be fixed already but at the same time, I find the typing to be wrong. I can pass into the Button component every prop I would like and it still works: 

![image](https://user-images.githubusercontent.com/14070311/69062069-0d360a80-0a23-11ea-95b4-ae46fdcf7fd9.png)

I dug a little bit into the issue and found that this type extends `ElementType` which is generic and by default, its parameter is `any`:

![image](https://user-images.githubusercontent.com/14070311/69062271-5c7c3b00-0a23-11ea-8ab9-1c0cc29f8054.png)

This way overridable components seem to be untyped when used with `Link`
![image](https://user-images.githubusercontent.com/14070311/69062921-4458eb80-0a24-11ea-95c4-9016d7987168.png)    :heavy_check_mark: 
