### PR TITLE
fix(notification): overflow

### DIFF
--- a/packages/picasso/src/Notification/styles.ts
+++ b/packages/picasso/src/Notification/styles.ts
@@ -6,7 +6,8 @@ PicassoProvider.override(() => ({
     message: {
       display: 'flex',
       padding: 0,
-      maxWidth: '72.5em'
+      maxWidth: '72.5em',
+      minWidth: 0
     }
   }
 }))
@@ -47,7 +48,9 @@ export default ({
 
     // Content
     content: {
-      color: text.primary
+      color: text.primary,
+      overflowWrap: 'break-word',
+      minWidth: 0
     },
     contentCloseButton: {
       paddingRight: '1.5em'


### PR DESCRIPTION
[FX-648](https://toptal-core.atlassian.net/browse/FX-648)

### Description

Fix the overflow of Notification component

### How to test

- Just type into the notification the text without any spaces and then limit the width of it. Overflow happens. With this fix, overflow is handled with the scroll.

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| ![image](https://user-images.githubusercontent.com/14070311/70794721-fcb94b80-1da6-11ea-83d6-bfaeabc6e0c7.png) | ![image](https://user-images.githubusercontent.com/14070311/70794322-11e1aa80-1da6-11ea-8148-4ad9374c648f.png)


### Review

- [ ] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that visuals specs are green [See the documentation](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)