### PR TITLE
chore: export `Autocomplete` internal props

### DIFF
--- a/packages/picasso/src/Autocomplete/index.ts
+++ b/packages/picasso/src/Autocomplete/index.ts
@@ -1,3 +1,6 @@
+import { OmitInternalProps } from '@toptal/picasso-shared'
+
+import { Props as OuterProps } from './Autocomplete'
 export { default } from './Autocomplete'
-export * from './Autocomplete'
 export * from './types'
+export type Props = OmitInternalProps<OuterProps>


### PR DESCRIPTION
### Description

To let user use internal `Autocomplete`'s props without using `OmitInternalProps`. Use the same approach as for `Checkbox` and `Input`

### How to test

- Include default `Autocomplete` and `Props` from the `@toptal/picasso/Autocomplete`

### Review

- [ ] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that visuals specs are green [See the documentation](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
