### PR TITLE
docs(Datepicker): fix invalid date in examples

### DIFF
--- a/packages/picasso-lab/src/DatePicker/story/WithCustomDayRendering.example.tsx
+++ b/packages/picasso-lab/src/DatePicker/story/WithCustomDayRendering.example.tsx
@@ -4,12 +4,12 @@ import { DatePicker } from '@toptal/picasso-lab'
 import { isBefore, isWithinInterval } from 'date-fns'
 
 const WithCustomDayRendering = () => {
-  const [datepickerValue, setDatepickerValue] = useState(new Date('12-12-2015'))
+  const [datepickerValue, setDatepickerValue] = useState(new Date('2015-12-12'))
 
-  const minDate = new Date('12-07-2015')
+  const minDate = new Date('2015-12-07')
 
   const disabledIntervals = [
-    { start: new Date('12-20-2015'), end: new Date('12-30-2015') }
+    { start: new Date('2015-12-20'), end: new Date('2015-12-30') }
   ]
 
   return (

--- a/packages/picasso-lab/src/DatePicker/story/WithSelectionLimits.example.tsx
+++ b/packages/picasso-lab/src/DatePicker/story/WithSelectionLimits.example.tsx
@@ -3,12 +3,12 @@ import { DatePicker } from '@toptal/picasso-lab'
 import { Search16 } from '@toptal/picasso'
 
 const WithSelectionLimitsExample = () => {
-  const [value, setValue] = useState(new Date('12-12-2015'))
-  const minDate = new Date('12-01-2015')
-  const maxDate = new Date('12-30-2015')
+  const [value, setValue] = useState(new Date('2015-12-12'))
+  const minDate = new Date('2015-12-01')
+  const maxDate = new Date('2015-12-30')
   const disabledIntervals = [
-    { start: new Date('12-03-2015'), end: new Date('12-08-2015') },
-    { start: new Date('12-20-2015'), end: new Date('12-30-2015') }
+    { start: new Date('2015-12-03'), end: new Date('2015-12-08') },
+    { start: new Date('2015-12-20'), end: new Date('2015-12-30') }
   ]
 
   return (


### PR DESCRIPTION
No ticket

Examples were broken in firefox because of stringified params in Date constructor.

