### PR TITLE
fix: add missing picasso utils exports

### DIFF
--- a/packages/picasso/src/utils/index.ts
+++ b/packages/picasso/src/utils/index.ts
@@ -22,6 +22,9 @@ export { default as disableUnsupportedProps } from './disable-unsupported-props'
 export { default as isNumber } from './is-number'
 export { default as isBoolean } from './is-boolean'
 export { default as isSubstring } from './is-substring'
+export { default as getNameInitials } from './get-name-initials'
+export { default as kebabToCamelCase } from './kebab-to-camel-case'
+
 export const Transitions = TransitionUtils
 
 export { Maybe } from './monads'


### PR DESCRIPTION
Saw that some[ Picasso are utils are used in Staff Portal,](https://github.com/toptal/staff-portal/blob/master/src/modules/tasks/components/EditableTaskAssignee/EditableTaskAssignee.tsx#L3) but haven't been added to the package exports, which forces users to use these imports
```
import getNameInitials from '@toptal/picasso/utils/get-name-initials'
```
instead of
```
import { getNameInitials } from '@toptal/picasso/utils'
```