### PR TITLE
chore: set Form default scroll offset

### DIFF
--- a/packages/picasso-forms/src/Form/Form.tsx
+++ b/packages/picasso-forms/src/Form/Form.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, ReactNode } from 'react'
+import React, { useCallback, useMemo, ReactNode } from 'react'
 import {
   Form as FinalForm,
   FormProps as FinalFormProps
@@ -18,7 +18,7 @@ import { createScrollToErrorDecorator } from '../utils'
 
 type AnyObject = Record<string, any>
 
-export type Props<T = AnyObject> = Omit<FinalFormProps<T>, 'validate'> & {
+export type Props<T = AnyObject> = FinalFormProps<T> & {
   successSubmitMessage?: ReactNode
   failedSubmitMessage?: ReactNode
   scrollOffsetTop?: number
@@ -35,6 +35,10 @@ export function Form<T = AnyObject>(props: Props<T>) {
     ...rest
   } = props
   const { showSuccess, showError } = useNotifications()
+  const scrollToErrorDecorator = useMemo(
+    () => createScrollToErrorDecorator({ scrollOffsetTop }),
+    [scrollOffsetTop]
+  )
 
   const handleSubmit = useCallback(
     async (values, form, callback) => {
@@ -63,7 +67,7 @@ export function Form<T = AnyObject>(props: Props<T>) {
         <PicassoForm onSubmit={handleSubmit}>{children}</PicassoForm>
       )}
       onSubmit={handleSubmit}
-      decorators={decorators.concat(createScrollToErrorDecorator({ scrollOffsetTop }))}
+      decorators={[...decorators, scrollToErrorDecorator]}
       // eslint-disable-next-line react/jsx-props-no-spreading
       {...rest}
     />

--- a/packages/picasso-forms/src/Form/story/BackendCommunication.example.tsx
+++ b/packages/picasso-forms/src/Form/story/BackendCommunication.example.tsx
@@ -25,7 +25,6 @@ const BackendCommunicationExample = () => {
         onSubmit={handleSubmit}
         successSubmitMessage='Login successful!'
         failedSubmitMessage='Login failed! Please try another combination of first and last names.'
-        scrollOffsetTop={100}
       >
         <Form.Input
           required

--- a/packages/picasso-forms/src/Form/story/CustomValidator.example.tsx
+++ b/packages/picasso-forms/src/Form/story/CustomValidator.example.tsx
@@ -23,7 +23,6 @@ const CustomValidatorExample = () => (
       name='userName'
       label='First name'
       placeholder='e.g. Bruce'
-      scrollOffsetTop={100}
     />
     <Form.NumberInput
       required

--- a/packages/picasso-forms/src/Form/story/Default.example.tsx
+++ b/packages/picasso-forms/src/Form/story/Default.example.tsx
@@ -3,7 +3,7 @@ import { Container } from '@toptal/picasso'
 import { Form } from '@toptal/picasso-forms'
 
 const DefaultExample = () => (
-  <Form onSubmit={values => console.log(values)} scrollOffsetTop={100}>
+  <Form onSubmit={values => console.log(values)}>
     <Form.Input
       enableReset
       onResetClick={(set: (value: string) => void) => {

--- a/packages/picasso-forms/src/Form/story/ParseInput.example.tsx
+++ b/packages/picasso-forms/src/Form/story/ParseInput.example.tsx
@@ -3,7 +3,7 @@ import { Container, Typography } from '@toptal/picasso'
 import { Form } from '@toptal/picasso-forms'
 
 const ParseInputExample = () => (
-  <Form onSubmit={values => console.log(values)} scrollOffsetTop={100}>
+  <Form onSubmit={values => console.log(values)}>
     <Container bottom='small'>
       <Typography size='medium'>
         I want to trim my first name from the empty spaces:

--- a/packages/picasso-forms/src/Form/story/index.jsx
+++ b/packages/picasso-forms/src/Form/story/index.jsx
@@ -104,7 +104,8 @@ page
       scrollOffsetTop: {
         name: 'scrollOffsetTop',
         type: 'number',
-        description: 'Offset from the viewport for inputs to focus on'
+        description:
+          'Offset from the viewport for inputs to focus on, defaults to the center of the window'
       }
     }
   })

--- a/packages/picasso-forms/src/SubmitButton/SubmitButton.tsx
+++ b/packages/picasso-forms/src/SubmitButton/SubmitButton.tsx
@@ -1,10 +1,10 @@
 import React from 'react'
-import { Button, ButtonProps } from '@toptal/picasso/Button'
+import { Button, Props as ButtonProps } from '@toptal/picasso/Button'
 import { useFormState } from 'react-final-form'
 
 export type Props = Omit<ButtonProps, 'type'>
 
-export const SubmitButton = (props: Omit<ButtonProps, 'type'>) => {
+export const SubmitButton = (props: Props) => {
   const { submitting } = useFormState()
   return (
     <Button

--- a/packages/picasso-forms/src/utils/scroll-to-error-decorator.ts
+++ b/packages/picasso-forms/src/utils/scroll-to-error-decorator.ts
@@ -2,6 +2,11 @@ import { FormApi, getIn } from 'final-form'
 
 import flatMap from './flat-map'
 
+const getDefaultScrollOffsetTop = () => {
+  if (!window) return 0
+  return window.innerHeight / 2 - 50
+}
+
 const scrollTo = (options: ScrollToOptions) => {
   try {
     window.scrollTo(options)
@@ -34,9 +39,11 @@ const scrollToError = (offsetTop: number, errors: object) => {
   scrollTo({ top, behavior: 'smooth' })
 }
 
-export default ({ scrollOffsetTop = 0 }: { scrollOffsetTop?: number }) => <T>(
-  form: FormApi<T>
-) => {
+export default ({
+  scrollOffsetTop = getDefaultScrollOffsetTop()
+}: {
+  scrollOffsetTop?: number
+}) => <T>(form: FormApi<T>) => {
   const originalSubmit = form.submit
   let state: { errors?: object; submitErrors?: object } = {}
 


### PR DESCRIPTION
### Description

In this PR we address 3 issues:
- Set default scroll offset top to a meaningful value that would include Picasso's header, enough space for input's label and padding from the header to label;
-  By some reason `validate` property was omitted from `Form`, we revert that;
- `SubmitButton`'s props import resolution was incorrect due to hoisting on compile time. To mitigate that, we import `Props` directly;

### Review

- ~Annotate all `props` in component with documentation~
- ~Create `examples` for component~
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that visuals specs are green [See the documentation](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
