### PR TITLE
chore(forms): allow to scroll to custom input elements

### DIFF
--- a/packages/picasso-forms/src/utils/scroll-to-error-decorator.ts
+++ b/packages/picasso-forms/src/utils/scroll-to-error-decorator.ts
@@ -18,7 +18,7 @@ const scrollTo = (options: ScrollToOptions) => {
 const formInputs = (form: HTMLFormElement) =>
   Array.from(form.elements).filter(
     element =>
-      element instanceof HTMLInputElement && typeof element.focus === 'function'
+      element instanceof HTMLElement && typeof element.focus === 'function'
   ) as HTMLInputElement[]
 
 const getInputs = (): HTMLInputElement[] => {


### PR DESCRIPTION
### Description

In the original implementation we've limited the scope of input selection to those that are subclasses of HTMLInputElement, however that disallows custom input elements as those won't have that object in their prototype chain. This PR addresses that.

### Review

- ~Annotate all `props` in component with documentation~
- ~Create `examples` for component~
- [x] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that visuals specs are green [See the documentation](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
