### PR TITLE
fix(Select): fix scrolling on hover of boundary elements

### DIFF
--- a/packages/picasso/src/ScrollMenu/ScrollMenu.tsx
+++ b/packages/picasso/src/ScrollMenu/ScrollMenu.tsx
@@ -53,11 +53,11 @@ const ScrollMenu: FunctionComponent<Props> = ({
     const scrollViewHeight = menuRef.current.offsetHeight
 
     const moveDirection =
-      prevSelectedIndex && prevSelectedIndex <= selectedIndex
+      prevSelectedIndex != null && prevSelectedIndex <= selectedIndex
         ? Direction.DOWN
         : Direction.UP
 
-    const countItemsOnScrollView = Math.floor(scrollViewHeight / itemHeight)
+    const countItemsOnScrollView = scrollViewHeight / itemHeight
     const topVisibleItem = currentScrollTop / itemHeight
     const bottomVisibleItem = topVisibleItem + countItemsOnScrollView - 1
 
@@ -68,7 +68,7 @@ const ScrollMenu: FunctionComponent<Props> = ({
       let scrollTop = 0
 
       if (moveDirection === Direction.UP) {
-        scrollTop = (selectedIndex - 1) * itemHeight
+        scrollTop = selectedIndex * itemHeight
       } else if (moveDirection === Direction.DOWN) {
         scrollTop = (selectedIndex - countItemsOnScrollView + 1) * itemHeight
       }

--- a/packages/picasso/src/Select/story/Default.example.jsx
+++ b/packages/picasso/src/Select/story/Default.example.jsx
@@ -24,7 +24,17 @@ const OPTIONS = [
   { value: '1', text: 'Option 1' },
   { value: '2', text: 'Option 2' },
   { value: '3', text: 'Option 3' },
-  { value: '4', text: 'Option 4' }
+  { value: '4', text: 'Option 4' },
+  { value: '5', text: 'Option 5' },
+  { value: '6', text: 'Option 6' },
+  { value: '7', text: 'Option 7' },
+  { value: '8', text: 'Option 8' },
+  { value: '9', text: 'Option 9' },
+  { value: '10', text: 'Option 10' },
+  { value: '11', text: 'Option 11' },
+  { value: '12', text: 'Option 12' },
+  { value: '13', text: 'Option 13' },
+  { value: '14', text: 'Option 14' }
 ]
 
 export default Example


### PR DESCRIPTION
[TA-1328](https://toptal-core.atlassian.net/browse/TA-1328)

### Description

Hovering of boundary elements was not working nicely:
1) When user hovers the bottom one it quickly scrolls to the very end
2) When user hovers the top element it jumps so that N-1 element becomes under the cursor

### How to test

- `yarn start`
- Open the [Select page](http://localhost:9001/?path=/story/forms-folder--select)
- With the 'Default' story check
1. Open the select, hover top and bottom boundary elements and ensure that it scrolls just to make a single element visible
2. Ensure that keyboard navigation works well

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| **Mouse:** https://share.getcloudapp.com/QwuK86B4 **Keyboard:** https://share.getcloudapp.com/eDu6EYLN | **Mouse:** https://share.getcloudapp.com/eDu6rz8E **Keyboard:**  https://share.getcloudapp.com/12uyk51N|

### Review

- [n/a] Annotate all `props` in component with documentation
- [n/a] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that visuals specs are green [See the documentation](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
