### PR TITLE
feat(use-modals): implement hideAllModals

### DIFF
--- a/packages/picasso/src/Modal/__snapshots__/test.tsx.snap
+++ b/packages/picasso/src/Modal/__snapshots__/test.tsx.snap
@@ -176,9 +176,7 @@ exports[`useModals opens and closes modal 2`] = `
 `;
 
 exports[`useModals shows multiple modals at the same time 1`] = `
-<body
-  style=""
->
+<body>
   <div>
     <div
       class="Picasso-root"

--- a/packages/picasso/src/Modal/test.tsx
+++ b/packages/picasso/src/Modal/test.tsx
@@ -99,7 +99,7 @@ test('given multiple modals are opened, when navigate from page then all modals 
 
     const handleShowClick = (number: number) => {
       showModal(() => (
-        <Modal container={document.body} open>
+        <Modal open>
           <p>Modal content {number}</p>
         </Modal>
       ))
@@ -139,16 +139,16 @@ test('given multiple modals are opened, when navigate from page then all modals 
   fireEvent.click(showModal2)
 
   // Check modals opened
-  expect(queryByText('Modal content 1')).toBeTruthy()
-  expect(queryByText('Modal content 2')).toBeTruthy()
+  expect(queryByText('Modal content 1')).toBeInTheDocument()
+  expect(queryByText('Modal content 2')).toBeInTheDocument()
 
   // Switch to other page
   const switchPages = getByText('Switch pages')
   fireEvent.click(switchPages)
 
   // Check all modals were auto-closed
-  expect(queryByText('Modal content 1')).toBeFalsy()
-  expect(queryByText('Modal content 2')).toBeFalsy()
+  expect(queryByText('Modal content 1')).not.toBeInTheDocument()
+  expect(queryByText('Modal content 2')).not.toBeInTheDocument()
 })
 
 test('useModals shows multiple modals at the same time', () => {

--- a/packages/picasso/src/utils/Modal/use-modals.tsx
+++ b/packages/picasso/src/utils/Modal/use-modals.tsx
@@ -34,12 +34,11 @@ const generateModalKey = (() => {
 
 const useModals = () => {
   const context = useContext(ModalContext)
-  const openedModalKeys = useRef<string[]>([])
+  const openedModalKeys = useRef<Set<string>>(new Set())
 
   const hideModal = useCallback(
     (key: string) => {
-      openedModalKeys.current = openedModalKeys.current.filter(it => it !== key)
-
+      openedModalKeys.current.delete(key)
       context.hideModal(key)
     },
     [context]
@@ -53,7 +52,7 @@ const useModals = () => {
     }
 
     const key = generateModalKey()
-    openedModalKeys.current = [...openedModalKeys.current, key]
+    openedModalKeys.current.add(key)
 
     context.showModal(key, modal)
 
@@ -61,16 +60,13 @@ const useModals = () => {
   }
 
   const hideAllModals = useCallback(() => {
-    openedModalKeys.current.forEach(key => {
-      hideModal(key)
-    })
+    const keys = [...openedModalKeys.current]
+    keys.forEach(hideModal)
   }, [hideModal])
 
   // Hide all modals when component is unmount
   useEffect(() => {
-    return () => {
-      hideAllModals()
-    }
+    return hideAllModals
   }, [hideAllModals])
 
   const showPrompt = (options: ShowPromptOptions) => {
@@ -114,8 +110,7 @@ const useModals = () => {
   return {
     showModal,
     showPrompt,
-    hideModal,
-    hideAllModals
+    hideModal
   }
 }
 


### PR DESCRIPTION
[FX-797]

### Description
added `hideAllModals` function which can close all modals created by a particular instance of `use-modals` hook.
That is 

GIVEN component `A` uses `use-modals` and opens modals `Ma1` and `Ma2` and component `B` uses `use-modals` and opens modals `Mb1` and `Mb2`  
WHEN `hideAllModals` from `A` is called 
THEN only `Ma1` and `Ma2`are closed while `Mb1` and `Mb2` persist.

If this is incorrect, please let me know.


[FX-797]: https://toptal-core.atlassian.net/browse/FX-797