### PR TITLE
fix(slider): get rid of error about incorrect class override

### DIFF
--- a/packages/picasso/src/Slider/Slider.tsx
+++ b/packages/picasso/src/Slider/Slider.tsx
@@ -87,13 +87,13 @@ export const Slider = forwardRef<HTMLElement, Props>(function Slider(
     onChange,
     ...rest
   } = props
-  const classes = useStyles(props)
+  const { wrapper, ...classes } = useStyles(props)
   const isTooltipAlwaysVisible = tooltip === 'on'
   const ValueLabelComponent = (UserDefinedTooltip ||
     DefaultTooltip(isTooltipAlwaysVisible)) as typeof UserDefinedTooltip
 
   return (
-    <div className={classes.wrapper}>
+    <div className={wrapper}>
       <MUISlider
         // eslint-disable-next-line react/jsx-props-no-spreading
         {...rest}


### PR DESCRIPTION
follow-up for #1152 

### Description

I can't reproduce this error on Picasso website or storybook, but it fails in our tests after updating Picasso.
We can't pass the full classes object override to MUI if it contains extra keys.

### How to test

- See no error in tests

### Screenshots

<img width="1361" alt="Screenshot 2020-03-06 at 17 03 55" src="https://user-images.githubusercontent.com/2437969/76100181-89e9f600-5fcc-11ea-98ff-ec5a097980f2.png">


### Review

- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure that visuals specs are green [See the documentation](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
