### PR TITLE
fix: export environment types for banner

### DIFF
--- a/packages/picasso/src/EnvironmentBanner/EnvironmentBanner.tsx
+++ b/packages/picasso/src/EnvironmentBanner/EnvironmentBanner.tsx
@@ -9,9 +9,11 @@ import {
 
 import styles from './styles'
 
+export type EnvironmentTypes = EnvironmentType<'temploy' | 'test'>
+
 export interface Props extends BaseProps {
   /** Name of the current environment */
-  environment: EnvironmentType<'temploy' | 'test'>
+  environment: EnvironmentTypes
   /** Name of the product to be rendered alongside enviroment (i.e. Blackfish, Talent, Portal, Billing) */
   productName: string
 }


### PR DESCRIPTION
### Description

The `environment` property type of the `EnvironmentBanner` needs to be exported so it can be reused by consumers. Please see the https://github.com/toptal/staff-portal/pull/686#discussion_r408876104 for the example.

### How to test

No tests for TS types modifications.

### Screenshots

No screenshots for TS types modifications.

### Review

- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure that visuals specs are green [See the documentation](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
