### PR TITLE
fix(tooltip): get rid of the modifier warning

### DIFF
--- a/packages/picasso/src/Popper/Popper.tsx
+++ b/packages/picasso/src/Popper/Popper.tsx
@@ -64,15 +64,13 @@ function getPopperOptions(popperOptions: PopperOptions) {
       ...popperOptions.modifiers,
       flip: {
         enabled: true,
-        // replace with optional chaining
-        ...(popperOptions.modifiers && popperOptions.modifiers.flip)
+        ...popperOptions.modifiers?.flip
       },
       preventOverflow: {
         enabled: true,
         boundariesElement: 'viewport',
         padding: 5,
-        // replace with optional chaining
-        ...(popperOptions.modifiers && popperOptions.modifiers.preventOverflow)
+        ...popperOptions.modifiers?.preventOverflow
       }
     }
   }

--- a/packages/picasso/src/Tooltip/Tooltip.tsx
+++ b/packages/picasso/src/Tooltip/Tooltip.tsx
@@ -82,12 +82,13 @@ export const Tooltip: FunctionComponent<Props> = ({
               enabled: Boolean(arrowRef),
               element: arrowRef
             },
-            ...(preventOverflow
-              ? {
-                  enabled: true,
-                  boundariesElement: 'scrollParent'
-                }
-              : {})
+            preventOverflow: {
+              enabled: preventOverflow,
+              boundariesElement: 'scrollParent'
+            },
+            hide: {
+              enabled: preventOverflow
+            }
           }
         }
       }}


### PR DESCRIPTION
re #1227

### Description

When `preventOverflow` modifier is disabled, the Tooltip component generates a warning on each
interaction

### How to test

- Open the `Trigger` Tooltip example
- Open dev tools and observe Console
- Move cursor in and out the trigger element

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| ![screencast 2020-04-10 15-51-36 2020-04-10 15_54_12](https://user-images.githubusercontent.com/2437969/78997771-8277b880-7b47-11ea-937d-399fd5fed8f7.gif)  | ![screencast 2020-04-10 16-24-39 2020-04-10 16_25_43](https://user-images.githubusercontent.com/2437969/78997977-f74af280-7b47-11ea-812a-77262d68efd3.gif) |

### Review

- [ ] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that visuals specs are green [See the documentation](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
