### PR TITLE
chore: fix warnings about storybook separators

### DIFF
--- a/.storybook/stories/Contributing.tsx
+++ b/.storybook/stories/Contributing.tsx
@@ -15,7 +15,7 @@ import CREATING_EXAMPLES from '../../docs/contribution/creating-examples.md'
 // @ts-ignore
 import VISUAL_SNAPSHOTS from '../../docs/contribution/visual-testing.md'
 
-storiesOf('Contribution|Folder', module)
+storiesOf('Contribution/Folder', module)
   .add('GitHub workflow', doc(GITHUB_WORKFLOW))
   .add('CSS naming', doc(CSS_NAMING))
   .add('JSS onboarding', doc(JSS_ONBOARDING))

--- a/.storybook/stories/Picasso.tsx
+++ b/.storybook/stories/Picasso.tsx
@@ -13,7 +13,7 @@ import SUPPORT from '../../docs/SUPPORT.md'
 // @ts-ignore
 import API_PRINCIPLES from '../../docs/api-principles.md'
 
-storiesOf('Picasso|Folder', module)
+storiesOf('Picasso/Folder', module)
   .add('Readme', doc(README))
   .add('Changelog', doc(CHANGELOG))
   .add('Lab Changelog', doc(LAB_CHANGELOG))


### PR DESCRIPTION
No ticket, just a fix for a warning

![image](https://user-images.githubusercontent.com/1291032/78110042-07a1f580-7403-11ea-98c0-ac3eb415c9f0.png)
