### PR TITLE
fix(tooltip): disable long press trigger on touch screens

### DIFF
--- a/packages/picasso/src/Tooltip/Tooltip.tsx
+++ b/packages/picasso/src/Tooltip/Tooltip.tsx
@@ -106,7 +106,7 @@ export const Tooltip: FunctionComponent<Props> = ({
       title={title}
       disableHoverListener={disableListeners}
       disableFocusListener={disableListeners}
-      disableTouchListener={disableListeners}
+      disableTouchListener
     >
       {children as ReactElement}
     </MUITooltip>


### PR DESCRIPTION
re #1175

### Description

Tooltips that are triggered on hover on a desktop should be triggered on click event on touch devices.

https://toptal-core.slack.com/archives/CCC3GP6CC/p1584537866141400

### How to test

- Use touch screen to trigger tooltip

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| ![screencast 2020-03-18 13-59-08 2020-03-18 14_00_21](https://user-images.githubusercontent.com/2437969/76963493-65bddb80-6921-11ea-8bfe-dc69acae7e72.gif) | ![screencast 2020-03-27 09-56-48 2020-03-27 10_02_19](https://user-images.githubusercontent.com/2437969/77739617-17d86000-7012-11ea-93f9-5c4c150790bd.gif) |

### Review

- [ ] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that visuals specs are green [See the documentation](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
