### PR TITLE
test(pageheader): wait for user avatar to load in PageHeader examples

### DIFF
--- a/packages/picasso/src/PageHeader/story/index.jsx
+++ b/packages/picasso/src/PageHeader/story/index.jsx
@@ -9,11 +9,14 @@ const chapter = PicassoBook.connectToPage(page =>
     .createChapter('Page.Header', 'A Header component')
     .addExample('PageHeader/story/Default.example.jsx', 'Default')
     .addExample('PageHeader/story/Variants.example.jsx', 'Variants')
-    .addExample('PageHeader/story/RightContent.example.jsx', 'Right content')
-    .addExample(
-      'PageHeader/story/ExtraMenuContent.example.jsx',
-      'Extra header menu content'
-    )
+    .addExample('PageHeader/story/RightContent.example.jsx', {
+      title: 'Right content',
+      waitUntilImagesLoaded: true
+    })
+    .addExample('PageHeader/story/ExtraMenuContent.example.jsx', {
+      title: 'Extra header menu content',
+      waitUntilImagesLoaded: true
+    })
     .addExample('PageHeader/story/Link.example.jsx', 'With link')
     .addExample('PageHeader/story/WithoutTitle.example.jsx', 'Without title')
 )


### PR DESCRIPTION
no ticket, flaky visual test https://jenkins-build.toptal.net/job/picasso-pr-specs/1335//Visual_20Regression_20Tests/

### Description

Visual tests for PageHeader component should wait for the user avatar image to load.

### How to test

- See green CI

### Review

- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure that visuals specs are green [See the documentation](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
