### PR TITLE
chore: use ie11 compatible things in manager-head

### DIFF
--- a/.storybook/manager-head.html
+++ b/.storybook/manager-head.html
@@ -6,7 +6,7 @@
   )
 
   // fix for IE11 to support forEach method
-  nonPicassoMetaTags = Array.from(nonPicassoMetaTags)
+  nonPicassoMetaTags = [].slice.call(nonPicassoMetaTags)
   nonPicassoMetaTags.forEach(function (metaTag) {
     const content = metaTag.getAttribute('content') || ''
 


### PR DESCRIPTION
### Description

Picasso doesn't work in IE11 now

<img width="1276" alt="Screenshot 2020-04-01 at 10 21 53" src="https://user-images.githubusercontent.com/2836281/78110266-4df75480-7403-11ea-857c-f5275b543135.png">

so moved all things to IE11 compatible functions