### PR TITLE
chore: make storybook build quiet

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "test:visual": "./bin/run-in-docker ./bin/test-visual",
     "lint": "davinci syntax lint code .",
     "start": "start-storybook -p 9001 -s ./.storybook/public -c .storybook",
-    "build:storybook": "build-storybook -s ./.storybook/public -c .storybook -o build/storybook",
+    "build:storybook": "build-storybook -s ./.storybook/public -c .storybook -o build/storybook --quiet",
     "release": "./bin/release",
     "build:dist": "cross-env NODE_ENV=production ./bin/build",
     "build": "yarn run generate:icons && yarn build:dist",


### PR DESCRIPTION
no ticket.

Get rid of useless verbose output at jenkins


![image](https://user-images.githubusercontent.com/1291032/69702373-25cbb200-1100-11ea-8eb2-44613dd3d0db.png)
