### PR TITLE
fix: allow value to be the same type as option

### DIFF
--- a/packages/picasso/src/Autocomplete/story/Autofill.example.tsx
+++ b/packages/picasso/src/Autocomplete/story/Autofill.example.tsx
@@ -47,7 +47,7 @@ const AutofillExample = () => (
         <Form.Field>
           <Form.Label>Country</Form.Label>
           <Autocomplete
-            value=''
+            value={undefined}
             options={options}
             width='full'
             name='country'
@@ -95,7 +95,7 @@ const AutofillExample = () => (
         <Form.Field>
           <Form.Label>Country</Form.Label>
           <Autocomplete
-            value=''
+            value={undefined}
             options={options}
             width='full'
             name='country'

--- a/packages/picasso/src/Autocomplete/story/Controlled.example.jsx
+++ b/packages/picasso/src/Autocomplete/story/Controlled.example.jsx
@@ -11,7 +11,7 @@ const options = [
 ]
 
 const Example = () => {
-  const [value, setValue] = useState(options[0].text)
+  const [value, setValue] = useState(options[0])
 
   return (
     <div>
@@ -21,11 +21,11 @@ const Example = () => {
         value={value}
         onSelect={item => {
           console.log('onSelect returns item object:', item)
-          setValue(item.text)
+          setValue(item)
         }}
         onChange={newValue => {
           console.log('onChange returns just item value:', newValue)
-          setValue(newValue)
+          setValue({ text: newValue })
         }}
       />
       <Container top={2}>
@@ -33,14 +33,14 @@ const Example = () => {
           <Grid.Item>
             <Button
               onClick={() => {
-                setValue(options[3].text)
+                setValue(options[3])
               }}
             >
               Set to country in your profile: Slovakia
             </Button>
             <Button
               onClick={() => {
-                setValue('')
+                setValue()
               }}
               variant='secondary-blue'
             >

--- a/packages/picasso/src/Autocomplete/story/CustomOptionRenderer.example.tsx
+++ b/packages/picasso/src/Autocomplete/story/CustomOptionRenderer.example.tsx
@@ -1,8 +1,7 @@
 import React from 'react'
-import { Item } from '@toptal/picasso/Autocomplete'
 import { Typography, Container, Autocomplete } from '@toptal/picasso'
 
-interface Country extends Item {
+interface Country {
   country: string
   capital: string
   code: string
@@ -19,17 +18,15 @@ const options: Country[] = [
 const CustomOptionRenderer = () => (
   <div>
     <Autocomplete
-      value=''
+      value={options[0]}
       placeholder='Start typing country...'
       options={options}
-      onSelect={(item: Item) => {
+      onSelect={item => {
         window.console.log('onSelect returns item object:', item)
         window.console.log('selected capital:', item.capital)
       }}
-      getKey={(item: Item) => (item as Country).code}
-      getDisplayValue={(item: Item | null) =>
-        (item && (item as Country).country) || ''
-      }
+      getKey={({ code }) => code}
+      getDisplayValue={item => (item ? item.country : '')}
       renderOption={(option: Partial<Country>, index) => (
         <Container>
           <Typography size='medium' weight='semibold'>

--- a/packages/picasso/src/Autocomplete/story/Default.example.jsx
+++ b/packages/picasso/src/Autocomplete/story/Default.example.jsx
@@ -2,16 +2,10 @@ import React, { useState } from 'react'
 import { Autocomplete, Form } from '@toptal/picasso'
 import { isSubstring } from '@toptal/picasso/utils'
 
-const allOptions = [
-  { text: 'Belarus' },
-  { text: 'Croatia' },
-  { text: 'Lithuania' },
-  { text: 'Slovakia' },
-  { text: 'Ukraine' }
-]
+const allOptions = ['Belarus', 'Croatia', 'Lithuania', 'Slovakia', 'Ukraine']
 
 const EMPTY_INPUT_VALUE = ''
-const getDisplayValue = item => (item ? item.text : EMPTY_INPUT_VALUE)
+const getDisplayValue = item => item || EMPTY_INPUT_VALUE
 const filterOptions = (str = '') => {
   if (str === '') {
     return allOptions
@@ -36,16 +30,11 @@ const Example = () => {
           value={value}
           options={options}
           onSelect={item => {
-            console.log('onSelect returns item object:', item)
-
-            const itemValue = getDisplayValue(item)
-
-            if (value !== itemValue) {
-              setValue(itemValue)
-            }
+            console.log('onSelect returns item value:', item)
+            setValue(item)
           }}
           onChange={newValue => {
-            console.log('onChange returns just item value:', newValue)
+            console.log('onChange returns input value:', newValue)
 
             setOptions(filterOptions(newValue))
             setValue(newValue)

--- a/packages/picasso/src/Autocomplete/story/DynamicOptions.example.jsx
+++ b/packages/picasso/src/Autocomplete/story/DynamicOptions.example.jsx
@@ -48,7 +48,7 @@ const Example = () => {
   )
 
   const handleChange = (inputValue, options) => {
-    setValue(inputValue)
+    setValue({ text: inputValue })
 
     if (options.isSelected) {
       return

--- a/packages/picasso/src/Autocomplete/story/InitialSetValue.example.jsx
+++ b/packages/picasso/src/Autocomplete/story/InitialSetValue.example.jsx
@@ -16,7 +16,7 @@ const Example = () => (
       options={options}
       onSelect={item => console.log('onSelect value:', item)}
       onChange={inputValue => console.log('onChange value:', inputValue)}
-      value='Belarus'
+      value={options[0]}
     />
   </div>
 )

--- a/packages/picasso/src/Autocomplete/story/OtherOption.example.jsx
+++ b/packages/picasso/src/Autocomplete/story/OtherOption.example.jsx
@@ -2,16 +2,10 @@ import React, { useState } from 'react'
 import { Autocomplete } from '@toptal/picasso'
 import { isSubstring } from '@toptal/picasso/utils'
 
-const allOptions = [
-  { text: 'Belarus' },
-  { text: 'Croatia' },
-  { text: 'Lithuania' },
-  { text: 'Slovakia' },
-  { text: 'Ukraine' }
-]
+const allOptions = ['Belarus', 'Croatia', 'Lithuania', 'Slovakia', 'Ukraine']
 
 const EMPTY_INPUT_VALUE = ''
-const getDisplayValue = item => (item ? item.text : EMPTY_INPUT_VALUE)
+const getDisplayValue = item => item || EMPTY_INPUT_VALUE
 const filterOptions = str =>
   str !== ''
     ? allOptions.filter(option => isSubstring(str, getDisplayValue(option)))
@@ -30,12 +24,7 @@ const Example = () => {
         options={options}
         onSelect={item => {
           console.log('onSelect returns item object:', item)
-
-          const itemValue = getDisplayValue(item)
-
-          if (value !== itemValue) {
-            setValue(itemValue)
-          }
+          setValue(item)
         }}
         onOtherOptionSelect={newValue => {
           console.log('onOtherOptionSelect returns item value:', newValue)

--- a/packages/picasso/src/Autocomplete/story/index.jsx
+++ b/packages/picasso/src/Autocomplete/story/index.jsx
@@ -30,7 +30,7 @@ page
   .addTextSection(
     `
 Autocomplete supports all the default HTML native props, as Input supports.
-    
+
 ### A note about browser autofilling
 
 Standard browser autofilling feature is disabled in this component by default, because it's used pretty rarely.


### PR DESCRIPTION
## Work in progress

### Description

Autocomplete value should be the same shape as its option so it can be used as a select in some cases. So I tried to make the Autocomplete accept a generic type.

### How to test

- The component should behave just like before

### Review

- [ ] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that visuals specs are green [See the documentation](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
