### PR TITLE
docs(MenuItem): fix warning about ref

### DIFF
--- a/packages/picasso/src/MenuItem/story/Router.example.jsx
+++ b/packages/picasso/src/MenuItem/story/Router.example.jsx
@@ -1,13 +1,13 @@
-import React from 'react'
+import React, { forwardRef } from 'react'
 import { Menu } from '@toptal/picasso'
 
 // Replace with `import { Link } from 'react-router-dom'`
-const Link = ({ to, children, ...rest }) => (
+const Link = forwardRef(({ to, children, ...rest }, ref) => (
   // eslint-disable-next-line react/jsx-props-no-spreading
-  <a href={to} {...rest}>
+  <a href={to} ref={ref} {...rest}>
     {children}
   </a>
-)
+))
 
 const MenuItemRouterExample = () => (
   <div>


### PR DESCRIPTION
No ticket

### Description

Fix a warning, thanks @bioform for notice 

### How to test

- open demo page with menu item, check console - no warnings should be there

### Review

- [ ] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that visuals specs are green [See the documentation](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
