### PR TITLE
fix(notificationprovider): fix notification spacing on pages with header

### DIFF
--- a/packages/shared/src/Picasso/NotificationsProvider/NotificationsProvider.tsx
+++ b/packages/shared/src/Picasso/NotificationsProvider/NotificationsProvider.tsx
@@ -1,10 +1,11 @@
 import { SnackbarProvider } from 'notistack'
 import React, { FunctionComponent } from 'react'
+import { makeStyles } from '@material-ui/styles'
 
+import styles from './styles'
 import { usePageHeader } from '../Picasso'
 
-// --- need to move to shared config
-export const headerHeight = { default: '4.5rem', smallAndMedium: '3rem' }
+const useStyles = makeStyles(styles)
 
 const MAX_NOTIFICATION_MESSAGES = 5
 
@@ -18,12 +19,21 @@ const NotificationsProvider: FunctionComponent<Props> = ({
   container
 }) => {
   const { hasPageHeader } = usePageHeader()
+  const classes = useStyles()
+
+  const containerAnchorOriginTop = hasPageHeader
+    ? classes.rootWithMargin
+    : undefined
 
   return (
     <SnackbarProvider
       maxSnack={MAX_NOTIFICATION_MESSAGES}
       domRoot={container}
-      style={hasPageHeader ? { marginTop: headerHeight.default } : undefined}
+      classes={{
+        containerAnchorOriginTopRight: containerAnchorOriginTop,
+        containerAnchorOriginTopLeft: containerAnchorOriginTop,
+        containerAnchorOriginTopCenter: containerAnchorOriginTop
+      }}
     >
       {children}
     </SnackbarProvider>

--- a/packages/shared/src/Picasso/NotificationsProvider/index.ts
+++ b/packages/shared/src/Picasso/NotificationsProvider/index.ts
@@ -1,0 +1,1 @@
+export { default } from './NotificationsProvider'

--- a/packages/shared/src/Picasso/NotificationsProvider/styles.ts
+++ b/packages/shared/src/Picasso/NotificationsProvider/styles.ts
@@ -1,0 +1,10 @@
+import { createStyles } from '@material-ui/core'
+
+// --- need to move to shared config
+export const headerHeight = { default: '4.5rem', smallAndMedium: '3rem' }
+
+export default createStyles({
+  rootWithMargin: {
+    marginTop: headerHeight.default
+  }
+})


### PR DESCRIPTION
re #1168

### Description
When the page is rendered with Page.Header, the spacing between notification messages is excessive.

Fixed by styling only the container, not all the snackbars
https://iamhosseindhv.com/notistack/api#classes

### How to test

1. Update the default example of Notifications stream with:
```jsx
import React from 'react'
import { Page, Button } from '@toptal/picasso'
import { useNotifications } from '@toptal/picasso/utils'

const DefaultExample = () => {
  const { showInfo } = useNotifications()

  return (
    <Page>
      <Page.Header></Page.Header>
    <Button
      variant='flat'
      onClick={() =>
        showInfo("That's one small step for a man, one giant leap for mankind.")
      }
    >
      Show general notification
    </Button>
    </Page>
  )
}

export default DefaultExample
```
2. Click on `Show general notification` button multiple times

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| ![Screenshot 2020-03-17 at 09 26 52](https://user-images.githubusercontent.com/2437969/76840529-a93c1b00-6837-11ea-8021-79600df3a27e.png) | ![Screenshot 2020-03-17 at 10 11 56](https://user-images.githubusercontent.com/2437969/76840595-c2dd6280-6837-11ea-9731-663d88ab586a.png) |

### Review

- [ ] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that visuals specs are green [See the documentation](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
