### PR TITLE
chore: clean yarn cache for picasso docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,19 +49,19 @@ RUN yarn config set workspaces-experimental true
 RUN yarn install --frozen-lockfile && yarn cache clean
 
 # needs to be +rw for rm and mkdir /build
-RUN chmod a+rw /app &&
-  chmod a+rw /app/packages/picasso &&
-  chmod a+rw /app/packages/picasso-lab &&
-  chmod a+rw /app/packages/picasso-forms &&
-  chmod a+rw /app/packages/picasso-charts &&
-  chmod a+rw /app/packages/topkit-analytics-charts &&
-  chmod a+rw /app/packages/shared &&
-  chmod a+rw /app/packages/picasso/CHANGELOG.md &&
-  chmod a+rw /app/packages/picasso-lab/CHANGELOG.md &&
-  chmod a+rw /app/packages/picasso-forms/CHANGELOG.md &&
-  chmod a+rw /app/packages/picasso-charts/CHANGELOG.md &&
-  chmod a+rw /app/packages/topkit-analytics-charts/CHANGELOG.md &&
-  chmod a+rw /app/packages/shared/CHANGELOG.md &&
+RUN chmod a+rw /app && \
+  chmod a+rw /app/packages/picasso && \
+  chmod a+rw /app/packages/picasso-lab && \
+  chmod a+rw /app/packages/picasso-forms && \
+  chmod a+rw /app/packages/picasso-charts && \
+  chmod a+rw /app/packages/topkit-analytics-charts && \
+  chmod a+rw /app/packages/shared && \
+  chmod a+rw /app/packages/picasso/CHANGELOG.md && \
+  chmod a+rw /app/packages/picasso-lab/CHANGELOG.md && \
+  chmod a+rw /app/packages/picasso-forms/CHANGELOG.md && \
+  chmod a+rw /app/packages/picasso-charts/CHANGELOG.md && \
+  chmod a+rw /app/packages/topkit-analytics-charts/CHANGELOG.md && \
+  chmod a+rw /app/packages/shared/CHANGELOG.md && \
   chmod a+rw /app/package.json
 
 COPY bin/entrypoint.sh /usr/local/bin/entrypoint.sh


### PR DESCRIPTION
### Description

It looks like our docker images started to fail in 10 minutes timeout, almost all of them. It looks like the size of images started to grow and `docker push` takes ages to finish, which takes the most of the time. (for example - https://jenkins-build.toptal.net/job/picasso-build-image/2322/console)

After some investigation I've found out that when we do `yarn install` we also store `yarn cache` and this cache can take up to `1.5GB` of space. So let's clean it before pushing the image 👍 

Also, it looks like the number of docker layers is huge, so by removing some `RUN` commands we can remove some layers