### PR TITLE
fix(tablebody): stripe all children

### DIFF
--- a/packages/picasso/src/TableBody/TableBody.tsx
+++ b/packages/picasso/src/TableBody/TableBody.tsx
@@ -3,8 +3,6 @@ import { withStyles } from '@material-ui/core/styles'
 import MUITableBody from '@material-ui/core/TableBody'
 import { StandardProps } from '@toptal/picasso-shared'
 
-import TableExpandableRow from '../TableExpandableRow'
-import TableRow from '../TableRow'
 import styles from './styles'
 
 export interface Props
@@ -17,16 +15,8 @@ export interface Props
 const decorateRows = (children: React.ReactNode) => {
   let stripeIndex = -1
 
-  // eslint-disable-next-line complexity
   return React.Children.map(children, child => {
     if (!React.isValidElement(child)) {
-      return child
-    }
-
-    const isTableRow =
-      child.type === TableRow || child.type === TableExpandableRow
-
-    if (!isTableRow) {
       return child
     }
 


### PR DESCRIPTION
No ticket. (Actually part of [TEA-583](https://toptal-core.atlassian.net/browse/TEA-853))

### Description

We don't need to check for the child type when applying decoration to children of `Table.Body` since the only acceptable child type for this element (`<tbody>`) is a row (`<tr>`).

### Review

- (n/a) Annotate all `props` in component with documentation
- (n/a) Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure that visuals specs are green [See the documentation](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)