### PR TITLE
fix(showmore): fix component capacity to totally hide description

### DIFF
--- a/packages/picasso/src/ShowMore/ShowMore.tsx
+++ b/packages/picasso/src/ShowMore/ShowMore.tsx
@@ -46,17 +46,19 @@ export const ShowMore = forwardRef<HTMLSpanElement, Props>(function ShowMore(
 
   return (
     <React.Fragment>
-      <Typography
-        // eslint-disable-next-line react/jsx-props-no-spreading
-        {...rest}
-        ref={ref}
-        size='medium'
-        color='dark-grey'
-        className={className}
-        style={style}
-      >
-        <Truncate lines={!shownMore && rows}>{children}</Truncate>
-      </Typography>
+      {shownMore || rows !== 0 ? (
+        <Typography
+          // eslint-disable-next-line react/jsx-props-no-spreading
+          {...rest}
+          ref={ref}
+          size='medium'
+          color='dark-grey'
+          className={className}
+          style={style}
+        >
+          <Truncate lines={!shownMore && rows}>{children}</Truncate>
+        </Typography>
+      ) : null}
       {!disableToggle && (
         <Link
           onClick={() => {


### PR DESCRIPTION
No ticket from TX team
[TPH-41]

### Description

`ShowMore` component does not work if `rows` prop has the value of `0`.
In this scenario, it shows all text instead AND show more link (as if it was not expanded).
We made a small change to make this component support this option.

### How to test

- Include `ShowMore` component with `rows={0}` option.

### Screenshots

Screenshots below refer to component being used with `rows={0}`:

| Before (collpased view)                                 | After (collpased view)                                  |
| --------------------------------------- | --------------------------------------- |
| <img width="256" alt="ShowMore collapsed" src="https://user-images.githubusercontent.com/4294777/80609908-0f0eeb80-8a0f-11ea-88d7-62915dcb3dec.png"> | <img width="186" alt="ShowMore collapsed" src="https://user-images.githubusercontent.com/4294777/80608603-64e29400-8a0d-11ea-8f34-1eb3ad0b77a9.png"> |

### Review

- [x] ~~Annotate all `props` in component with documentation~~ (component props keeps the same)
- [x] ~~Create `examples` for component~~ (component keeps behaving the same)
- [x] ~~Ensure that deployed demo has expected results and good examples~~ (component already exists)
- [x] Ensure that visuals specs are green [See the documentation](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)

[TPH-41]: https://toptal-core.atlassian.net/browse/TPH-41