### PR TITLE
feat: disable overviewblock outline

### DIFF
--- a/packages/picasso-lab/src/OverviewBlock/OverviewBlock.tsx
+++ b/packages/picasso-lab/src/OverviewBlock/OverviewBlock.tsx
@@ -83,13 +83,16 @@ export const OverviewBlock: OverridableComponent<Props> & StaticProps =
       color[partName] = colorName
     }
 
+    const isClickable = Boolean(onClick)
+
     return (
       <Component
         // eslint-disable-next-line react/jsx-props-no-spreading
         {...rest}
         ref={ref}
         className={cx(
-          { [classes.clickable]: Boolean(onClick) },
+          { [classes.clickable]: isClickable },
+          { [classes.disableOutline]: !isClickable },
           classes.root,
           className
         )}

--- a/packages/picasso-lab/src/OverviewBlock/styles.ts
+++ b/packages/picasso-lab/src/OverviewBlock/styles.ts
@@ -18,6 +18,9 @@ export default ({ palette }: Theme) =>
         backgroundColor: palette.grey.lighter
       }
     },
+    disableOutline: {
+      outline: 'none'
+    },
     title: {
       fontSize: rem('11px')
     }


### PR DESCRIPTION
[FX-766]

### Description

Disabled the CSS outline for the OverviewBlock component.

### How to test

- FIXME: Add the steps describing how to verify your changes

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| ![image](https://user-images.githubusercontent.com/12392666/74699266-2ffed780-523b-11ea-97a5-8bc62a738992.png) | ![image](https://user-images.githubusercontent.com/12392666/74699280-3ab96c80-523b-11ea-8cb4-cd1194eb2025.png) |

### Review

- [ ] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that visuals specs are green [See the documentation](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)


[FX-766]: https://toptal-core.atlassian.net/browse/FX-766