### PR TITLE
fix(Select): allow changing dynamic options

### DIFF
--- a/packages/picasso/src/Select/Select.tsx
+++ b/packages/picasso/src/Select/Select.tsx
@@ -299,6 +299,10 @@ export const Select = forwardRef<HTMLInputElement, Props>(function Select(
     setOptions(filteredOptions)
   }
 
+  const handleFocus = () => {
+    filterOptions(EMPTY_INPUT_VALUE)
+  }
+
   const handleBlur = (event: React.FocusEvent<HTMLInputElement>) => {
     if (!multiple) {
       const hasValue = inputValue !== EMPTY_INPUT_VALUE
@@ -357,7 +361,8 @@ export const Select = forwardRef<HTMLInputElement, Props>(function Select(
     options,
     onSelect: handleSelect,
     onChange: handleChange,
-    onBlur: handleBlur
+    onBlur: handleBlur,
+    onFocus: handleFocus
   })
 
   const emptySelectValue = multiple ? [] : ''
@@ -484,7 +489,7 @@ export const Select = forwardRef<HTMLInputElement, Props>(function Select(
         />
         {dropDownIcon}
       </div>
-      {Boolean(options.length) && (
+      {Boolean(options.length) && !disabled && (
         <Popper autoWidth open={isOpen} anchorEl={inputWrapperRef.current}>
           {renderOptions({
             options,

--- a/packages/picasso/src/Select/useSelect.ts
+++ b/packages/picasso/src/Select/useSelect.ts
@@ -97,6 +97,7 @@ interface Props {
     inputValue: string
   ) => void
   onBlur?: (event: React.FocusEvent<HTMLInputElement>) => void
+  onFocus?: (event: React.FocusEvent<HTMLInputElement>) => void
   getDisplayValue: (item: Option | null) => string
 }
 
@@ -109,6 +110,7 @@ const useSelect = ({
   onKeyDown = () => {},
   onSelect = () => {},
   onBlur = () => {},
+  onFocus = () => {},
   getDisplayValue
 }: Props): {
   getItemProps: (index: number, item: Option) => ItemProps
@@ -169,7 +171,8 @@ const useSelect = ({
     }
   })
 
-  const handleFocusOrClick = () => {
+  const handleFocusOrClick = (event: React.FocusEvent<HTMLInputElement>) => {
+    onFocus(event)
     setOpen(true)
     setHighlightedIndex(FIRST_ITEM_INDEX)
   }


### PR DESCRIPTION
### Description

There is a bug now with `Options` for Select.
If you change `options` prop on the fly when component is mounted. The change will be applied only at the second `focus`. This is a consequence of _not controlled_ `options` prop.

This is a fast fix for this issue, it might work in all cases, but we may investigate more this case to provide a better experience of the component usage

P.S. also fixed the issue with `disabled` Select, so when you click on it - options will not appear