### PR TITLE
feat: add class name to Tooltip content container

### DIFF
--- a/packages/picasso/src/Tooltip/Tooltip.tsx
+++ b/packages/picasso/src/Tooltip/Tooltip.tsx
@@ -41,6 +41,8 @@ export interface Props extends StandardProps, HTMLAttributes<HTMLDivElement> {
   disableListeners?: boolean
   /** Allows tooltip to change its placement when it overflows */
   preventOverflow?: boolean
+  /** Tooltip's content container class */
+  contentClassName?: string
 }
 
 export const Tooltip: FunctionComponent<Props> = ({
@@ -58,6 +60,7 @@ export const Tooltip: FunctionComponent<Props> = ({
   variant,
   disableListeners,
   preventOverflow,
+  contentClassName,
   ...rest
 }) => {
   const [arrowRef, setArrowRef] = useState<HTMLSpanElement | null>(null)
@@ -95,9 +98,13 @@ export const Tooltip: FunctionComponent<Props> = ({
       classes={{
         popper:
           variant === 'light' ? classes.arrowPopperLight : classes.arrowPopper,
-        tooltip: cx(classes.tooltip, {
-          [classes.light]: variant === 'light'
-        })
+        tooltip: cx(
+          classes.tooltip,
+          {
+            [classes.light]: variant === 'light'
+          },
+          contentClassName
+        )
       }}
       className={className}
       style={style}


### PR DESCRIPTION
No ticket.

### Description

#### Expected [(design link)](https://app.abstract.com/projects/e7151a30-716b-11e9-aeb9-4db1a1401fcd/branches/283fa992-c03f-4da5-bdbe-0bb7502d8c38/commits/301f924953114e2dad186995ff48e3c91fadfb2f/files/E40296FA-2693-498E-9CBD-71C9BB7E3BE3/layers/6E67709E-FE37-467C-8827-CB312E1B8D75?mode=design):

![image](https://user-images.githubusercontent.com/26530524/79503887-4db4a700-8008-11ea-91c9-0755f12ba542.png)

#### Actual:

![image](https://user-images.githubusercontent.com/26530524/79504072-9d936e00-8008-11ea-9d14-bec9ae9137d4.png)

---

It's not possible because there's no way to customize the Tooltip's content container. So I'm exposing a new prop allowing to pass a class to the content itself.

### Example usage / What we're actually gonna do

```ts
import React, { Fragment } from 'react'
import { Button, Container, Tooltip } from '@toptal/picasso'
import { createGlobalStyle } from 'styled-components'

const TooltipContentStyle = createGlobalStyle`
  .TP-timesheetLinkTooltipContent {
    max-width: initial;
    padding: 0;
  }
`

const Content = () => (
  <Fragment>
    <TooltipContentStyle />
    The content here.
  </Fragment>
)

const TimesheetLinkDetails = () => (
  <Tooltip content={<Content />} contentClassName='TP-timesheetLinkTooltipContent' placement='top'>
    <ArrowDropDown16 color='dark-grey' />
  </Tooltip>
)

export default TimesheetLinkDetails
```

Do you guys think of another approach, or is this one enough?

### Review

- [X] Annotate all `props` in component with documentation
- (n/a) Create `examples` for component
- (n/a) Ensure that deployed demo has expected results and good examples
- [X] Ensure that visuals specs are green [See the documentation](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
