### PR TITLE
fix(favicon): prevent webpack compilation warning

### DIFF
--- a/packages/shared/src/Favicon/icons/index.ts
+++ b/packages/shared/src/Favicon/icons/index.ts
@@ -1,8 +1,12 @@
 import { EnvironmentType } from '../types'
 
 const getIcons = (environment: EnvironmentType) => {
-  if (environment === 'staging' || environment === 'production') {
-    return import(`./${environment}`)
+  if (environment === 'staging') {
+    return import('./staging')
+  }
+
+  if (environment === 'production') {
+    return import('./production')
   }
 
   return import('./development')


### PR DESCRIPTION
re #1124

### Description

Avoid param passed to dynamic import to avoid bundling declaration file on the consumer side.

The parametrized dynamic import we have
```
import(`${environment}`)
```
makes Webpack attempt to bundle all modules from the folder, including declaration `index.d.ts.

<img width="563" alt="Screenshot 2020-02-21 at 14 12 42" src="https://user-images.githubusercontent.com/2437969/75042566-e32b3300-54be-11ea-9738-3b3769827a79.png">

### How to test

- Check out master Talent Portal
- use the version from this branch
- I run `yarn build:dist` in the shared package and copied the output folder to my `node_modules` due to #1127

### Review

- [ ] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that visuals specs are green [See the documentation](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
