### PR TITLE
fix: follow up fix for autocomplete with null options

### DIFF
--- a/packages/picasso/src/Autocomplete/useAutocomplete.ts
+++ b/packages/picasso/src/Autocomplete/useAutocomplete.ts
@@ -184,10 +184,6 @@ const useAutocomplete = ({
     onKeyDown: (event: KeyboardEvent<HTMLInputElement>) => {
       onKeyDown(event, value)
 
-      if (!Array.isArray(options)) {
-        return
-      }
-
       const key = normalizeArrowKey(event)
 
       if (key === 'ArrowUp') {
@@ -195,7 +191,11 @@ const useAutocomplete = ({
 
         setOpen(true)
         setHighlightedIndex(
-          getNextWrappingIndex(-1, highlightedIndex, options.length)
+          getNextWrappingIndex(
+            -1,
+            highlightedIndex,
+            options ? options.length : 0
+          )
         )
       }
 
@@ -204,7 +204,11 @@ const useAutocomplete = ({
 
         setOpen(true)
         setHighlightedIndex(
-          getNextWrappingIndex(1, highlightedIndex, options.length)
+          getNextWrappingIndex(
+            1,
+            highlightedIndex,
+            options ? options.length : 0
+          )
         )
       }
 
@@ -225,7 +229,7 @@ const useAutocomplete = ({
 
         event.preventDefault()
 
-        const item = options[highlightedIndex]
+        const item = options ? options[highlightedIndex] : null
 
         if (item == null) {
           return


### PR DESCRIPTION
[FX-757](https://toptal-core.atlassian.net/browse/FX-757)

### Description

Right now if `null` is passed as option TS complains because of incorrect typings. Also, code throws an error because it assumes that options are always array: `TypeError: Cannot read property 'every' of null`

1. Fix typings
2. Add guards which check if we have options as an array before operating on it

The errors that need to be fixed as well:

- `TagSelector` and `Autocomplete` should clear input value on Esc regardless of options value;
- `TagSelector` keyboard navigation through the menu has the wrong highlighted index.

### How to test

- checkout the current branch;
- navigate to the Demo page using the URL from the comment by @toptal-devbot below;
- paste the following code and focus into the `Autocomplete` input, there should be no errors
```
import React, { useState, useCallback } from 'react'
import { Autocomplete } from '@toptal/picasso'

const AutocompleteDefaultExample = () => {
  const handleChange = (inputValue, options) => {}
  return (
    <div>
      <Autocomplete
        value={'value'}
        onChange={handleChange}
        options={null}
        showOtherOption={true}
        placeholder='Start typing Mongolia...'
      />
    </div>
  )
}

export default AutocompleteDefaultExample
```

### Screenshots

No screenshots for the fix.

### Review

- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure that visuals specs are green [See the documentation](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
