### PR TITLE
chore: update required picasso and picasso-shared versions

### DIFF
--- a/packages/picasso-charts/package.json
+++ b/packages/picasso-charts/package.json
@@ -20,7 +20,7 @@
     "url": "https://github.com/toptal/picasso/issues"
   },
   "peerDependencies": {
-    "@toptal/picasso": "^4.21.0"
+    "@toptal/picasso": "^4.49.2"
   },
   "dependencies": {
     "@types/recharts": "^1.8.7",

--- a/packages/picasso-forms/package.json
+++ b/packages/picasso-forms/package.json
@@ -22,8 +22,8 @@
     "url": "https://github.com/toptal/picasso/issues"
   },
   "peerDependencies": {
-    "@toptal/picasso": "^4.21.0",
-    "@toptal/picasso-shared": "^1.3.0",
+    "@toptal/picasso": "^4.49.2",
+    "@toptal/picasso-shared": "^1.11.1",
     "react": "^16.12.0",
     "react-dom": "^16.12.0"
   },

--- a/packages/picasso-lab/package.json
+++ b/packages/picasso-lab/package.json
@@ -22,8 +22,8 @@
     "url": "https://github.com/toptal/picasso/issues"
   },
   "peerDependencies": {
-    "@toptal/picasso": "^4.21.0",
-    "@toptal/picasso-shared": "^1.3.0",
+    "@toptal/picasso": "^4.49.2",
+    "@toptal/picasso-shared": "^1.11.1",
     "react": "^16.12.0",
     "react-dom": "^16.12.0"
   },


### PR DESCRIPTION
[FX-906]

### Description

To avoid collisions let's update picasso and picasso-shared in peerDependencies our other packages

https://github.com/lerna/lerna/issues/1575 - seems lerna is not going to support that update automatically

Seems same problem in [material-ui](https://github.com/mui-org/material-ui/commit/ee9974955edb64081b7242baa1483c451178422b#diff-abe3bab105c444555185d7a19ad2c73dL37)

### How to test

- believe me

### Review

- [ ] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that visuals specs are green [See the documentation](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)


[FX-906]: https://toptal-core.atlassian.net/browse/FX-906