### PR TITLE
chore: remove fancy Example names

### DIFF
--- a/.storybook/stories/tutorials/Forms/story/Forms.1.example.jsx
+++ b/.storybook/stories/tutorials/Forms/story/Forms.1.example.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Grid, Form, Input } from '@toptal/picasso'
 
-const FormsExample = () => (
+const Example = () => (
   <div>
     <Grid justifyContent='center' alignItems='center'>
       <Grid.Item small={12} medium={8} large={6}>
@@ -15,4 +15,4 @@ const FormsExample = () => (
   </div>
 )
 
-export default FormsExample
+export default Example

--- a/.storybook/stories/tutorials/Forms/story/Forms.2.example.jsx
+++ b/.storybook/stories/tutorials/Forms/story/Forms.2.example.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Grid, Checkbox, Select, Input, Form } from '@toptal/picasso'
 
-const FormsExample = () => (
+const Example = () => (
   <div>
     <Grid justifyContent='center' alignItems='center'>
       <Grid.Item small={12} medium={8} large={6}>
@@ -38,4 +38,4 @@ const OPTIONS = [
   { value: '4', text: 'Option 4' }
 ]
 
-export default FormsExample
+export default Example

--- a/.storybook/stories/tutorials/Forms/story/Forms.3.example.jsx
+++ b/.storybook/stories/tutorials/Forms/story/Forms.3.example.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Grid, Checkbox, Select, Input, Form } from '@toptal/picasso'
 
-const FormsExample = () => (
+const Example = () => (
   <div>
     <Grid justifyContent='center' alignItems='center'>
       <Grid.Item small={12} medium={8} large={6}>
@@ -53,4 +53,4 @@ const OPTIONS = [
   { value: '4', text: 'Option 4' }
 ]
 
-export default FormsExample
+export default Example

--- a/.storybook/stories/tutorials/Forms/story/Forms.4.example.jsx
+++ b/.storybook/stories/tutorials/Forms/story/Forms.4.example.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Grid, Checkbox, Select, Input, Form } from '@toptal/picasso'
 
-const FormsExample = () => (
+const Example = () => (
   <div>
     <Grid justifyContent='center' alignItems='center'>
       <Grid.Item small={12} medium={8} large={6}>
@@ -65,4 +65,4 @@ const OPTIONS = [
   { value: '4', text: 'Option 4' }
 ]
 
-export default FormsExample
+export default Example

--- a/.storybook/stories/tutorials/Forms/story/Forms.final.example.jsx
+++ b/.storybook/stories/tutorials/Forms/story/Forms.final.example.jsx
@@ -11,7 +11,7 @@ import {
   Form
 } from '@toptal/picasso'
 
-const FormsExample = () => (
+const Example = () => (
   <div>
     <Grid justifyContent='center' alignItems='center'>
       <Grid.Item small={12} medium={8} large={6}>
@@ -88,4 +88,4 @@ const HorizontalRadioGroup = styled(Radio.Group)`
   flex-direction: row;
 `
 
-export default FormsExample
+export default Example

--- a/.storybook/stories/tutorials/Layout/story/Layout.1.example.jsx
+++ b/.storybook/stories/tutorials/Layout/story/Layout.1.example.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Page } from '@toptal/picasso'
 
-const LayoutExample = () => (
+const Example = () => (
   <div style={{ height: '40rem' }}>
     <Page>
       <Page.Header title='How to layout a page' />
@@ -11,4 +11,4 @@ const LayoutExample = () => (
   </div>
 )
 
-export default LayoutExample
+export default Example

--- a/.storybook/stories/tutorials/Layout/story/Layout.2.example.jsx
+++ b/.storybook/stories/tutorials/Layout/story/Layout.2.example.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Page, Container } from '@toptal/picasso'
 
-const LayoutExample = () => (
+const Example = () => (
   <div style={{ height: '40rem' }}>
     <Page>
       <Page.Header title='How to layout a page' />
@@ -14,4 +14,4 @@ const LayoutExample = () => (
   </div>
 )
 
-export default LayoutExample
+export default Example

--- a/.storybook/stories/tutorials/Layout/story/Layout.3.example.jsx
+++ b/.storybook/stories/tutorials/Layout/story/Layout.3.example.jsx
@@ -12,7 +12,7 @@ const SidebarMenu = () => (
   </Sidebar>
 )
 
-const LayoutExample = () => (
+const Example = () => (
   <div style={{ height: '40rem' }}>
     <Page>
       <Page.Header title='How to layout a page' />
@@ -25,4 +25,4 @@ const LayoutExample = () => (
   </div>
 )
 
-export default LayoutExample
+export default Example

--- a/.storybook/stories/tutorials/Layout/story/Layout.final.example.jsx
+++ b/.storybook/stories/tutorials/Layout/story/Layout.final.example.jsx
@@ -47,7 +47,7 @@ const MainContent = () => (
   </StyledMainContentContainer>
 )
 
-const LayoutExample = () => (
+const Example = () => (
   <div style={{ height: '40rem' }}>
     <Page>
       <Page.Header title='How to layout a page' />
@@ -69,4 +69,4 @@ const StyledDetailsContainer = styled(Container)`
   background-color: ${palette.common.white};
 `
 
-export default LayoutExample
+export default Example

--- a/.storybook/stories/tutorials/Spacings/story/Spacings.1.example.jsx
+++ b/.storybook/stories/tutorials/Spacings/story/Spacings.1.example.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Container, Paper } from '@toptal/picasso'
 
-const SpacingsExample = () => (
+const Example = () => (
   <div style={{ width: '35rem' }}>
     <Paper>
       <Container padded='medium'>Card content</Container>
@@ -9,4 +9,4 @@ const SpacingsExample = () => (
   </div>
 )
 
-export default SpacingsExample
+export default Example

--- a/.storybook/stories/tutorials/Spacings/story/Spacings.2.example.jsx
+++ b/.storybook/stories/tutorials/Spacings/story/Spacings.2.example.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Container, Typography, Paper, Stepper } from '@toptal/picasso'
 
-const SpacingsExample = () => (
+const Example = () => (
   <div style={{ width: '35rem' }}>
     <Paper>
       <Container padded='medium'>
@@ -23,4 +23,4 @@ const SpacingsExample = () => (
   </div>
 )
 
-export default SpacingsExample
+export default Example

--- a/.storybook/stories/tutorials/Spacings/story/Spacings.final.example.jsx
+++ b/.storybook/stories/tutorials/Spacings/story/Spacings.final.example.jsx
@@ -10,7 +10,7 @@ const JobCandidate = () => (
   </Container>
 )
 
-const SpacingsExample = () => (
+const Example = () => (
   <div style={{ width: '35rem' }}>
     <Paper>
       <Container padded='medium'>
@@ -43,4 +43,4 @@ const SpacingsExample = () => (
   </div>
 )
 
-export default SpacingsExample
+export default Example

--- a/packages/picasso/src/Accordion/story/AccordionGroup.example.jsx
+++ b/packages/picasso/src/Accordion/story/AccordionGroup.example.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Accordion } from '@toptal/picasso'
 
-const AccordionAccordionGroupExample = () => (
+const Example = () => (
   <div style={{ width: '430px' }}>
     <Accordion content={<DetailsDogDefinitionPanel />}>
       <Accordion.Summary>What is a dog?</Accordion.Summary>
@@ -42,4 +42,4 @@ const DetailsDogAcquirePanel = () => (
   </Accordion.Details>
 )
 
-export default AccordionAccordionGroupExample
+export default Example

--- a/packages/picasso/src/Accordion/story/Controlled.example.jsx
+++ b/packages/picasso/src/Accordion/story/Controlled.example.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Accordion, Button, Container } from '@toptal/picasso'
 
-const AccordionControlledExample = () => {
+const Example = () => {
   const [expanded, setExpanded] = React.useState(true)
 
   return (
@@ -24,4 +24,4 @@ const DetailsDogDefinitionPanel = () => (
   </Accordion.Details>
 )
 
-export default AccordionControlledExample
+export default Example

--- a/packages/picasso/src/Accordion/story/CustomFontStyling.example.jsx
+++ b/packages/picasso/src/Accordion/story/CustomFontStyling.example.jsx
@@ -9,7 +9,7 @@ const DetailsDogDefinitionPanel = () => (
   </Typography>
 )
 
-const AccordionDefaultExample = () => {
+const Example = () => {
   return (
     <div style={{ width: '430px' }}>
       <Accordion content={<DetailsDogDefinitionPanel />}>
@@ -19,4 +19,4 @@ const AccordionDefaultExample = () => {
   )
 }
 
-export default AccordionDefaultExample
+export default Example

--- a/packages/picasso/src/Accordion/story/Default.example.jsx
+++ b/packages/picasso/src/Accordion/story/Default.example.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Accordion } from '@toptal/picasso'
 
-const AccordionDefaultExample = () => {
+const Example = () => {
   return (
     <div style={{ width: '430px' }}>
       <Accordion content={<DetailsDogDefinitionPanel />}>
@@ -19,4 +19,4 @@ const DetailsDogDefinitionPanel = () => (
   </Accordion.Details>
 )
 
-export default AccordionDefaultExample
+export default Example

--- a/packages/picasso/src/AccountSelect/story/Default.example.jsx
+++ b/packages/picasso/src/AccountSelect/story/Default.example.jsx
@@ -22,7 +22,7 @@ const accounts = [
   }
 ]
 
-const AccountSelectDefaultExample = () => (
+const Example = () => (
   <div>
     <AccountSelect
       accounts={accounts}
@@ -31,4 +31,4 @@ const AccountSelectDefaultExample = () => (
   </div>
 )
 
-export default AccountSelectDefaultExample
+export default Example

--- a/packages/picasso/src/AccountSelect/story/Page.example.jsx
+++ b/packages/picasso/src/AccountSelect/story/Page.example.jsx
@@ -29,7 +29,7 @@ const accounts = [
   }
 ]
 
-const AccountSelectPageExample = () => (
+const Example = () => (
   <Page>
     <Page.Content>
       <Grid justifyContent='center'>
@@ -52,4 +52,4 @@ const AccountSelectPageExample = () => (
   </Page>
 )
 
-export default AccountSelectPageExample
+export default Example

--- a/packages/picasso/src/Amount/story/Currency.example.jsx
+++ b/packages/picasso/src/Amount/story/Currency.example.jsx
@@ -1,7 +1,7 @@
 import { Amount, Container, Typography } from '@toptal/picasso'
 import React from 'react'
 
-const ButtonDisabledExample = () => (
+const Example = () => (
   <div>
     <Container bottom={1}>
       <Typography>
@@ -21,4 +21,4 @@ const ButtonDisabledExample = () => (
   </div>
 )
 
-export default ButtonDisabledExample
+export default Example

--- a/packages/picasso/src/Amount/story/Default.example.jsx
+++ b/packages/picasso/src/Amount/story/Default.example.jsx
@@ -1,7 +1,7 @@
 import { Amount, Container, Typography } from '@toptal/picasso'
 import React from 'react'
 
-const ButtonDisabledExample = () => (
+const Example = () => (
   <div>
     <Container bottom={1}>
       <Typography>
@@ -21,4 +21,4 @@ const ButtonDisabledExample = () => (
   </div>
 )
 
-export default ButtonDisabledExample
+export default Example

--- a/packages/picasso/src/Autocomplete/story/Controlled.example.jsx
+++ b/packages/picasso/src/Autocomplete/story/Controlled.example.jsx
@@ -10,7 +10,7 @@ const options = [
   { text: 'Ukraine', value: 'UA' }
 ]
 
-const AutocompleteControlledItemExample = () => {
+const Example = () => {
   const [value, setValue] = useState(options[0].text)
 
   return (
@@ -53,4 +53,4 @@ const AutocompleteControlledItemExample = () => {
   )
 }
 
-export default AutocompleteControlledItemExample
+export default Example

--- a/packages/picasso/src/Autocomplete/story/Default.example.jsx
+++ b/packages/picasso/src/Autocomplete/story/Default.example.jsx
@@ -24,7 +24,7 @@ const filterOptions = (str = '') => {
   return result.length > 0 ? result : null
 }
 
-const AutocompleteDefaultExample = () => {
+const Example = () => {
   const [value, setValue] = useState(EMPTY_INPUT_VALUE)
   const [options, setOptions] = useState(allOptions)
 
@@ -55,4 +55,4 @@ const AutocompleteDefaultExample = () => {
   )
 }
 
-export default AutocompleteDefaultExample
+export default Example

--- a/packages/picasso/src/Autocomplete/story/DynamicOptions.example.jsx
+++ b/packages/picasso/src/Autocomplete/story/DynamicOptions.example.jsx
@@ -32,7 +32,7 @@ const loadOptions = inputValue =>
     setTimeout(() => resolve(result), 1000)
   })
 
-const AutocompleteDynamicOptionsExample = () => {
+const Example = () => {
   const [value, setValue] = useState('')
   const [options, setOptions] = useState(null)
   const [loading, setLoading] = useState(false)
@@ -78,4 +78,4 @@ const AutocompleteDynamicOptionsExample = () => {
   )
 }
 
-export default AutocompleteDynamicOptionsExample
+export default Example

--- a/packages/picasso/src/Autocomplete/story/Error.example.jsx
+++ b/packages/picasso/src/Autocomplete/story/Error.example.jsx
@@ -1,10 +1,10 @@
 import React from 'react'
 import { Autocomplete } from '@toptal/picasso'
 
-const ErrorExample = () => (
+const Example = () => (
   <div>
     <Autocomplete error placeholder='Error input...' value='' />
   </div>
 )
 
-export default ErrorExample
+export default Example

--- a/packages/picasso/src/Autocomplete/story/FullWidth.example.jsx
+++ b/packages/picasso/src/Autocomplete/story/FullWidth.example.jsx
@@ -9,7 +9,7 @@ const options = [
   { text: 'Ukraine' }
 ]
 
-const AutocompleteFullWidthExample = () => (
+const Example = () => (
   <div>
     <Autocomplete
       placeholder='Start typing country...'
@@ -20,4 +20,4 @@ const AutocompleteFullWidthExample = () => (
   </div>
 )
 
-export default AutocompleteFullWidthExample
+export default Example

--- a/packages/picasso/src/Autocomplete/story/InitialSetValue.example.jsx
+++ b/packages/picasso/src/Autocomplete/story/InitialSetValue.example.jsx
@@ -9,7 +9,7 @@ const options = [
   { text: 'Ukraine' }
 ]
 
-const AutocompleteInitialSetValueExample = () => (
+const Example = () => (
   <div>
     <Autocomplete
       placeholder='Start typing country...'
@@ -21,4 +21,4 @@ const AutocompleteInitialSetValueExample = () => (
   </div>
 )
 
-export default AutocompleteInitialSetValueExample
+export default Example

--- a/packages/picasso/src/Autocomplete/story/Loading.example.jsx
+++ b/packages/picasso/src/Autocomplete/story/Loading.example.jsx
@@ -9,7 +9,7 @@ const options = [
   { text: 'Ukraine' }
 ]
 
-const AutocompleteLoadingExample = () => (
+const Example = () => (
   <div>
     <Autocomplete
       placeholder='Loading state...'
@@ -20,4 +20,4 @@ const AutocompleteLoadingExample = () => (
   </div>
 )
 
-export default AutocompleteLoadingExample
+export default Example

--- a/packages/picasso/src/Autocomplete/story/OtherOption.example.jsx
+++ b/packages/picasso/src/Autocomplete/story/OtherOption.example.jsx
@@ -17,7 +17,7 @@ const filterOptions = str =>
     ? allOptions.filter(option => isSubstring(str, getDisplayValue(option)))
     : allOptions
 
-const AutocompleteOtherOptionExample = () => {
+const Example = () => {
   const [value, setValue] = useState(EMPTY_INPUT_VALUE)
   const [options, setOptions] = useState(allOptions)
 
@@ -54,4 +54,4 @@ const AutocompleteOtherOptionExample = () => {
   )
 }
 
-export default AutocompleteOtherOptionExample
+export default Example

--- a/packages/picasso/src/Autocomplete/story/WithIcons.example.jsx
+++ b/packages/picasso/src/Autocomplete/story/WithIcons.example.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Afternoon16, Autocomplete } from '@toptal/picasso'
 
-const AutocompleteIconsExample = () => (
+const Example = () => (
   <div>
     <Autocomplete
       icon={<Afternoon16 />}
@@ -11,4 +11,4 @@ const AutocompleteIconsExample = () => (
   </div>
 )
 
-export default AutocompleteIconsExample
+export default Example

--- a/packages/picasso/src/Avatar/story/Default.example.jsx
+++ b/packages/picasso/src/Avatar/story/Default.example.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Avatar } from '@toptal/picasso'
 
-const AvatarDefaultExample = () => (
+const Example = () => (
   <div>
     <Avatar
       alt='Jacqueline Roque. Pablo Picasso, 1954'
@@ -11,4 +11,4 @@ const AvatarDefaultExample = () => (
   </div>
 )
 
-export default AvatarDefaultExample
+export default Example

--- a/packages/picasso/src/Avatar/story/Sizes.example.jsx
+++ b/packages/picasso/src/Avatar/story/Sizes.example.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Avatar, Container } from '@toptal/picasso'
 
-const AvatarSizesExample = () => (
+const Example = () => (
   <div>
     <Container>
       <Container inline>
@@ -66,4 +66,4 @@ const AvatarSizesExample = () => (
   </div>
 )
 
-export default AvatarSizesExample
+export default Example

--- a/packages/picasso/src/Avatar/story/Variants.example.jsx
+++ b/packages/picasso/src/Avatar/story/Variants.example.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Avatar, Container } from '@toptal/picasso'
 
-const AvatarVariantsExample = () => (
+const Example = () => (
   <div>
     <Container inline>
       <Avatar
@@ -35,4 +35,4 @@ const AvatarVariantsExample = () => (
   </div>
 )
 
-export default AvatarVariantsExample
+export default Example

--- a/packages/picasso/src/Button/story/CircularIconButton.example.jsx
+++ b/packages/picasso/src/Button/story/CircularIconButton.example.jsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { Button } from '@toptal/picasso'
 import { Settings16, Settings24 } from '@toptal/picasso/Icon'
 
-const ButtonIconButtonsExample = () => (
+const Example = () => (
   <div>
     <Button icon={<Settings16 />} circular size='small' />
     <Button icon={<Settings16 />} circular />
@@ -10,4 +10,4 @@ const ButtonIconButtonsExample = () => (
   </div>
 )
 
-export default ButtonIconButtonsExample
+export default Example

--- a/packages/picasso/src/Button/story/Disabled.example.jsx
+++ b/packages/picasso/src/Button/story/Disabled.example.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Button } from '@toptal/picasso'
 
-const ButtonDisabledExample = () => (
+const Example = () => (
   <div>
     <Button disabled>Disabled</Button>
     <Button disabled variant='secondary-red'>
@@ -10,4 +10,4 @@ const ButtonDisabledExample = () => (
   </div>
 )
 
-export default ButtonDisabledExample
+export default Example

--- a/packages/picasso/src/Button/story/FullWidth.example.jsx
+++ b/packages/picasso/src/Button/story/FullWidth.example.jsx
@@ -1,10 +1,10 @@
 import React from 'react'
 import { Button } from '@toptal/picasso'
 
-const ButtonFullWidthExample = () => (
+const Example = () => (
   <div>
     <Button fullWidth>Full width</Button>
   </div>
 )
 
-export default ButtonFullWidthExample
+export default Example

--- a/packages/picasso/src/Button/story/IconButtons.example.jsx
+++ b/packages/picasso/src/Button/story/IconButtons.example.jsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { Button } from '@toptal/picasso'
 import { Settings16, Settings24 } from '@toptal/picasso/Icon'
 
-const ButtonIconButtonsExample = () => (
+const Example = () => (
   <div>
     <Button icon={<Settings16 />} size='small' />
     <Button icon={<Settings16 />} />
@@ -10,4 +10,4 @@ const ButtonIconButtonsExample = () => (
   </div>
 )
 
-export default ButtonIconButtonsExample
+export default Example

--- a/packages/picasso/src/Button/story/IconButtonsWithText.example.jsx
+++ b/packages/picasso/src/Button/story/IconButtonsWithText.example.jsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { Button } from '@toptal/picasso'
 import { Settings16 } from '@toptal/picasso/Icon'
 
-const ButtonIconButtonsWithTextExample = () => (
+const Example = () => (
   <div>
     <Button icon={<Settings16 />}>Cog</Button>
     <Button icon={<Settings16 />} iconPosition='right'>
@@ -11,4 +11,4 @@ const ButtonIconButtonsWithTextExample = () => (
   </div>
 )
 
-export default ButtonIconButtonsWithTextExample
+export default Example

--- a/packages/picasso/src/Button/story/Loading.example.jsx
+++ b/packages/picasso/src/Button/story/Loading.example.jsx
@@ -1,10 +1,10 @@
 import React from 'react'
 import { Button } from '@toptal/picasso'
 
-const ButtonLoadingExample = () => (
+const Example = () => (
   <div>
     <Button loading>Default</Button>
   </div>
 )
 
-export default ButtonLoadingExample
+export default Example

--- a/packages/picasso/src/Button/story/Sizes.example.jsx
+++ b/packages/picasso/src/Button/story/Sizes.example.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Button } from '@toptal/picasso'
 
-const ButtonSizesExample = () => (
+const Example = () => (
   <div>
     <Button size='small'>Small</Button>
     <Button size='medium'>Medium (default)</Button>
@@ -9,4 +9,4 @@ const ButtonSizesExample = () => (
   </div>
 )
 
-export default ButtonSizesExample
+export default Example

--- a/packages/picasso/src/Button/story/States.example.jsx
+++ b/packages/picasso/src/Button/story/States.example.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Button } from '@toptal/picasso'
 
-const ButtonStatesExample = () => (
+const Example = () => (
   <div>
     <Button>Normal</Button>
     <Button hovered>Hovered</Button>
@@ -10,4 +10,4 @@ const ButtonStatesExample = () => (
   </div>
 )
 
-export default ButtonStatesExample
+export default Example

--- a/packages/picasso/src/Button/story/Variants.example.jsx
+++ b/packages/picasso/src/Button/story/Variants.example.jsx
@@ -3,7 +3,7 @@ import { Button, Container, Typography } from '@toptal/picasso'
 import { palette } from '@toptal/picasso/utils'
 import { Copy24, Twitter24, Linkedin24 } from '@toptal/picasso/Icon'
 
-const ButtonVariantsExample = () => (
+const Example = () => (
   <div>
     <Typography variant='heading' size='small'>
       Primary:
@@ -68,4 +68,4 @@ const ButtonVariantsExample = () => (
   </div>
 )
 
-export default ButtonVariantsExample
+export default Example

--- a/packages/picasso/src/ButtonGroup/story/ButtonGroup.example.jsx
+++ b/packages/picasso/src/ButtonGroup/story/ButtonGroup.example.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Button } from '@toptal/picasso'
 
-const ButtonButtonGroupExample = () => (
+const Example = () => (
   <div>
     <Button.Group>
       <Button>First</Button>
@@ -12,4 +12,4 @@ const ButtonButtonGroupExample = () => (
   </div>
 )
 
-export default ButtonButtonGroupExample
+export default Example

--- a/packages/picasso/src/ButtonGroup/story/ButtonGroupWithActiveSecondaryBlue.example.jsx
+++ b/packages/picasso/src/ButtonGroup/story/ButtonGroupWithActiveSecondaryBlue.example.jsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react'
 import { Button } from '@toptal/picasso'
 
-const ButtonGroupWithActiveSecondaryBlueExample = () => {
+const Example = () => {
   const [active, setActive] = useState(1)
 
   return (
@@ -40,4 +40,4 @@ const ButtonGroupWithActiveSecondaryBlueExample = () => {
   )
 }
 
-export default ButtonGroupWithActiveSecondaryBlueExample
+export default Example

--- a/packages/picasso/src/ButtonGroup/story/ButtonGroupWithSecondaryBlue.example.jsx
+++ b/packages/picasso/src/ButtonGroup/story/ButtonGroupWithSecondaryBlue.example.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Button } from '@toptal/picasso'
 
-const ButtonGroupWithSecondaryBlueExample = () => (
+const Example = () => (
   <div>
     <Button.Group>
       <Button variant='secondary-blue'>First</Button>
@@ -12,4 +12,4 @@ const ButtonGroupWithSecondaryBlueExample = () => (
   </div>
 )
 
-export default ButtonGroupWithSecondaryBlueExample
+export default Example

--- a/packages/picasso/src/Checkbox/story/CheckboxGroupHorizontal.example.jsx
+++ b/packages/picasso/src/Checkbox/story/CheckboxGroupHorizontal.example.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Checkbox } from '@toptal/picasso'
 
-const CheckboxGroupHorizontalExample = () => {
+const Example = () => {
   return (
     <Checkbox.Group horizontal>
       <Checkbox label='Checkbox 1' value='checkbox1' />
@@ -11,4 +11,4 @@ const CheckboxGroupHorizontalExample = () => {
   )
 }
 
-export default CheckboxGroupHorizontalExample
+export default Example

--- a/packages/picasso/src/Checkbox/story/CheckboxGroupVertical.example.jsx
+++ b/packages/picasso/src/Checkbox/story/CheckboxGroupVertical.example.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Checkbox } from '@toptal/picasso'
 
-const CheckboxGroupVerticalExample = () => {
+const Example = () => {
   return (
     <Checkbox.Group>
       <Checkbox label='Checkbox 1' value='checkbox1' />
@@ -11,4 +11,4 @@ const CheckboxGroupVerticalExample = () => {
   )
 }
 
-export default CheckboxGroupVerticalExample
+export default Example

--- a/packages/picasso/src/Checkbox/story/Controlled.example.jsx
+++ b/packages/picasso/src/Checkbox/story/Controlled.example.jsx
@@ -1,11 +1,11 @@
 import React from 'react'
 import { Checkbox } from '@toptal/picasso'
 
-const CheckboxControlledExample = () => (
+const Example = () => (
   <Checkbox.Group>
     <Checkbox checked={false} id='checkbox-unchecked' label='Unchecked' />
     <Checkbox checked id='checkbox-checked' label='Checked' />
   </Checkbox.Group>
 )
 
-export default CheckboxControlledExample
+export default Example

--- a/packages/picasso/src/Checkbox/story/Disabled.example.jsx
+++ b/packages/picasso/src/Checkbox/story/Disabled.example.jsx
@@ -1,11 +1,11 @@
 import React from 'react'
 import { Checkbox } from '@toptal/picasso'
 
-const CheckboxDisabledExample = () => (
+const Example = () => (
   <Checkbox.Group>
     <Checkbox checked={false} disabled label='Unchecked' />
     <Checkbox checked disabled label='Checked' />
   </Checkbox.Group>
 )
 
-export default CheckboxDisabledExample
+export default Example

--- a/packages/picasso/src/Checkbox/story/Indeterminate.example.jsx
+++ b/packages/picasso/src/Checkbox/story/Indeterminate.example.jsx
@@ -1,10 +1,10 @@
 import React from 'react'
 import { Checkbox } from '@toptal/picasso'
 
-const CheckboxIndeterminateExample = () => (
+const Example = () => (
   <div>
     <Checkbox indeterminate label='Select all' />
   </div>
 )
 
-export default CheckboxIndeterminateExample
+export default Example

--- a/packages/picasso/src/Checkbox/story/Required.example.jsx
+++ b/packages/picasso/src/Checkbox/story/Required.example.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Checkbox, Grid } from '@toptal/picasso'
 
-const CheckboxRequiredExample = () => (
+const Example = () => (
   <Grid>
     <Grid.Item large={3}>
       <Checkbox
@@ -12,4 +12,4 @@ const CheckboxRequiredExample = () => (
   </Grid>
 )
 
-export default CheckboxRequiredExample
+export default Example

--- a/packages/picasso/src/Checkbox/story/Uncontrolled.example.jsx
+++ b/packages/picasso/src/Checkbox/story/Uncontrolled.example.jsx
@@ -1,10 +1,10 @@
 import React from 'react'
 import { Checkbox } from '@toptal/picasso'
 
-const CheckboxUncontrolledExample = () => (
+const Example = () => (
   <div>
     <Checkbox label='Checkbox' />
   </div>
 )
 
-export default CheckboxUncontrolledExample
+export default Example

--- a/packages/picasso/src/Container/story/Bordered.example.jsx
+++ b/packages/picasso/src/Container/story/Bordered.example.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Container } from '@toptal/picasso'
 
-const ContainerDefaultExample = () => (
+const Example = () => (
   <div>
     <Container bordered padded='large'>
       With default border
@@ -9,4 +9,4 @@ const ContainerDefaultExample = () => (
   </div>
 )
 
-export default ContainerDefaultExample
+export default Example

--- a/packages/picasso/src/Container/story/Default.example.jsx
+++ b/packages/picasso/src/Container/story/Default.example.jsx
@@ -1,11 +1,11 @@
 import React from 'react'
 import { Container } from '@toptal/picasso'
 
-const ContainerDefaultExample = () => (
+const Example = () => (
   <div>
     <Container bottom='large'>Some text</Container>
     <Container left='small'>Some more text</Container>
   </div>
 )
 
-export default ContainerDefaultExample
+export default Example

--- a/packages/picasso/src/Container/story/Inline.example.jsx
+++ b/packages/picasso/src/Container/story/Inline.example.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Container } from '@toptal/picasso'
 
-const ContainerInlineExample = () => (
+const Example = () => (
   <div>
     <Container inline right='large'>
       <span>Some inline text</span>
@@ -10,4 +10,4 @@ const ContainerInlineExample = () => (
   </div>
 )
 
-export default ContainerInlineExample
+export default Example

--- a/packages/picasso/src/Container/story/Spacing.example.jsx
+++ b/packages/picasso/src/Container/story/Spacing.example.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Container, Paper, Grid } from '@toptal/picasso'
 
-const ContainerSpacingExample = () => (
+const Example = () => (
   <div>
     <Container bottom='small'>Outer spacing</Container>
     <Grid>
@@ -83,4 +83,4 @@ const ContainerSpacingExample = () => (
   </div>
 )
 
-export default ContainerSpacingExample
+export default Example

--- a/packages/picasso/src/Container/story/Variant.example.jsx
+++ b/packages/picasso/src/Container/story/Variant.example.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Container, Typography } from '@toptal/picasso'
 
-const ContainerDefaultExample = () => (
+const Example = () => (
   <Container flex direction='column'>
     <Container bottom='medium'>
       <Typography variant='heading' size='medium'>
@@ -55,4 +55,4 @@ const ContainerDefaultExample = () => (
   </Container>
 )
 
-export default ContainerDefaultExample
+export default Example

--- a/packages/picasso/src/Dropdown/story/ButtonDropdown.example.jsx
+++ b/packages/picasso/src/Dropdown/story/ButtonDropdown.example.jsx
@@ -3,7 +3,7 @@ import { Dropdown, Button, Menu } from '@toptal/picasso'
 
 const handleClick = () => window.alert('Item clicked')
 
-const ButtonDropdownExample = () => (
+const Example = () => (
   <div>
     <Dropdown
       content={
@@ -22,4 +22,4 @@ const ButtonDropdownExample = () => (
   </div>
 )
 
-export default ButtonDropdownExample
+export default Example

--- a/packages/picasso/src/Dropdown/story/CustomContent.example.jsx
+++ b/packages/picasso/src/Dropdown/story/CustomContent.example.jsx
@@ -10,7 +10,7 @@ import {
 } from '@toptal/picasso'
 
 // Autofocus will force scrolling to the bottom of the portal, so we disable portal
-const ComplexDefaultExample = () => (
+const Example = () => (
   <div>
     <Dropdown content={<ComplexContent />} disableAutoClose disablePortal>
       Open Dropdown
@@ -51,4 +51,4 @@ const OPTIONS = [
   { value: '4', text: 'Option 4' }
 ]
 
-export default ComplexDefaultExample
+export default Example

--- a/packages/picasso/src/Dropdown/story/CustomTrigger.example.jsx
+++ b/packages/picasso/src/Dropdown/story/CustomTrigger.example.jsx
@@ -3,7 +3,7 @@ import { Dropdown, Menu, UserBadge } from '@toptal/picasso'
 
 const handleClick = () => window.alert('Item clicked')
 
-const DropdownHeaderExample = () => (
+const Example = () => (
   <div>
     <Dropdown
       content={
@@ -24,4 +24,4 @@ const DropdownHeaderExample = () => (
   </div>
 )
 
-export default DropdownHeaderExample
+export default Example

--- a/packages/picasso/src/Dropdown/story/Default.example.jsx
+++ b/packages/picasso/src/Dropdown/story/Default.example.jsx
@@ -3,7 +3,7 @@ import { Dropdown, Menu } from '@toptal/picasso'
 
 const handleClick = () => window.alert('Item clicked')
 
-const DropdownDefaultExample = () => (
+const Example = () => (
   <div>
     <Dropdown
       content={
@@ -20,4 +20,4 @@ const DropdownDefaultExample = () => (
   </div>
 )
 
-export default DropdownDefaultExample
+export default Example

--- a/packages/picasso/src/Dropdown/story/PositionsAndOffsets.example.jsx
+++ b/packages/picasso/src/Dropdown/story/PositionsAndOffsets.example.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Dropdown, Menu, Container, Typography } from '@toptal/picasso'
 
-const DropdownDefaultExample = () => (
+const Example = () => (
   <div>
     <Container bottom='xsmall'>
       <Typography>Popper placement</Typography>
@@ -109,4 +109,4 @@ const DropdownDefaultExample = () => (
   </div>
 )
 
-export default DropdownDefaultExample
+export default Example

--- a/packages/picasso/src/Dropdown/story/SmallArrow.example.jsx
+++ b/packages/picasso/src/Dropdown/story/SmallArrow.example.jsx
@@ -3,7 +3,7 @@ import { Dropdown, Menu } from '@toptal/picasso'
 
 const handleClick = () => window.alert('Item clicked')
 
-const MediumArrowExample = () => (
+const Example = () => (
   <div>
     <Dropdown
       content={
@@ -20,4 +20,4 @@ const MediumArrowExample = () => (
   </div>
 )
 
-export default MediumArrowExample
+export default Example

--- a/packages/picasso/src/EnvironmentBanner/story/Variants.example.jsx
+++ b/packages/picasso/src/EnvironmentBanner/story/Variants.example.jsx
@@ -3,7 +3,7 @@ import { Container, EnvironmentBanner, Typography } from '@toptal/picasso'
 
 const CONTAINER_HEIGHT = '2rem'
 
-const EnvironmentBannerVariantsExample = () => (
+const Example = () => (
   <div>
     <Container style={{ position: 'relative', height: CONTAINER_HEIGHT }}>
       <Typography variant='heading' size='small'>
@@ -40,4 +40,4 @@ const EnvironmentBannerVariantsExample = () => (
   </div>
 )
 
-export default EnvironmentBannerVariantsExample
+export default Example

--- a/packages/picasso/src/FileInput/story/AllowedExtensions.example.jsx
+++ b/packages/picasso/src/FileInput/story/AllowedExtensions.example.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { FileInput, Form } from '@toptal/picasso'
 
-const FileInputAllowedExtensionsExample = () => (
+const Example = () => (
   <div>
     <Form.Field hint='Accept png image files'>
       <FileInput accept='image/png' status='No file uploaded.' />
@@ -21,4 +21,4 @@ const FileInputAllowedExtensionsExample = () => (
   </div>
 )
 
-export default FileInputAllowedExtensionsExample
+export default Example

--- a/packages/picasso/src/FileInput/story/Default.example.jsx
+++ b/packages/picasso/src/FileInput/story/Default.example.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { FileInput, Container } from '@toptal/picasso'
 
-const FileInputDefaultExample = () => (
+const Example = () => (
   <div>
     <Container bottom='small'>
       <FileInput status='No file uploaded.' />
@@ -15,4 +15,4 @@ const FileInputDefaultExample = () => (
   </div>
 )
 
-export default FileInputDefaultExample
+export default Example

--- a/packages/picasso/src/FileInput/story/Disabled.example.jsx
+++ b/packages/picasso/src/FileInput/story/Disabled.example.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { FileInput, Container } from '@toptal/picasso'
 
-const FileInputDisabledExample = () => (
+const Example = () => (
   <div>
     <Container bottom='small'>
       <FileInput disabled status='No file uploaded.' />
@@ -16,4 +16,4 @@ const FileInputDisabledExample = () => (
   </div>
 )
 
-export default FileInputDisabledExample
+export default Example

--- a/packages/picasso/src/FileInput/story/Error.example.jsx
+++ b/packages/picasso/src/FileInput/story/Error.example.jsx
@@ -1,10 +1,10 @@
 import React from 'react'
 import { FileInput } from '@toptal/picasso'
 
-const FileInputErrorExample = () => (
+const Example = () => (
   <div>
     <FileInput error status='Upload failed.' />
   </div>
 )
 
-export default FileInputErrorExample
+export default Example

--- a/packages/picasso/src/FileInput/story/Uploader.example.jsx
+++ b/packages/picasso/src/FileInput/story/Uploader.example.jsx
@@ -53,7 +53,7 @@ const useUploader = config => {
   }
 }
 
-const FileInputUploaderExample = () => {
+const Example = () => {
   const MAX_SIZE = 2
 
   const { error, progress, file, status, upload } = useUploader({
@@ -77,4 +77,4 @@ const FileInputUploaderExample = () => {
   )
 }
 
-export default FileInputUploaderExample
+export default Example

--- a/packages/picasso/src/FileInput/story/Uploading.example.jsx
+++ b/packages/picasso/src/FileInput/story/Uploading.example.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { FileInput, Container } from '@toptal/picasso'
 
-const FileInputUploadingExample = () => (
+const Example = () => (
   <div>
     <Container bottom='small'>
       <FileInput progress={42} status='File uploading in progress...' />
@@ -13,4 +13,4 @@ const FileInputUploadingExample = () => (
   </div>
 )
 
-export default FileInputUploadingExample
+export default Example

--- a/packages/picasso/src/FormField/story/FormField.example.jsx
+++ b/packages/picasso/src/FormField/story/FormField.example.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Form, Grid, Select, Input, Checkbox, Radio } from '@toptal/picasso'
 
-const FormFieldExample = () => (
+const Example = () => (
   <Grid>
     <Grid.Item small={5}>
       <Form>
@@ -74,4 +74,4 @@ const OPTIONS = [
   { value: '4', text: 'Option 4' }
 ]
 
-export default FormFieldExample
+export default Example

--- a/packages/picasso/src/Grid/story/Alignment.example.jsx
+++ b/packages/picasso/src/Grid/story/Alignment.example.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Grid, Button } from '@toptal/picasso'
 
-const GridAlignmentExample = () => (
+const Example = () => (
   <div>
     <Grid justifyContent='flex-start'>
       <Grid.Item>
@@ -23,4 +23,4 @@ const GridAlignmentExample = () => (
   </div>
 )
 
-export default GridAlignmentExample
+export default Example

--- a/packages/picasso/src/Grid/story/Direction.example.jsx
+++ b/packages/picasso/src/Grid/story/Direction.example.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Grid, Button, Container, Typography } from '@toptal/picasso'
 
-const GridDirectionExample = () => (
+const Example = () => (
   <div>
     <Container bottom='large'>
       <Container bottom='small'>
@@ -33,4 +33,4 @@ const GridDirectionExample = () => (
   </div>
 )
 
-export default GridDirectionExample
+export default Example

--- a/packages/picasso/src/Grid/story/Wrapping.example.jsx
+++ b/packages/picasso/src/Grid/story/Wrapping.example.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Grid, Button, Container, Typography } from '@toptal/picasso'
 
-const GridWrappingExample = () => (
+const Example = () => (
   <div>
     <Container bottom='large'>
       <Container bottom='small'>
@@ -65,4 +65,4 @@ const GridWrappingExample = () => (
   </div>
 )
 
-export default GridWrappingExample
+export default Example

--- a/packages/picasso/src/GridItem/story/CenteredLayout.example.jsx
+++ b/packages/picasso/src/GridItem/story/CenteredLayout.example.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Grid, Page, Typography } from '@toptal/picasso'
 
-const GridCenteredLayoutExample = () => (
+const Example = () => (
   <Page>
     <Page.Header title='Onboarding' />
     <Page.Content>
@@ -29,4 +29,4 @@ const SampleContainer = ({ children }) => (
   </div>
 )
 
-export default GridCenteredLayoutExample
+export default Example

--- a/packages/picasso/src/GridItem/story/Default.example.jsx
+++ b/packages/picasso/src/GridItem/story/Default.example.jsx
@@ -10,7 +10,7 @@ const ContentContainer = ({ children }) => (
   </Container>
 )
 
-const GridDefaultExample = () => (
+const Example = () => (
   <Grid>
     <Grid.Item small={1}>
       <ContentContainer>1</ContentContainer>
@@ -96,4 +96,4 @@ const GridDefaultExample = () => (
   </Grid>
 )
 
-export default GridDefaultExample
+export default Example

--- a/packages/picasso/src/GridItem/story/Responsive.example.jsx
+++ b/packages/picasso/src/GridItem/story/Responsive.example.jsx
@@ -28,7 +28,7 @@ const ContentContainer = ({ children }) => (
   </Container>
 )
 
-const GridDefaultExample = () => {
+const Example = () => {
   return (
     <Grid>
       <Grid.Item small={12} medium={6} large={3}>
@@ -55,4 +55,4 @@ const GridDefaultExample = () => {
   )
 }
 
-export default GridDefaultExample
+export default Example

--- a/packages/picasso/src/GridItem/story/SampleLayout.example.jsx
+++ b/packages/picasso/src/GridItem/story/SampleLayout.example.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Grid, Page, Typography } from '@toptal/picasso'
 
-const GridSampleLayoutExample = () => (
+const Example = () => (
   <Page>
     <Page.Header title='Onboarding' />
     <Page.Content>
@@ -33,4 +33,4 @@ const SampleContainer = ({ children }) => (
   </div>
 )
 
-export default GridSampleLayoutExample
+export default Example

--- a/packages/picasso/src/Helpbox/story/Actions.example.jsx
+++ b/packages/picasso/src/Helpbox/story/Actions.example.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Helpbox, Container, Button } from '@toptal/picasso'
 
-const HelpboxDefaultExample = () => (
+const Example = () => (
   <Container>
     <Helpbox variant='yellow'>
       <Helpbox.Title>Heading Small</Helpbox.Title>
@@ -24,4 +24,4 @@ const HelpboxDefaultExample = () => (
   </Container>
 )
 
-export default HelpboxDefaultExample
+export default Example

--- a/packages/picasso/src/Helpbox/story/Closeable.example.jsx
+++ b/packages/picasso/src/Helpbox/story/Closeable.example.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Helpbox, Container } from '@toptal/picasso'
 
-const HelpboxDefaultExample = () => (
+const Example = () => (
   <Container>
     <Helpbox variant='green' onClose={() => window.alert('Close clicked')}>
       <Helpbox.Title>Heading Small</Helpbox.Title>
@@ -18,4 +18,4 @@ const HelpboxDefaultExample = () => (
   </Container>
 )
 
-export default HelpboxDefaultExample
+export default Example

--- a/packages/picasso/src/Helpbox/story/Default.example.jsx
+++ b/packages/picasso/src/Helpbox/story/Default.example.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Helpbox, Container } from '@toptal/picasso'
 
-const HelpboxDefaultExample = () => (
+const Example = () => (
   <Container>
     <Container bottom='small'>
       <Helpbox>
@@ -90,4 +90,4 @@ const HelpboxDefaultExample = () => (
   </Container>
 )
 
-export default HelpboxDefaultExample
+export default Example

--- a/packages/picasso/src/Icon/story/Color.example.jsx
+++ b/packages/picasso/src/Icon/story/Color.example.jsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { Container } from '@toptal/picasso'
 import { Settings16 } from '@toptal/picasso/Icon'
 
-const IconExample = () => (
+const Example = () => (
   <div>
     <Container inline right='small'>
       <Settings16 color='red' />
@@ -21,4 +21,4 @@ const IconExample = () => (
   </div>
 )
 
-export default IconExample
+export default Example

--- a/packages/picasso/src/Icon/story/Default.example.jsx
+++ b/packages/picasso/src/Icon/story/Default.example.jsx
@@ -1,10 +1,10 @@
 import React from 'react'
 import { Settings16 } from '@toptal/picasso/Icon'
 
-const IconExample = () => (
+const Example = () => (
   <div>
     <Settings16 />
   </div>
 )
 
-export default IconExample
+export default Example

--- a/packages/picasso/src/Icon/story/List.example.jsx
+++ b/packages/picasso/src/Icon/story/List.example.jsx
@@ -6,7 +6,7 @@ import * as icons from '@toptal/picasso/Icon'
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const { Logo, LogoEmblem, DropdownArrows16, ...listIcons } = icons
 
-const IconListExample = () => {
+const Example = () => {
   const [filter, setFilter] = React.useState('')
 
   const handleFilter = e => setFilter(e.target.value)
@@ -63,4 +63,4 @@ const IconListExample = () => {
   )
 }
 
-export default IconListExample
+export default Example

--- a/packages/picasso/src/Icon/story/Scale.example.jsx
+++ b/packages/picasso/src/Icon/story/Scale.example.jsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { Container } from '@toptal/picasso'
 import { Settings16, Settings24 } from '@toptal/picasso/Icon'
 
-const IconExample = () => (
+const Example = () => (
   <div>
     <Container inline right='small'>
       <Settings16 scale={2} />
@@ -19,4 +19,4 @@ const IconExample = () => (
   </div>
 )
 
-export default IconExample
+export default Example

--- a/packages/picasso/src/Icon/story/WithText.example.jsx
+++ b/packages/picasso/src/Icon/story/WithText.example.jsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { Container } from '@toptal/picasso'
 import { Settings16, Settings24 } from '@toptal/picasso/Icon'
 
-const IconWithTextExample = () => (
+const Example = () => (
   <div>
     <div>
       <Settings16 style={{ marginRight: '0.5rem' }} />
@@ -16,4 +16,4 @@ const IconWithTextExample = () => (
   </div>
 )
 
-export default IconWithTextExample
+export default Example

--- a/packages/picasso/src/Image/story/Default.example.jsx
+++ b/packages/picasso/src/Image/story/Default.example.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Image } from '@toptal/picasso'
 
-const ImageDefaultExample = () => (
+const Example = () => (
   <div>
     <Image
       src='./jacqueline-with-flowers-1954.jpg'
@@ -11,4 +11,4 @@ const ImageDefaultExample = () => (
   </div>
 )
 
-export default ImageDefaultExample
+export default Example

--- a/packages/picasso/src/Image/story/Variants.example.jsx
+++ b/packages/picasso/src/Image/story/Variants.example.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Image, Container } from '@toptal/picasso'
 
-const ImageVariantsExample = () => (
+const Example = () => (
   <div>
     <Container inline>
       <Image
@@ -21,4 +21,4 @@ const ImageVariantsExample = () => (
   </div>
 )
 
-export default ImageVariantsExample
+export default Example

--- a/packages/picasso/src/Indicator/story/Default.example.jsx
+++ b/packages/picasso/src/Indicator/story/Default.example.jsx
@@ -1,7 +1,7 @@
 import React, { Fragment } from 'react'
 import { Indicator, Typography, Container } from '@toptal/picasso'
 
-const IndicatorDefaultExample = () => (
+const Example = () => (
   <Fragment>
     <Container bottom='medium'>
       <Container inline right='small'>
@@ -30,4 +30,4 @@ const IndicatorDefaultExample = () => (
   </Fragment>
 )
 
-export default IndicatorDefaultExample
+export default Example

--- a/packages/picasso/src/Input/story/AutoFill.example.jsx
+++ b/packages/picasso/src/Input/story/AutoFill.example.jsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react'
 import { Input } from '@toptal/picasso'
 
-const AutoFillExample = () => {
+const Example = () => {
   const [value, setValue] = useState('')
 
   const handleChange = event => {
@@ -20,4 +20,4 @@ const AutoFillExample = () => {
   )
 }
 
-export default AutoFillExample
+export default Example

--- a/packages/picasso/src/Input/story/Default.example.jsx
+++ b/packages/picasso/src/Input/story/Default.example.jsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react'
 import { Input } from '@toptal/picasso'
 
-const InputDefaultExample = () => {
+const Example = () => {
   const [value, setValue] = useState('Text')
 
   const handleChange = event => {
@@ -13,4 +13,4 @@ const InputDefaultExample = () => {
   )
 }
 
-export default InputDefaultExample
+export default Example

--- a/packages/picasso/src/Input/story/Disabled.example.jsx
+++ b/packages/picasso/src/Input/story/Disabled.example.jsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react'
 import { Input, Container } from '@toptal/picasso'
 
-const InputDisabledExample = () => {
+const Example = () => {
   const [value, setValue] = useState('Text')
 
   const handleChange = event => {
@@ -18,4 +18,4 @@ const InputDisabledExample = () => {
   )
 }
 
-export default InputDisabledExample
+export default Example

--- a/packages/picasso/src/Input/story/Error.example.jsx
+++ b/packages/picasso/src/Input/story/Error.example.jsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react'
 import { Input, Container } from '@toptal/picasso'
 
-const InputErrorExample = () => {
+const Example = () => {
   const [value, setValue] = useState('Text')
 
   const handleChange = event => {
@@ -18,4 +18,4 @@ const InputErrorExample = () => {
   )
 }
 
-export default InputErrorExample
+export default Example

--- a/packages/picasso/src/Input/story/FullWidth.example.jsx
+++ b/packages/picasso/src/Input/story/FullWidth.example.jsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react'
 import { Input } from '@toptal/picasso'
 
-const InputFullWidthExample = () => {
+const Example = () => {
   const [value, setValue] = useState('Text')
 
   const handleChange = event => {
@@ -18,4 +18,4 @@ const InputFullWidthExample = () => {
   )
 }
 
-export default InputFullWidthExample
+export default Example

--- a/packages/picasso/src/Input/story/Multiline.example.jsx
+++ b/packages/picasso/src/Input/story/Multiline.example.jsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react'
 import { Input, Container } from '@toptal/picasso'
 
-const InputMultilineExample = () => {
+const Example = () => {
   const [value, setValue] = useState('Multiline text')
 
   const handleChange = event => {
@@ -20,4 +20,4 @@ const InputMultilineExample = () => {
   )
 }
 
-export default InputMultilineExample
+export default Example

--- a/packages/picasso/src/Input/story/MultilineExpand.example.jsx
+++ b/packages/picasso/src/Input/story/MultilineExpand.example.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Input, Container, Typography } from '@toptal/picasso'
 
-const InputMultilineExpandExample = () => {
+const Example = () => {
   return (
     <Container flex direction='column'>
       <Container padded='small'>
@@ -35,4 +35,4 @@ const InputMultilineExpandExample = () => {
   )
 }
 
-export default InputMultilineExpandExample
+export default Example

--- a/packages/picasso/src/Input/story/Sizes.example.jsx
+++ b/packages/picasso/src/Input/story/Sizes.example.jsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react'
 import { Input, Container, Typography } from '@toptal/picasso'
 
-const InputSizesExample = () => {
+const Example = () => {
   const [value, setValue] = useState()
 
   const handleChange = event => {
@@ -40,4 +40,4 @@ const InputSizesExample = () => {
   )
 }
 
-export default InputSizesExample
+export default Example

--- a/packages/picasso/src/Input/story/WithIcon.example.jsx
+++ b/packages/picasso/src/Input/story/WithIcon.example.jsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react'
 import { Input, Container } from '@toptal/picasso'
 import { Search16 } from '@toptal/picasso/Icon'
 
-const InputWithIconExample = () => {
+const Example = () => {
   const [value, setValue] = useState('Text')
 
   const handleChange = event => {
@@ -42,4 +42,4 @@ const InputWithIconExample = () => {
   )
 }
 
-export default InputWithIconExample
+export default Example

--- a/packages/picasso/src/Label/story/Disabled.example.jsx
+++ b/packages/picasso/src/Label/story/Disabled.example.jsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { Label } from '@toptal/picasso'
 import { Settings16 } from '@toptal/picasso/Icon'
 
-const LabelDisabledExample = () => (
+const Example = () => (
   <div>
     <Label disabled icon={<Settings16 />} onDelete={handleDelete}>
       Label
@@ -14,4 +14,4 @@ function handleDelete() {
   window.alert('You clicked the delete icon.')
 }
 
-export default LabelDisabledExample
+export default Example

--- a/packages/picasso/src/Label/story/Dismissible.example.jsx
+++ b/packages/picasso/src/Label/story/Dismissible.example.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Label } from '@toptal/picasso'
 
-const LabelDismissibleExample = () => (
+const Example = () => (
   <div>
     <Label onDelete={handleDelete}>Label</Label>
   </div>
@@ -11,4 +11,4 @@ function handleDelete() {
   window.alert('You clicked the delete icon.')
 }
 
-export default LabelDismissibleExample
+export default Example

--- a/packages/picasso/src/Label/story/Variants.example.jsx
+++ b/packages/picasso/src/Label/story/Variants.example.jsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { Container, Label, Settings16 } from '@toptal/picasso'
 import { palette } from '@toptal/picasso/utils'
 
-const LabelVariantsExample = () => (
+const Example = () => (
   <Container flex>
     <Container right='small' top={0.5}>
       <Label icon={<Settings16 />} variant='grey'>
@@ -34,4 +34,4 @@ const LabelVariantsExample = () => (
   </Container>
 )
 
-export default LabelVariantsExample
+export default Example

--- a/packages/picasso/src/Label/story/WithIcon.example.jsx
+++ b/packages/picasso/src/Label/story/WithIcon.example.jsx
@@ -2,10 +2,10 @@ import React from 'react'
 import { Label } from '@toptal/picasso'
 import { Settings16 } from '@toptal/picasso/Icon'
 
-const LabelDefaultExample = () => (
+const Example = () => (
   <div>
     <Label icon={<Settings16 />}>Label</Label>
   </div>
 )
 
-export default LabelDefaultExample
+export default Example

--- a/packages/picasso/src/LabelGroup/story/LabelGroup.example.jsx
+++ b/packages/picasso/src/LabelGroup/story/LabelGroup.example.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Label } from '@toptal/picasso'
 
-const LabelGroupExample = () => (
+const Example = () => (
   <Label.Group>
     <Label>Angular JS</Label>
     <Label>React JS</Label>
@@ -14,4 +14,4 @@ const handleDelete = () => {
   window.alert('You clicked the delete icon.')
 }
 
-export default LabelGroupExample
+export default Example

--- a/packages/picasso/src/Loader/story/ControlledValue.example.jsx
+++ b/packages/picasso/src/Loader/story/ControlledValue.example.jsx
@@ -1,10 +1,10 @@
 import React from 'react'
 import { Loader } from '@toptal/picasso'
 
-const LoaderControlledValueExample = () => (
+const Example = () => (
   <div>
     <Loader value={48}>48%</Loader>
   </div>
 )
 
-export default LoaderControlledValueExample
+export default Example

--- a/packages/picasso/src/Loader/story/Default.example.jsx
+++ b/packages/picasso/src/Loader/story/Default.example.jsx
@@ -1,10 +1,10 @@
 import React from 'react'
 import { Loader } from '@toptal/picasso'
 
-const LoaderDefaultExample = () => (
+const Example = () => (
   <div>
     <Loader />
   </div>
 )
 
-export default LoaderDefaultExample
+export default Example

--- a/packages/picasso/src/Loader/story/Indeterminate.example.jsx
+++ b/packages/picasso/src/Loader/story/Indeterminate.example.jsx
@@ -1,10 +1,10 @@
 import React from 'react'
 import { Loader } from '@toptal/picasso'
 
-const LoaderIndeterminateExample = () => (
+const Example = () => (
   <div>
     <Loader indeterminate>Loading...</Loader>
   </div>
 )
 
-export default LoaderIndeterminateExample
+export default Example

--- a/packages/picasso/src/Loader/story/Inline.example.jsx
+++ b/packages/picasso/src/Loader/story/Inline.example.jsx
@@ -1,11 +1,11 @@
 import React from 'react'
 import { Loader } from '@toptal/picasso'
 
-const LoaderInlineExample = () => (
+const Example = () => (
   <div>
     <Loader inline />
     <span>Content...</span>
   </div>
 )
 
-export default LoaderInlineExample
+export default Example

--- a/packages/picasso/src/Loader/story/Sizes.example.jsx
+++ b/packages/picasso/src/Loader/story/Sizes.example.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Loader, Container } from '@toptal/picasso'
 
-const LoaderSizesExample = () => (
+const Example = () => (
   <div>
     <Container bottom='large'>
       <Loader size='small'>small</Loader>
@@ -13,4 +13,4 @@ const LoaderSizesExample = () => (
   </div>
 )
 
-export default LoaderSizesExample
+export default Example

--- a/packages/picasso/src/Loader/story/Variants.example.jsx
+++ b/packages/picasso/src/Loader/story/Variants.example.jsx
@@ -1,10 +1,10 @@
 import React from 'react'
 import { Loader } from '@toptal/picasso'
 
-const LoaderVariantExample = () => (
+const Example = () => (
   <div style={{ color: 'purple' }}>
     <Loader variant='inherit'>inherit</Loader>
   </div>
 )
 
-export default LoaderVariantExample
+export default Example

--- a/packages/picasso/src/Loader/story/WithLabel.example.jsx
+++ b/packages/picasso/src/Loader/story/WithLabel.example.jsx
@@ -1,10 +1,10 @@
 import React from 'react'
 import { Loader } from '@toptal/picasso'
 
-const LoaderWithLabelExample = () => (
+const Example = () => (
   <div>
     <Loader>Loading...</Loader>
   </div>
 )
 
-export default LoaderWithLabelExample
+export default Example

--- a/packages/picasso/src/Logo/story/Default.example.jsx
+++ b/packages/picasso/src/Logo/story/Default.example.jsx
@@ -1,10 +1,10 @@
 import React from 'react'
 import { Logo } from '@toptal/picasso'
 
-const LogoDefaultExample = () => (
+const Example = () => (
   <div>
     <Logo />
   </div>
 )
 
-export default LogoDefaultExample
+export default Example

--- a/packages/picasso/src/Logo/story/Emblem.example.jsx
+++ b/packages/picasso/src/Logo/story/Emblem.example.jsx
@@ -1,10 +1,10 @@
 import React from 'react'
 import { Logo } from '@toptal/picasso'
 
-const LogoEmblemExample = () => (
+const Example = () => (
   <div>
     <Logo emblem />
   </div>
 )
 
-export default LogoEmblemExample
+export default Example

--- a/packages/picasso/src/Logo/story/Variants.example.jsx
+++ b/packages/picasso/src/Logo/story/Variants.example.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Logo, Container } from '@toptal/picasso'
 
-const LogoVariantsExample = () => (
+const Example = () => (
   <div>
     <div>
       <LogoContainer bgcolor='#ffffff' inline right='small'>
@@ -52,4 +52,4 @@ const LogoContainer = ({ children, bgcolor, inline, right }) => (
   </Container>
 )
 
-export default LogoVariantsExample
+export default Example

--- a/packages/picasso/src/Menu/story/Default.example.jsx
+++ b/packages/picasso/src/Menu/story/Default.example.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Menu } from '@toptal/picasso'
 
-const DefaultExample = () => {
+const Example = () => {
   const handleClick = () => {
     window.alert('Menu item is clicked')
   }
@@ -17,4 +17,4 @@ const DefaultExample = () => {
   )
 }
 
-export default DefaultExample
+export default Example

--- a/packages/picasso/src/Menu/story/Drilldown.example.jsx
+++ b/packages/picasso/src/Menu/story/Drilldown.example.jsx
@@ -8,7 +8,7 @@ import {
   Button
 } from '@toptal/picasso'
 
-const DrilldownExample = () => {
+const Example = () => {
   const handleClick = () => {
     console.log('Menu item is clicked')
   }
@@ -112,4 +112,4 @@ const DrilldownExample = () => {
   )
 }
 
-export default DrilldownExample
+export default Example

--- a/packages/picasso/src/MenuItem/story/Router.example.jsx
+++ b/packages/picasso/src/MenuItem/story/Router.example.jsx
@@ -9,7 +9,7 @@ const Link = forwardRef(({ to, children, ...rest }, ref) => (
   </a>
 ))
 
-const MenuItemRouterExample = () => (
+const Example = () => (
   <div>
     <Menu>
       <Menu.Item as={Link} to='/#home'>
@@ -25,4 +25,4 @@ const MenuItemRouterExample = () => (
   </div>
 )
 
-export default MenuItemRouterExample
+export default Example

--- a/packages/picasso/src/Modal/story/Default.example.jsx
+++ b/packages/picasso/src/Modal/story/Default.example.jsx
@@ -82,7 +82,7 @@ const ModalDialog = ({ modalId, hideModal }) => {
   )
 }
 
-const ModalDefaultExample = () => {
+const Example = () => {
   const { showModal, hideModal } = useModals()
 
   const handleClick = () => {
@@ -100,4 +100,4 @@ const ModalDefaultExample = () => {
   )
 }
 
-export default ModalDefaultExample
+export default Example

--- a/packages/picasso/src/Modal/story/MaxHeight.example.jsx
+++ b/packages/picasso/src/Modal/story/MaxHeight.example.jsx
@@ -106,7 +106,7 @@ const ModalDialog = ({ modalId, hideModal }) => {
   )
 }
 
-const MaxHeightExample = () => {
+const Example = () => {
   const { showModal, hideModal } = useModals()
 
   const handleClick = () => {
@@ -124,4 +124,4 @@ const MaxHeightExample = () => {
   )
 }
 
-export default MaxHeightExample
+export default Example

--- a/packages/picasso/src/Modal/story/Sizes.example.jsx
+++ b/packages/picasso/src/Modal/story/Sizes.example.jsx
@@ -59,7 +59,7 @@ const ModalDialog = ({ modalId, hideModal, size }) => (
   </Modal>
 )
 
-const ModalSizesExample = () => {
+const Example = () => {
   const { showModal, hideModal } = useModals()
 
   const handleSmallClick = () => {
@@ -97,4 +97,4 @@ const ModalSizesExample = () => {
   )
 }
 
-export default ModalSizesExample
+export default Example

--- a/packages/picasso/src/MonthSelect/story/Default.example.jsx
+++ b/packages/picasso/src/MonthSelect/story/Default.example.jsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react'
 import { MonthSelect } from '@toptal/picasso'
 
-const DefaultExample = () => {
+const Example = () => {
   const [selectedOption, setSelectedOption] = useState()
 
   const onChange = e => {
@@ -18,4 +18,4 @@ const DefaultExample = () => {
   )
 }
 
-export default DefaultExample
+export default Example

--- a/packages/picasso/src/MonthSelect/story/Filter.example.jsx
+++ b/packages/picasso/src/MonthSelect/story/Filter.example.jsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react'
 import { Grid, Form, MonthSelect, YearSelect } from '@toptal/picasso'
 
-const FilterExample = () => {
+const Example = () => {
   const [startMonth, setStartMonth] = useState()
   const [endMonth, setEndMonth] = useState()
   const [startYear, setStartYear] = useState()
@@ -106,4 +106,4 @@ const FilterExample = () => {
   )
 }
 
-export default FilterExample
+export default Example

--- a/packages/picasso/src/Notification/story/Actions.example.jsx
+++ b/packages/picasso/src/Notification/story/Actions.example.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Notification, Link } from '@toptal/picasso'
 
-const NotificationActionsExample = () => (
+const Example = () => (
   <div>
     <Notification variant='green'>
       The time zone in your profile is set to (UTC -08:00) America - Los
@@ -12,4 +12,4 @@ const NotificationActionsExample = () => (
   </div>
 )
 
-export default NotificationActionsExample
+export default Example

--- a/packages/picasso/src/Notification/story/BoxShadow.example.jsx
+++ b/packages/picasso/src/Notification/story/BoxShadow.example.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Notification, Container, Typography } from '@toptal/picasso'
 
-const NotificationBoxElevatedExample = () => (
+const Example = () => (
   <div>
     <Container bottom={1}>
       <Typography variant='heading' size='small'>
@@ -15,4 +15,4 @@ const NotificationBoxElevatedExample = () => (
   </div>
 )
 
-export default NotificationBoxElevatedExample
+export default Example

--- a/packages/picasso/src/Notification/story/Close.example.jsx
+++ b/packages/picasso/src/Notification/story/Close.example.jsx
@@ -5,7 +5,7 @@ const mockOnClose = () => {
   window.alert("You've clicked the close icon.")
 }
 
-const NotificationCloseExample = () => (
+const Example = () => (
   <div>
     <Container bottom={1}>
       <Typography variant='heading' size='small'>
@@ -19,4 +19,4 @@ const NotificationCloseExample = () => (
   </div>
 )
 
-export default NotificationCloseExample
+export default Example

--- a/packages/picasso/src/Notification/story/Default.example.jsx
+++ b/packages/picasso/src/Notification/story/Default.example.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Notification } from '@toptal/picasso'
 
-const NotificationDefaultExample = () => (
+const Example = () => (
   <div>
     <Notification>
       The time zone in your profile is set to (UTC -08:00) America - Los
@@ -10,4 +10,4 @@ const NotificationDefaultExample = () => (
   </div>
 )
 
-export default NotificationDefaultExample
+export default Example

--- a/packages/picasso/src/Notification/story/FullWidth.example.jsx
+++ b/packages/picasso/src/Notification/story/FullWidth.example.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Notification, Container, Typography } from '@toptal/picasso'
 
-const NotificationFullWidthExample = () => (
+const Example = () => (
   <div>
     <Container bottom={1}>
       <Typography variant='heading' size='small'>
@@ -15,4 +15,4 @@ const NotificationFullWidthExample = () => (
   </div>
 )
 
-export default NotificationFullWidthExample
+export default Example

--- a/packages/picasso/src/Notification/story/Icon.example.jsx
+++ b/packages/picasso/src/Notification/story/Icon.example.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Notification, Github16 } from '@toptal/picasso'
 
-const NotificationIconExample = () => (
+const Example = () => (
   <div>
     <Notification icon={<Github16 />}>
       The time zone in your profile is set to (UTC -08:00) America - Los
@@ -10,4 +10,4 @@ const NotificationIconExample = () => (
   </div>
 )
 
-export default NotificationIconExample
+export default Example

--- a/packages/picasso/src/Notification/story/Variants.example.jsx
+++ b/packages/picasso/src/Notification/story/Variants.example.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Notification, Container, Typography } from '@toptal/picasso'
 
-const NotificationVariantsExample = () => (
+const Example = () => (
   <div>
     <Container bottom={1}>
       <Container bottom={1}>
@@ -48,4 +48,4 @@ const NotificationVariantsExample = () => (
   </div>
 )
 
-export default NotificationVariantsExample
+export default Example

--- a/packages/picasso/src/Page/story/Default.example.jsx
+++ b/packages/picasso/src/Page/story/Default.example.jsx
@@ -7,7 +7,7 @@ const StyledMainContentContainer = styled(Container)`
   flex: 1;
 `
 
-const PageDefaultExample = () => (
+const Example = () => (
   <div style={{ height: '30rem' }}>
     <Page>
       <Page.Header rightContent={<RightContent />} title='Default example' />
@@ -66,4 +66,4 @@ const Content = () => (
   </StyledMainContentContainer>
 )
 
-export default PageDefaultExample
+export default Example

--- a/packages/picasso/src/Page/story/FullWidth.example.jsx
+++ b/packages/picasso/src/Page/story/FullWidth.example.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Page, Container, Menu, Typography } from '@toptal/picasso'
 
-const PageFullWidthExample = () => (
+const Example = () => (
   <div style={{ height: '30rem' }}>
     <Page width='full'>
       <Page.Header rightContent={<RightContent />} title='Full width example' />
@@ -44,4 +44,4 @@ const Content = () => (
   </Container>
 )
 
-export default PageFullWidthExample
+export default Example

--- a/packages/picasso/src/Page/story/Scroll.example.jsx
+++ b/packages/picasso/src/Page/story/Scroll.example.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Page, Container, Typography } from '@toptal/picasso'
 
-const PageScrollExample = () => (
+const Example = () => (
   <div style={{ maxHeight: '30rem', overflowY: 'scroll' }}>
     <Page>
       <Page.Header title='Scrollable example' />
@@ -57,4 +57,4 @@ const Content = () => (
   </Container>
 )
 
-export default PageScrollExample
+export default Example

--- a/packages/picasso/src/Page/story/WideWidth.example.jsx
+++ b/packages/picasso/src/Page/story/WideWidth.example.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Page, Container, Menu, Typography } from '@toptal/picasso'
 
-const PageWideWidthExample = () => (
+const Example = () => (
   <div style={{ height: '30rem' }}>
     <Page width='wide'>
       <Page.Header rightContent={<RightContent />} title='Wide width example' />
@@ -44,4 +44,4 @@ const Content = () => (
   </Container>
 )
 
-export default PageWideWidthExample
+export default Example

--- a/packages/picasso/src/Page/story/WithBanner.example.jsx
+++ b/packages/picasso/src/Page/story/WithBanner.example.jsx
@@ -7,7 +7,7 @@ const StyledMainContentContainer = styled(Container)`
   flex: 1;
 `
 
-const WithBannerExample = () => (
+const Example = () => (
   <div style={{ maxHeight: '30rem' }}>
     <Page>
       <Page.Header rightContent={<RightContent />} title='Default example' />
@@ -59,4 +59,4 @@ const Content = () => (
   </StyledMainContentContainer>
 )
 
-export default WithBannerExample
+export default Example

--- a/packages/picasso/src/PageBanner/story/Default.example.jsx
+++ b/packages/picasso/src/PageBanner/story/Default.example.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Page, Container } from '@toptal/picasso'
 
-const PageBannerDefaultExample = () => (
+const Example = () => (
   <Container bottom='small'>
     <Page.Banner>
       We are now in the process of reviewing your profile. After your profile
@@ -10,4 +10,4 @@ const PageBannerDefaultExample = () => (
   </Container>
 )
 
-export default PageBannerDefaultExample
+export default Example

--- a/packages/picasso/src/PageContent/story/Default.example.jsx
+++ b/packages/picasso/src/PageContent/story/Default.example.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Page, Container, Typography } from '@toptal/picasso'
 
-const PageContentDefaultExample = () => (
+const Example = () => (
   <div style={{ height: '30rem' }}>
     <Page.Content>
       <Content />
@@ -26,4 +26,4 @@ const Content = () => (
   </Container>
 )
 
-export default PageContentDefaultExample
+export default Example

--- a/packages/picasso/src/PageFooter/story/Default.example.jsx
+++ b/packages/picasso/src/PageFooter/story/Default.example.jsx
@@ -1,10 +1,10 @@
 import React from 'react'
 import { Page } from '@toptal/picasso'
 
-const FooterDefaultExample = () => (
+const Example = () => (
   <div>
     <Page.Footer />
   </div>
 )
 
-export default FooterDefaultExample
+export default Example

--- a/packages/picasso/src/PageFooter/story/RightContent.example.jsx
+++ b/packages/picasso/src/PageFooter/story/RightContent.example.jsx
@@ -12,7 +12,7 @@ const StyledLink = styled(Link)`
   }
 `
 
-const FooterRightContentExample = () => (
+const Example = () => (
   <div>
     <Page.Footer rightContent={<Links />} />
   </div>
@@ -42,4 +42,4 @@ const Links = () => (
   </Fragment>
 )
 
-export default FooterRightContentExample
+export default Example

--- a/packages/picasso/src/PageHeader/story/Default.example.jsx
+++ b/packages/picasso/src/PageHeader/story/Default.example.jsx
@@ -1,10 +1,10 @@
 import React from 'react'
 import { Page } from '@toptal/picasso'
 
-const PageHeaderDefaultExample = () => (
+const Example = () => (
   <div style={{ height: '4.5rem' }}>
     <Page.Header title='Onboarding' />
   </div>
 )
 
-export default PageHeaderDefaultExample
+export default Example

--- a/packages/picasso/src/PageHeader/story/ExtraMenuContent.example.jsx
+++ b/packages/picasso/src/PageHeader/story/ExtraMenuContent.example.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Page, Menu, Container, Button, Label } from '@toptal/picasso'
 
-const PageHeaderExtraMenuContentExample = () => (
+const Example = () => (
   <div style={{ height: '4.5rem' }}>
     <Page.Header
       rightContent={<RightContent />}
@@ -30,4 +30,4 @@ const RightContent = () => (
   </Page.HeaderMenu>
 )
 
-export default PageHeaderExtraMenuContentExample
+export default Example

--- a/packages/picasso/src/PageHeader/story/LeftContent.example.jsx
+++ b/packages/picasso/src/PageHeader/story/LeftContent.example.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Page, Container, Button, Input, Search16 } from '@toptal/picasso'
 
-const PageHeaderLeftContentExample = () => (
+const Example = () => (
   <div style={{ height: '4.5rem' }}>
     <Page.Header
       actionItems={
@@ -21,4 +21,4 @@ const LeftContent = () => (
   </Container>
 )
 
-export default PageHeaderLeftContentExample
+export default Example

--- a/packages/picasso/src/PageHeader/story/Link.example.jsx
+++ b/packages/picasso/src/PageHeader/story/Link.example.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Link, Page } from '@toptal/picasso'
 
-const PageHeaderLinkExample = () => (
+const Example = () => (
   <div style={{ height: '4.5rem' }}>
     <Page.Header
       title='Onboarding'
@@ -10,4 +10,4 @@ const PageHeaderLinkExample = () => (
   </div>
 )
 
-export default PageHeaderLinkExample
+export default Example

--- a/packages/picasso/src/PageHeader/story/RightContent.example.jsx
+++ b/packages/picasso/src/PageHeader/story/RightContent.example.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Page, Menu, Container, Button } from '@toptal/picasso'
 
-const PageHeaderRightContentExample = () => (
+const Example = () => (
   <div style={{ height: '4.5rem' }}>
     <Page.Header
       actionItems={
@@ -30,4 +30,4 @@ const RightContent = () => (
   </Page.HeaderMenu>
 )
 
-export default PageHeaderRightContentExample
+export default Example

--- a/packages/picasso/src/PageHeader/story/Variants.example.jsx
+++ b/packages/picasso/src/PageHeader/story/Variants.example.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Page, Container } from '@toptal/picasso'
 
-const PageHeaderDefaultExample = () => (
+const Example = () => (
   <div>
     <Container style={{ position: 'relative', height: '6rem' }}>
       <Page.Header variant='light' title='Light' />
@@ -12,4 +12,4 @@ const PageHeaderDefaultExample = () => (
   </div>
 )
 
-export default PageHeaderDefaultExample
+export default Example

--- a/packages/picasso/src/PageHeader/story/WithoutTitle.example.jsx
+++ b/packages/picasso/src/PageHeader/story/WithoutTitle.example.jsx
@@ -1,10 +1,10 @@
 import React from 'react'
 import { Page } from '@toptal/picasso'
 
-const PageHeaderDefaultExample = () => (
+const Example = () => (
   <div style={{ height: '4.5rem' }}>
     <Page.Header />
   </div>
 )
 
-export default PageHeaderDefaultExample
+export default Example

--- a/packages/picasso/src/Pagination/story/Default.example.jsx
+++ b/packages/picasso/src/Pagination/story/Default.example.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Pagination } from '@toptal/picasso'
 
-const PaginationDefaultExample = () => (
+const Example = () => (
   <div>
     <Pagination
       activePage={4}
@@ -15,4 +15,4 @@ const handlePageChange = page => {
   window.alert('Page changed to ' + page)
 }
 
-export default PaginationDefaultExample
+export default Example

--- a/packages/picasso/src/Pagination/story/Disabled.example.jsx
+++ b/packages/picasso/src/Pagination/story/Disabled.example.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Pagination } from '@toptal/picasso'
 
-const PaginationDisabledExample = () => (
+const Example = () => (
   <div>
     <Pagination
       activePage={4}
@@ -14,4 +14,4 @@ const PaginationDisabledExample = () => (
 
 const handlePageChange = () => {}
 
-export default PaginationDisabledExample
+export default Example

--- a/packages/picasso/src/Pagination/story/Variants.example.jsx
+++ b/packages/picasso/src/Pagination/story/Variants.example.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Pagination, Container, Typography } from '@toptal/picasso'
 
-const PaginationDefaultExample = () => (
+const Example = () => (
   <Container flex direction='column' justifyContent='space-between'>
     <Container bottom='xsmall'>
       <Typography variant='heading' size='small'>
@@ -129,4 +129,4 @@ const handlePageChange = page => {
   window.alert('Page changed to ' + page)
 }
 
-export default PaginationDefaultExample
+export default Example

--- a/packages/picasso/src/Paper/story/Default.example.jsx
+++ b/packages/picasso/src/Paper/story/Default.example.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Paper, Typography, Container } from '@toptal/picasso'
 
-const PaperDefaultExample = () => (
+const Example = () => (
   <div style={{ width: '25rem' }}>
     <Paper>
       <Container padded='small'>
@@ -19,4 +19,4 @@ const PaperDefaultExample = () => (
   </div>
 )
 
-export default PaperDefaultExample
+export default Example

--- a/packages/picasso/src/Radio/story/CustomLabel.example.jsx
+++ b/packages/picasso/src/Radio/story/CustomLabel.example.jsx
@@ -69,7 +69,7 @@ const PayoneerPicker = () => {
   )
 }
 
-const CustomLabelExample = () => (
+const Example = () => (
   <div>
     <Container
       bordered
@@ -83,4 +83,4 @@ const CustomLabelExample = () => (
   </div>
 )
 
-export default CustomLabelExample
+export default Example

--- a/packages/picasso/src/Radio/story/Default.example.jsx
+++ b/packages/picasso/src/Radio/story/Default.example.jsx
@@ -1,10 +1,10 @@
 import React from 'react'
 import { Radio } from '@toptal/picasso'
 
-const RadioDefaultExample = () => (
+const Example = () => (
   <div>
     <Radio label='Radio' />
   </div>
 )
 
-export default RadioDefaultExample
+export default Example

--- a/packages/picasso/src/Radio/story/Disabled.example.jsx
+++ b/packages/picasso/src/Radio/story/Disabled.example.jsx
@@ -1,10 +1,10 @@
 import React from 'react'
 import { Radio } from '@toptal/picasso'
 
-const RadioDisabledExample = () => (
+const Example = () => (
   <div>
     <Radio disabled label='Disabled' />
   </div>
 )
 
-export default RadioDisabledExample
+export default Example

--- a/packages/picasso/src/Radio/story/RadioGroupHorizontal.example.jsx
+++ b/packages/picasso/src/Radio/story/RadioGroupHorizontal.example.jsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react'
 import { Radio } from '@toptal/picasso'
 
-const RadioGroupHorizontalExample = () => {
+const Example = () => {
   const [value, setValue] = useState(null)
 
   return (
@@ -18,4 +18,4 @@ const RadioGroupHorizontalExample = () => {
   )
 }
 
-export default RadioGroupHorizontalExample
+export default Example

--- a/packages/picasso/src/Radio/story/RadioGroupVertical.example.jsx
+++ b/packages/picasso/src/Radio/story/RadioGroupVertical.example.jsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react'
 import { Radio } from '@toptal/picasso'
 
-const RadioGroupVerticalExample = () => {
+const Example = () => {
   const [value, setValue] = useState(null)
 
   return (
@@ -17,4 +17,4 @@ const RadioGroupVerticalExample = () => {
   )
 }
 
-export default RadioGroupVerticalExample
+export default Example

--- a/packages/picasso/src/Select/story/AutoFocus.example.jsx
+++ b/packages/picasso/src/Select/story/AutoFocus.example.jsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react'
 import { Select, Button, Container } from '@toptal/picasso'
 
-const SelectCustomOptionExample = () => {
+const Example = () => {
   const [value, setValue] = useState()
   const [show, setShow] = useState(false)
 
@@ -39,4 +39,4 @@ const OPTIONS = [
   { value: '4', text: 'Option 4' }
 ]
 
-export default SelectCustomOptionExample
+export default Example

--- a/packages/picasso/src/Select/story/ChosenOption.example.jsx
+++ b/packages/picasso/src/Select/story/ChosenOption.example.jsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react'
 import { Select } from '@toptal/picasso'
 
-const SelectChosenOptionExample = () => {
+const Example = () => {
   const [value, setValue] = useState('3')
 
   const handleChange = event => {
@@ -26,4 +26,4 @@ const OPTIONS = [
   { value: '4', text: 'Option 4' }
 ]
 
-export default SelectChosenOptionExample
+export default Example

--- a/packages/picasso/src/Select/story/CustomDisplayValue.example.jsx
+++ b/packages/picasso/src/Select/story/CustomDisplayValue.example.jsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react'
 import { Select } from '@toptal/picasso'
 
-const SelectDefaultExample = () => {
+const Example = () => {
   const [value, setValue] = useState()
 
   const handleChange = event => {
@@ -38,4 +38,4 @@ const OPTIONS = [
   { value: '4', text: 'Option 4' }
 ]
 
-export default SelectDefaultExample
+export default Example

--- a/packages/picasso/src/Select/story/CustomOptions.example.jsx
+++ b/packages/picasso/src/Select/story/CustomOptions.example.jsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react'
 import { Select } from '@toptal/picasso'
 
-const SelectCustomOptionExample = () => {
+const Example = () => {
   const [value, setValue] = useState()
 
   const handleChange = event => {
@@ -32,4 +32,4 @@ const OPTIONS = [
   }
 ]
 
-export default SelectCustomOptionExample
+export default Example

--- a/packages/picasso/src/Select/story/Default.example.jsx
+++ b/packages/picasso/src/Select/story/Default.example.jsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react'
 import { Select } from '@toptal/picasso'
 
-const SelectDefaultExample = () => {
+const Example = () => {
   const [value, setValue] = useState()
 
   const handleChange = event => {
@@ -27,4 +27,4 @@ const OPTIONS = [
   { value: '4', text: 'Option 4' }
 ]
 
-export default SelectDefaultExample
+export default Example

--- a/packages/picasso/src/Select/story/Disabled.example.jsx
+++ b/packages/picasso/src/Select/story/Disabled.example.jsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react'
 import { Select } from '@toptal/picasso'
 
-const SelectDisabledExample = () => {
+const Example = () => {
   const [value, setValue] = useState()
 
   const handleChange = event => {
@@ -27,4 +27,4 @@ const OPTIONS = [
   { value: '4', text: 'Option 4' }
 ]
 
-export default SelectDisabledExample
+export default Example

--- a/packages/picasso/src/Select/story/Error.example.jsx
+++ b/packages/picasso/src/Select/story/Error.example.jsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react'
 import { Select } from '@toptal/picasso'
 
-const SelectErrorExample = () => {
+const Example = () => {
   const [value, setValue] = useState()
 
   const handleChange = event => {
@@ -27,4 +27,4 @@ const OPTIONS = [
   { value: '4', text: 'Option 4' }
 ]
 
-export default SelectErrorExample
+export default Example

--- a/packages/picasso/src/Select/story/FullWidth.example.jsx
+++ b/packages/picasso/src/Select/story/FullWidth.example.jsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react'
 import { Select } from '@toptal/picasso'
 
-const SelectFullWidthExample = () => {
+const Example = () => {
   const [value, setValue] = useState()
 
   const handleChange = event => {
@@ -26,4 +26,4 @@ const OPTIONS = [
   { value: '4', text: 'Option 4' }
 ]
 
-export default SelectFullWidthExample
+export default Example

--- a/packages/picasso/src/Select/story/Loading.example.jsx
+++ b/packages/picasso/src/Select/story/Loading.example.jsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react'
 import { Select } from '@toptal/picasso'
 
-const SelectLoadingExample = () => {
+const Example = () => {
   const [value, setValue] = useState()
 
   const handleChange = event => {
@@ -28,4 +28,4 @@ const OPTIONS = [
   { value: '4', text: 'Option 4' }
 ]
 
-export default SelectLoadingExample
+export default Example

--- a/packages/picasso/src/Select/story/MenuWidth.example.jsx
+++ b/packages/picasso/src/Select/story/MenuWidth.example.jsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react'
 import { Select, Container } from '@toptal/picasso'
 
-const MenuWidthExample = () => {
+const Example = () => {
   const [value, setValue] = useState()
 
   const handleChange = event => {
@@ -32,4 +32,4 @@ const OPTIONS = [
   { value: '4', text: '4' }
 ]
 
-export default MenuWidthExample
+export default Example

--- a/packages/picasso/src/Select/story/Multiple.example.jsx
+++ b/packages/picasso/src/Select/story/Multiple.example.jsx
@@ -8,7 +8,7 @@ const OPTIONS = [
   { value: '4', text: 'Option 4' }
 ]
 
-const SelectMultipleExample = () => {
+const Example = () => {
   const [values, setValues] = useState([])
 
   const handleChange = event => {
@@ -27,4 +27,4 @@ const SelectMultipleExample = () => {
   )
 }
 
-export default SelectMultipleExample
+export default Example

--- a/packages/picasso/src/Select/story/Native.example.jsx
+++ b/packages/picasso/src/Select/story/Native.example.jsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react'
 import { Select } from '@toptal/picasso'
 
-const SelectNativeExample = () => {
+const Example = () => {
   const [value, setValue] = useState()
 
   const handleChange = event => {
@@ -27,4 +27,4 @@ const OPTIONS = [
   { value: '4', text: 'Option 4' }
 ]
 
-export default SelectNativeExample
+export default Example

--- a/packages/picasso/src/Select/story/ResetButton.example.jsx
+++ b/packages/picasso/src/Select/story/ResetButton.example.jsx
@@ -8,7 +8,7 @@ const OPTIONS = [
   { value: '4', text: 'Option 4' }
 ]
 
-const SelectResetButtonExample = () => {
+const Example = () => {
   const [values, setValues] = useState([])
 
   const handleChange = event => {
@@ -28,4 +28,4 @@ const SelectResetButtonExample = () => {
   )
 }
 
-export default SelectResetButtonExample
+export default Example

--- a/packages/picasso/src/Select/story/ShrinkWidth.example.jsx
+++ b/packages/picasso/src/Select/story/ShrinkWidth.example.jsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react'
 import { Select, Container } from '@toptal/picasso'
 import { Settings16 } from '@toptal/picasso/Icon'
 
-const ShrinkWidthExample = () => {
+const Example = () => {
   const [value, setValue] = useState()
 
   const handleChange = event => {
@@ -41,4 +41,4 @@ const OPTIONS = [
   { value: '4', text: '4' }
 ]
 
-export default ShrinkWidthExample
+export default Example

--- a/packages/picasso/src/Select/story/Sizes.example.jsx
+++ b/packages/picasso/src/Select/story/Sizes.example.jsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react'
 import { Select, Container, Typography } from '@toptal/picasso'
 
-const SelectSizesExample = () => {
+const Example = () => {
   const [value, setValue] = useState()
 
   const handleChange = event => {
@@ -51,4 +51,4 @@ const OPTIONS = [
   { value: '4', text: 'Option 4' }
 ]
 
-export default SelectSizesExample
+export default Example

--- a/packages/picasso/src/Select/story/WithIcon.example.jsx
+++ b/packages/picasso/src/Select/story/WithIcon.example.jsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react'
 import { Select, Container } from '@toptal/picasso'
 import { Settings16 } from '@toptal/picasso/Icon'
 
-const SelectWithIconExample = () => {
+const Example = () => {
   const [value, setValue] = useState()
 
   const handleChange = event => {
@@ -54,4 +54,4 @@ const OPTIONS = [
   { value: '4', text: 'Option 4' }
 ]
 
-export default SelectWithIconExample
+export default Example

--- a/packages/picasso/src/ShowMore/story/CustomLimit.example.jsx
+++ b/packages/picasso/src/ShowMore/story/CustomLimit.example.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { ShowMore } from '@toptal/picasso'
 
-const CustomLimitExample = () => (
+const Example = () => (
   <div style={{ width: '430px' }}>
     <ShowMore rows={2}>
       Lorem ipsum dolor sit amet consectetur adipisicing elit. Eos earum vitae
@@ -25,4 +25,4 @@ const CustomLimitExample = () => (
   </div>
 )
 
-export default CustomLimitExample
+export default Example

--- a/packages/picasso/src/ShowMore/story/Default.example.jsx
+++ b/packages/picasso/src/ShowMore/story/Default.example.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { ShowMore } from '@toptal/picasso'
 
-const ShowMoreDefaultExample = () => (
+const Example = () => (
   <div style={{ width: '430px' }}>
     <ShowMore>
       Lorem ipsum dolor sit amet consectetur adipisicing elit. Eos earum vitae
@@ -25,4 +25,4 @@ const ShowMoreDefaultExample = () => (
   </div>
 )
 
-export default ShowMoreDefaultExample
+export default Example

--- a/packages/picasso/src/ShowMore/story/Expanded.example.jsx
+++ b/packages/picasso/src/ShowMore/story/Expanded.example.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { ShowMore } from '@toptal/picasso'
 
-const ShowMoreExpandedExample = () => (
+const Example = () => (
   <div style={{ width: '430px' }}>
     <ShowMore initialExpanded>
       Lorem ipsum dolor sit amet consectetur adipisicing elit. Eos earum vitae
@@ -25,4 +25,4 @@ const ShowMoreExpandedExample = () => (
   </div>
 )
 
-export default ShowMoreExpandedExample
+export default Example

--- a/packages/picasso/src/ShowMore/story/ToggleDisabled.example.jsx
+++ b/packages/picasso/src/ShowMore/story/ToggleDisabled.example.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { ShowMore } from '@toptal/picasso'
 
-const ShowMoreDisabledToggleExample = () => (
+const Example = () => (
   <div style={{ width: '430px' }}>
     <ShowMore disableToggle>
       Lorem ipsum dolor sit amet consectetur adipisicing elit. Eos earum vitae
@@ -25,4 +25,4 @@ const ShowMoreDisabledToggleExample = () => (
   </div>
 )
 
-export default ShowMoreDisabledToggleExample
+export default Example

--- a/packages/picasso/src/Sidebar/story/Default.example.jsx
+++ b/packages/picasso/src/Sidebar/story/Default.example.jsx
@@ -14,7 +14,7 @@ import {
   Help16
 } from '@toptal/picasso/Icon'
 
-const SidebarDefaultExample = () => (
+const Example = () => (
   <div
     style={{
       height: '58rem',
@@ -72,4 +72,4 @@ const SidebarDefaultExample = () => (
   </div>
 )
 
-export default SidebarDefaultExample
+export default Example

--- a/packages/picasso/src/Sidebar/story/Menu.example.jsx
+++ b/packages/picasso/src/Sidebar/story/Menu.example.jsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { Sidebar, Grid, Typography } from '@toptal/picasso'
 import { Referrals16 } from '@toptal/picasso/Icon'
 
-const SidebarVariantsExample = () => (
+const Example = () => (
   <Grid spacing={32}>
     <Grid.Item style={{ height: '30rem' }}>
       <Typography variant='heading' size='small'>
@@ -118,4 +118,4 @@ const SidebarVariantsExample = () => (
   </Grid>
 )
 
-export default SidebarVariantsExample
+export default Example

--- a/packages/picasso/src/Sidebar/story/Variants.example.jsx
+++ b/packages/picasso/src/Sidebar/story/Variants.example.jsx
@@ -21,7 +21,7 @@ import {
   Help16
 } from '@toptal/picasso/Icon'
 
-const SidebarVariantsExample = () => (
+const Example = () => (
   <Grid spacing={32}>
     <Grid.Item style={{ height: '58rem' }}>
       <Typography variant='heading' size='small'>
@@ -131,4 +131,4 @@ const SidebarVariantsExample = () => (
   </Grid>
 )
 
-export default SidebarVariantsExample
+export default Example

--- a/packages/picasso/src/Sidebar/story/WithoutIcons.example.jsx
+++ b/packages/picasso/src/Sidebar/story/WithoutIcons.example.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Sidebar, Logo, Typography, Grid } from '@toptal/picasso'
 
-const SidebarIconlessExample = () => (
+const Example = () => (
   <Grid spacing={32}>
     <Grid.Item style={{ height: '58rem' }}>
       <Typography variant='heading' size='small'>
@@ -95,4 +95,4 @@ const SidebarIconlessExample = () => (
   </Grid>
 )
 
-export default SidebarIconlessExample
+export default Example

--- a/packages/picasso/src/Slider/story/Controlled.example.jsx
+++ b/packages/picasso/src/Slider/story/Controlled.example.jsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react'
 import { Button, Grid, Slider } from '@toptal/picasso'
 import { Plus16, Minus16 } from '@toptal/picasso/Icon'
 
-const SliderControlledExample = () => {
+const Example = () => {
   const [value, setValue] = useState(0)
   const handleChange = (_, newValue) => {
     setValue(newValue)
@@ -41,4 +41,4 @@ const SliderControlledExample = () => {
   )
 }
 
-export default SliderControlledExample
+export default Example

--- a/packages/picasso/src/Slider/story/Default.example.jsx
+++ b/packages/picasso/src/Slider/story/Default.example.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Container, Slider } from '@toptal/picasso'
 
-const SliderDefaultExample = () => {
+const Example = () => {
   const handleChange = (event, value) => {
     window.console.log('onChange: ', value)
   }
@@ -13,4 +13,4 @@ const SliderDefaultExample = () => {
   )
 }
 
-export default SliderDefaultExample
+export default Example

--- a/packages/picasso/src/Slider/story/InitialValue.example.jsx
+++ b/packages/picasso/src/Slider/story/InitialValue.example.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Container, Slider } from '@toptal/picasso'
 
-const SliderDefaultValueExample = () => {
+const Example = () => {
   return (
     <Container>
       <Slider defaultValue={8} />
@@ -9,4 +9,4 @@ const SliderDefaultValueExample = () => {
   )
 }
 
-export default SliderDefaultValueExample
+export default Example

--- a/packages/picasso/src/Slider/story/Marks.example.jsx
+++ b/packages/picasso/src/Slider/story/Marks.example.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Container, Slider } from '@toptal/picasso'
 
-const SliderMarksExample = () => {
+const Example = () => {
   const handleChange = (event, value) => {
     window.console.log('onChange: ', value)
   }
@@ -13,4 +13,4 @@ const SliderMarksExample = () => {
   )
 }
 
-export default SliderMarksExample
+export default Example

--- a/packages/picasso/src/Slider/story/Range.example.jsx
+++ b/packages/picasso/src/Slider/story/Range.example.jsx
@@ -8,7 +8,7 @@ const renderLabel = val => {
   return <Typography color='inherit'>GMT+{formattedVal}:00</Typography>
 }
 
-const SliderRangeExample = () => {
+const Example = () => {
   const [value, setValue] = React.useState([10, 20])
 
   const handleChange = (_, newValue) => {
@@ -34,4 +34,4 @@ const SliderRangeExample = () => {
   )
 }
 
-export default SliderRangeExample
+export default Example

--- a/packages/picasso/src/Slider/story/Tooltip.example.jsx
+++ b/packages/picasso/src/Slider/story/Tooltip.example.jsx
@@ -8,7 +8,7 @@ const formatLabel = val => {
   return <Typography color='inherit'>GMT+{formattedVal}:00</Typography>
 }
 
-const SliderTooltipExample = () => {
+const Example = () => {
   return (
     <Container padded='small'>
       <Container>
@@ -39,4 +39,4 @@ const SliderTooltipExample = () => {
   )
 }
 
-export default SliderTooltipExample
+export default Example

--- a/packages/picasso/src/Stepper/story/Default.example.jsx
+++ b/packages/picasso/src/Stepper/story/Default.example.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Stepper, Container } from '@toptal/picasso'
 
-const StepperDefaultExample = () => (
+const Example = () => (
   <div>
     <Container padded='medium'>
       <Stepper steps={['Step 1', 'Step 2', 'Step 3', 'Step 4']} />
@@ -18,4 +18,4 @@ const StepperDefaultExample = () => (
   </div>
 )
 
-export default StepperDefaultExample
+export default Example

--- a/packages/picasso/src/Stepper/story/FullWidth.example.jsx
+++ b/packages/picasso/src/Stepper/story/FullWidth.example.jsx
@@ -1,10 +1,10 @@
 import React from 'react'
 import { Stepper } from '@toptal/picasso'
 
-const StepperFullWidthExample = () => (
+const Example = () => (
   <div style={{ width: '40rem' }}>
     <Stepper fullWidth steps={['Step 1', 'Step 2', 'Step 3', 'Step 4']} />
   </div>
 )
 
-export default StepperFullWidthExample
+export default Example

--- a/packages/picasso/src/Stepper/story/Variants.example.jsx
+++ b/packages/picasso/src/Stepper/story/Variants.example.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Stepper, Container, Typography } from '@toptal/picasso'
 
-const StepperVariantsExample = () => (
+const Example = () => (
   <div>
     <Typography>Default:</Typography>
     <Container padded='medium'>
@@ -16,4 +16,4 @@ const StepperVariantsExample = () => (
   </div>
 )
 
-export default StepperVariantsExample
+export default Example

--- a/packages/picasso/src/Tab/story/CustomValue.example.jsx
+++ b/packages/picasso/src/Tab/story/CustomValue.example.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Container, Tabs } from '@toptal/picasso'
 
-const CustomValueExample = () => {
+const Example = () => {
   const [value, setValue] = React.useState(false)
 
   function handleChange(event, newValue) {
@@ -23,4 +23,4 @@ const CustomValueExample = () => {
   )
 }
 
-export default CustomValueExample
+export default Example

--- a/packages/picasso/src/Tab/story/Disabled.example.jsx
+++ b/packages/picasso/src/Tab/story/Disabled.example.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Container, Tabs } from '@toptal/picasso'
 
-const DisabledTabExample = () => {
+const Example = () => {
   const [value, setValue] = React.useState(0)
 
   function handleChange(event, newValue) {
@@ -29,4 +29,4 @@ const DisabledTabExample = () => {
   )
 }
 
-export default DisabledTabExample
+export default Example

--- a/packages/picasso/src/Table/story/Default.example.jsx
+++ b/packages/picasso/src/Table/story/Default.example.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Table } from '@toptal/picasso'
 
-const TableDefaultExample = () => (
+const Example = () => (
   <div>
     <Table>
       <Table.Head>
@@ -75,4 +75,4 @@ const data = [
   )
 ]
 
-export default TableDefaultExample
+export default Example

--- a/packages/picasso/src/Table/story/Select.example.jsx
+++ b/packages/picasso/src/Table/story/Select.example.jsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react'
 import { Table, Checkbox } from '@toptal/picasso'
 
-const SelectTableExample = () => {
+const Example = () => {
   const [selected, setSelected] = useState([])
 
   const handleClick = (event, id) => {
@@ -95,4 +95,4 @@ const data = [
   )
 ]
 
-export default SelectTableExample
+export default Example

--- a/packages/picasso/src/TableCell/story/Alignments.example.jsx
+++ b/packages/picasso/src/TableCell/story/Alignments.example.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Table } from '@toptal/picasso'
 
-const TableCellDefaultExample = () => (
+const Example = () => (
   <div>
     <Table>
       <Table.Head>
@@ -51,4 +51,4 @@ const data = [
   createData('Logan Burton', 'Developer', 'Microsoft', 'CTO', 'United States')
 ]
 
-export default TableCellDefaultExample
+export default Example

--- a/packages/picasso/src/Tabs/story/Default.example.jsx
+++ b/packages/picasso/src/Tabs/story/Default.example.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Container, Tabs } from '@toptal/picasso'
 
-const TabsDefaultExample = () => {
+const Example = () => {
   const [value, setValue] = React.useState(0)
 
   function handleChange(event, newValue) {
@@ -29,4 +29,4 @@ const TabsDefaultExample = () => {
   )
 }
 
-export default TabsDefaultExample
+export default Example

--- a/packages/picasso/src/TagSelector/story/Default.example.jsx
+++ b/packages/picasso/src/TagSelector/story/Default.example.jsx
@@ -29,7 +29,7 @@ const filterOptions = (str = '') => {
   return result.length > 0 ? result : null
 }
 
-const TagSelectorDefaultExample = () => {
+const Example = () => {
   const [options, setOptions] = useState(allOptions)
   const [value, setValue] = useState([])
   const [inputValue, setInputValue] = useState(EMPTY_INPUT_VALUE)
@@ -57,4 +57,4 @@ const TagSelectorDefaultExample = () => {
   )
 }
 
-export default TagSelectorDefaultExample
+export default Example

--- a/packages/picasso/src/TagSelector/story/InitialSetValue.example.jsx
+++ b/packages/picasso/src/TagSelector/story/InitialSetValue.example.jsx
@@ -23,7 +23,7 @@ const filterOptions = value =>
     ? allOptions.filter(option => isSubstring(value, getDisplayValue(option)))
     : allOptions
 
-const TagSelectorDefaultExample = () => {
+const Example = () => {
   const [options, setOptions] = useState(allOptions)
   const [value, setValue] = useState(allOptions.slice(0, 3))
   const [inputValue, setInputValue] = useState(EMPTY_INPUT_VALUE)
@@ -50,4 +50,4 @@ const TagSelectorDefaultExample = () => {
   )
 }
 
-export default TagSelectorDefaultExample
+export default Example

--- a/packages/picasso/src/TagSelector/story/Loading.example.jsx
+++ b/packages/picasso/src/TagSelector/story/Loading.example.jsx
@@ -10,10 +10,10 @@ const options = [
   { text: 'Ukraine', value: 'UA' }
 ]
 
-const TagSelectorLoadingExample = () => (
+const Example = () => (
   <div>
     <TagSelector placeholder='Loading state...' options={options} loading />
   </div>
 )
 
-export default TagSelectorLoadingExample
+export default Example

--- a/packages/picasso/src/TagSelector/story/OtherOption.example.jsx
+++ b/packages/picasso/src/TagSelector/story/OtherOption.example.jsx
@@ -23,7 +23,7 @@ const filterOptions = value =>
     ? allOptions.filter(option => isSubstring(value, getDisplayValue(option)))
     : allOptions
 
-const TagSelectorOtherOptionExample = () => {
+const Example = () => {
   const [options, setOptions] = useState(allOptions)
   const [value, setValue] = useState([])
   const [inputValue, setInputValue] = useState(EMPTY_INPUT_VALUE)
@@ -55,4 +55,4 @@ const TagSelectorOtherOptionExample = () => {
   )
 }
 
-export default TagSelectorOtherOptionExample
+export default Example

--- a/packages/picasso/src/Tooltip/story/Arrow.example.jsx
+++ b/packages/picasso/src/Tooltip/story/Arrow.example.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Tooltip, Button, Container } from '@toptal/picasso'
 
-const TooltipArrowExample = () => (
+const Example = () => (
   <div
     style={{
       textAlign: 'center',
@@ -23,4 +23,4 @@ const TooltipArrowExample = () => (
   </div>
 )
 
-export default TooltipArrowExample
+export default Example

--- a/packages/picasso/src/Tooltip/story/Default.example.jsx
+++ b/packages/picasso/src/Tooltip/story/Default.example.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Tooltip, Button } from '@toptal/picasso'
 
-const TooltipDefaultExample = () => (
+const Example = () => (
   <div style={{ width: '320px', height: '120px', padding: '2rem' }}>
     <Tooltip content='Content goes here...' open placement='right'>
       <Button>Test me</Button>
@@ -9,4 +9,4 @@ const TooltipDefaultExample = () => (
   </div>
 )
 
-export default TooltipDefaultExample
+export default Example

--- a/packages/picasso/src/Tooltip/story/Interactive.example.jsx
+++ b/packages/picasso/src/Tooltip/story/Interactive.example.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Tooltip, Button, Container } from '@toptal/picasso'
 
-const TooltipArrowExample = () => (
+const Example = () => (
   <div style={{ textAlign: 'center' }}>
     <Container top='large' bottom='large' left='large' right='large' inline>
       <Tooltip content='You can not hover inside!' placement='top'>
@@ -16,4 +16,4 @@ const TooltipArrowExample = () => (
   </div>
 )
 
-export default TooltipArrowExample
+export default Example

--- a/packages/picasso/src/Tooltip/story/Placement.example.jsx
+++ b/packages/picasso/src/Tooltip/story/Placement.example.jsx
@@ -3,7 +3,7 @@ import { Tooltip, Button, Container } from '@toptal/picasso'
 
 const placements = ['left', 'bottom', 'top', 'right']
 
-const TooltipPlacementExample = () => (
+const Example = () => (
   <div style={{ width: '800px', height: '230px', padding: '3rem 6rem' }}>
     {placements.map(placement => (
       <Container
@@ -22,4 +22,4 @@ const TooltipPlacementExample = () => (
   </div>
 )
 
-export default TooltipPlacementExample
+export default Example

--- a/packages/picasso/src/Tooltip/story/Trigger.example.jsx
+++ b/packages/picasso/src/Tooltip/story/Trigger.example.jsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react'
 import { Tooltip, Button, Container } from '@toptal/picasso'
 import { ClickAwayListener } from '@toptal/picasso/utils'
 
-const TooltipArrowExample = () => {
+const Example = () => {
   const [open, setOpen] = useState(false)
 
   const handleTooltipOpen = () => setOpen(true)
@@ -26,4 +26,4 @@ const TooltipArrowExample = () => {
   )
 }
 
-export default TooltipArrowExample
+export default Example

--- a/packages/picasso/src/Tooltip/story/Variant.example.jsx
+++ b/packages/picasso/src/Tooltip/story/Variant.example.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Tooltip, Button, Container } from '@toptal/picasso'
 
-const TooltipArrowExample = () => (
+const Example = () => (
   <div
     style={{
       textAlign: 'center',
@@ -23,4 +23,4 @@ const TooltipArrowExample = () => (
   </div>
 )
 
-export default TooltipArrowExample
+export default Example

--- a/packages/picasso/src/Typography/story/Alignment.example.jsx
+++ b/packages/picasso/src/Typography/story/Alignment.example.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Typography, Container } from '@toptal/picasso'
 
-const TypographyAlignmentExample = () => (
+const Example = () => (
   <div>
     <Container bottom='small'>
       <Typography align='left'>Left</Typography>
@@ -13,4 +13,4 @@ const TypographyAlignmentExample = () => (
   </div>
 )
 
-export default TypographyAlignmentExample
+export default Example

--- a/packages/picasso/src/Typography/story/As.example.jsx
+++ b/packages/picasso/src/Typography/story/As.example.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { Typography } from '@toptal/picasso'
 
-const TypographyAsExample = () => <Typography as='h5'>Just text</Typography>
+const Example = () => <Typography as='h5'>Just text</Typography>
 
-export default TypographyAsExample
+export default Example

--- a/packages/picasso/src/Typography/story/Colors.example.jsx
+++ b/packages/picasso/src/Typography/story/Colors.example.jsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { Typography, Container } from '@toptal/picasso'
 import { palette } from '@toptal/picasso/utils'
 
-const TypographyColorsExample = () => (
+const Example = () => (
   <div>
     <Container bottom={1}>
       <Typography color='blue'>Blue</Typography>
@@ -37,4 +37,4 @@ const TypographyColorsExample = () => (
   </div>
 )
 
-export default TypographyColorsExample
+export default Example

--- a/packages/picasso/src/Typography/story/Default.example.jsx
+++ b/packages/picasso/src/Typography/story/Default.example.jsx
@@ -1,10 +1,10 @@
 import React from 'react'
 import { Typography } from '@toptal/picasso'
 
-const TypographyDefaultExample = () => (
+const Example = () => (
   <div>
     <Typography>Just text</Typography>
   </div>
 )
 
-export default TypographyDefaultExample
+export default Example

--- a/packages/picasso/src/Typography/story/Headings.example.jsx
+++ b/packages/picasso/src/Typography/story/Headings.example.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Typography, Container } from '@toptal/picasso'
 
-const TypographyHeadingsExample = () => (
+const Example = () => (
   <div>
     <Container bottom='small'>
       <Typography variant='heading' size='small'>
@@ -24,4 +24,4 @@ const TypographyHeadingsExample = () => (
   </div>
 )
 
-export default TypographyHeadingsExample
+export default Example

--- a/packages/picasso/src/Typography/story/InheritSize.example.jsx
+++ b/packages/picasso/src/Typography/story/InheritSize.example.jsx
@@ -1,10 +1,10 @@
 import React from 'react'
 import { Typography } from '@toptal/picasso'
 
-const TypographyAlignmentExample = () => (
+const Example = () => (
   <div style={{ fontSize: '2rem' }}>
     <Typography>Inherit font size</Typography>
   </div>
 )
 
-export default TypographyAlignmentExample
+export default Example

--- a/packages/picasso/src/Typography/story/LineThrough.example.jsx
+++ b/packages/picasso/src/Typography/story/LineThrough.example.jsx
@@ -1,10 +1,10 @@
 import React from 'react'
 import { Typography } from '@toptal/picasso'
 
-const LineThroughExample = () => (
+const Example = () => (
   <div>
     <Typography lineThrough>Struck text</Typography>
   </div>
 )
 
-export default LineThroughExample
+export default Example

--- a/packages/picasso/src/Typography/story/Types.example.jsx
+++ b/packages/picasso/src/Typography/story/Types.example.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Typography, Container } from '@toptal/picasso'
 
-const TypographyTypesExample = () => (
+const Example = () => (
   <div>
     <Container bottom='small'>
       <Typography size='large'>Body Large</Typography>
@@ -20,4 +20,4 @@ const TypographyTypesExample = () => (
   </div>
 )
 
-export default TypographyTypesExample
+export default Example

--- a/packages/picasso/src/Typography/story/Underline.example.jsx
+++ b/packages/picasso/src/Typography/story/Underline.example.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Typography, Container } from '@toptal/picasso'
 
-const UnderlineExample = () => (
+const Example = () => (
   <div>
     <Container bottom='small'>
       <Typography underline>solid</Typography>
@@ -12,4 +12,4 @@ const UnderlineExample = () => (
   </div>
 )
 
-export default UnderlineExample
+export default Example

--- a/packages/picasso/src/Typography/story/Weights.example.jsx
+++ b/packages/picasso/src/Typography/story/Weights.example.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Typography, Container } from '@toptal/picasso'
 
-const TypographyWeightsExample = () => (
+const Example = () => (
   <div>
     <Container bottom='small'>
       <Typography weight='thin'>Thin</Typography>
@@ -18,4 +18,4 @@ const TypographyWeightsExample = () => (
   </div>
 )
 
-export default TypographyWeightsExample
+export default Example

--- a/packages/picasso/src/UserBadge/story/Alignment.example.jsx
+++ b/packages/picasso/src/UserBadge/story/Alignment.example.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { UserBadge, Grid, Typography } from '@toptal/picasso'
 
-const UserBadgeAlignmentExample = () => (
+const Example = () => (
   <div>
     <Grid direction='column'>
       <Grid.Item>
@@ -75,4 +75,4 @@ const UserBadgeAlignmentExample = () => (
   </div>
 )
 
-export default UserBadgeAlignmentExample
+export default Example

--- a/packages/picasso/src/UserBadge/story/Custom.example.jsx
+++ b/packages/picasso/src/UserBadge/story/Custom.example.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { UserBadge, Typography, Avatar, Container } from '@toptal/picasso'
 
-const UserBadgeCustomExample = () => (
+const Example = () => (
   <div>
     <UserBadge
       name='Jacqueline Roque'
@@ -26,4 +26,4 @@ const UserBadgeCustomExample = () => (
   </div>
 )
 
-export default UserBadgeCustomExample
+export default Example

--- a/packages/picasso/src/UserBadge/story/CustomName.example.jsx
+++ b/packages/picasso/src/UserBadge/story/CustomName.example.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { UserBadge, Link, Typography } from '@toptal/picasso'
 
-const UserBadgeTitleExample = () => (
+const Example = () => (
   <UserBadge
     name='Jacqueline Roque'
     renderName={name => <Link href='#'>{name}</Link>}
@@ -12,4 +12,4 @@ const UserBadgeTitleExample = () => (
   </UserBadge>
 )
 
-export default UserBadgeTitleExample
+export default Example

--- a/packages/picasso/src/UserBadge/story/Default.example.jsx
+++ b/packages/picasso/src/UserBadge/story/Default.example.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { UserBadge, Grid, Typography } from '@toptal/picasso'
 
-const UserBadgeDefaultExample = () => (
+const Example = () => (
   <div>
     <Grid direction='column'>
       <Grid.Item>
@@ -19,4 +19,4 @@ const UserBadgeDefaultExample = () => (
   </div>
 )
 
-export default UserBadgeDefaultExample
+export default Example

--- a/packages/picasso/src/UserBadge/story/Invert.example.jsx
+++ b/packages/picasso/src/UserBadge/story/Invert.example.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { UserBadge, Grid, Typography } from '@toptal/picasso'
 
-const UserBadgeInvertExample = () => (
+const Example = () => (
   <div>
     <Grid direction='column'>
       <Grid.Item>
@@ -35,4 +35,4 @@ const UserBadgeInvertExample = () => (
   </div>
 )
 
-export default UserBadgeInvertExample
+export default Example

--- a/packages/picasso/src/UserBadge/story/Sizes.example.jsx
+++ b/packages/picasso/src/UserBadge/story/Sizes.example.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { UserBadge, Grid, Typography } from '@toptal/picasso'
 
-const UserBadgeSizesExample = () => (
+const Example = () => (
   <div>
     <Grid direction='column'>
       <Grid.Item>
@@ -25,4 +25,4 @@ const UserBadgeSizesExample = () => (
   </div>
 )
 
-export default UserBadgeSizesExample
+export default Example

--- a/packages/picasso/src/UserBadge/story/Title.example.jsx
+++ b/packages/picasso/src/UserBadge/story/Title.example.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { UserBadge, Link, Typography } from '@toptal/picasso'
 
-const UserBadgeTitleExample = () => (
+const Example = () => (
   <UserBadge
     name='Jacqueline Roque'
     title='UI specialist'
@@ -13,4 +13,4 @@ const UserBadgeTitleExample = () => (
   </UserBadge>
 )
 
-export default UserBadgeTitleExample
+export default Example

--- a/packages/picasso/src/YearSelect/story/Default.example.jsx
+++ b/packages/picasso/src/YearSelect/story/Default.example.jsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react'
 import { YearSelect } from '@toptal/picasso'
 
-const DefaultExample = () => {
+const Example = () => {
   const [year, setYear] = useState()
 
   const onChange = event => {
@@ -22,4 +22,4 @@ const DefaultExample = () => {
   )
 }
 
-export default DefaultExample
+export default Example

--- a/packages/picasso/src/utils/Breakpoints/story/Breakpoints.example.jsx
+++ b/packages/picasso/src/utils/Breakpoints/story/Breakpoints.example.jsx
@@ -4,7 +4,7 @@ import { Grid, Paper, Image, Typography, Container } from '@toptal/picasso'
 
 const breakpointsList = Object.entries(breakpoints)
 
-const BreakpointsExample = () => (
+const Example = () => (
   <Grid spacing={16}>
     {breakpointsList.map(([breakpointName, breakpointValue], index) => {
       const prevBreakpoint = breakpointsList[index - 1]
@@ -46,4 +46,4 @@ const BreakpointsExample = () => (
   </Grid>
 )
 
-export default BreakpointsExample
+export default Example

--- a/packages/picasso/src/utils/Breakpoints/story/MediaQueries.example.jsx
+++ b/packages/picasso/src/utils/Breakpoints/story/MediaQueries.example.jsx
@@ -11,8 +11,8 @@ const StyledBox = styled.div`
   }
 `
 
-const MediaQueriesExample = () => (
+const Example = () => (
   <StyledBox>Box will become blue on small and medium screen sizes</StyledBox>
 )
 
-export default MediaQueriesExample
+export default Example

--- a/packages/picasso/src/utils/Breakpoints/story/useBreakpoint.example.jsx
+++ b/packages/picasso/src/utils/Breakpoints/story/useBreakpoint.example.jsx
@@ -2,7 +2,7 @@ import React, { Fragment } from 'react'
 import { useBreakpoint } from '@toptal/picasso/utils'
 import { Typography } from '@toptal/picasso'
 
-const UseScreenExample = () => {
+const Example = () => {
   const isSmall = useBreakpoint('small')
   const isSmallOrMedium = useBreakpoint(['small', 'medium'])
 
@@ -14,4 +14,4 @@ const UseScreenExample = () => {
   )
 }
 
-export default UseScreenExample
+export default Example

--- a/packages/picasso/src/utils/Breakpoints/story/useScreens.example.jsx
+++ b/packages/picasso/src/utils/Breakpoints/story/useScreens.example.jsx
@@ -2,7 +2,7 @@ import React, { Fragment } from 'react'
 import { useScreens } from '@toptal/picasso/utils'
 import { Typography, Button } from '@toptal/picasso'
 
-const UseScreenExample = () => {
+const Example = () => {
   const screens = useScreens()
 
   return (
@@ -44,4 +44,4 @@ const UseScreenExample = () => {
   )
 }
 
-export default UseScreenExample
+export default Example

--- a/packages/picasso/src/utils/Colors/story/Default.example.jsx
+++ b/packages/picasso/src/utils/Colors/story/Default.example.jsx
@@ -4,7 +4,7 @@ import { Grid, Paper, Typography, Container } from '@toptal/picasso'
 
 const colorGroups = Object.entries(palette)
 
-const ColorsExample = () => (
+const Example = () => (
   <Fragment>
     {colorGroups.map(([colorGroupName, colorGroup]) => (
       <Fragment key={colorGroupName}>
@@ -50,4 +50,4 @@ const ColorRectangle = ({ color }) => (
   />
 )
 
-export default ColorsExample
+export default Example

--- a/packages/picasso/src/utils/Colors/story/HowToUse.example.jsx
+++ b/packages/picasso/src/utils/Colors/story/HowToUse.example.jsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { palette } from '@toptal/picasso/utils'
 import { Typography } from '@toptal/picasso'
 
-const HowToUseExample = () => (
+const Example = () => (
   <Typography>
     Use the color just directly from Picasso. For example,
     <span style={{ color: palette.blue.main }}>
@@ -11,4 +11,4 @@ const HowToUseExample = () => (
   </Typography>
 )
 
-export default HowToUseExample
+export default Example

--- a/packages/picasso/src/utils/Notifications/story/Custom.example.jsx
+++ b/packages/picasso/src/utils/Notifications/story/Custom.example.jsx
@@ -8,7 +8,7 @@ const StyledCustomNotification = styled(Container)`
   box-shadow: ${shadows[3]};
 `
 
-const CustomExample = () => {
+const Example = () => {
   const { showCustomNotification, closeNotification } = useNotifications()
 
   return (
@@ -42,4 +42,4 @@ const CustomExample = () => {
   )
 }
 
-export default CustomExample
+export default Example

--- a/packages/picasso/src/utils/Notifications/story/Default.example.jsx
+++ b/packages/picasso/src/utils/Notifications/story/Default.example.jsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { Button } from '@toptal/picasso'
 import { useNotifications } from '@toptal/picasso/utils'
 
-const DefaultExample = () => {
+const Example = () => {
   const { showInfo } = useNotifications()
 
   return (
@@ -17,4 +17,4 @@ const DefaultExample = () => {
   )
 }
 
-export default DefaultExample
+export default Example

--- a/packages/picasso/src/utils/Notifications/story/GeneralNotifications.example.jsx
+++ b/packages/picasso/src/utils/Notifications/story/GeneralNotifications.example.jsx
@@ -3,7 +3,7 @@ import { Button, Container } from '@toptal/picasso'
 import { Pencil16 } from '@toptal/picasso/Icon'
 import { useNotifications } from '@toptal/picasso/utils'
 
-const GeneralNotificationsExample = () => {
+const Example = () => {
   const { showInfo } = useNotifications()
 
   return (
@@ -26,4 +26,4 @@ const GeneralNotificationsExample = () => {
   )
 }
 
-export default GeneralNotificationsExample
+export default Example

--- a/packages/picasso/src/utils/Notifications/story/Options.example.jsx
+++ b/packages/picasso/src/utils/Notifications/story/Options.example.jsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { Button } from '@toptal/picasso'
 import { useNotifications } from '@toptal/picasso/utils'
 
-const NotificationOptionsExample = () => {
+const Example = () => {
   const { showError } = useNotifications()
 
   return (
@@ -22,4 +22,4 @@ const NotificationOptionsExample = () => {
   )
 }
 
-export default NotificationOptionsExample
+export default Example

--- a/packages/picasso/src/utils/Notifications/story/Variants.example.jsx
+++ b/packages/picasso/src/utils/Notifications/story/Variants.example.jsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { Button, Container } from '@toptal/picasso'
 import { useNotifications } from '@toptal/picasso/utils'
 
-const VariantsExample = () => {
+const Example = () => {
   const { showError, showInfo, showSuccess } = useNotifications()
 
   return (
@@ -34,4 +34,4 @@ const VariantsExample = () => {
   )
 }
 
-export default VariantsExample
+export default Example

--- a/packages/shared/src/Picasso/story/DisableResponsiveUI.example.jsx
+++ b/packages/shared/src/Picasso/story/DisableResponsiveUI.example.jsx
@@ -12,7 +12,7 @@ import {
   Sidebar
 } from '@toptal/picasso'
 
-const PageDefaultExample = () => (
+const Example = () => (
   <div style={{ height: '30rem' }}>
     <Page>
       <Page.Header rightContent={<RightContent />} title='Default example' />
@@ -91,7 +91,7 @@ const Content = () => (
 const Index = () => (
   <div id='root'>
     <Picasso responsive={false}>
-      <PageDefaultExample />
+      <Example />
     </Picasso>
   </div>
 )


### PR DESCRIPTION
No ticket

### Description

We regularly struggle to name correctly the examples. We often copy-paste them and forget to rename them. Since their names do not seem to deliver any value to people lets call all of them just `Example`. 

### Review

- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure that visuals specs are green [See the documentation](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)