### PR TITLE
fix(dropdown): fix closing dropdown by item click on mobile

### DIFF
--- a/packages/picasso/src/Dropdown/Dropdown.tsx
+++ b/packages/picasso/src/Dropdown/Dropdown.tsx
@@ -189,6 +189,15 @@ export const Dropdown = forwardRef<HTMLDivElement, Props>(function Dropdown(
     close: () => forceClose()
   }
 
+  const handleClickAway = (event: React.MouseEvent<Document>) => {
+    const target = event.target
+    if (anchorEl && target instanceof Node && anchorEl.contains(target)) {
+      return
+    }
+
+    forceClose()
+  }
+
   return (
     <div
       // eslint-disable-next-line react/jsx-props-no-spreading
@@ -216,7 +225,7 @@ export const Dropdown = forwardRef<HTMLDivElement, Props>(function Dropdown(
           autoWidth={false}
           container={popperContainer}
         >
-          <ClickAwayListener onClickAway={() => forceClose()}>
+          <ClickAwayListener onClickAway={handleClickAway}>
             <Grow in={isOpen} appear>
               <Paper
                 className={classes.content}


### PR DESCRIPTION
re #786

### Description

Dropdown menu can be toggled by the anchor click, but on mobile, the second click reopened the menu instead of closing it.

I adapted the solution from the material-ui [Menu example](https://material-ui.com/components/menus/#menulist-composition)

```js
const handleClose = (event) => {
    if (anchorRef.current && anchorRef.current.contains(event.target)) {
      return;
    }

    setOpen(false);
  };
```

### How to test

1. Go to dropdown example
2. Click the anchor to toggle the dropdown
3. Click away to close it
4. Repeat 2 and 3 on a touch device (or Chrome device mode)

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| ![screencast 2020-04-17 09-10-15 2020-04-17 09_10_43](https://user-images.githubusercontent.com/2437969/79542103-57332300-808b-11ea-92e4-cdd25024d7a4.gif) | ![screencast 2020-04-17 09-11-21 2020-04-17 09_11_46](https://user-images.githubusercontent.com/2437969/79542199-7b8eff80-808b-11ea-8151-8042bc27cb3a.gif) |

### Review

- [ ] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that visuals specs are green [See the documentation](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
