### PR TITLE
fix(Select): issue with options stuck in Chrome when reset

### DIFF
--- a/packages/picasso/src/OutlinedInput/OutlinedInput.tsx
+++ b/packages/picasso/src/OutlinedInput/OutlinedInput.tsx
@@ -84,6 +84,9 @@ const ResetButton = ({
       variant='transparent'
       size='small'
       onClick={onClick}
+      onFocus={(
+        event: React.FocusEvent<HTMLButtonElement | HTMLAnchorElement>
+      ) => event.stopPropagation()}
     />
   </InputAdornment>
 )

--- a/packages/picasso/src/Select/useSelect.ts
+++ b/packages/picasso/src/Select/useSelect.ts
@@ -263,6 +263,7 @@ const useSelect = ({
       // keep select options closed
       event.stopPropagation()
 
+      setOpen(false)
       setHighlightedIndex(null)
       handleSelect(event, null)
     }


### PR DESCRIPTION
### Description

Fix of a bug in Chrome that when reset button is clicked, the focus is passed to the Select and options list got stuck at the screen