### PR TITLE
fix(Select): make Select a generic

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -6,3 +6,6 @@ packages/picasso-charts/src/LineChart/index.ts
 packages/picasso-charts/src/index.ts
 packages/topkit-analytics-charts/src/AnalyticsChart/index.ts
 packages/picasso/src/utils/Transitions/index.ts
+packages/picasso/src/Select/index.ts
+packages/picasso/src/MonthSelect/index.ts
+packages/picasso/src/YearSelect/index.ts

--- a/packages/picasso-forms/src/Select/Select.tsx
+++ b/packages/picasso-forms/src/Select/Select.tsx
@@ -1,18 +1,30 @@
 import React from 'react'
 import { Select as PicassoSelect } from '@toptal/picasso'
-import { Props as SelectProps } from '@toptal/picasso/Select'
+import { SelectProps, ValueType } from '@toptal/picasso/Select'
 import { generateRandomStringOrGetEmptyInTest } from '@toptal/picasso/utils'
 
 import FieldWrapper, { FieldProps } from '../FieldWrapper'
 
-export type Props = SelectProps & FieldProps<SelectProps['value']>
+export type Props<T extends ValueType, M extends boolean = false> = SelectProps<
+  T,
+  M
+> &
+  FieldProps<SelectProps<T, M>['value']>
 
