### PR TITLE
chore(Drawer): onClose property should be optional

### DIFF
--- a/packages/picasso-lab/src/Drawer/Drawer.tsx
+++ b/packages/picasso-lab/src/Drawer/Drawer.tsx
@@ -19,7 +19,7 @@ export interface Props extends BaseProps {
   /** Specify the drawer title */
   title: ReactNode
   /** Callback fired when the component requests to be closed. */
-  onClose: () => void
+  onClose?: () => void
 }
 
 const useStyles = makeStyles(styles, { name: 'PicassoDrawer' })


### PR DESCRIPTION
[SP-948](https://toptal-core.atlassian.net/browse/SP-948)

### Description

Drawer changes to make the onClose property optional.

### Review

- [ ] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that visuals specs are green [See the documentation](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
