### PR TITLE
feat(form): scroll to first input with errors and add submit button

### DIFF
--- a/packages/picasso-forms/package.json
+++ b/packages/picasso-forms/package.json
@@ -30,7 +30,6 @@
   "dependencies": {
     "classnames": "^2.2.6",
     "final-form": "^4.18.6",
-    "final-form-focus": "^1.1.2",
     "react-final-form": "^6.3.5"
   },
   "devDependencies": {

--- a/packages/picasso-forms/src/Form/story/BackendCommunication.example.tsx
+++ b/packages/picasso-forms/src/Form/story/BackendCommunication.example.tsx
@@ -1,15 +1,10 @@
-import React, { useState, useCallback } from 'react'
-import { Button, Container, Typography } from '@toptal/picasso'
+import React, { useCallback } from 'react'
+import { Container, Typography } from '@toptal/picasso'
 import { Form } from '@toptal/picasso-forms'
 
 const BackendCommunicationExample = () => {
-  const [isLoading, setIsLoading] = useState(false)
-
   const handleSubmit = useCallback(async (values: any) => {
-    setIsLoading(true)
     const result = await api.submit(values)
-
-    setIsLoading(false)
 
     if (result !== 'success') {
       return {
@@ -30,6 +25,7 @@ const BackendCommunicationExample = () => {
         onSubmit={handleSubmit}
         successSubmitMessage='Login successful!'
         failedSubmitMessage='Login failed! Please try another combination of first and last names.'
+        scrollOffsetTop={100}
       >
         <Form.Input
           required
@@ -45,9 +41,7 @@ const BackendCommunicationExample = () => {
         />
 
         <Container top='small'>
-          <Button type='submit' loading={isLoading}>
-            Login
-          </Button>
+          <Form.SubmitButton>Login</Form.SubmitButton>
         </Container>
       </Form>
     </Container>

--- a/packages/picasso-forms/src/Form/story/CustomValidator.example.tsx
+++ b/packages/picasso-forms/src/Form/story/CustomValidator.example.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Button, Container } from '@toptal/picasso'
+import { Container } from '@toptal/picasso'
 import { Form } from '@toptal/picasso-forms'
 
 const minMaxValidator = (value: string | number) => {
@@ -23,6 +23,7 @@ const CustomValidatorExample = () => (
       name='userName'
       label='First name'
       placeholder='e.g. Bruce'
+      scrollOffsetTop={100}
     />
     <Form.NumberInput
       required
@@ -33,7 +34,7 @@ const CustomValidatorExample = () => (
     />
 
     <Container top='small'>
-      <Button type='submit'>Submit</Button>
+      <Form.SubmitButton>Submit</Form.SubmitButton>
     </Container>
   </Form>
 )

--- a/packages/picasso-forms/src/Form/story/Default.example.tsx
+++ b/packages/picasso-forms/src/Form/story/Default.example.tsx
@@ -1,9 +1,9 @@
 import React from 'react'
-import { Button, Container } from '@toptal/picasso'
+import { Container } from '@toptal/picasso'
 import { Form } from '@toptal/picasso-forms'
 
 const DefaultExample = () => (
-  <Form onSubmit={values => console.log(values)}>
+  <Form onSubmit={values => console.log(values)} scrollOffsetTop={100}>
     <Form.Input
       enableReset
       onResetClick={(set: (value: string) => void) => {
@@ -55,7 +55,7 @@ const DefaultExample = () => (
     />
 
     <Container top='small'>
-      <Button type='submit'>Submit</Button>
+      <Form.SubmitButton>Submit</Form.SubmitButton>
     </Container>
   </Form>
 )

--- a/packages/picasso-forms/src/Form/story/ParseInput.example.tsx
+++ b/packages/picasso-forms/src/Form/story/ParseInput.example.tsx
@@ -1,9 +1,9 @@
 import React from 'react'
-import { Button, Container, Typography } from '@toptal/picasso'
+import { Container, Typography } from '@toptal/picasso'
 import { Form } from '@toptal/picasso-forms'
 
 const ParseInputExample = () => (
-  <Form onSubmit={values => console.log(values)}>
+  <Form onSubmit={values => console.log(values)} scrollOffsetTop={100}>
     <Container bottom='small'>
       <Typography size='medium'>
         I want to trim my first name from the empty spaces:
@@ -18,7 +18,7 @@ const ParseInputExample = () => (
     />
 
     <Container top='small'>
-      <Button type='submit'>Submit</Button>
+      <Form.SubmitButton>Submit</Form.SubmitButton>
     </Container>
   </Form>
 )

--- a/packages/picasso-forms/src/Form/story/index.jsx
+++ b/packages/picasso-forms/src/Form/story/index.jsx
@@ -100,6 +100,11 @@ page
         type: 'ReactNode',
         description:
           'Message to display in a tooltip when form submittion failed'
+      },
+      scrollOffsetTop: {
+        name: 'scrollOffsetTop',
+        type: 'number',
+        description: 'Offset from the viewport for inputs to focus on'
       }
     }
   })

--- a/packages/picasso-forms/src/SubmitButton/SubmitButton.tsx
+++ b/packages/picasso-forms/src/SubmitButton/SubmitButton.tsx
@@ -1,0 +1,24 @@
+import React from 'react'
+import { Button, ButtonProps } from '@toptal/picasso/Button'
+import { useFormState } from 'react-final-form'
+
+export type Props = Omit<ButtonProps, 'type'>
+
+export const SubmitButton = (props: Omit<ButtonProps, 'type'>) => {
+  const { submitting } = useFormState()
+  return (
+    <Button
+      type='submit'
+      disabled={submitting}
+      loading={submitting}
+      // eslint-disable-next-line react/jsx-props-no-spreading
+      {...props}
+    />
+  )
+}
+
+SubmitButton.defaultProps = {}
+
+SubmitButton.displayName = 'SubmitButton'
+
+export default SubmitButton

--- a/packages/picasso-forms/src/SubmitButton/index.ts
+++ b/packages/picasso-forms/src/SubmitButton/index.ts
@@ -1,0 +1,1 @@
+export { default } from './SubmitButton'

--- a/packages/picasso-forms/src/utils/flat-map.ts
+++ b/packages/picasso-forms/src/utils/flat-map.ts
@@ -1,0 +1,4 @@
+export const flatMap = <T, K>(arr: T[], fn: (item: T) => K[]) =>
+  arr.reduce<K[]>((acc, item) => acc.concat(fn(item)), [])
+
+export default flatMap

--- a/packages/picasso-forms/src/utils/index.ts
+++ b/packages/picasso-forms/src/utils/index.ts
@@ -1,1 +1,3 @@
 export { default as validators } from './validators'
+export { default as createScrollToErrorDecorator } from './scroll-to-error-decorator'
+export { default as flatMap } from './flat-map'

--- a/packages/picasso-forms/src/utils/scroll-to-error-decorator.ts
+++ b/packages/picasso-forms/src/utils/scroll-to-error-decorator.ts
@@ -1,0 +1,72 @@
+import { FormApi, getIn } from 'final-form'
+import flatMap from './flat-map'
+
+const scrollTo = (options: ScrollToOptions) => {
+  try {
+    window.scrollTo(options)
+  } catch {
+    window.scrollTo(options.left ?? 0, options.top ?? 0)
+  }
+}
+
+const formInputs = (form: HTMLFormElement) =>
+  Array.from(form.elements).filter(
+    element => element instanceof HTMLInputElement && typeof element.focus === 'function'
+  ) as HTMLInputElement[]
+
+const getInputs = (): HTMLInputElement[] => {
+  if (typeof document === 'undefined') return []
+  return flatMap(Array.from(document.forms), formInputs)
+}
+
+const findInputWithError = (inputs: HTMLInputElement[], errors: {}) =>
+  inputs.find(input => input.name && getIn(errors, input.name))
+
+const scrollToError = (offsetTop: number, errors: object) => {
+  const firstInput = findInputWithError(getInputs(), errors)
+  if (!firstInput) return
+
+  firstInput.focus({ preventScroll: true })
+  const top =
+    firstInput.getBoundingClientRect().top + window.pageYOffset - offsetTop
+  scrollTo({ top, behavior: 'smooth' })
+}
+
+export default ({ scrollOffsetTop = 0 }: { scrollOffsetTop?: number }) => <T>(
+  form: FormApi<T>
+) => {
+  const originalSubmit = form.submit
+  let state: { errors?: object; submitErrors?: object } = {}
+
+  const unsubscribe = form.subscribe(
+    nextState => {
+      state = nextState
+    },
+    { errors: true, submitErrors: true }
+  )
+
+  const scrollOnErrors = () => {
+    const { errors = {}, submitErrors = {} } = state
+    if (Object.keys(errors).length) {
+      scrollToError(scrollOffsetTop, errors)
+    } else if (Object.keys(submitErrors).length) {
+      scrollToError(scrollOffsetTop, submitErrors)
+    }
+  }
+
+  // Rewrite submit function
+  form.submit = () => {
+    const result = originalSubmit.call(form)
+    if (result && typeof result.then === 'function') {
+      result.then(scrollOnErrors).catch(() => {})
+    } else {
+      scrollOnErrors()
+    }
+    return result
+  }
+
+  return () => {
+    unsubscribe()
+    form.submit = originalSubmit
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -10619,11 +10619,6 @@ fill-range@^7.0.1:
   dependencies:
     to-regex-range "^5.0.1"
 
-final-form-focus@^1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/final-form-focus/-/final-form-focus-1.1.2.tgz#8ea5c4bd802e220cebaa47a587bb0be164eb6806"
-  integrity sha512-Gd+Bd2Ll7ijo3/sd6kJ/bwLkhc2bUJPxTON6fIqee/008EJpACWhT+zoWCm9q6NcfMcWRS+Sp5ikRX8iqdXeGQ==
-
 final-form@^4.18.6:
   version "4.18.6"
   resolved "https://registry.yarnpkg.com/final-form/-/final-form-4.18.6.tgz#3539c53d04e6603a0cc11c78dc830755add986d4"


### PR DESCRIPTION
### Description

In this PR we cover 3 changes:
- Replace `final-form-focus` with custom one with support for smooth scrolling
- Add `Form.SubmitButton` with `loading` properties preset based on the form context
- Make `successSubmitMessage` and `failedSubmitMessage` optional

### How to test

- Open example with BE communication
- Fill in the form
- Click `Submit`
- **Expected:** 
  - _Safari:_ Window to jump to the fist input with an error
  - _Firefox, Chrome:_ Window to scroll to the fist input with an error

### Review

- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that visuals specs are green [See the documentation](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
