### PR TITLE
fix(datepicker): fix the picker in Safari

### DIFF
--- a/packages/picasso-lab/src/Calendar/Calendar.tsx
+++ b/packages/picasso-lab/src/Calendar/Calendar.tsx
@@ -38,7 +38,9 @@ const getNormalizedValue = (value: DateOrDateRangeType | undefined) => {
   return { start, end }
 }
 
-export interface Props extends BaseProps {
+export interface Props
+  extends BaseProps,
+    Omit<React.HTMLAttributes<HTMLDivElement>, 'onChange' | 'onBlur'> {
   onChange: (value: DateOrDateRangeType) => void
   onBlur?: (event: React.FocusEvent<HTMLDivElement>) => void
   range?: boolean
@@ -59,7 +61,7 @@ export const Calendar = forwardRef<HTMLDivElement, Props>(function Calendar(
   ref
 ) {
   const classes = useStyles(props)
-  const { range = false, activeMonth, value, onChange, onBlur } = props
+  const { range = false, activeMonth, value, onChange, onBlur, ...rest } = props
 
   const handleChange = (selection: Date | SimpleReactCalendarRangeType) => {
     if (isDateRange(selection)) {
@@ -72,7 +74,7 @@ export const Calendar = forwardRef<HTMLDivElement, Props>(function Calendar(
   }
 
   return (
-    <div ref={ref} onBlur={onBlur}>
+    <div {...rest} ref={ref} onBlur={onBlur}>
       <SimpleReactCalendar
         selected={getNormalizedValue(value)}
         onSelect={handleChange}

--- a/packages/picasso-lab/src/DatePicker/DatePicker.tsx
+++ b/packages/picasso-lab/src/DatePicker/DatePicker.tsx
@@ -9,6 +9,7 @@ import React, {
 import PopperJs from 'popper.js'
 import formatDate from 'date-fns/format'
 import isValid from 'date-fns/isValid'
+import { Theme, makeStyles } from '@material-ui/core/styles'
 import { BaseProps } from '@toptal/picasso-shared'
 import { Container, Input, Form, InputAdornment } from '@toptal/picasso'
 import Popper from '@toptal/picasso/Popper'
@@ -16,6 +17,7 @@ import { Props as InputProps } from '@toptal/picasso/Input'
 import { Calendar16 } from '@toptal/picasso/Icon'
 
 import Calendar, { DateOrDateRangeType, DateRangeType } from '../Calendar'
+import styles from './styles'
 
 export interface Props
   extends BaseProps,
@@ -59,18 +61,25 @@ const isDateValid = (date: string, pattern: string) => {
   return date.length === pattern.length && isValid(new Date(date))
 }
 
-export const DatePicker = ({
-  range,
-  hideOnSelect,
-  displayDateFormat,
-  editDateFormat,
-  onBlur,
-  onChange,
-  value,
-  width,
-  icon,
-  ...rest
-}: Props) => {
+const useStyles = makeStyles<Theme, Props>(styles, {
+  name: 'PicassoDatePicker'
+})
+
+export const DatePicker = (props: Props) => {
+  const {
+    range,
+    hideOnSelect,
+    displayDateFormat,
+    editDateFormat,
+    onBlur,
+    onChange,
+    value,
+    width,
+    icon,
+    ...rest
+  } = props
+  const classes = useStyles(props)
+
   const inputProps = rest
   const errorMessage = `Entered date is invalid, please, check the format "${editDateFormat!.toLowerCase()}"`
 
@@ -240,6 +249,8 @@ export const DatePicker = ({
             value={value}
             onChange={handleCalendarChange}
             onBlur={handleBlur}
+            className={classes.calendar}
+            tabIndex={-1}
           />
         </Popper>
       )}

--- a/packages/picasso-lab/src/DatePicker/styles.ts
+++ b/packages/picasso-lab/src/DatePicker/styles.ts
@@ -1,3 +1,8 @@
 import { createStyles } from '@material-ui/core/styles'
 
-export default () => createStyles({})
+export default () =>
+  createStyles({
+    calendar: {
+      outline: 'none'
+    }
+  })


### PR DESCRIPTION
fix #1000

### Description

event.relatedTarget property can be null for blur events when the next focus target is not valid. We
make the div a valid focus target by adding the tab index attribute.

### How to test

- Visit the storybook using Safari browser

### Screenshots
![screencast 2020-01-08 12-40-47 2020-01-08 12_42_23](https://user-images.githubusercontent.com/2437969/71975477-57ae5900-3214-11ea-8d8b-a1d99ad6242b.gif)

Outline is set to `none` to prevent
<img width="434" alt="Screenshot 2020-01-08 at 12 28 15" src="https://user-images.githubusercontent.com/2437969/71975501-672da200-3214-11ea-989a-a5e90923919d.png">




### Review

- [ ] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that visuals specs are green [See the documentation](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
