### PR TITLE
feat(Icon): [FX-593] Fix type of color prop

### DIFF
--- a/packages/picasso/src/Icon/Ach16.tsx
+++ b/packages/picasso/src/Icon/Ach16.tsx
@@ -29,7 +29,7 @@ const SvgAch16 = forwardRef(function SvgAch16(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/Ach32.tsx
+++ b/packages/picasso/src/Icon/Ach32.tsx
@@ -29,7 +29,7 @@ const SvgAch32 = forwardRef(function SvgAch32(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/Afternoon16.tsx
+++ b/packages/picasso/src/Icon/Afternoon16.tsx
@@ -29,7 +29,7 @@ const SvgAfternoon16 = forwardRef(function SvgAfternoon16(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/Afternoon24.tsx
+++ b/packages/picasso/src/Icon/Afternoon24.tsx
@@ -29,7 +29,7 @@ const SvgAfternoon24 = forwardRef(function SvgAfternoon24(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/ArrowDownMinor16.tsx
+++ b/packages/picasso/src/Icon/ArrowDownMinor16.tsx
@@ -29,7 +29,7 @@ const SvgArrowDownMinor16 = forwardRef(function SvgArrowDownMinor16(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/ArrowDownMinor24.tsx
+++ b/packages/picasso/src/Icon/ArrowDownMinor24.tsx
@@ -29,7 +29,7 @@ const SvgArrowDownMinor24 = forwardRef(function SvgArrowDownMinor24(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/ArrowDropDown16.tsx
+++ b/packages/picasso/src/Icon/ArrowDropDown16.tsx
@@ -29,7 +29,7 @@ const SvgArrowDropDown16 = forwardRef(function SvgArrowDropDown16(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/ArrowDropDown24.tsx
+++ b/packages/picasso/src/Icon/ArrowDropDown24.tsx
@@ -29,7 +29,7 @@ const SvgArrowDropDown24 = forwardRef(function SvgArrowDropDown24(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/ArrowDropUp16.tsx
+++ b/packages/picasso/src/Icon/ArrowDropUp16.tsx
@@ -29,7 +29,7 @@ const SvgArrowDropUp16 = forwardRef(function SvgArrowDropUp16(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/ArrowDropUp24.tsx
+++ b/packages/picasso/src/Icon/ArrowDropUp24.tsx
@@ -29,7 +29,7 @@ const SvgArrowDropUp24 = forwardRef(function SvgArrowDropUp24(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/ArrowLongDown16.tsx
+++ b/packages/picasso/src/Icon/ArrowLongDown16.tsx
@@ -29,7 +29,7 @@ const SvgArrowLongDown16 = forwardRef(function SvgArrowLongDown16(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/ArrowLongDown24.tsx
+++ b/packages/picasso/src/Icon/ArrowLongDown24.tsx
@@ -29,7 +29,7 @@ const SvgArrowLongDown24 = forwardRef(function SvgArrowLongDown24(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/ArrowLongUp16.tsx
+++ b/packages/picasso/src/Icon/ArrowLongUp16.tsx
@@ -29,7 +29,7 @@ const SvgArrowLongUp16 = forwardRef(function SvgArrowLongUp16(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/ArrowLongUp24.tsx
+++ b/packages/picasso/src/Icon/ArrowLongUp24.tsx
@@ -29,7 +29,7 @@ const SvgArrowLongUp24 = forwardRef(function SvgArrowLongUp24(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/ArrowUpMinor16.tsx
+++ b/packages/picasso/src/Icon/ArrowUpMinor16.tsx
@@ -29,7 +29,7 @@ const SvgArrowUpMinor16 = forwardRef(function SvgArrowUpMinor16(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/ArrowUpMinor24.tsx
+++ b/packages/picasso/src/Icon/ArrowUpMinor24.tsx
@@ -29,7 +29,7 @@ const SvgArrowUpMinor24 = forwardRef(function SvgArrowUpMinor24(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/BackMinor16.tsx
+++ b/packages/picasso/src/Icon/BackMinor16.tsx
@@ -29,7 +29,7 @@ const SvgBackMinor16 = forwardRef(function SvgBackMinor16(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/BackMinor24.tsx
+++ b/packages/picasso/src/Icon/BackMinor24.tsx
@@ -29,7 +29,7 @@ const SvgBackMinor24 = forwardRef(function SvgBackMinor24(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/BankWire16.tsx
+++ b/packages/picasso/src/Icon/BankWire16.tsx
@@ -29,7 +29,7 @@ const SvgBankWire16 = forwardRef(function SvgBankWire16(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/BankWire24.tsx
+++ b/packages/picasso/src/Icon/BankWire24.tsx
@@ -29,7 +29,7 @@ const SvgBankWire24 = forwardRef(function SvgBankWire24(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/Behance16.tsx
+++ b/packages/picasso/src/Icon/Behance16.tsx
@@ -29,7 +29,7 @@ const SvgBehance16 = forwardRef(function SvgBehance16(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/Behance24.tsx
+++ b/packages/picasso/src/Icon/Behance24.tsx
@@ -29,7 +29,7 @@ const SvgBehance24 = forwardRef(function SvgBehance24(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/Bell16.tsx
+++ b/packages/picasso/src/Icon/Bell16.tsx
@@ -29,7 +29,7 @@ const SvgBell16 = forwardRef(function SvgBell16(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/Bell24.tsx
+++ b/packages/picasso/src/Icon/Bell24.tsx
@@ -29,7 +29,7 @@ const SvgBell24 = forwardRef(function SvgBell24(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/Billing16.tsx
+++ b/packages/picasso/src/Icon/Billing16.tsx
@@ -29,7 +29,7 @@ const SvgBilling16 = forwardRef(function SvgBilling16(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/Billing24.tsx
+++ b/packages/picasso/src/Icon/Billing24.tsx
@@ -29,7 +29,7 @@ const SvgBilling24 = forwardRef(function SvgBilling24(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/Calendar16.tsx
+++ b/packages/picasso/src/Icon/Calendar16.tsx
@@ -29,7 +29,7 @@ const SvgCalendar16 = forwardRef(function SvgCalendar16(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/Calendar24.tsx
+++ b/packages/picasso/src/Icon/Calendar24.tsx
@@ -29,7 +29,7 @@ const SvgCalendar24 = forwardRef(function SvgCalendar24(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/CalendarReminder16.tsx
+++ b/packages/picasso/src/Icon/CalendarReminder16.tsx
@@ -29,7 +29,7 @@ const SvgCalendarReminder16 = forwardRef(function SvgCalendarReminder16(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/CalendarReminder24.tsx
+++ b/packages/picasso/src/Icon/CalendarReminder24.tsx
@@ -29,7 +29,7 @@ const SvgCalendarReminder24 = forwardRef(function SvgCalendarReminder24(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/Candidates16.tsx
+++ b/packages/picasso/src/Icon/Candidates16.tsx
@@ -29,7 +29,7 @@ const SvgCandidates16 = forwardRef(function SvgCandidates16(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/Candidates24.tsx
+++ b/packages/picasso/src/Icon/Candidates24.tsx
@@ -29,7 +29,7 @@ const SvgCandidates24 = forwardRef(function SvgCandidates24(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/Certificate16.tsx
+++ b/packages/picasso/src/Icon/Certificate16.tsx
@@ -29,7 +29,7 @@ const SvgCertificate16 = forwardRef(function SvgCertificate16(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/Certificate24.tsx
+++ b/packages/picasso/src/Icon/Certificate24.tsx
@@ -29,7 +29,7 @@ const SvgCertificate24 = forwardRef(function SvgCertificate24(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/Chat16.tsx
+++ b/packages/picasso/src/Icon/Chat16.tsx
@@ -29,7 +29,7 @@ const SvgChat16 = forwardRef(function SvgChat16(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/Chat24.tsx
+++ b/packages/picasso/src/Icon/Chat24.tsx
@@ -29,7 +29,7 @@ const SvgChat24 = forwardRef(function SvgChat24(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/Check16.tsx
+++ b/packages/picasso/src/Icon/Check16.tsx
@@ -29,7 +29,7 @@ const SvgCheck16 = forwardRef(function SvgCheck16(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/Check24.tsx
+++ b/packages/picasso/src/Icon/Check24.tsx
@@ -29,7 +29,7 @@ const SvgCheck24 = forwardRef(function SvgCheck24(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/CheckMinor16.tsx
+++ b/packages/picasso/src/Icon/CheckMinor16.tsx
@@ -29,7 +29,7 @@ const SvgCheckMinor16 = forwardRef(function SvgCheckMinor16(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/CheckMinor24.tsx
+++ b/packages/picasso/src/Icon/CheckMinor24.tsx
@@ -29,7 +29,7 @@ const SvgCheckMinor24 = forwardRef(function SvgCheckMinor24(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/Chevron16.tsx
+++ b/packages/picasso/src/Icon/Chevron16.tsx
@@ -29,7 +29,7 @@ const SvgChevron16 = forwardRef(function SvgChevron16(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/Chevron24.tsx
+++ b/packages/picasso/src/Icon/Chevron24.tsx
@@ -29,7 +29,7 @@ const SvgChevron24 = forwardRef(function SvgChevron24(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/ChevronMinor16.tsx
+++ b/packages/picasso/src/Icon/ChevronMinor16.tsx
@@ -29,7 +29,7 @@ const SvgChevronMinor16 = forwardRef(function SvgChevronMinor16(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/ChevronMinor24.tsx
+++ b/packages/picasso/src/Icon/ChevronMinor24.tsx
@@ -29,7 +29,7 @@ const SvgChevronMinor24 = forwardRef(function SvgChevronMinor24(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/ChevronRight16.tsx
+++ b/packages/picasso/src/Icon/ChevronRight16.tsx
@@ -29,7 +29,7 @@ const SvgChevronRight16 = forwardRef(function SvgChevronRight16(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/ChevronRight24.tsx
+++ b/packages/picasso/src/Icon/ChevronRight24.tsx
@@ -29,7 +29,7 @@ const SvgChevronRight24 = forwardRef(function SvgChevronRight24(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/Close16.tsx
+++ b/packages/picasso/src/Icon/Close16.tsx
@@ -29,7 +29,7 @@ const SvgClose16 = forwardRef(function SvgClose16(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/Close24.tsx
+++ b/packages/picasso/src/Icon/Close24.tsx
@@ -29,7 +29,7 @@ const SvgClose24 = forwardRef(function SvgClose24(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/CloseMinor16.tsx
+++ b/packages/picasso/src/Icon/CloseMinor16.tsx
@@ -29,7 +29,7 @@ const SvgCloseMinor16 = forwardRef(function SvgCloseMinor16(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/CloseMinor24.tsx
+++ b/packages/picasso/src/Icon/CloseMinor24.tsx
@@ -29,7 +29,7 @@ const SvgCloseMinor24 = forwardRef(function SvgCloseMinor24(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/Code16.tsx
+++ b/packages/picasso/src/Icon/Code16.tsx
@@ -29,7 +29,7 @@ const SvgCode16 = forwardRef(function SvgCode16(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/Code24.tsx
+++ b/packages/picasso/src/Icon/Code24.tsx
@@ -29,7 +29,7 @@ const SvgCode24 = forwardRef(function SvgCode24(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/Copy16.tsx
+++ b/packages/picasso/src/Icon/Copy16.tsx
@@ -29,7 +29,7 @@ const SvgCopy16 = forwardRef(function SvgCopy16(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/Copy24.tsx
+++ b/packages/picasso/src/Icon/Copy24.tsx
@@ -29,7 +29,7 @@ const SvgCopy24 = forwardRef(function SvgCopy24(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/CreditCard16.tsx
+++ b/packages/picasso/src/Icon/CreditCard16.tsx
@@ -29,7 +29,7 @@ const SvgCreditCard16 = forwardRef(function SvgCreditCard16(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/CreditCard32.tsx
+++ b/packages/picasso/src/Icon/CreditCard32.tsx
@@ -29,7 +29,7 @@ const SvgCreditCard32 = forwardRef(function SvgCreditCard32(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/Done16.tsx
+++ b/packages/picasso/src/Icon/Done16.tsx
@@ -29,7 +29,7 @@ const SvgDone16 = forwardRef(function SvgDone16(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/Done24.tsx
+++ b/packages/picasso/src/Icon/Done24.tsx
@@ -29,7 +29,7 @@ const SvgDone24 = forwardRef(function SvgDone24(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/Download16.tsx
+++ b/packages/picasso/src/Icon/Download16.tsx
@@ -29,7 +29,7 @@ const SvgDownload16 = forwardRef(function SvgDownload16(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/Download24.tsx
+++ b/packages/picasso/src/Icon/Download24.tsx
@@ -29,7 +29,7 @@ const SvgDownload24 = forwardRef(function SvgDownload24(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/Dribble16.tsx
+++ b/packages/picasso/src/Icon/Dribble16.tsx
@@ -29,7 +29,7 @@ const SvgDribble16 = forwardRef(function SvgDribble16(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/Dribble24.tsx
+++ b/packages/picasso/src/Icon/Dribble24.tsx
@@ -29,7 +29,7 @@ const SvgDribble24 = forwardRef(function SvgDribble24(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/DropdownArrows16.tsx
+++ b/packages/picasso/src/Icon/DropdownArrows16.tsx
@@ -29,7 +29,7 @@ const SvgDropdownArrows16 = forwardRef(function SvgDropdownArrows16(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/Education16.tsx
+++ b/packages/picasso/src/Icon/Education16.tsx
@@ -29,7 +29,7 @@ const SvgEducation16 = forwardRef(function SvgEducation16(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/Education24.tsx
+++ b/packages/picasso/src/Icon/Education24.tsx
@@ -29,7 +29,7 @@ const SvgEducation24 = forwardRef(function SvgEducation24(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/Email16.tsx
+++ b/packages/picasso/src/Icon/Email16.tsx
@@ -29,7 +29,7 @@ const SvgEmail16 = forwardRef(function SvgEmail16(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/Email24.tsx
+++ b/packages/picasso/src/Icon/Email24.tsx
@@ -29,7 +29,7 @@ const SvgEmail24 = forwardRef(function SvgEmail24(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/Evening16.tsx
+++ b/packages/picasso/src/Icon/Evening16.tsx
@@ -29,7 +29,7 @@ const SvgEvening16 = forwardRef(function SvgEvening16(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/Evening24.tsx
+++ b/packages/picasso/src/Icon/Evening24.tsx
@@ -29,7 +29,7 @@ const SvgEvening24 = forwardRef(function SvgEvening24(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/Exclamation16.tsx
+++ b/packages/picasso/src/Icon/Exclamation16.tsx
@@ -29,7 +29,7 @@ const SvgExclamation16 = forwardRef(function SvgExclamation16(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/Exclamation24.tsx
+++ b/packages/picasso/src/Icon/Exclamation24.tsx
@@ -29,7 +29,7 @@ const SvgExclamation24 = forwardRef(function SvgExclamation24(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/Facebook16.tsx
+++ b/packages/picasso/src/Icon/Facebook16.tsx
@@ -29,7 +29,7 @@ const SvgFacebook16 = forwardRef(function SvgFacebook16(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/Facebook24.tsx
+++ b/packages/picasso/src/Icon/Facebook24.tsx
@@ -29,7 +29,7 @@ const SvgFacebook24 = forwardRef(function SvgFacebook24(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/Filter16.tsx
+++ b/packages/picasso/src/Icon/Filter16.tsx
@@ -29,7 +29,7 @@ const SvgFilter16 = forwardRef(function SvgFilter16(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/Filter24.tsx
+++ b/packages/picasso/src/Icon/Filter24.tsx
@@ -29,7 +29,7 @@ const SvgFilter24 = forwardRef(function SvgFilter24(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/Fullscreen16.tsx
+++ b/packages/picasso/src/Icon/Fullscreen16.tsx
@@ -29,7 +29,7 @@ const SvgFullscreen16 = forwardRef(function SvgFullscreen16(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/Fullscreen24.tsx
+++ b/packages/picasso/src/Icon/Fullscreen24.tsx
@@ -29,7 +29,7 @@ const SvgFullscreen24 = forwardRef(function SvgFullscreen24(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/Github16.tsx
+++ b/packages/picasso/src/Icon/Github16.tsx
@@ -29,7 +29,7 @@ const SvgGithub16 = forwardRef(function SvgGithub16(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/Github24.tsx
+++ b/packages/picasso/src/Icon/Github24.tsx
@@ -29,7 +29,7 @@ const SvgGithub24 = forwardRef(function SvgGithub24(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/Globe16.tsx
+++ b/packages/picasso/src/Icon/Globe16.tsx
@@ -29,7 +29,7 @@ const SvgGlobe16 = forwardRef(function SvgGlobe16(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/Globe24.tsx
+++ b/packages/picasso/src/Icon/Globe24.tsx
@@ -29,7 +29,7 @@ const SvgGlobe24 = forwardRef(function SvgGlobe24(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/Guests16.tsx
+++ b/packages/picasso/src/Icon/Guests16.tsx
@@ -29,7 +29,7 @@ const SvgGuests16 = forwardRef(function SvgGuests16(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/Guests24.tsx
+++ b/packages/picasso/src/Icon/Guests24.tsx
@@ -29,7 +29,7 @@ const SvgGuests24 = forwardRef(function SvgGuests24(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/Help16.tsx
+++ b/packages/picasso/src/Icon/Help16.tsx
@@ -29,7 +29,7 @@ const SvgHelp16 = forwardRef(function SvgHelp16(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/Help24.tsx
+++ b/packages/picasso/src/Icon/Help24.tsx
@@ -29,7 +29,7 @@ const SvgHelp24 = forwardRef(function SvgHelp24(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/Info16.tsx
+++ b/packages/picasso/src/Icon/Info16.tsx
@@ -29,7 +29,7 @@ const SvgInfo16 = forwardRef(function SvgInfo16(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/Info24.tsx
+++ b/packages/picasso/src/Icon/Info24.tsx
@@ -29,7 +29,7 @@ const SvgInfo24 = forwardRef(function SvgInfo24(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/Instagram16.tsx
+++ b/packages/picasso/src/Icon/Instagram16.tsx
@@ -29,7 +29,7 @@ const SvgInstagram16 = forwardRef(function SvgInstagram16(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/Instagram24.tsx
+++ b/packages/picasso/src/Icon/Instagram24.tsx
@@ -29,7 +29,7 @@ const SvgInstagram24 = forwardRef(function SvgInstagram24(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/JobChange16.tsx
+++ b/packages/picasso/src/Icon/JobChange16.tsx
@@ -29,7 +29,7 @@ const SvgJobChange16 = forwardRef(function SvgJobChange16(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/JobChange24.tsx
+++ b/packages/picasso/src/Icon/JobChange24.tsx
@@ -29,7 +29,7 @@ const SvgJobChange24 = forwardRef(function SvgJobChange24(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/Jobs16.tsx
+++ b/packages/picasso/src/Icon/Jobs16.tsx
@@ -29,7 +29,7 @@ const SvgJobs16 = forwardRef(function SvgJobs16(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/Jobs24.tsx
+++ b/packages/picasso/src/Icon/Jobs24.tsx
@@ -29,7 +29,7 @@ const SvgJobs24 = forwardRef(function SvgJobs24(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/Language16.tsx
+++ b/packages/picasso/src/Icon/Language16.tsx
@@ -29,7 +29,7 @@ const SvgLanguage16 = forwardRef(function SvgLanguage16(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/Language24.tsx
+++ b/packages/picasso/src/Icon/Language24.tsx
@@ -29,7 +29,7 @@ const SvgLanguage24 = forwardRef(function SvgLanguage24(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/Leave16.tsx
+++ b/packages/picasso/src/Icon/Leave16.tsx
@@ -29,7 +29,7 @@ const SvgLeave16 = forwardRef(function SvgLeave16(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/Leave24.tsx
+++ b/packages/picasso/src/Icon/Leave24.tsx
@@ -29,7 +29,7 @@ const SvgLeave24 = forwardRef(function SvgLeave24(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/LegalInfo16.tsx
+++ b/packages/picasso/src/Icon/LegalInfo16.tsx
@@ -29,7 +29,7 @@ const SvgLegalInfo16 = forwardRef(function SvgLegalInfo16(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/LegalInfo24.tsx
+++ b/packages/picasso/src/Icon/LegalInfo24.tsx
@@ -29,7 +29,7 @@ const SvgLegalInfo24 = forwardRef(function SvgLegalInfo24(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/Length16.tsx
+++ b/packages/picasso/src/Icon/Length16.tsx
@@ -29,7 +29,7 @@ const SvgLength16 = forwardRef(function SvgLength16(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/Length24.tsx
+++ b/packages/picasso/src/Icon/Length24.tsx
@@ -29,7 +29,7 @@ const SvgLength24 = forwardRef(function SvgLength24(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/Linkedin16.tsx
+++ b/packages/picasso/src/Icon/Linkedin16.tsx
@@ -29,7 +29,7 @@ const SvgLinkedin16 = forwardRef(function SvgLinkedin16(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/Linkedin24.tsx
+++ b/packages/picasso/src/Icon/Linkedin24.tsx
@@ -29,7 +29,7 @@ const SvgLinkedin24 = forwardRef(function SvgLinkedin24(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/Lock16.tsx
+++ b/packages/picasso/src/Icon/Lock16.tsx
@@ -29,7 +29,7 @@ const SvgLock16 = forwardRef(function SvgLock16(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/Lock24.tsx
+++ b/packages/picasso/src/Icon/Lock24.tsx
@@ -29,7 +29,7 @@ const SvgLock24 = forwardRef(function SvgLock24(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/Logo.tsx
+++ b/packages/picasso/src/Icon/Logo.tsx
@@ -29,7 +29,7 @@ const SvgLogo = forwardRef(function SvgLogo(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/LogoEmblem.tsx
+++ b/packages/picasso/src/Icon/LogoEmblem.tsx
@@ -29,7 +29,7 @@ const SvgLogoEmblem = forwardRef(function SvgLogoEmblem(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/Message16.tsx
+++ b/packages/picasso/src/Icon/Message16.tsx
@@ -29,7 +29,7 @@ const SvgMessage16 = forwardRef(function SvgMessage16(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/Message24.tsx
+++ b/packages/picasso/src/Icon/Message24.tsx
@@ -29,7 +29,7 @@ const SvgMessage24 = forwardRef(function SvgMessage24(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/MicrophoneOff16.tsx
+++ b/packages/picasso/src/Icon/MicrophoneOff16.tsx
@@ -29,7 +29,7 @@ const SvgMicrophoneOff16 = forwardRef(function SvgMicrophoneOff16(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/MicrophoneOff24.tsx
+++ b/packages/picasso/src/Icon/MicrophoneOff24.tsx
@@ -29,7 +29,7 @@ const SvgMicrophoneOff24 = forwardRef(function SvgMicrophoneOff24(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/MicrophoneOn16.tsx
+++ b/packages/picasso/src/Icon/MicrophoneOn16.tsx
@@ -29,7 +29,7 @@ const SvgMicrophoneOn16 = forwardRef(function SvgMicrophoneOn16(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/MicrophoneOn24.tsx
+++ b/packages/picasso/src/Icon/MicrophoneOn24.tsx
@@ -29,7 +29,7 @@ const SvgMicrophoneOn24 = forwardRef(function SvgMicrophoneOn24(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/Minus16.tsx
+++ b/packages/picasso/src/Icon/Minus16.tsx
@@ -29,7 +29,7 @@ const SvgMinus16 = forwardRef(function SvgMinus16(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/Minus24.tsx
+++ b/packages/picasso/src/Icon/Minus24.tsx
@@ -29,7 +29,7 @@ const SvgMinus24 = forwardRef(function SvgMinus24(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/More16.tsx
+++ b/packages/picasso/src/Icon/More16.tsx
@@ -29,7 +29,7 @@ const SvgMore16 = forwardRef(function SvgMore16(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/More24.tsx
+++ b/packages/picasso/src/Icon/More24.tsx
@@ -29,7 +29,7 @@ const SvgMore24 = forwardRef(function SvgMore24(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/Morning16.tsx
+++ b/packages/picasso/src/Icon/Morning16.tsx
@@ -29,7 +29,7 @@ const SvgMorning16 = forwardRef(function SvgMorning16(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/Morning24.tsx
+++ b/packages/picasso/src/Icon/Morning24.tsx
@@ -29,7 +29,7 @@ const SvgMorning24 = forwardRef(function SvgMorning24(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/NewCandidate16.tsx
+++ b/packages/picasso/src/Icon/NewCandidate16.tsx
@@ -29,7 +29,7 @@ const SvgNewCandidate16 = forwardRef(function SvgNewCandidate16(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/NewCandidate24.tsx
+++ b/packages/picasso/src/Icon/NewCandidate24.tsx
@@ -29,7 +29,7 @@ const SvgNewCandidate24 = forwardRef(function SvgNewCandidate24(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/Night16.tsx
+++ b/packages/picasso/src/Icon/Night16.tsx
@@ -29,7 +29,7 @@ const SvgNight16 = forwardRef(function SvgNight16(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/Night24.tsx
+++ b/packages/picasso/src/Icon/Night24.tsx
@@ -29,7 +29,7 @@ const SvgNight24 = forwardRef(function SvgNight24(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/Okr16.tsx
+++ b/packages/picasso/src/Icon/Okr16.tsx
@@ -29,7 +29,7 @@ const SvgOkr16 = forwardRef(function SvgOkr16(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/Okr24.tsx
+++ b/packages/picasso/src/Icon/Okr24.tsx
@@ -29,7 +29,7 @@ const SvgOkr24 = forwardRef(function SvgOkr24(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/Overlap16.tsx
+++ b/packages/picasso/src/Icon/Overlap16.tsx
@@ -29,7 +29,7 @@ const SvgOverlap16 = forwardRef(function SvgOverlap16(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/Overlap24.tsx
+++ b/packages/picasso/src/Icon/Overlap24.tsx
@@ -29,7 +29,7 @@ const SvgOverlap24 = forwardRef(function SvgOverlap24(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/Overview16.tsx
+++ b/packages/picasso/src/Icon/Overview16.tsx
@@ -29,7 +29,7 @@ const SvgOverview16 = forwardRef(function SvgOverview16(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/Overview24.tsx
+++ b/packages/picasso/src/Icon/Overview24.tsx
@@ -29,7 +29,7 @@ const SvgOverview24 = forwardRef(function SvgOverview24(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/Participants16.tsx
+++ b/packages/picasso/src/Icon/Participants16.tsx
@@ -29,7 +29,7 @@ const SvgParticipants16 = forwardRef(function SvgParticipants16(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/Participants24.tsx
+++ b/packages/picasso/src/Icon/Participants24.tsx
@@ -29,7 +29,7 @@ const SvgParticipants24 = forwardRef(function SvgParticipants24(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/Pencil16.tsx
+++ b/packages/picasso/src/Icon/Pencil16.tsx
@@ -29,7 +29,7 @@ const SvgPencil16 = forwardRef(function SvgPencil16(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/Pencil24.tsx
+++ b/packages/picasso/src/Icon/Pencil24.tsx
@@ -29,7 +29,7 @@ const SvgPencil24 = forwardRef(function SvgPencil24(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/Performance16.tsx
+++ b/packages/picasso/src/Icon/Performance16.tsx
@@ -29,7 +29,7 @@ const SvgPerformance16 = forwardRef(function SvgPerformance16(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/Performance24.tsx
+++ b/packages/picasso/src/Icon/Performance24.tsx
@@ -29,7 +29,7 @@ const SvgPerformance24 = forwardRef(function SvgPerformance24(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/Phone16.tsx
+++ b/packages/picasso/src/Icon/Phone16.tsx
@@ -29,7 +29,7 @@ const SvgPhone16 = forwardRef(function SvgPhone16(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/Phone24.tsx
+++ b/packages/picasso/src/Icon/Phone24.tsx
@@ -29,7 +29,7 @@ const SvgPhone24 = forwardRef(function SvgPhone24(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/Pin16.tsx
+++ b/packages/picasso/src/Icon/Pin16.tsx
@@ -29,7 +29,7 @@ const SvgPin16 = forwardRef(function SvgPin16(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/Pin24.tsx
+++ b/packages/picasso/src/Icon/Pin24.tsx
@@ -29,7 +29,7 @@ const SvgPin24 = forwardRef(function SvgPin24(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/Plus16.tsx
+++ b/packages/picasso/src/Icon/Plus16.tsx
@@ -29,7 +29,7 @@ const SvgPlus16 = forwardRef(function SvgPlus16(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/Plus24.tsx
+++ b/packages/picasso/src/Icon/Plus24.tsx
@@ -29,7 +29,7 @@ const SvgPlus24 = forwardRef(function SvgPlus24(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/PortfolioDesigner16.tsx
+++ b/packages/picasso/src/Icon/PortfolioDesigner16.tsx
@@ -29,7 +29,7 @@ const SvgPortfolioDesigner16 = forwardRef(function SvgPortfolioDesigner16(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/PortfolioDesigner24.tsx
+++ b/packages/picasso/src/Icon/PortfolioDesigner24.tsx
@@ -29,7 +29,7 @@ const SvgPortfolioDesigner24 = forwardRef(function SvgPortfolioDesigner24(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/PortfolioFinance16.tsx
+++ b/packages/picasso/src/Icon/PortfolioFinance16.tsx
@@ -29,7 +29,7 @@ const SvgPortfolioFinance16 = forwardRef(function SvgPortfolioFinance16(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/PortfolioFinance24.tsx
+++ b/packages/picasso/src/Icon/PortfolioFinance24.tsx
@@ -29,7 +29,7 @@ const SvgPortfolioFinance24 = forwardRef(function SvgPortfolioFinance24(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/Profile16.tsx
+++ b/packages/picasso/src/Icon/Profile16.tsx
@@ -29,7 +29,7 @@ const SvgProfile16 = forwardRef(function SvgProfile16(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/Profile24.tsx
+++ b/packages/picasso/src/Icon/Profile24.tsx
@@ -29,7 +29,7 @@ const SvgProfile24 = forwardRef(function SvgProfile24(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/ReferralBonus16.tsx
+++ b/packages/picasso/src/Icon/ReferralBonus16.tsx
@@ -29,7 +29,7 @@ const SvgReferralBonus16 = forwardRef(function SvgReferralBonus16(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/ReferralBonus24.tsx
+++ b/packages/picasso/src/Icon/ReferralBonus24.tsx
@@ -29,7 +29,7 @@ const SvgReferralBonus24 = forwardRef(function SvgReferralBonus24(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/Referrals16.tsx
+++ b/packages/picasso/src/Icon/Referrals16.tsx
@@ -29,7 +29,7 @@ const SvgReferrals16 = forwardRef(function SvgReferrals16(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/Referrals24.tsx
+++ b/packages/picasso/src/Icon/Referrals24.tsx
@@ -29,7 +29,7 @@ const SvgReferrals24 = forwardRef(function SvgReferrals24(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/Representatives16.tsx
+++ b/packages/picasso/src/Icon/Representatives16.tsx
@@ -29,7 +29,7 @@ const SvgRepresentatives16 = forwardRef(function SvgRepresentatives16(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/Representatives24.tsx
+++ b/packages/picasso/src/Icon/Representatives24.tsx
@@ -29,7 +29,7 @@ const SvgRepresentatives24 = forwardRef(function SvgRepresentatives24(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/Resouces24.tsx
+++ b/packages/picasso/src/Icon/Resouces24.tsx
@@ -29,7 +29,7 @@ const SvgResouces24 = forwardRef(function SvgResouces24(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/Resources16.tsx
+++ b/packages/picasso/src/Icon/Resources16.tsx
@@ -29,7 +29,7 @@ const SvgResources16 = forwardRef(function SvgResources16(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/Rotate16.tsx
+++ b/packages/picasso/src/Icon/Rotate16.tsx
@@ -29,7 +29,7 @@ const SvgRotate16 = forwardRef(function SvgRotate16(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/Rotate24.tsx
+++ b/packages/picasso/src/Icon/Rotate24.tsx
@@ -29,7 +29,7 @@ const SvgRotate24 = forwardRef(function SvgRotate24(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/Search16.tsx
+++ b/packages/picasso/src/Icon/Search16.tsx
@@ -29,7 +29,7 @@ const SvgSearch16 = forwardRef(function SvgSearch16(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/Search24.tsx
+++ b/packages/picasso/src/Icon/Search24.tsx
@@ -29,7 +29,7 @@ const SvgSearch24 = forwardRef(function SvgSearch24(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/Settings16.tsx
+++ b/packages/picasso/src/Icon/Settings16.tsx
@@ -29,7 +29,7 @@ const SvgSettings16 = forwardRef(function SvgSettings16(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/Settings24.tsx
+++ b/packages/picasso/src/Icon/Settings24.tsx
@@ -29,7 +29,7 @@ const SvgSettings24 = forwardRef(function SvgSettings24(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/Share16.tsx
+++ b/packages/picasso/src/Icon/Share16.tsx
@@ -29,7 +29,7 @@ const SvgShare16 = forwardRef(function SvgShare16(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/Share24.tsx
+++ b/packages/picasso/src/Icon/Share24.tsx
@@ -29,7 +29,7 @@ const SvgShare24 = forwardRef(function SvgShare24(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/Skills16.tsx
+++ b/packages/picasso/src/Icon/Skills16.tsx
@@ -29,7 +29,7 @@ const SvgSkills16 = forwardRef(function SvgSkills16(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/Skills24.tsx
+++ b/packages/picasso/src/Icon/Skills24.tsx
@@ -29,7 +29,7 @@ const SvgSkills24 = forwardRef(function SvgSkills24(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/Skype16.tsx
+++ b/packages/picasso/src/Icon/Skype16.tsx
@@ -29,7 +29,7 @@ const SvgSkype16 = forwardRef(function SvgSkype16(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/Skype24.tsx
+++ b/packages/picasso/src/Icon/Skype24.tsx
@@ -29,7 +29,7 @@ const SvgSkype24 = forwardRef(function SvgSkype24(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/Slack16.tsx
+++ b/packages/picasso/src/Icon/Slack16.tsx
@@ -29,7 +29,7 @@ const SvgSlack16 = forwardRef(function SvgSlack16(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/Slack24.tsx
+++ b/packages/picasso/src/Icon/Slack24.tsx
@@ -29,7 +29,7 @@ const SvgSlack24 = forwardRef(function SvgSlack24(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/Sort16.tsx
+++ b/packages/picasso/src/Icon/Sort16.tsx
@@ -29,7 +29,7 @@ const SvgSort16 = forwardRef(function SvgSort16(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/Sort24.tsx
+++ b/packages/picasso/src/Icon/Sort24.tsx
@@ -29,7 +29,7 @@ const SvgSort24 = forwardRef(function SvgSort24(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/Star16.tsx
+++ b/packages/picasso/src/Icon/Star16.tsx
@@ -29,7 +29,7 @@ const SvgStar16 = forwardRef(function SvgStar16(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/Star24.tsx
+++ b/packages/picasso/src/Icon/Star24.tsx
@@ -29,7 +29,7 @@ const SvgStar24 = forwardRef(function SvgStar24(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/StarSolid16.tsx
+++ b/packages/picasso/src/Icon/StarSolid16.tsx
@@ -29,7 +29,7 @@ const SvgStarSolid16 = forwardRef(function SvgStarSolid16(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/Switch16.tsx
+++ b/packages/picasso/src/Icon/Switch16.tsx
@@ -29,7 +29,7 @@ const SvgSwitch16 = forwardRef(function SvgSwitch16(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/Switch24.tsx
+++ b/packages/picasso/src/Icon/Switch24.tsx
@@ -29,7 +29,7 @@ const SvgSwitch24 = forwardRef(function SvgSwitch24(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/Tasks16.tsx
+++ b/packages/picasso/src/Icon/Tasks16.tsx
@@ -29,7 +29,7 @@ const SvgTasks16 = forwardRef(function SvgTasks16(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/Tasks24.tsx
+++ b/packages/picasso/src/Icon/Tasks24.tsx
@@ -29,7 +29,7 @@ const SvgTasks24 = forwardRef(function SvgTasks24(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/Team16.tsx
+++ b/packages/picasso/src/Icon/Team16.tsx
@@ -29,7 +29,7 @@ const SvgTeam16 = forwardRef(function SvgTeam16(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/Team24.tsx
+++ b/packages/picasso/src/Icon/Team24.tsx
@@ -29,7 +29,7 @@ const SvgTeam24 = forwardRef(function SvgTeam24(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/Telegram16.tsx
+++ b/packages/picasso/src/Icon/Telegram16.tsx
@@ -29,7 +29,7 @@ const SvgTelegram16 = forwardRef(function SvgTelegram16(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/Telegram24.tsx
+++ b/packages/picasso/src/Icon/Telegram24.tsx
@@ -29,7 +29,7 @@ const SvgTelegram24 = forwardRef(function SvgTelegram24(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/Terms16.tsx
+++ b/packages/picasso/src/Icon/Terms16.tsx
@@ -29,7 +29,7 @@ const SvgTerms16 = forwardRef(function SvgTerms16(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/Terms24.tsx
+++ b/packages/picasso/src/Icon/Terms24.tsx
@@ -29,7 +29,7 @@ const SvgTerms24 = forwardRef(function SvgTerms24(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/ThumbsDown16.tsx
+++ b/packages/picasso/src/Icon/ThumbsDown16.tsx
@@ -29,7 +29,7 @@ const SvgThumbsDown16 = forwardRef(function SvgThumbsDown16(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/ThumbsDown24.tsx
+++ b/packages/picasso/src/Icon/ThumbsDown24.tsx
@@ -29,7 +29,7 @@ const SvgThumbsDown24 = forwardRef(function SvgThumbsDown24(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/ThumbsUp16.tsx
+++ b/packages/picasso/src/Icon/ThumbsUp16.tsx
@@ -29,7 +29,7 @@ const SvgThumbsUp16 = forwardRef(function SvgThumbsUp16(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/ThumbsUp24.tsx
+++ b/packages/picasso/src/Icon/ThumbsUp24.tsx
@@ -29,7 +29,7 @@ const SvgThumbsUp24 = forwardRef(function SvgThumbsUp24(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/Time16.tsx
+++ b/packages/picasso/src/Icon/Time16.tsx
@@ -29,7 +29,7 @@ const SvgTime16 = forwardRef(function SvgTime16(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/Time24.tsx
+++ b/packages/picasso/src/Icon/Time24.tsx
@@ -29,7 +29,7 @@ const SvgTime24 = forwardRef(function SvgTime24(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/Trash16.tsx
+++ b/packages/picasso/src/Icon/Trash16.tsx
@@ -29,7 +29,7 @@ const SvgTrash16 = forwardRef(function SvgTrash16(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/Trash24.tsx
+++ b/packages/picasso/src/Icon/Trash24.tsx
@@ -29,7 +29,7 @@ const SvgTrash24 = forwardRef(function SvgTrash24(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/Twitter16.tsx
+++ b/packages/picasso/src/Icon/Twitter16.tsx
@@ -29,7 +29,7 @@ const SvgTwitter16 = forwardRef(function SvgTwitter16(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/Twitter24.tsx
+++ b/packages/picasso/src/Icon/Twitter24.tsx
@@ -29,7 +29,7 @@ const SvgTwitter24 = forwardRef(function SvgTwitter24(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/UiGuidelines16.tsx
+++ b/packages/picasso/src/Icon/UiGuidelines16.tsx
@@ -29,7 +29,7 @@ const SvgUiGuidelines16 = forwardRef(function SvgUiGuidelines16(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/UiGuidelines24.tsx
+++ b/packages/picasso/src/Icon/UiGuidelines24.tsx
@@ -29,7 +29,7 @@ const SvgUiGuidelines24 = forwardRef(function SvgUiGuidelines24(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/Update16.tsx
+++ b/packages/picasso/src/Icon/Update16.tsx
@@ -29,7 +29,7 @@ const SvgUpdate16 = forwardRef(function SvgUpdate16(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/Update24.tsx
+++ b/packages/picasso/src/Icon/Update24.tsx
@@ -29,7 +29,7 @@ const SvgUpdate24 = forwardRef(function SvgUpdate24(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/UploadDocument16.tsx
+++ b/packages/picasso/src/Icon/UploadDocument16.tsx
@@ -29,7 +29,7 @@ const SvgUploadDocument16 = forwardRef(function SvgUploadDocument16(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/UploadDocument24.tsx
+++ b/packages/picasso/src/Icon/UploadDocument24.tsx
@@ -29,7 +29,7 @@ const SvgUploadDocument24 = forwardRef(function SvgUploadDocument24(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/VideoOff16.tsx
+++ b/packages/picasso/src/Icon/VideoOff16.tsx
@@ -29,7 +29,7 @@ const SvgVideoOff16 = forwardRef(function SvgVideoOff16(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/VideoOff24.tsx
+++ b/packages/picasso/src/Icon/VideoOff24.tsx
@@ -29,7 +29,7 @@ const SvgVideoOff24 = forwardRef(function SvgVideoOff24(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/VideoOn16.tsx
+++ b/packages/picasso/src/Icon/VideoOn16.tsx
@@ -29,7 +29,7 @@ const SvgVideoOn16 = forwardRef(function SvgVideoOn16(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/VideoOn24.tsx
+++ b/packages/picasso/src/Icon/VideoOn24.tsx
@@ -29,7 +29,7 @@ const SvgVideoOn24 = forwardRef(function SvgVideoOn24(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/View16.tsx
+++ b/packages/picasso/src/Icon/View16.tsx
@@ -29,7 +29,7 @@ const SvgView16 = forwardRef(function SvgView16(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/View24.tsx
+++ b/packages/picasso/src/Icon/View24.tsx
@@ -29,7 +29,7 @@ const SvgView24 = forwardRef(function SvgView24(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/Whatsapp16.tsx
+++ b/packages/picasso/src/Icon/Whatsapp16.tsx
@@ -29,7 +29,7 @@ const SvgWhatsapp16 = forwardRef(function SvgWhatsapp16(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/Whatsapp24.tsx
+++ b/packages/picasso/src/Icon/Whatsapp24.tsx
@@ -29,7 +29,7 @@ const SvgWhatsapp24 = forwardRef(function SvgWhatsapp24(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/WorkExperience16.tsx
+++ b/packages/picasso/src/Icon/WorkExperience16.tsx
@@ -29,7 +29,7 @@ const SvgWorkExperience16 = forwardRef(function SvgWorkExperience16(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/WorkExperience24.tsx
+++ b/packages/picasso/src/Icon/WorkExperience24.tsx
@@ -29,7 +29,7 @@ const SvgWorkExperience24 = forwardRef(function SvgWorkExperience24(
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
-  if (availableClasses[`${colorClassName}`]) {
+  if (availableClasses[colorClassName]) {
     classes.push(availableClasses[colorClassName])
   }
 

--- a/packages/picasso/src/Icon/_generatorTemplate.js
+++ b/packages/picasso/src/Icon/_generatorTemplate.js
@@ -87,7 +87,7 @@ const iconTemplate = ({ template }, opts, { componentName, jsx }) => {
       const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
       const colorClassName = kebabToCamelCase(\`\${color}\`)
 
-      if (availableClasses[\`\${colorClassName}\`]) {
+      if (availableClasses[colorClassName]) {
         classes.push(availableClasses[colorClassName])
       }
 


### PR DESCRIPTION
[FX-593](https://toptal-core.atlassian.net/browse/FX-593)

BREAKING CHANGE:
- Icon: Change type of color prop. Now it accepts string.
`<Settings16 color={palette.red.main} />` -> `<Settings16 color='red' />`

### Description

We had changed the type of `color` prop to accept only strings:
`<Settings16 color={palette.red.main} />` -> `<Settings16 color='red' />`

All examples where changed already in v3