### PR TITLE
chore: update storybook version on release docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@
 
 <br/>
 
-[![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release)
-[![](https://img.shields.io/badge/npm-3.45.0-brightgreen.svg)](https://www.npmjs.com/package/@toptal/picasso)
+[![lerna](https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg)](https://lerna.js.org/)
+[![](https://img.shields.io/badge/npm-4.1.1-brightgreen.svg)](https://www.npmjs.com/package/@toptal/picasso)
 [![#-frontend-exp-core](https://img.shields.io/badge/slack-%23--frontend--exp--core-green.svg)](https://slack.com)
 
 ## Installation instructions

--- a/bin/release-docs
+++ b/bin/release-docs
@@ -1,5 +1,7 @@
 #!/usr/bin/env sh
 
+# Update README.md version
+node -e "require('./bin/utils').bumpReadmeVersion('./packages/picasso', './README.md')"
 yarn build:storybook
 
 # archive ./build/storybook folder to the shared folder with docker root

--- a/bin/utils/bump-readme-version.js
+++ b/bin/utils/bump-readme-version.js
@@ -14,16 +14,16 @@ const getPackageJsonVersion = packageRootDir => {
   return nextVersion
 }
 
-const bumpReadmeVersion = packageRootDir => {
+const bumpReadmeVersion = (packageRootDir, outputReadmePath) => {
   log('')
   log(
     `Bumping README.md version inside build folder of the package: ${packageRootDir}`
   )
 
-  const outputReadme = path.resolve(
-    packageRootDir,
-    `./${BUILD_FOLDER}/README.md`
-  )
+  const outputReadme = outputReadmePath
+    ? path.resolve(outputReadmePath)
+    : path.resolve(packageRootDir, `./${BUILD_FOLDER}/README.md`)
+
   const outputReadmeContent = fs.readFileSync(outputReadme, 'utf8')
   const nextVersion = getPackageJsonVersion(packageRootDir)
 


### PR DESCRIPTION
### Description

Fix `semantic-release` badge and replace with `lerna`
Update version when releasing docs (README.md)