### PR TITLE
feat(input): add autoFocus prop explicitly to docs

### DIFF
--- a/packages/picasso/src/Input/Input.tsx
+++ b/packages/picasso/src/Input/Input.tsx
@@ -46,6 +46,8 @@ export interface Props
   inputProps?: InputBaseComponentProps
   /** Whether `Input` should be rendered as `TextArea` or not */
   multiline?: boolean
+  /** If true, the input element will be focused during the first mount */
+  autoFocus?: boolean
   /** Specify rows amount for `TextArea` */
   rows?: string | number
   /** Maximum number of rows to display when multiline option is set to true. */
@@ -240,6 +242,7 @@ export const Input = forwardRef<HTMLInputElement, Props>(function Input(
     inputProps,
     children,
     multiline,
+    autoFocus,
     width,
     className,
     style,
@@ -287,6 +290,7 @@ export const Input = forwardRef<HTMLInputElement, Props>(function Input(
       error={error}
       disabled={disabled}
       multiline={multiline}
+      autoFocus={autoFocus}
       rows={rows}
       rowsMax={rowsMax}
       type={type}

--- a/packages/picasso/src/Input/test.tsx
+++ b/packages/picasso/src/Input/test.tsx
@@ -44,3 +44,15 @@ test('shows counter for multiline input', () => {
 
   expect(container).toMatchSnapshot()
 })
+
+test('is focused when autoFocus', () => {
+  const { getByPlaceholderText } = render(
+    <Picasso loadFonts={false}>
+      <Input autoFocus placeholder='test input' />
+    </Picasso>
+  )
+
+  const input = getByPlaceholderText('test input')
+
+  expect(document.activeElement).toEqual(input)
+})

--- a/packages/picasso/src/OutlinedInput/OutlinedInput.tsx
+++ b/packages/picasso/src/OutlinedInput/OutlinedInput.tsx
@@ -35,6 +35,8 @@ export interface Props
   value?: ValueType
   /** Whether `Input` should be rendered as `TextArea` or not */
   multiline?: boolean
+  /** If true, the input element will be focused during the first mount */
+  autoFocus?: boolean
   /** Specify rows amount for `TextArea` */
   rows?: string | number
   /* Maximum number of rows to display when multiline option is set to true. */
@@ -60,6 +62,7 @@ const OutlinedInput = forwardRef<HTMLInputElement, Props>(
       className,
       style,
       multiline,
+      autoFocus,
       rows,
       rowsMax,
       width,
@@ -104,6 +107,7 @@ const OutlinedInput = forwardRef<HTMLInputElement, Props>(
         startAdornment={startAdornment}
         endAdornment={endAdornment}
         multiline={multiline}
+        autoFocus={autoFocus}
         rows={rows}
         rowsMax={rowsMax}
         onChange={onChange}


### PR DESCRIPTION
[FX-714](https://toptal-core.atlassian.net/browse/FX-714)

### Description

autoFocus prop was supproted implicitly by the Input. In this PR I add it into the docs and add the test to ensure this prop is allways supported.

### Review

- [x] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that visuals specs are green [See the documentation](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)