### PR TITLE
fix: [FX-855] Fix class names collision for chrome extensions

### DIFF
--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -28,7 +28,6 @@
   "dependencies": {
     "classnames": "^2.2.6",
     "color": "^3.1.1",
-    "global": "^4.4.0",
     "notistack": "^0.9.7",
     "react-modal-hook": "^2.0.0"
   },

--- a/packages/shared/src/Picasso/Picasso.tsx
+++ b/packages/shared/src/Picasso/Picasso.tsx
@@ -19,8 +19,6 @@ import React, {
 import { ModalProvider } from 'react-modal-hook'
 import { makeStyles } from '@material-ui/styles'
 import { Helmet } from 'react-helmet'
-// @ts-ignore
-import { window } from 'global'
 
 import CssBaseline from '../CssBaseline'
 import {
@@ -226,18 +224,16 @@ const Picasso: FunctionComponent<PicassoProps> = ({
     PicassoBreakpoints.disableMobileBreakpoints()
   }
 
+  const generateRandomString = () =>
+    Math.random()
+      .toString(36)
+      .substring(7)
   const generateProjectSeed = () => {
     if (process.env.NODE_ENV === 'test') {
       return ''
     }
 
-    if (window.PicassoCssNamespace === undefined) {
-      window.PicassoCssNamespace = 0
-      return ''
-    }
-
-    window.PicassoCssNamespace = window.PicassoCssNamespace + 1
-    return window.PicassoCssNamespace
+    return generateRandomString()
   }
   const generateClassName = createGenerateClassName({
     // if there are multiples instances of Picasso

--- a/yarn.lock
+++ b/yarn.lock
@@ -10848,7 +10848,7 @@ global-prefix@^3.0.0:
     kind-of "^6.0.2"
     which "^1.3.1"
 
-global@^4.3.0, global@^4.3.2, global@^4.4.0:
+global@^4.3.0, global@^4.3.2:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/global/-/global-4.4.0.tgz#3e7b105179006a323ed71aafca3e9c57a5cc6406"
   integrity sha512-wv/LAoHdRE3BeTGz53FAamhGlPLhlssK45usmGFThIi4XqnBmjKQ16u+RNbP7WvigRZDxUsM0J3gcQ5yicaL0w==


### PR DESCRIPTION
[FX-855]

### Description

It turned out that it's not that easy to access `window` object of the page from the Chrome Extension. So returned back to random string generation.


[FX-855]: https://toptal-core.atlassian.net/browse/FX-855