### PR TITLE
fix(Notification): [FX-701] Fix missing context in Modal

### DIFF
--- a/packages/shared/src/Picasso/Picasso.tsx
+++ b/packages/shared/src/Picasso/Picasso.tsx
@@ -163,11 +163,9 @@ const Picasso: FunctionComponent<PicassoProps> = ({
     {loadFonts && <FontsLoader />}
     {reset && <CssBaseline />}
     <PicassoGlobalStylesProvider RootComponent={RootComponent!}>
-      <ModalProvider>
-        <NotificationsProvider container={notificationContainer}>
-          {children}
-        </NotificationsProvider>
-      </ModalProvider>
+      <NotificationsProvider container={notificationContainer}>
+        <ModalProvider>{children}</ModalProvider>
+      </NotificationsProvider>
     </PicassoGlobalStylesProvider>
   </MuiThemeProvider>
 )


### PR DESCRIPTION
[FX-701](https://toptal-core.atlassian.net/browse/FX-701)

### Description
Fix for this issue:

<img width="1277" alt="Screenshot 2020-01-09 at 15 28 37" src="https://user-images.githubusercontent.com/2836281/72071558-bf3bd580-32f4-11ea-804c-aa5c2ee9f2de.png">


It's not a really clear issue, but it looks like this error is happening because Modal usually mounted to the `document.body` and in some cases missing notistack context

It looks like if we change the order - it works correctly because only modal (inner part) is working with using the React portal mechanism.