### PR TITLE
fix(DatePicker): highlight differently not selectable dates

### DIFF
--- a/packages/picasso-lab/src/Calendar/Calendar.tsx
+++ b/packages/picasso-lab/src/Calendar/Calendar.tsx
@@ -116,7 +116,7 @@ export const Calendar = forwardRef<HTMLDivElement, Props>(function Calendar(
                 [classes.today]: isToday,
                 [classes.grayed]:
                   (isMonthPrev || isMonthNext) && !isSelected && !isDisabled,
-                [classes.disabled]: isDisabled,
+                [classes.disabled]: isDisabled || !isSelectable,
                 [classes.startSelection]: isSelectionStart,
                 [classes.endSelection]: isSelectionEnd
               })}


### PR DESCRIPTION
[FX-764]

### Description

Not selectable dates should be displayed properly with minDate and maxDate specified, fixed that

### How to test

- check demo, last example in DatePicker section

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| Insert screenshots or screen recordings | Insert screenshots or screen recordings |

### Review

- [ ] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that visuals specs are green [See the documentation](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)


[FX-764]: https://toptal-core.atlassian.net/browse/FX-764