### PR TITLE
fix: autocomplete with null options

### DIFF
--- a/packages/picasso/src/Autocomplete/Autocomplete.tsx
+++ b/packages/picasso/src/Autocomplete/Autocomplete.tsx
@@ -50,7 +50,7 @@ export interface Props
   /** Label to show when no options were found */
   noOptionsText?: string
   /** List of options */
-  options?: Item[]
+  options?: Item[] | null
   /** A function that takes a display value from the option item */
   getDisplayValue?: (item: Item | null) => string
   /**  Callback invoked when key is pressed */
@@ -154,7 +154,8 @@ export const Autocomplete = forwardRef<HTMLInputElement, Props>(
     const shouldShowOtherOption =
       showOtherOption &&
       value &&
-      options!.every(option => getDisplayValue!(option) !== value)
+      Array.isArray(options) &&
+      options.every(option => getDisplayValue!(option) !== value)
 
     const optionsMenu = options && (
       <ScrollMenu selectedIndex={highlightedIndex}>

--- a/packages/picasso/src/Autocomplete/test.tsx
+++ b/packages/picasso/src/Autocomplete/test.tsx
@@ -275,6 +275,23 @@ describe('Autocomplete', () => {
     expect(getByText(noOptionsText)).not.toBeNull()
   })
 
+  test('when "options" prop is null, no options are shown on focus', () => {
+    const PLACEHOLDER_TEXT = 'Start typing here...'
+    const NO_OPTIONS_TEXT = 'No options'
+
+    const { getByPlaceholderText, queryByText } = renderAutocomplete({
+      placeholder: PLACEHOLDER_TEXT,
+      noOptionsText: NO_OPTIONS_TEXT,
+      value: '',
+      options: null
+    })
+
+    const input = getByPlaceholderText(PLACEHOLDER_TEXT)
+
+    fireEvent.focus(input)
+    expect(queryByText(NO_OPTIONS_TEXT)).toBeNull()
+  })
+
   test('renders options customly', async () => {
     const api = renderAutocomplete({
       placeholder: 'Start typing here...',

--- a/packages/picasso/src/Autocomplete/useAutocomplete.ts
+++ b/packages/picasso/src/Autocomplete/useAutocomplete.ts
@@ -71,7 +71,7 @@ function getNextWrappingIndex(
 
 interface Props {
   value: string
-  options?: Item[]
+  options?: Item[] | null
   enableAutofill?: boolean
   autoComplete?: string
   onSelect?: (item: Item) => void
@@ -182,6 +182,12 @@ const useAutocomplete = ({
     },
 
     onKeyDown: (event: KeyboardEvent<HTMLInputElement>) => {
+      onKeyDown(event, value)
+
+      if (!Array.isArray(options)) {
+        return
+      }
+
       const key = normalizeArrowKey(event)
 
       if (key === 'ArrowUp') {
@@ -237,8 +243,6 @@ const useAutocomplete = ({
         setHighlightedIndex(null)
         handleChange(getDisplayValue(null))
       }
-
-      onKeyDown(event, value)
     },
 
     onBlur: () => setOpen(false),

--- a/packages/picasso/src/TagSelector/TagSelector.tsx
+++ b/packages/picasso/src/TagSelector/TagSelector.tsx
@@ -41,7 +41,7 @@ export interface Props
   /** Allow to show the other option in the list of options */
   showOtherOption?: boolean
   /** List of options with unique labels */
-  options?: Item[]
+  options?: Item[] | null
   /** The list of values of the selected options, required for a controlled component. */
   value?: Item[]
   /** A function that takes a display value from the option item */
@@ -129,7 +129,7 @@ export const TagSelector = forwardRef<HTMLInputElement, Props>(
       )
     }
 
-    const autocompleteOptions: AutocompleteItem[] =
+    const autocompleteOptions: AutocompleteItem[] | null =
       options && options.filter(option => !isIncluded(values, option))
 
     const labels = (


### PR DESCRIPTION
[FX-757](https://toptal-core.atlassian.net/browse/FX-757)

### Description

Right now if `null` is passed as option TS complains because of incorrect typings. Also, code throws an error because it assumes that options are always array: `TypeError: Cannot read property 'every' of null`

1. Fix typings
2. Add guards which check if we have options as an array before operating on it

### How to test

- checkout the current branch;
- navigate to the Demo page using the URL from the comment by @toptal-devbot below;
- paste the following code and focus into the `Autocomplete` input, there should be no errors
```
import React, { useState, useCallback } from 'react'
import { Autocomplete } from '@toptal/picasso'

const AutocompleteDefaultExample = () => {
  const handleChange = (inputValue, options) => {}
  return (
    <div>
      <Autocomplete
        value={'value'}
        onChange={handleChange}
        options={null}
        showOtherOption={true}
        placeholder='Start typing Mongolia...'
      />
    </div>
  )
}

export default AutocompleteDefaultExample
```

### Screenshots

No screenshots for the fix.

### Review

- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure that visuals specs are green [See the documentation](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
