### PR TITLE
fix: useBreakpoint flicky implementation

### DIFF
--- a/packages/shared/src/Picasso/config/breakpoints.ts
+++ b/packages/shared/src/Picasso/config/breakpoints.ts
@@ -119,7 +119,10 @@ export const useScreenSize = () => {
 
 export const useBreakpoint = (sizes: BreakpointKeys[] | BreakpointKeys) => {
   const mediaQueryString = screens(...([] as BreakpointKeys[]).concat(sizes))
-  const mediaQuery = useMediaQuery(mediaQueryString)
+  const mediaQuery = useMediaQuery(mediaQueryString, {
+    noSsr: true
+  })
+
   if (!mediaQueryString) return false
 
   return mediaQuery


### PR DESCRIPTION
No ticket.

### Description

There was this issue where we were getting the wrong value on first render and the correct one on re-render. Example:

![bouncy-optimized](https://user-images.githubusercontent.com/26530524/80256873-0d7fa500-8656-11ea-8b50-b4871b1e7145.gif)

[This issue on MUI repository](https://github.com/mui-org/material-ui/issues/14336) explains why this was happening.

This PR fixes it:

![fixed-optimized](https://user-images.githubusercontent.com/26530524/80256787-cee9ea80-8655-11ea-8e5f-94b2963421b0.gif)


### Review

- (n/a) Annotate all `props` in component with documentation
- (n/a) Create `examples` for component
- (n/a) Ensure that deployed demo has expected results and good examples
- [X] Ensure that visuals specs are green [See the documentation](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)