### PR TITLE
fix(DatePicker): trigger onChange if input is emptied by user

### DIFF
--- a/packages/picasso-lab/src/DatePicker/DatePicker.tsx
+++ b/packages/picasso-lab/src/DatePicker/DatePicker.tsx
@@ -38,7 +38,7 @@ export interface Props
   /** Date that will be selected in Datepicker */
   value?: DateOrDateRangeType
   /** Method that will be invoked with selected values */
-  onChange: (value: DateOrDateRangeType) => void
+  onChange: (value: DateOrDateRangeType | null) => void
   /** Invoked when user goes away from Datepicker input */
   onBlur?: () => void
   /** Whether calendar supports single date selection or range */
@@ -177,7 +177,9 @@ export const DatePicker = (props: Props) => {
     // TODO: add char filtering (only number , `-` or ` ` allowed)
     setInputValue(nextInputValue)
 
-    if (isDateValid(nextInputValue, editDateFormat!)) {
+    if (!nextInputValue) {
+      onChange(null)
+    } else if (isDateValid(nextInputValue, editDateFormat!)) {
       onChange(new Date(nextInputValue))
     }
   }

--- a/packages/picasso-lab/src/DatePicker/test.tsx
+++ b/packages/picasso-lab/src/DatePicker/test.tsx
@@ -35,10 +35,26 @@ describe('DatePicker', () => {
 
     const day15 = getByText(/15/)
 
+    // this line leads to a warning, wrapping into `act` doesn't help
     fireEvent.mouseOver(day15)
 
     const tooltip = getByText('tooltip content')
 
-    expect(tooltip).toBeInTheDOM()
+    expect(tooltip).toBeInTheDocument()
+  })
+
+  test('custom day rendering', () => {
+    const date = new Date('2015-12-12')
+    const handleChange = jest.fn()
+
+    const { getByPlaceholderText } = render(
+      <DatePicker placeholder='input' value={date} onChange={handleChange} />
+    )
+
+    const input = getByPlaceholderText('input')
+
+    fireEvent.change(input, { target: { value: '' } })
+
+    expect(handleChange).toBeCalledWith(null)
   })
 })


### PR DESCRIPTION
[FX-795]

### Description

If user empties the input manually, we need to trigger `onChange`

### How to test

- check demo

### Review

- [ ] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that visuals specs are green [See the documentation](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)


[FX-795]: https://toptal-core.atlassian.net/browse/FX-795