-export const Select = ({ name, id = name, ...rest }: Props) => {
+export const Select = <T extends ValueType, M extends boolean = false>({
+  name,
+  id = name,
+  ...rest
+}: Props<T, M>) => {
   const randomizedId = id ? generateRandomStringOrGetEmptyInTest(id) : undefined
 
   return (
-    // eslint-disable-next-line react/jsx-props-no-spreading
-    <FieldWrapper<SelectProps> {...rest} name={name} id={randomizedId}>
+    <FieldWrapper<SelectProps<any, any>>
+      // eslint-disable-next-line react/jsx-props-no-spreading
+      {...rest}
+      name={name}
+      id={randomizedId}
+    >
       {(selectProps: SelectProps) => {
         return (
           <PicassoSelect

--- a/packages/picasso/src/MonthSelect/__snapshots__/test.tsx.snap
+++ b/packages/picasso/src/MonthSelect/__snapshots__/test.tsx.snap
@@ -6,14 +6,14 @@ exports[`MonthSelect default render 1`] = `
     class="Picasso-root"
   >
     <div
-      class="Select-root Select-rootFull"
+      class="makeStyles-root makeStyles-rootFull"
     >
       <div
-        class="Select-inputWrapper"
+        class="makeStyles-inputWrapper"
       >
         <div
           aria-autocomplete="list"
-          class="MuiInputBase-root MuiOutlinedInput-root OutlinedInput-root OutlinedInput-rootFull OutlinedInput-rootMedium Select-input MuiInputBase-fullWidth"
+          class="MuiInputBase-root MuiOutlinedInput-root OutlinedInput-root OutlinedInput-rootFull OutlinedInput-rootMedium makeStyles-input MuiInputBase-fullWidth"
           role="textbox"
         >
           <input
@@ -40,7 +40,7 @@ exports[`MonthSelect default render 1`] = `
           </fieldset>
         </div>
         <svg
-          class="SvgDropdownArrows16-root Select-caret"
+          class="SvgDropdownArrows16-root makeStyles-caret"
           style="min-width: 16px; min-height: 16px;"
           viewBox="0 0 16 16"
         >

--- a/packages/picasso/src/MonthSelect/index.ts
+++ b/packages/picasso/src/MonthSelect/index.ts
@@ -1,6 +1,2 @@
-import { OmitInternalProps } from '@toptal/picasso-shared'
-
-import { Props } from './MonthSelect'
-
+export type { Props as MonthSelectProps } from './MonthSelect'
 export { default } from './MonthSelect'
-export type MonthSelectProps = OmitInternalProps<Props>

--- a/packages/picasso/src/Select/__snapshots__/test.tsx.snap
+++ b/packages/picasso/src/Select/__snapshots__/test.tsx.snap
@@ -6,15 +6,15 @@ exports[`renders native select 1`] = `
     class="Picasso-root"
   >
     <div
-      class="Select-root Select-rootFull"
+      class="makeStyles-root makeStyles-rootFull"
     >
       <div
         aria-autocomplete="list"
-        class="MuiInputBase-root MuiOutlinedInput-root OutlinedInput-root OutlinedInput-rootFull OutlinedInput-rootMedium Select-nativeInput MuiInputBase-fullWidth"
+        class="MuiInputBase-root MuiOutlinedInput-root OutlinedInput-root OutlinedInput-rootFull OutlinedInput-rootMedium makeStyles-nativeInput MuiInputBase-fullWidth"
       >
         <select
           aria-invalid="false"
-          class="MuiNativeSelect-root Select-select MuiNativeSelect-select MuiInputBase-input MuiOutlinedInput-input OutlinedInput-input OutlinedInput-inputMedium"
+          class="MuiNativeSelect-root makeStyles-select MuiNativeSelect-select MuiInputBase-input MuiOutlinedInput-input OutlinedInput-input OutlinedInput-inputMedium"
         >
           <option
             disabled=""
@@ -43,7 +43,7 @@ exports[`renders native select 1`] = `
           </option>
         </select>
         <svg
-          class="SvgDropdownArrows16-root Select-caret"
+          class="SvgDropdownArrows16-root makeStyles-caret"
           style="min-width: 16px; min-height: 16px;"
           viewBox="0 0 16 16"
         >
@@ -77,20 +77,20 @@ exports[`renders select 1`] = `
     class="Picasso-root"
   >
     <div
-      class="Select-root Select-rootFull"
+      class="makeStyles-root makeStyles-rootFull"
     >
       <div
-        class="Select-inputWrapper"
+        class="makeStyles-inputWrapper"
       >
         <div
           aria-autocomplete="list"
-          class="MuiInputBase-root MuiOutlinedInput-root OutlinedInput-root OutlinedInput-rootFull OutlinedInput-rootMedium Select-input Select-readOnlyInput MuiInputBase-fullWidth"
+          class="MuiInputBase-root MuiOutlinedInput-root OutlinedInput-root OutlinedInput-rootFull OutlinedInput-rootMedium makeStyles-input makeStyles-readOnlyInput MuiInputBase-fullWidth"
           role="textbox"
         >
           <input
             aria-invalid="false"
             autocomplete="off"
-            class="MuiInputBase-input MuiOutlinedInput-input OutlinedInput-input OutlinedInput-inputMedium Select-readOnlyInput"
+            class="MuiInputBase-input MuiOutlinedInput-input OutlinedInput-input OutlinedInput-inputMedium makeStyles-readOnlyInput"
             readonly=""
             size="1"
             type="text"
@@ -112,7 +112,7 @@ exports[`renders select 1`] = `
           </fieldset>
         </div>
         <svg
-          class="SvgDropdownArrows16-root Select-caret"
+          class="SvgDropdownArrows16-root makeStyles-caret"
           style="min-width: 16px; min-height: 16px;"
           viewBox="0 0 16 16"
         >

--- a/packages/picasso/src/Select/index.ts
+++ b/packages/picasso/src/Select/index.ts
@@ -1,7 +1,2 @@
-import { OmitInternalProps } from '@toptal/picasso-shared'
-
-import { Props as InternalSelectProps } from './Select'
+export type { Props, Props as SelectProps, ValueType } from './Select'
 export { default } from './Select'
-export type SelectProps = OmitInternalProps<InternalSelectProps>
-/** @deprecated Use SelectProps instead */
-export type Props = SelectProps

--- a/packages/picasso/src/Select/story/Autofill.example.tsx
+++ b/packages/picasso/src/Select/story/Autofill.example.tsx
@@ -1,13 +1,13 @@
 import React, { useState, ChangeEvent } from 'react'
-import { Select, Container, Form } from '@toptal/picasso'
+import { Container, Form, Select } from '@toptal/picasso'
 
 const Example = () => {
-  const [value, setValue] = useState<string | string[] | number>()
+  const [value, setValue] = useState<string>()
 
   const handleChange = (
     event: ChangeEvent<{
       name?: string | undefined
-      value: string | string[] | number
+      value: string
     }>
   ) => {
     console.log('Select value:', event.target.value)

--- a/packages/picasso/src/Select/story/SearchBehavior.example.tsx
+++ b/packages/picasso/src/Select/story/SearchBehavior.example.tsx
@@ -2,13 +2,13 @@ import React, { useState, ChangeEvent } from 'react'
 import { Select, Button, Container } from '@toptal/picasso'
 
 const SelectSearchBehaviourExample = () => {
-  const [value, setValue] = useState<string | string[] | number>()
+  const [value, setValue] = useState<string>()
   const [options, setOptions] = useState(OPTIONS_WHEN_SEARCH_DISABLED)
 
   const handleChange = (
     event: ChangeEvent<{
-      name?: string | undefined
-      value: string | string[] | number
+      name?: string
+      value: string
     }>
   ) => {
     console.log('Select value:', event.target.value)

--- a/packages/picasso/src/Select/story/index.jsx
+++ b/packages/picasso/src/Select/story/index.jsx
@@ -1,10 +1,10 @@
-import { Select } from '../Select'
+import Select from '../Select'
 
 import PicassoBook from '~/.storybook/components/PicassoBook'
 
 const page = PicassoBook.section('Forms').createPage(
   'Select',
-  `Selects are interactive elements that prompt users to make selections 
+  `Selects are interactive elements that prompt users to make selections
     or take actions from a set of list of available options.`
 )
 

--- a/packages/picasso/src/Select/types.ts
+++ b/packages/picasso/src/Select/types.ts
@@ -1,6 +1,6 @@
-export type Option = {
+export type Option<T extends string | number = string | number> = {
   key?: number
   text: string
-  value: string | number
+  value: T
   [prop: string]: string | number | undefined
 }

--- a/packages/picasso/src/YearSelect/YearSelect.tsx
+++ b/packages/picasso/src/YearSelect/YearSelect.tsx
@@ -1,22 +1,26 @@
-import React, { forwardRef, useMemo, ChangeEvent } from 'react'
-import { JssProps, OmitInternalProps } from '@toptal/picasso-shared'
+import React, { useMemo, Ref } from 'react'
 
 import Select, { Props as SelectProps } from '../Select'
+import { forwardRef, documentable } from '../utils/forward-ref'
 
-type AdjustedSelectProps = OmitInternalProps<
-  Omit<SelectProps, 'onChange' | 'options'>
-> &
-  Partial<JssProps>
+type AdjustedSelectProps<M extends boolean> = Omit<
+  SelectProps<number, M>,
+  'options'
+>
 
-export interface Props extends AdjustedSelectProps {
+/**
+ * YearSelect props are generalized over multiselect property. If you want `onChange`
+ * to take handler that can take array (for multiselect) you should set `Multiple`
+ * to `true`. By default it's single select.
+ *
+ * @param Multiple The `boolean` type of the `multiple` property to indicate whether `onChange` will expect handler to accept plain `number` or array of `number`s
+ */
+export interface Props<Multiple extends boolean>
+  extends AdjustedSelectProps<Multiple> {
   /** a year select starts from. e.g. 2017 */
   from: number
   /** a year select ends at. e.g. 2019 */
   to: number
-  /** Callback invoked when picker changes its state. */
-  onChange: (
-    event: ChangeEvent<{ name?: string | undefined; value: unknown }>
-  ) => void
 }
 
 function generateOptions(from: number, to: number) {
@@ -32,27 +36,26 @@ function generateOptions(from: number, to: number) {
   })
 }
 
-export const YearSelect = forwardRef<HTMLInputElement, Props>(
-  function YearSelect({ from, to, onChange, ...rest }, ref) {
-    const handleChange = (
-      event: ChangeEvent<{ name?: string | undefined; value: unknown }>
+export const YearSelect = documentable(
+  forwardRef(
+    <M extends boolean = false>(
+      { from, to, ...rest }: Props<M>,
+      ref: Ref<HTMLInputElement>
     ) => {
-      onChange(event)
-    }
+      if (!to || !from) {
+        throw new Error(
+          `Invalid range. Please check the values you have passed: from: ${from}, to: ${to}`
+        )
+      }
 
-    if (!to || !from) {
-      throw new Error(
-        `Invalid range. Please check the values you have passed: from: ${from}, to: ${to}`
+      const options = useMemo(() => generateOptions(from, to), [from, to])
+
+      return (
+        // eslint-disable-next-line react/jsx-props-no-spreading
+        <Select {...rest} ref={ref} options={options} />
       )
     }
-
-    const options = useMemo(() => generateOptions(from, to), [from, to])
-
-    return (
-      // eslint-disable-next-line react/jsx-props-no-spreading
-      <Select {...rest} ref={ref} options={options} onChange={handleChange} />
-    )
-  }
+  )
 )
 
 YearSelect.defaultProps = {}

--- a/packages/picasso/src/YearSelect/__snapshots__/test.tsx.snap
+++ b/packages/picasso/src/YearSelect/__snapshots__/test.tsx.snap
@@ -6,14 +6,14 @@ exports[`YearSelect default render 1`] = `
     class="Picasso-root"
   >
     <div
-      class="Select-root Select-rootFull"
+      class="makeStyles-root makeStyles-rootFull"
     >
       <div
-        class="Select-inputWrapper"
+        class="makeStyles-inputWrapper"
       >
         <div
           aria-autocomplete="list"
-          class="MuiInputBase-root MuiOutlinedInput-root OutlinedInput-root OutlinedInput-rootFull OutlinedInput-rootMedium Select-input MuiInputBase-fullWidth"
+          class="MuiInputBase-root MuiOutlinedInput-root OutlinedInput-root OutlinedInput-rootFull OutlinedInput-rootMedium makeStyles-input MuiInputBase-fullWidth"
           role="textbox"
         >
           <input
@@ -40,7 +40,7 @@ exports[`YearSelect default render 1`] = `
           </fieldset>
         </div>
         <svg
-          class="SvgDropdownArrows16-root Select-caret"
+          class="SvgDropdownArrows16-root makeStyles-caret"
           style="min-width: 16px; min-height: 16px;"
           viewBox="0 0 16 16"
         >

--- a/packages/picasso/src/YearSelect/index.ts
+++ b/packages/picasso/src/YearSelect/index.ts
@@ -1,6 +1,2 @@
-import { OmitInternalProps } from '@toptal/picasso-shared'
-
-import { Props } from './YearSelect'
-
+export type { Props as YearSelectProps } from './YearSelect'
 export { default } from './YearSelect'
-export type YearSelectProps = OmitInternalProps<Props>

--- a/packages/picasso/src/utils/forward-ref.ts
+++ b/packages/picasso/src/utils/forward-ref.ts
@@ -1,0 +1,38 @@
+import React from 'react'
+
+export type Component<T, P> = T & {
+  defaultProps?: Partial<P>
+  displayName?: string
+}
+
+/**
+ * Wraps the exotic generic functional component type returned by the `forwardRef`.
+ * This function adopts the type of the exotic compoennt to take `defaultProps` and
+ * `displayName`.
+ *
+ * @see forwardRef
+ *
+ * @param component exotic component returned by `forwardRef`
+ */
+export const documentable = <T, P>(component: T): Component<T, P> => component
+
+/**
+ * Wrapper around React.forwardRef that preserves genericity of the passed `Component`.
+ * @note If you need to set `defaultProps` and `displayName` properties, you need to wrap
+ * result of this function into `documentable`,
+ *
+ * @see documentable
+ *
+ * @warning ⚠️ Use it only when you need to preserve genericity of the component as it
+ * omits some type checks on the prop type of the component and IT DOESN'T ADD ref
+ * property type to the list of props — you have to do it on your own. If you don't
+ * care about genericity use React.forwardRef directly.
+ *
+ * @param component React component conforming to forwardRef type constraints
+ */
+export const forwardRef = <P, T>(
+  component: (props: P, ref: React.Ref<T>) => React.ReactElement | null
+) =>
+  (React.forwardRef(component) as unknown) as (
+    props: P
+  ) => React.ReactElement | null


### PR DESCRIPTION
### Description

Make all `Select` components generic over `value`, `options`, and `multiple` properties types.

### How to test

- Open https://github.com/toptal/picasso/blob/generic-select/packages/picasso/src/Select/story/Autofill.example.tsx
- Change `value`'s type to `number`
- _Expected:_ Compiler error: it should request a `string`
- Add `multiple` property
- _Expected:_ Compiler error: it should request `string[]` in `value` and event handler

### Review

- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure that visuals specs are green [See the documentation](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
