### PR TITLE
feat: add role for reset button

### DIFF
--- a/packages/picasso/src/Autocomplete/__snapshots__/test.tsx.snap
+++ b/packages/picasso/src/Autocomplete/__snapshots__/test.tsx.snap
@@ -109,6 +109,7 @@ exports[`Autocomplete static behavior default render 1`] = `
           >
             <button
               class="MuiButtonBase-root PicassoButton-circular PicassoButton-small PicassoButton-transparent PicassoButton-root"
+              role="reset"
               tabindex="0"
               type="button"
             >

--- a/packages/picasso/src/Input/__snapshots__/test.tsx.snap
+++ b/packages/picasso/src/Input/__snapshots__/test.tsx.snap
@@ -149,6 +149,7 @@ exports[`should show reset button 1`] = `
       >
         <button
           class="MuiButtonBase-root PicassoButton-circular PicassoButton-small PicassoButton-transparent PicassoButton-root"
+          role="reset"
           tabindex="0"
           type="button"
         >

--- a/packages/picasso/src/OutlinedInput/OutlinedInput.tsx
+++ b/packages/picasso/src/OutlinedInput/OutlinedInput.tsx
@@ -83,6 +83,7 @@ const ResetButton = ({
       circular
       variant='transparent'
       size='small'
+      role='reset'
       onClick={onClick}
       onFocus={(
         event: React.FocusEvent<HTMLButtonElement | HTMLAnchorElement>


### PR DESCRIPTION
### Description

The reset button for `DatePicker` should have a role that would make navigation easier in tests via React Testing Library methods. Please see the discussion at https://toptal-core.slack.com/archives/CERF5NHT3/p1582725959064600

### Review

- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure that visuals specs are green [See the documentation](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
