### PR TITLE
fix(datepicker): fix resetting to empty value

### DIFF
--- a/packages/picasso-lab/src/DatePicker/DatePicker.tsx
+++ b/packages/picasso-lab/src/DatePicker/DatePicker.tsx
@@ -98,6 +98,7 @@ export const DatePicker = (props: Props) => {
 
   useLayoutEffect(() => {
     if (!value) {
+      setInputValue(EMPTY_INPUT_VALUE)
       return
     }
 


### PR DESCRIPTION
### Description

Datepicker ignores external attempts to clear its value. this changes fixes the issue.

### How to test

Try to set DatePicker's value to empty string (or anything falsy), from outside of DatePicker.

### Screenshots

![datepicker-reset-value](https://user-images.githubusercontent.com/176665/72167371-51161200-33cb-11ea-9e63-2ce5aa16af10.gif)
DatePicker's value is cleared upon change of the Select field above (due to another issue Select's dropdown is not visible on this gif).

### Review

- [n/a] Annotate all `props` in component with documentation
- [n/a] Create `examples` for component
- [n/a] Ensure that deployed demo has expected results and good examples
- [x] Ensure that visuals specs are green [See the documentation](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
