### PR TITLE
fix: correct typings for withClasses HOC

### DIFF
--- a/packages/picasso/src/ButtonGroup/ButtonGroup.tsx
+++ b/packages/picasso/src/ButtonGroup/ButtonGroup.tsx
@@ -8,7 +8,7 @@ import styles from './styles'
 
 export interface Props extends StandardProps, HTMLAttributes<HTMLDivElement> {
   /** List of `Button` components which you want to render as `ButtonGroup` */
-  children?: ReactNode
+  children: ReactNode
 }
 
 export const ButtonGroup = forwardRef<HTMLDivElement, Props>(

--- a/packages/picasso/src/ButtonGroup/test.tsx
+++ b/packages/picasso/src/ButtonGroup/test.tsx
@@ -1,27 +1,23 @@
-import React, { ReactNode } from 'react'
+import React from 'react'
 import { render, cleanup } from '@testing-library/react'
 import Picasso from '@toptal/picasso-shared'
 
 import ButtonGroup from './ButtonGroup'
 import Button from '../Button'
 
-const renderButtonGroup = (children: ReactNode) => {
-  return render(
-    <Picasso loadFonts={false}>
-      <ButtonGroup>{children}</ButtonGroup>
-    </Picasso>
-  )
-}
-
 afterEach(cleanup)
 
 describe('ButtonGroup', () => {
   test('render', () => {
-    const { container } = renderButtonGroup([
-      <Button key='1' />,
-      <Button key='2' active />,
-      <Button key='3' />
-    ])
+    const { container } = render(
+      <Picasso loadFonts={false}>
+        <ButtonGroup>
+          <Button key='1' />
+          <Button key='2' active />
+          <Button key='3' />
+        </ButtonGroup>
+      </Picasso>
+    )
 
     expect(container).toMatchSnapshot()
   })

--- a/packages/shared/src/styles/withClasses/test.tsx
+++ b/packages/shared/src/styles/withClasses/test.tsx
@@ -1,12 +1,13 @@
 import React, { ReactElement } from 'react'
 import { render, cleanup, RenderResult } from '@testing-library/react'
 
+import { Classes } from '../types'
 // --- horrible fix, we need to have a dependency to @toptal/picasso here
 import { Button } from '../../../../../packages/picasso'
 import Picasso from '../../Picasso'
 import withClasses from './withClasses'
 
-const TestComponent = (props: { children: ReactElement }) => {
+const TestComponent = (props: { children: ReactElement; classes: Classes }) => {
   const { children } = props
 
   return children

--- a/packages/shared/src/styles/withClasses/withClasses.tsx
+++ b/packages/shared/src/styles/withClasses/withClasses.tsx
@@ -11,8 +11,10 @@ export interface WithClassesProps {
 }
 
 export default (config: Config) => {
-  return <P extends object>(Component: ComponentType<P>) => {
-    const WithClasses = (props: P & WithClassesProps) => {
+  const withClasses = <T extends WithClassesProps>(
+    Component: ComponentType<T>
+  ) => {
+    const Wrapper = (props: T) => {
       const { children, classes } = props
 
       const modifiedChildren = React.Children.map(children, childNode => {
@@ -37,8 +39,10 @@ export default (config: Config) => {
       return <Component {...props}>{modifiedChildren}</Component>
     }
 
-    WithClasses.displayName = Component.displayName || Component.name
+    Wrapper.displayName = Component.displayName || Component.name
 
-    return WithClasses
+    return Wrapper
   }
+
+  return withClasses
 }


### PR DESCRIPTION
[FX-662](https://toptal-core.atlassian.net/browse/FX-662)

### Description

Seems, during fixing eslint rules I introduced a bug that broke `Button.Group` because of `withClasses` usage.
 
Weird note: no one unit test caught this problem :( 

### How to test

- release canary and check on testbed

### Review

- [ ] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that visuals specs are green [See the documentation](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
