### PR TITLE
fix(modal): avoid circular dependency between modal and useModals hook

### DIFF
--- a/packages/picasso/src/Modal/Modal.tsx
+++ b/packages/picasso/src/Modal/Modal.tsx
@@ -17,7 +17,7 @@ import {
 } from '@toptal/picasso-shared'
 
 import { Close16 } from '../Icon'
-import { useCombinedRefs } from '../utils'
+import useCombinedRefs from '../utils/use-combined-refs'
 import { ModalManager } from '../utils/Modal'
 import ModalTitle from '../ModalTitle'
 import ModalContent from '../ModalContent'

--- a/packages/picasso/src/ModalTitle/ModalTitle.tsx
+++ b/packages/picasso/src/ModalTitle/ModalTitle.tsx
@@ -3,7 +3,7 @@ import { withStyles } from '@material-ui/core/styles'
 import cx from 'classnames'
 import { StandardProps } from '@toptal/picasso-shared'
 
-import { Typography } from '../'
+import Typography from '../Typography'
 import styles from './styles'
 
 export interface Props extends StandardProps, HTMLAttributes<HTMLDivElement> {


### PR DESCRIPTION
re #1144

### Description

Circular dependencies cause `jest` to misbehave, depending on the import order.

### How to test

To reproduce error:
- check out https://github.com/toptal/talent-portal-frontend/pull/418
- run `yarn test:ci`
- see Picasso util functions being undefined

### Screenshot
<img width="1384" alt="Screenshot 2020-03-03 at 10 33 52" src="https://user-images.githubusercontent.com/2437969/75762190-8e977b80-5d3a-11ea-875d-c859a276ca2b.png">

### Review

- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure that visuals specs are green [See the documentation](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
