### PR TITLE
feat: add PageHead component

### DIFF
--- a/.storybook/addons.js
+++ b/.storybook/addons.js
@@ -2,3 +2,4 @@ import 'storybook-readme/register'
 import '@storybook/addon-viewport/register'
 require('./addons/menu-expander/register')
 require('./addons/anchor-link-handler/register')
+require('./addons/document-title/register')

--- a/.storybook/addons/document-title/index.js
+++ b/.storybook/addons/document-title/index.js
@@ -1,0 +1,5 @@
+export const updateDocumentTitle = api => () => {
+  const storyData = api.getCurrentStoryData()
+
+  document.title = `Picasso | ${storyData.name}`
+}

--- a/.storybook/addons/document-title/register.js
+++ b/.storybook/addons/document-title/register.js
@@ -1,0 +1,8 @@
+import addons from '@storybook/addons'
+import { STORY_RENDERED } from '@storybook/core-events'
+
+import { updateDocumentTitle } from './index'
+
+addons.register('TitleAddon', api => {
+  api.on(STORY_RENDERED, updateDocumentTitle(api))
+})

--- a/packages/picasso/package.json
+++ b/packages/picasso/package.json
@@ -31,6 +31,7 @@
     "@toptal/picasso-shared": "^1.4.0",
     "classnames": "^2.2.6",
     "notistack": "^0.9.7",
+    "react-helmet": "^5.2.1",
     "react-modal-hook": "^2.0.0",
     "react-router-dom": "^5.0.1",
     "react-truncate": "^2.4.0"
@@ -38,6 +39,7 @@
   "devDependencies": {
     "@testing-library/jest-dom": "^5.1.1",
     "@types/classnames": "^2.2.9",
+    "@types/react-helmet": "^5.0.15",
     "@types/react-router-dom": "^5.1.3",
     "cross-env": "^6.0.3"
   },

--- a/packages/picasso/src/Page/Page.tsx
+++ b/packages/picasso/src/Page/Page.tsx
@@ -7,6 +7,7 @@ import {
   CompoundedComponentWithRef
 } from '@toptal/picasso-shared'
 
+import PageHead from '../PageHead'
 import PageHeader from '../PageHeader'
 import PageHeaderMenu from '../PageHeaderMenu'
 import PageFooter from '../PageFooter'
@@ -28,6 +29,7 @@ export interface Props extends StandardProps, HTMLAttributes<HTMLDivElement> {
 }
 
 interface StaticProps {
+  Head: typeof PageHead
   Header: typeof PageHeader
   HeaderMenu: typeof PageHeaderMenu
   Content: typeof PageContent
@@ -71,6 +73,8 @@ Page.Footer = PageFooter
 Page.Sidebar = PageSidebar
 
 Page.Banner = PageBanner
+
+Page.Head = PageHead
 
 export default withStyles(styles)(Page) as PicassoComponentWithRef<
   Props,

--- a/packages/picasso/src/Page/story/index.jsx
+++ b/packages/picasso/src/Page/story/index.jsx
@@ -1,4 +1,5 @@
 import pageHeaderStory from '../../PageHeader/story'
+import pageHeadStory from '../../PageHead/story'
 import pageHeaderMenuStory from '../../PageHeaderMenu/story'
 import pageContentStory from '../../PageContent/story'
 import pageFooterStory from '../../PageFooter/story'
@@ -16,6 +17,7 @@ page
   .createTabChapter('Props')
   .addComponentDocs({ component: Page, name: 'Page' })
   .addComponentDocs(pageHeaderStory.componentDocs)
+  .addComponentDocs(pageHeadStory.componentDocs)
   .addComponentDocs(pageHeaderMenuStory.componentDocs)
   .addComponentDocs(pageContentStory.componentDocs)
   .addComponentDocs(pageFooterStory.componentDocs)
@@ -41,6 +43,8 @@ page
   })
 
 page.connect(pageHeaderStory.chapter)
+
+page.connect(pageHeadStory.chapter)
 
 page.connect(pageContentStory.chapter)
 

--- a/packages/picasso/src/PageHead/PageHead.tsx
+++ b/packages/picasso/src/PageHead/PageHead.tsx
@@ -1,0 +1,17 @@
+import React, { ReactNode } from 'react'
+import { Helmet, HelmetProps } from 'react-helmet'
+
+export interface Props extends HelmetProps {
+  /** content that goes to the document head */
+  children?: ReactNode
+}
+
+export const PageHead = (props: Props) => {
+  const { children, ...rest } = props
+
+  return <Helmet {...rest}>{children}</Helmet>
+}
+
+PageHead.displayName = 'PageHead'
+
+export default PageHead

