### PR TITLE
feat: disable responsive ui

### DIFF
--- a/packages/picasso/src/Page/styles.ts
+++ b/packages/picasso/src/Page/styles.ts
@@ -2,12 +2,13 @@ import { createStyles, Theme } from '@material-ui/core/styles'
 
 import { headerHeight } from '../PageHeader/styles'
 
-export default ({ screens }: Theme) =>
+export default ({ screens, layout }: Theme) =>
   createStyles({
     root: {
       display: 'flex',
       flexDirection: 'column',
       height: '100%',
+      ...(layout.contentMinWidth && { minWidth: layout.contentMinWidth }),
 
       '& > footer, & > header': {
         flex: 0

--- a/packages/shared/src/Picasso/Picasso.tsx
+++ b/packages/shared/src/Picasso/Picasso.tsx
@@ -22,12 +22,13 @@ import CssBaseline from '../CssBaseline'
 import {
   palette,
   layout,
+  breakpoints,
+  screens,
   transitions,
   typography,
   sizes,
-  breakpoints,
-  screens,
-  shadows
+  shadows,
+  PicassoBreakpoints
 } from './config'
 import FontsLoader from './FontsLoader'
 import Provider from './PicassoProvider'
@@ -180,6 +181,8 @@ interface PicassoProps {
   loadFavicon?: boolean
   /** Whether to apply Picasso CSS reset */
   reset?: boolean
+  /** Sets a minimum width of the page */
+  responsive?: boolean
   /** Notification DOMNode for createPortal */
   notificationContainer?: HTMLElement
   /** Component that is used to render root node  */
@@ -190,26 +193,35 @@ const Picasso: FunctionComponent<PicassoProps> = ({
   loadFonts,
   loadFavicon,
   reset,
+  responsive,
   children,
   notificationContainer,
   RootComponent
-}) => (
-  <MuiThemeProvider theme={PicassoProvider.theme}>
-    <Viewport />
-    {loadFonts && <FontsLoader />}
-    {reset && <CssBaseline />}
-    {loadFavicon && <Favicon />}
-    <PicassoGlobalStylesProvider RootComponent={RootComponent!}>
-      <NotificationsProvider container={notificationContainer}>
-        <ModalProvider>{children}</ModalProvider>
-      </NotificationsProvider>
-    </PicassoGlobalStylesProvider>
-  </MuiThemeProvider>
-)
+}) => {
+  if (!responsive) {
+    PicassoProvider.disableResponsiveStyle()
+    PicassoBreakpoints.disableMobileBreakpoints()
+  }
+
+  return (
+    <MuiThemeProvider theme={PicassoProvider.theme}>
+      <Viewport />
+      {loadFonts && <FontsLoader />}
+      {reset && <CssBaseline />}
+      {loadFavicon && <Favicon />}
+      <PicassoGlobalStylesProvider RootComponent={RootComponent!}>
+        <NotificationsProvider container={notificationContainer}>
+          <ModalProvider>{children}</ModalProvider>
+        </NotificationsProvider>
+      </PicassoGlobalStylesProvider>
+    </MuiThemeProvider>
+  )
+}
 
 Picasso.defaultProps = {
   loadFonts: true,
   loadFavicon: true,
+  responsive: true,
   reset: true,
   RootComponent: PicassoRootNode
 }

--- a/packages/shared/src/Picasso/PicassoProvider.tsx
+++ b/packages/shared/src/Picasso/PicassoProvider.tsx
@@ -8,6 +8,10 @@ export class PicassoProvider {
     this.theme = theme
   }
 
+  disableResponsiveStyle() {
+    this.theme.layout.contentMinWidth = '768px'
+  }
+
   override(getOverride: (theme: Theme) => Partial<Overrides>) {
     const newOverride = getOverride(this.theme)
 

--- a/packages/shared/src/Picasso/config/index.ts
+++ b/packages/shared/src/Picasso/config/index.ts
@@ -5,11 +5,12 @@ export { default as typography } from './typography'
 export { default as sizes } from './sizes'
 export {
   default as breakpoints,
+  PicassoBreakpoints,
   screens,
-  useScreenSize,
   isScreenSize,
-  useBreakpoint,
   breakpointsList,
+  useScreenSize,
+  useBreakpoint,
   useScreens
 } from './breakpoints'
 export { default as layout } from './layout'

--- a/packages/shared/src/Picasso/config/layout.ts
+++ b/packages/shared/src/Picasso/config/layout.ts
@@ -1,6 +1,7 @@
 export interface Layout {
   contentWidthWide: string
   contentWidth: string
+  contentMinWidth?: string
   contentPaddingHorizontal: string
 }
 

--- a/packages/shared/src/Picasso/config/test.ts
+++ b/packages/shared/src/Picasso/config/test.ts
@@ -1,0 +1,170 @@
+import { isScreenSize, screens, PicassoBreakpoints } from './'
+
+const SCREEN_SIZES = {
+  small: 500,
+  medium: 750,
+  large: 990,
+  extraLarge: 1000
+}
+
+describe('responsive breakpoint utils', () => {
+  describe('media query generation', () => {
+    test('small', () => {
+      const mediaQuery = screens('small')
+      expect(mediaQuery).toEqual('@media (max-width: 576px)')
+    })
+
+    test('small medium', () => {
+      const mediaQuery = screens('small', 'medium')
+      expect(mediaQuery).toEqual(
+        '@media (max-width: 576px), (min-width: 576px) and (max-width: 768px)'
+      )
+    })
+
+    test('small medium large', () => {
+      const mediaQuery = screens('small', 'medium', 'large')
+      expect(mediaQuery).toEqual(
+        '@media (max-width: 576px), (min-width: 576px) and (max-width: 768px), (min-width: 768px) and (max-width: 992px)'
+      )
+    })
+  })
+
+  describe('screen size checks', () => {
+    test('small breakpoint no screen size', () => {
+      const isSmall = isScreenSize('small')
+      expect(isSmall).toBeFalsy()
+    })
+
+    test('small breakpoint on a small screen', () => {
+      const isSmall = isScreenSize('small', SCREEN_SIZES.small)
+      expect(isSmall).toBeTruthy()
+    })
+
+    test('small breakpoint on a large screen', () => {
+      const isSmall = isScreenSize('small', SCREEN_SIZES.large)
+      expect(isSmall).toBeFalsy()
+    })
+
+    test('medium breakpoint no screen size', () => {
+      const isMedium = isScreenSize('medium')
+      expect(isMedium).toBeFalsy()
+    })
+
+    test('medium breakpoint on a small screen', () => {
+      const isMedium = isScreenSize('medium', SCREEN_SIZES.small)
+      expect(isMedium).toBeFalsy()
+    })
+
+    test('medium breakpoint on a medium screen', () => {
+      const isMedium = isScreenSize('medium', SCREEN_SIZES.medium)
+      expect(isMedium).toBeTruthy()
+    })
+
+    test('medium breakpoint on a large screen', () => {
+      const isMedium = isScreenSize('medium', SCREEN_SIZES.large)
+      expect(isMedium).toBeFalsy()
+    })
+
+    test('large breakpoint on a medium screen', () => {
+      const isLarge = isScreenSize('large', SCREEN_SIZES.medium)
+      expect(isLarge).toBeFalsy()
+    })
+
+    test('large breakpoint on a large screen', () => {
+      const isLarge = isScreenSize('large', SCREEN_SIZES.large)
+      expect(isLarge).toBeTruthy()
+    })
+
+    test('extra large breakpoint on a  large screen', () => {
+      const isExtraLarge = isScreenSize('extra-large', SCREEN_SIZES.large)
+      expect(isExtraLarge).toBeFalsy()
+    })
+
+    test('extra large breakpoint on a extra large screen', () => {
+      const isExtraLarge = isScreenSize('extra-large', SCREEN_SIZES.extraLarge)
+      expect(isExtraLarge).toBeTruthy()
+    })
+  })
+})
+
+describe('non-responsive breakpoint utils', () => {
+  beforeAll(() => {
+    PicassoBreakpoints.disableMobileBreakpoints()
+  })
+
+  describe('media query generation', () => {
+    test('small', () => {
+      const mediaQuery = screens('small')
+      expect(mediaQuery).toEqual('')
+    })
+
+    test('small medium', () => {
+      const mediaQuery = screens('small', 'medium')
+      expect(mediaQuery).toEqual('')
+    })
+
+    test('small medium large', () => {
+      const mediaQuery = screens('small', 'medium', 'large')
+      expect(mediaQuery).toEqual(
+        '@media (min-width: 768px) and (max-width: 992px)'
+      )
+    })
+  })
+
+  describe('screen size checks', () => {
+    test('small breakpoint no screen size', () => {
+      const isSmall = isScreenSize('small')
+      expect(isSmall).toBeFalsy()
+    })
+
+    test('small breakpoint on a small screen', () => {
+      const isSmall = isScreenSize('small', SCREEN_SIZES.small)
+      expect(isSmall).toBeTruthy()
+    })
+
+    test('small breakpoint on a large screen', () => {
+      const isSmall = isScreenSize('small', SCREEN_SIZES.large)
+      expect(isSmall).toBeFalsy()
+    })
+
+    test('medium breakpoint no screen size', () => {
+      const isMedium = isScreenSize('medium')
+      expect(isMedium).toBeFalsy()
+    })
+
+    test('medium breakpoint on a small screen', () => {
+      const isMedium = isScreenSize('medium', SCREEN_SIZES.small)
+      expect(isMedium).toBeFalsy()
+    })
+
+    test('medium breakpoint on a medium screen', () => {
+      const isMedium = isScreenSize('medium', SCREEN_SIZES.medium)
+      expect(isMedium).toBeFalsy()
+    })
+
+    test('medium breakpoint on a large screen', () => {
+      const isMedium = isScreenSize('medium', SCREEN_SIZES.large)
+      expect(isMedium).toBeFalsy()
+    })
+
+    test('large breakpoint on a medium screen', () => {
+      const isLarge = isScreenSize('large', SCREEN_SIZES.medium)
+      expect(isLarge).toBeFalsy()
+    })
+
+    test('large breakpoint on a large screen', () => {
+      const isLarge = isScreenSize('large', SCREEN_SIZES.large)
+      expect(isLarge).toBeTruthy()
+    })
+
+    test('extra large breakpoint on a  large screen', () => {
+      const isExtraLarge = isScreenSize('extra-large', SCREEN_SIZES.large)
+      expect(isExtraLarge).toBeFalsy()
+    })
+
+    test('extra large breakpoint on a extra large screen', () => {
+      const isExtraLarge = isScreenSize('extra-large', SCREEN_SIZES.extraLarge)
+      expect(isExtraLarge).toBeTruthy()
+    })
+  })
+})

--- a/packages/shared/src/Picasso/story/DisableResponsiveUI.example.jsx
+++ b/packages/shared/src/Picasso/story/DisableResponsiveUI.example.jsx
@@ -1,0 +1,99 @@
+import React from 'react'
+import styled from 'styled-components'
+// In actual application you can simply do
+// import Picasso, { Page, Container } from '@toptal/picasso'
+import {
+  default as Picasso,
+  Grid,
+  Page,
+  Container,
+  Menu,
+  Typography,
+  Sidebar
+} from '@toptal/picasso'
+
+const PageDefaultExample = () => (
+  <div style={{ height: '30rem' }}>
+    <Page>
+      <Page.Header rightContent={<RightContent />} title='Default example' />
+      <Page.Content>
+        <SidebarMenu />
+        <Content />
+      </Page.Content>
+      <Page.Footer />
+    </Page>
+  </div>
+)
+
+const handleClick = () => window.alert('Item clicked')
+
+const SidebarMenu = () => (
+  <Sidebar>
+    <Sidebar.Menu>
+      <Sidebar.Item>Home</Sidebar.Item>
+      <Sidebar.Item>Contacts</Sidebar.Item>
+      <Sidebar.Item>Team</Sidebar.Item>
+    </Sidebar.Menu>
+  </Sidebar>
+)
+
+const RightContent = () => (
+  <Page.HeaderMenu
+    name='Jacqueline Roque'
+    avatar='./jacqueline-with-flowers-1954-square.jpg'
+  >
+    <Menu>
+      <Menu.Item onClick={handleClick}>My Account</Menu.Item>
+      <Menu.Item onClick={handleClick}>Log Out</Menu.Item>
+    </Menu>
+  </Page.HeaderMenu>
+)
+const StyledMainContentContainer = styled(Container)`
+  flex: 1;
+`
+const Content = () => (
+  <StyledMainContentContainer
+    top='small'
+    bottom='small'
+    left='small'
+    right='small'
+  >
+    <Typography align='center' variant='heading' size='large'>
+      Default example
+    </Typography>
+    <Grid>
+      <Grid.Item small={6}>
+        <p>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+          eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad
+          minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+          aliquip ex ea commodo consequat. Duis aute irure dolor in
+          reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
+          pariatur. Excepteur sint occaecat cupidatat non proident, sunt in
+          culpa qui officia deserunt mollit anim id est laborum.
+        </p>
+      </Grid.Item>
+      <Grid.Item small={6}>
+        <p>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
+          eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad
+          minim veniam, quis nostrud exercitation ullamco laboris nisi ut
+          aliquip ex ea commodo consequat. Duis aute irure dolor in
+          reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
+          pariatur. Excepteur sint occaecat cupidatat non proident, sunt in
+          culpa qui officia deserunt mollit anim id est laborum.
+        </p>
+      </Grid.Item>
+    </Grid>
+  </StyledMainContentContainer>
+)
+
+const Index = () => (
+  <div id='root'>
+    <Picasso responsive={false}>
+      <PageDefaultExample />
+    </Picasso>
+  </div>
+)
+
+export default Index

--- a/packages/shared/src/Picasso/story/index.jsx
+++ b/packages/shared/src/Picasso/story/index.jsx
@@ -20,4 +20,10 @@ page
   .createTabChapter('Props')
   .addComponentDocs({ component: Picasso, name: 'Picasso' })
 
-page.createChapter().addExample('Picasso/story/Default.example.jsx', 'Default')
+page
+  .createChapter()
+  .addExample('Picasso/story/Default.example.jsx', 'Default')
+  .addExample(
+    'Picasso/story/DisableResponsiveUI.example.jsx',
+    'Responsive Disabled'
+  ) // picasso-skip-visuals


### PR DESCRIPTION
[FX-736]

### Description
Added an optional `responsive` prop to the `Picasso` root component. Its default value is `true`

How Picasso works differently than before when `responsive` is true:
- breakpoint values and media queries dict are stored as a class field instead of a variable - https://github.com/toptal/picasso/pull/1113/files#diff-0def246ea83d4cfac63edf0d4d664207R12
- no other changes in use or functionality, just a difference in how the values mentioned are stored

How Picasso works differently when `responsive` is false:
- the conditional in the `Picasso` root component is triggered - https://github.com/toptal/picasso/pull/1113/files#diff-a8abd2991db67ad3d05f1f58cdbb0473R170
- The `Page` component gets a min width of 768px
- `xs` and `sm` breakpoints are reset to `-1` from their default values. I chose `-1` as the override because positive numbers including 0 are used by default. A negative number is invalid as a breakpoint and would make it more obvious that the breakpoint should not be used - https://github.com/toptal/picasso/pull/1113/files#diff-0def246ea83d4cfac63edf0d4d664207R41
- the `small` and `medium` media queries strings are reset to empty strings - https://github.com/toptal/picasso/pull/1113/files#diff-0def246ea83d4cfac63edf0d4d664207R44


### How to test

Go to https://picasso.toptal.net/fx-739-disable-responsive-ui/?path=/story/components-folder--picasso#responsive-disabled

Make sure the responsive UI (like the Sidebar, logo or nav collapsing) doesn't turn on the page remains in desktop mode, overflowing horizontally

### Screenshots

| Responsive enabled                                 | Responsive disabled                                  |
| --------------------------------------- | --------------------------------------- |
| ![localhost_9001__path=_story_picasso-folder--readme](https://user-images.githubusercontent.com/12392666/74426805-fc196000-4e90-11ea-957f-de59a34f644f.png) | ![picasso toptal net_fx-739-disable-responsive-ui__path=_story_components-folder--picasso](https://user-images.githubusercontent.com/12392666/74425835-4c8fbe00-4e8f-11ea-9015-561233ced1ba.png) |


### Review

- [ ] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that visuals specs are green [See the documentation](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)



[FX-736]: https://toptal-core.atlassian.net/browse/FX-736