### PR TITLE
feat(Input): hide input when type is hidden

### DIFF
--- a/packages/picasso/src/OutlinedInput/OutlinedInput.tsx
+++ b/packages/picasso/src/OutlinedInput/OutlinedInput.tsx
@@ -141,7 +141,8 @@ const OutlinedInput = forwardRef<HTMLInputElement, Props>(
           root: cx(
             classes.root,
             classes[`root${capitalize(width!)}`],
-            classes[`root${capitalize(size!)}`]
+            classes[`root${capitalize(size!)}`],
+            { [`${classes.hidden}`]: type === 'hidden' }
           ),
           input: cx(classes.input, classes[`input${capitalize(size!)}`]),
           inputMultiline: classes.inputMultiline

--- a/packages/picasso/src/OutlinedInput/styles.ts
+++ b/packages/picasso/src/OutlinedInput/styles.ts
@@ -79,6 +79,9 @@ export default ({ sizes: { input } }: Theme) =>
         visibility: 'visible'
       }
     },
+    hidden: {
+      display: 'none'
+    },
     rootSmall: {
       padding: '0.25rem 0.625rem',
       height: '1.5rem'


### PR DESCRIPTION
[FX-729]

### How to test
Add `type='hidden'` to input and observe empty UI

### Review

- [n/a] Annotate all `props` in component with documentation
- [n/a] Create `examples` for component
- [n/a] Ensure that deployed demo has expected results and good examples
- [x] Ensure that visuals specs are green [See the documentation](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)


[FX-729]: https://toptal-core.atlassian.net/browse/FX-729