### PR TITLE
feat: allow custom value for the overview block

### DIFF
--- a/packages/picasso-lab/src/OverviewBlock/OverviewBlock.tsx
+++ b/packages/picasso-lab/src/OverviewBlock/OverviewBlock.tsx
@@ -3,7 +3,8 @@ import React, {
   ElementType,
   FunctionComponent,
   HTMLAttributes,
-  MouseEvent
+  MouseEvent,
+  ReactNode
 } from 'react'
 import { Theme, makeStyles } from '@material-ui/core/styles'
 import cx from 'classnames'
@@ -36,7 +37,7 @@ type ColorSettings = {
 export type Props = BaseProps &
   HTMLAttributes<HTMLButtonElement> & {
     /** Counter value  */
-    value: string
+    value: ReactNode
     /** Counter title  */
     label: string
     /** The color variant  */


### PR DESCRIPTION
[SPT-405](https://toptal-core.atlassian.net/browse/SPT-405)

### Description

Allow custom value for the `OverviewBlock` component.
In some cases, we need to display a custom value in the overview block, for example, a tooltip or a link.

![image](https://user-images.githubusercontent.com/2583281/81697113-77c58180-946d-11ea-92ce-94c5f4831293.png)

### Review

- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure that visuals specs are green [See the documentation](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
