### PR TITLE
fix(tagselector): pass `getKey` function to Autocomplete

### DIFF
--- a/packages/picasso/src/TagSelector/TagSelector.tsx
+++ b/packages/picasso/src/TagSelector/TagSelector.tsx
@@ -117,7 +117,7 @@ export const TagSelector = forwardRef<HTMLInputElement, Props>(
       onOtherOptionSelect!(value)
     }
 
-    const getKey = (item: Item) => {
+    const getKey = (item: Item): string => {
       if (customGetKey) {
         return customGetKey(item)
       }
@@ -129,6 +129,8 @@ export const TagSelector = forwardRef<HTMLInputElement, Props>(
       console.error(
         'TagSelector expects you to provide key prop value with getKey or Item.value!'
       )
+
+      return ''
     }
 
     const autocompleteOptions: AutocompleteItem[] | null =
@@ -170,6 +172,7 @@ export const TagSelector = forwardRef<HTMLInputElement, Props>(
         getDisplayValue={getDisplayValue}
         renderOption={renderOption}
         enableReset={false}
+        getKey={getKey}
       />
     )
   }


### PR DESCRIPTION
### Description

Fix error inside the `Tagselector`: 

```
Warning: Encountered two children with the same key, `.0:$Afghanistan`. Keys 
```

### How to test

1. Create options list with two options. Both options must have the same `text`

### Screenshots

<img width="720" alt="Picasso | TagSelector 2020-03-31 23-14-31" src="https://user-images.githubusercontent.com/1824723/78071039-70f31b80-73a5-11ea-96f2-36d9ae31b2b2.png">


### Review

- [ ] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that visuals specs are green [See the documentation](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
