### PR TITLE
fix(slider): fix accessibility of setting value by click on the line

### DIFF
--- a/packages/picasso/src/Slider/Slider.tsx
+++ b/packages/picasso/src/Slider/Slider.tsx
@@ -1,5 +1,5 @@
 import React, { forwardRef, ChangeEvent } from 'react'
-import { withStyles } from '@material-ui/core/styles'
+import { makeStyles, Theme } from '@material-ui/core/styles'
 import MUISlider, {
   SliderProps,
   ValueLabelProps
@@ -7,6 +7,8 @@ import MUISlider, {
 import { Tooltip } from '@toptal/picasso'
 
 import styles from './styles'
+
+const useStyles = makeStyles<Theme, Props>(styles)
 
 type Value = number | number[]
 type ValueLabelDisplay = 'on' | 'auto' | 'off'
@@ -69,12 +71,14 @@ const DefaultTooltip = (
 }
 
 export const Slider = forwardRef<HTMLElement, Props>(function Slider(
-  {
+  props,
+  ref
+) {
+  const {
     min,
     max,
     value,
     defaultValue = 0,
-    classes,
     tooltip,
     tooltipFormat,
     TooltipComponent: UserDefinedTooltip,
@@ -82,30 +86,31 @@ export const Slider = forwardRef<HTMLElement, Props>(function Slider(
     disabled,
     onChange,
     ...rest
-  },
-  ref
-) {
+  } = props
+  const classes = useStyles(props)
   const isTooltipAlwaysVisible = tooltip === 'on'
   const ValueLabelComponent = (UserDefinedTooltip ||
     DefaultTooltip(isTooltipAlwaysVisible)) as typeof UserDefinedTooltip
 
   return (
-    <MUISlider
-      // eslint-disable-next-line react/jsx-props-no-spreading
-      {...rest}
-      ref={ref}
-      defaultValue={defaultValue}
-      value={value}
-      min={min}
-      max={max}
-      step={step}
-      disabled={disabled}
-      classes={classes}
-      ValueLabelComponent={ValueLabelComponent}
-      valueLabelFormat={tooltipFormat}
-      valueLabelDisplay={tooltip}
-      onChange={onChange}
-    />
+    <div className={classes.wrapper}>
+      <MUISlider
+        // eslint-disable-next-line react/jsx-props-no-spreading
+        {...rest}
+        ref={ref}
+        defaultValue={defaultValue}
+        value={value}
+        min={min}
+        max={max}
+        step={step}
+        disabled={disabled}
+        classes={classes}
+        ValueLabelComponent={ValueLabelComponent}
+        valueLabelFormat={tooltipFormat}
+        valueLabelDisplay={tooltip}
+        onChange={onChange}
+      />
+    </div>
   )
 })
 
@@ -118,4 +123,4 @@ Slider.defaultProps = {
   tooltip: 'off'
 }
 
-export default withStyles(styles)(Slider)
+export default Slider

--- a/packages/picasso/src/Slider/__snapshots__/test.tsx.snap
+++ b/packages/picasso/src/Slider/__snapshots__/test.tsx.snap
@@ -2,62 +2,70 @@
 
 exports[`Slider default render 1`] = `
 <div>
-  <span
-    class="MuiSlider-root Slider-root MuiSlider-colorPrimary"
+  <div
+    class="makeStyles-wrapper"
   >
     <span
-      class="MuiSlider-rail Slider-rail"
-    />
-    <span
-      class="MuiSlider-track Slider-track"
-      style="left: 0%; width: 0%;"
-    />
-    <input
-      type="hidden"
-      value="0"
-    />
-    <span
-      aria-orientation="horizontal"
-      aria-valuemax="100"
-      aria-valuemin="0"
-      aria-valuenow="0"
-      class="MuiSlider-thumb Slider-thumb MuiSlider-thumbColorPrimary"
-      data-index="0"
-      role="slider"
-      style="left: 0%;"
-      tabindex="0"
-    />
-  </span>
+      class="MuiSlider-root makeStyles-root MuiSlider-colorPrimary"
+    >
+      <span
+        class="MuiSlider-rail makeStyles-rail"
+      />
+      <span
+        class="MuiSlider-track makeStyles-track"
+        style="left: 0%; width: 0%;"
+      />
+      <input
+        type="hidden"
+        value="0"
+      />
+      <span
+        aria-orientation="horizontal"
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="0"
+        class="MuiSlider-thumb makeStyles-thumb MuiSlider-thumbColorPrimary"
+        data-index="0"
+        role="slider"
+        style="left: 0%;"
+        tabindex="0"
+      />
+    </span>
+  </div>
 </div>
 `;
 
 exports[`Slider with initial value 1`] = `
 <div>
-  <span
-    class="MuiSlider-root Slider-root MuiSlider-colorPrimary"
+  <div
+    class="makeStyles-wrapper"
   >
     <span
-      class="MuiSlider-rail Slider-rail"
-    />
-    <span
-      class="MuiSlider-track Slider-track"
-      style="left: 0%; width: 4%;"
-    />
-    <input
-      type="hidden"
-      value="4"
-    />
-    <span
-      aria-orientation="horizontal"
-      aria-valuemax="100"
-      aria-valuemin="0"
-      aria-valuenow="4"
-      class="MuiSlider-thumb Slider-thumb MuiSlider-thumbColorPrimary"
-      data-index="0"
-      role="slider"
-      style="left: 4%;"
-      tabindex="0"
-    />
-  </span>
+      class="MuiSlider-root makeStyles-root MuiSlider-colorPrimary"
+    >
+      <span
+        class="MuiSlider-rail makeStyles-rail"
+      />
+      <span
+        class="MuiSlider-track makeStyles-track"
+        style="left: 0%; width: 4%;"
+      />
+      <input
+        type="hidden"
+        value="4"
+      />
+      <span
+        aria-orientation="horizontal"
+        aria-valuemax="100"
+        aria-valuemin="0"
+        aria-valuenow="4"
+        class="MuiSlider-thumb makeStyles-thumb MuiSlider-thumbColorPrimary"
+        data-index="0"
+        role="slider"
+        style="left: 4%;"
+        tabindex="0"
+      />
+    </span>
+  </div>
 </div>
 `;

--- a/packages/picasso/src/Slider/styles.ts
+++ b/packages/picasso/src/Slider/styles.ts
@@ -13,11 +13,14 @@ PicassoProvider.override(() => ({
 
 export default ({ palette }: Theme) =>
   createStyles({
+    wrapper: {
+      margin: `${rem('6px')} 0`
+    },
     root: {
       display: 'block',
       color: palette.grey.main,
-      margin: `${rem('6px')} 0`,
-      padding: 0,
+      padding: `${rem('6px')} 0`,
+      margin: `-${rem('6px')} 0`,
       height: rem('1px')
     },
     rail: {


### PR DESCRIPTION
re #1151

### Description

Replace margin with padding to increase the interactive area around 1px line.

### How to test

- https://picasso.toptal.net/fix-accessibility-of-the-slider/?path=/story/components-folder--slider

### Screenshots

#### Before
![screencast 2020-03-06 11-26-47 2020-03-06 11_27_31](https://user-images.githubusercontent.com/2437969/76076368-0534b300-5f9f-11ea-8518-3e2e012af050.gif)

#### After
![screencast 2020-03-06 11-39-22 2020-03-06 11_39_49](https://user-images.githubusercontent.com/2437969/76076460-357c5180-5f9f-11ea-82dd-381d2bbfaa04.gif)


### Review

- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure that visuals specs are green [See the documentation](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
