### PR TITLE
fix(input): document rowsMax prop

### DIFF
--- a/packages/picasso/src/Input/Input.tsx
+++ b/packages/picasso/src/Input/Input.tsx
@@ -48,7 +48,7 @@ export interface Props
   multiline?: boolean
   /** Specify rows amount for `TextArea` */
   rows?: string | number
-  /* Maximum number of rows to display when multiline option is set to true. */
+  /** Maximum number of rows to display when multiline option is set to true. */
   rowsMax?: string | number
   /** Type attribute of the Input element. It should be a valid HTML5 input type */
   type?: string


### PR DESCRIPTION
[FX-597](https://toptal-core.atlassian.net/browse/FX-597)

### Description

Turned out, the task in the ticket 597 is already done. `rowsMax` prop is already there and naming it `maxRows` as requested would be a breaking change.

It was not documented though because of the small typo, which I am fixing in this PR.

Here is how everything currently works, I believe this is exactly what is requested in 597

![Peek 2019-12-13 10-20](https://user-images.githubusercontent.com/14070311/70785333-0df85d00-1d93-11ea-912f-996d3bb437b8.gif)
 