### PR TITLE
fix: fix tree-shaking

### DIFF
--- a/package.json
+++ b/package.json
@@ -121,10 +121,6 @@
       "git add"
     ]
   },
-  "sideEffects": [
-    "**/styles.ts",
-    "**/styles.js"
-  ],
   "config": {
     "commitizen": {
       "path": "./node_modules/cz-conventional-changelog"

--- a/packages/picasso-lab/package.json
+++ b/packages/picasso-lab/package.json
@@ -37,5 +37,9 @@
   "devDependencies": {
     "@types/classnames": "^2.2.9",
     "cross-env": "^6.0.3"
-  }
+  },
+  "sideEffects": [
+    "**/styles.ts",
+    "**/styles.js"
+  ]
 }

--- a/packages/picasso/package.json
+++ b/packages/picasso/package.json
@@ -45,5 +45,9 @@
     "lodash": "^4.17.12",
     "**/marksy/marked": "^0.6.0",
     "**/npx/npm": "^5.7.1"
-  }
+  },
+  "sideEffects": [
+    "**/styles.ts",
+    "**/styles.js"
+  ]
 }

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -35,5 +35,9 @@
     "@types/classnames": "^2.2.9",
     "@types/color": "^3.0.0",
     "cross-env": "^6.0.3"
-  }
+  },
+  "sideEffects": [
+    "**/styles.ts",
+    "**/styles.js"
+  ]
 }


### PR DESCRIPTION
### Description

We are missing `sideEffects` in packages right now, which is turning off tree-shaking for Picasso users