### PR TITLE
feat(autocomplete): add extra `onFocus`/`onBlur` event handlers

### DIFF
--- a/packages/picasso-forms/src/utils/scroll-to-error-decorator.ts
+++ b/packages/picasso-forms/src/utils/scroll-to-error-decorator.ts
@@ -1,4 +1,5 @@
 import { FormApi, getIn } from 'final-form'
+
 import flatMap from './flat-map'
 
 const scrollTo = (options: ScrollToOptions) => {
@@ -11,7 +12,8 @@ const scrollTo = (options: ScrollToOptions) => {
 
 const formInputs = (form: HTMLFormElement) =>
   Array.from(form.elements).filter(
-    element => element instanceof HTMLInputElement && typeof element.focus === 'function'
+    element =>
+      element instanceof HTMLInputElement && typeof element.focus === 'function'
   ) as HTMLInputElement[]
 
 const getInputs = (): HTMLInputElement[] => {

--- a/packages/picasso/src/Autocomplete/Autocomplete.tsx
+++ b/packages/picasso/src/Autocomplete/Autocomplete.tsx
@@ -6,7 +6,8 @@ import React, {
   forwardRef,
   ReactNode,
   ComponentType,
-  useRef
+  useRef,
+  FocusEventHandler
 } from 'react'
 import { withStyles } from '@material-ui/core/styles'
 import capitalize from '@material-ui/core/utils/capitalize'
@@ -60,6 +61,10 @@ export interface Props
     event: KeyboardEvent<HTMLInputElement>,
     inputValue: string
   ) => void
+  /** Focus event handler */
+  onFocus?: FocusEventHandler<HTMLInputElement>
+  /** Blur event handler */
+  onBlur?: FocusEventHandler<HTMLInputElement>
   /** ReactNode for labels that will be used as start InputAdornment - */
   startAdornment?: ReactNode
   /** ReactNode for labels that will be used as end InputAdornment - */
@@ -103,6 +108,8 @@ export const Autocomplete = forwardRef<HTMLInputElement, Props>(
       width,
       showOtherOption,
       onKeyDown,
+      onFocus,
+      onBlur,
       inputComponent,
       renderOption,
       endAdornment,
@@ -148,6 +155,8 @@ export const Autocomplete = forwardRef<HTMLInputElement, Props>(
       onOtherOptionSelect,
       onChange,
       onKeyDown,
+      onFocus,
+      onBlur,
       enableReset,
       showOtherOption
     })
@@ -258,6 +267,8 @@ Autocomplete.defaultProps = {
   noOptionsText: 'No options',
   onChange: () => {},
   onKeyDown: () => {},
+  onFocus: () => {},
+  onBlur: () => {},
   onOtherOptionSelect: () => {},
   onSelect: () => {},
   options: [],

--- a/packages/picasso/src/Autocomplete/test.tsx
+++ b/packages/picasso/src/Autocomplete/test.tsx
@@ -24,7 +24,9 @@ const renderAutocomplete = (props: OmitInternalProps<Props>) => {
     autoComplete,
     onChange,
     onSelect,
-    onOtherOptionSelect
+    onOtherOptionSelect,
+    onFocus,
+    onBlur
   } = props
 
   return render(
@@ -40,6 +42,8 @@ const renderAutocomplete = (props: OmitInternalProps<Props>) => {
       onChange={onChange}
       onSelect={onSelect}
       onOtherOptionSelect={onOtherOptionSelect}
+      onFocus={onFocus}
+      onBlur={onBlur}
     />
   )
 }
@@ -73,11 +77,13 @@ describe('Autocomplete', () => {
 
   describe('dynamic behavior', () => {
     test('on focus', () => {
+      const onFocus = jest.fn()
       const { getByText, getByPlaceholderText, getByRole } = renderAutocomplete(
         {
           placeholder,
           options: testOptions,
-          value: ''
+          value: '',
+          onFocus
         }
       )
 
@@ -90,6 +96,8 @@ describe('Autocomplete', () => {
 
       // first option is highlighted
       expect(firstOptionListItem!.getAttribute('aria-selected')).toBe('true')
+      // calls onFocus handler
+      expect(onFocus).toHaveBeenCalledTimes(1)
       // menu contains all the options displayed
       expect(menu).toMatchSnapshot()
     })

--- a/packages/picasso/src/Autocomplete/useAutocomplete.ts
+++ b/packages/picasso/src/Autocomplete/useAutocomplete.ts
@@ -1,6 +1,6 @@
 /* eslint-disable complexity, max-statements */ // Squiggly lines makes code difficult to work with
 
-import { KeyboardEvent, useState, ChangeEvent } from 'react'
+import { KeyboardEvent, useState, ChangeEvent, FocusEventHandler } from 'react'
 
 import { Item, ChangedOptions } from './types'
 
@@ -65,6 +65,8 @@ interface Props {
     event: KeyboardEvent<HTMLInputElement>,
     inputValue: string
   ) => void
+  onFocus?: FocusEventHandler<HTMLInputElement>
+  onBlur?: FocusEventHandler<HTMLInputElement>
   getDisplayValue: (item: Item | null) => string
   enableReset?: boolean
   showOtherOption?: boolean
@@ -75,6 +77,8 @@ const useAutocomplete = ({
   options = [],
   onChange = () => {},
   onKeyDown = () => {},
+  onFocus = () => {},
+  onBlur = () => {},
   onSelect = () => {},
   onOtherOptionSelect = () => {},
   getDisplayValue,
@@ -142,7 +146,7 @@ const useAutocomplete = ({
     }
   })
 
-  const handleFocusOrClick = () => {
+  const handleClick = () => {
     if (isOpen) {
       return
     }
@@ -151,10 +155,20 @@ const useAutocomplete = ({
     setHighlightedIndex(FIRST_ITEM_INDEX)
   }
 
+  const handleFocus: FocusEventHandler<HTMLInputElement> = event => {
+    handleClick()
+    onFocus(event)
+  }
+
+  const handleBlur: FocusEventHandler<HTMLInputElement> = event => {
+    setOpen(false)
+    onBlur(event)
+  }
+
   const getInputProps = () => ({
     'aria-autocomplete': 'list' as React.AriaAttributes['aria-autocomplete'],
-    onFocus: handleFocusOrClick,
-    onClick: handleFocusOrClick,
+    onFocus: handleFocus,
+    onClick: handleClick,
     onChange: (
       event: ChangeEvent<
         HTMLTextAreaElement | HTMLInputElement | HTMLSelectElement
@@ -232,7 +246,7 @@ const useAutocomplete = ({
       }
     },
 
-    onBlur: () => setOpen(false),
+    onBlur: handleBlur,
     enableReset,
     onResetClick: () => {
       handleChange(getDisplayValue(null))

--- a/packages/picasso/src/TagSelector/TagSelector.tsx
+++ b/packages/picasso/src/TagSelector/TagSelector.tsx
@@ -4,7 +4,8 @@ import React, {
   forwardRef,
   ComponentType,
   InputHTMLAttributes,
-  ReactNode
+  ReactNode,
+  FocusEventHandler
 } from 'react'
 import { withStyles } from '@material-ui/core/styles'
 import { StandardProps } from '@toptal/picasso-shared'
@@ -54,6 +55,10 @@ export interface Props
   inputValue?: string
   /**  Callback invoked when `input` element value is changed */
   onInputChange?: (inputValue: string) => void
+  /** Focus event handler */
+  onFocus?: FocusEventHandler<HTMLInputElement>
+  /** Blur event handler */
+  onBlur?: FocusEventHandler<HTMLInputElement>
   /** Width of the component */
   width?: 'full' | 'shrink' | 'auto'
   /** Specifies whether the autofill enabled or not, disabled by default */
@@ -78,6 +83,8 @@ export const TagSelector = forwardRef<HTMLInputElement, Props>(
       onChange,
       inputValue = '',
       onInputChange,
+      onFocus,
+      onBlur,
       width,
       enableAutofill,
       getKey: customGetKey,
@@ -162,6 +169,8 @@ export const TagSelector = forwardRef<HTMLInputElement, Props>(
         onOtherOptionSelect={handleOtherOptionSelect}
         onChange={onInputChange}
         onKeyDown={handleKeyDown}
+        onFocus={onFocus}
+        onBlur={onBlur}
         startAdornment={labels}
         loading={loading}
         inputComponent={TagSelectorInput as ComponentType<InputProps>}


### PR DESCRIPTION
### Description

We need to listen to `focus` and `blur` events on `Autocomplete` and `TagSelector`

### How to test

- assign `onFocus` and `onBlur` events on `Autocomplete` or `TagSelector` Components

### Review

- [x] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [x] Ensure that visuals specs are green [See the documentation](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
