### PR TITLE
fix(datepicker): remove notice from disable days

### DIFF
--- a/packages/picasso-lab/src/Calendar/Calendar.tsx
+++ b/packages/picasso-lab/src/Calendar/Calendar.tsx
@@ -193,6 +193,7 @@ export const Calendar = forwardRef<HTMLDivElement, Props>(function Calendar(
         minDate={minDate}
         maxDate={maxDate}
         disabledIntervals={disabledIntervals}
+        getNoticeContent={() => null}
       />
     </div>
   )


### PR DESCRIPTION
closes #1268

### Description

Remove the error message after clicking on the disabled date on the date picker.

### How to test

- Go to Selection Limit example
- Click on disabled date
- See no error message

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| ![screencast 2020-04-29 07-55-32 2020-04-29 07_58_16](https://user-images.githubusercontent.com/2437969/80569594-8cc7fc80-89f9-11ea-9729-cebc9d1654fc.gif) | ![screencast 2020-04-29 10-15-53 2020-04-29 10_16_26](https://user-images.githubusercontent.com/2437969/80574646-87bb7b00-8a02-11ea-94a1-c144987bcf7d.gif) |

### Review

- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure that visuals specs are green [See the documentation](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