--- a/packages/picasso/src/PageHead/index.ts
+++ b/packages/picasso/src/PageHead/index.ts
@@ -1,0 +1,2 @@
+export { default } from './PageHead'
+export * from './PageHead'

--- a/packages/picasso/src/PageHead/story/index.jsx
+++ b/packages/picasso/src/PageHead/story/index.jsx
@@ -1,0 +1,21 @@
+import { PageHead } from '../PageHead'
+
+import PicassoBook from '~/.storybook/components/PicassoBook'
+
+const componentDocs = PicassoBook.createComponentDocs(PageHead, 'Page.Head')
+
+const chapter = PicassoBook.connectToPage(page =>
+  page.createChapter('Page.Head', 'Manipulate with document head')
+    .addTextSection(`
+      This component is a wrapper around react-helmet, you can use Page.Head as a drop-in replacement
+
+      <Page.Head>
+        <title>My custom title</title>
+      </Page.Head>
+    `)
+)
+
+export default {
+  chapter,
+  componentDocs
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4519,6 +4519,13 @@
   dependencies:
     "@types/react" "*"
 
+"@types/react-helmet@^5.0.15":
+  version "5.0.15"
+  resolved "https://registry.yarnpkg.com/@types/react-helmet/-/react-helmet-5.0.15.tgz#af0370617307e9f062c6aee0f1f5588224ce646e"
+  integrity sha512-CCjqvecDJTXRrHG8aTc2YECcQCl26za/q+NaBRvy/wtm0Uh38koM2dpv2bG1xJV4ckz3t1lm2/5KU6nt2s9BWg==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react-hot-loader@^4.1.0":
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/@types/react-hot-loader/-/react-hot-loader-4.1.1.tgz#8bc0a4add6b97ae833e5124a5591d5320026aa24"
@@ -16365,6 +16372,16 @@ react-helmet-async@^1.0.2:
     react-fast-compare "2.0.4"
     shallowequal "1.1.0"
 
+react-helmet@^5.2.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/react-helmet/-/react-helmet-5.2.1.tgz#16a7192fdd09951f8e0fe22ffccbf9bb3e591ffa"
+  integrity sha512-CnwD822LU8NDBnjCpZ4ySh8L6HYyngViTZLfBBb3NjtrpN8m49clH8hidHouq20I51Y6TpCTISCBbqiY5GamwA==
+  dependencies:
+    object-assign "^4.1.1"
+    prop-types "^15.5.4"
+    react-fast-compare "^2.0.2"
+    react-side-effect "^1.1.0"
+
 react-hot-loader@*, react-hot-loader@^4.12.12:
   version "4.12.18"
   resolved "https://registry.yarnpkg.com/react-hot-loader/-/react-hot-loader-4.12.18.tgz#a9029e34af2690d76208f9a35189d73c2dfea6a7"
@@ -16491,6 +16508,13 @@ react-router@5.1.2:
     react-is "^16.6.0"
     tiny-invariant "^1.0.2"
     tiny-warning "^1.0.0"
+
+react-side-effect@^1.1.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/react-side-effect/-/react-side-effect-1.2.0.tgz#0e940c78faba0c73b9b0eba9cd3dda8dfb7e7dae"
+  integrity sha512-v1ht1aHg5k/thv56DRcjw+WtojuuDHFUgGfc+bFHOWsF4ZK6C2V57DO0Or0GPsg6+LSTE0M6Ry/gfzhzSwbc5w==
+  dependencies:
+    shallowequal "^1.0.1"
 
 react-source-render@^3.0.0-5:
   version "3.0.0-5"
@@ -17697,7 +17721,7 @@ shallow-equal@^1.1.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/shallow-equal/-/shallow-equal-1.2.0.tgz#fd828d2029ff4e19569db7e19e535e94e2d1f5cc"
 
-shallowequal@1.1.0, shallowequal@^1.0.2, shallowequal@^1.1.0:
+shallowequal@1.1.0, shallowequal@^1.0.1, shallowequal@^1.0.2, shallowequal@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/shallowequal/-/shallowequal-1.1.0.tgz#188d521de95b9087404fd4dcb68b13df0ae4e7f8"
 


### PR DESCRIPTION
[FX-122]

### Description

Add and re-export react-helmet, it will be up to user to manipulate it

### How to test

- probably it makes sense to add some demo page

### Review

- [ ] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that visuals specs are green [See the documentation](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)


[FX-122]: https://toptal-core.atlassian.net/browse/FX-122