### PR TITLE
fix: add ts check for picasso-forms examples

### DIFF
--- a/packages/picasso-forms/src/Form/story/CustomValidator.example.tsx
+++ b/packages/picasso-forms/src/Form/story/CustomValidator.example.tsx
@@ -2,7 +2,11 @@ import React from 'react'
 import { Container } from '@toptal/picasso'
 import { Form } from '@toptal/picasso-forms'
 
-const minMaxValidator = (value: string | number) => {
+const minMaxValidator = (value?: string | number) => {
+  if (value === undefined) {
+    return undefined
+  }
+
   const number = Number(value)
 
   if (number < 0) {

--- a/packages/picasso-forms/src/Input/Input.tsx
+++ b/packages/picasso-forms/src/Input/Input.tsx
@@ -4,11 +4,15 @@ import { Props as InputProps } from '@toptal/picasso/Input'
 
 import FieldWrapper, { FieldProps } from '../FieldWrapper'
 
-export type Props = InputProps & FieldProps<InputProps['value']>
+export type FormInputProps = Omit<InputProps, 'onResetClick'> & {
+  /** Callback invoked when reset button was clicked */
+  onResetClick?: (set: (value: string) => void) => void
+}
+export type Props = FormInputProps & FieldProps<InputProps['value']>
 
 export const Input = (props: Props) => (
   // eslint-disable-next-line react/jsx-props-no-spreading
-  <FieldWrapper<InputProps> {...props}>
+  <FieldWrapper<FormInputProps> {...props}>
     {(inputProps: InputProps) => {
       // eslint-disable-next-line react/jsx-props-no-spreading
       return <PicassoInput {...inputProps} />

--- a/packages/picasso/src/NumberInput/NumberInput.tsx
+++ b/packages/picasso/src/NumberInput/NumberInput.tsx
@@ -17,7 +17,7 @@ export interface Props
     >,
     BaseProps {
   /** Value of the `input` element. */
-  value: string | number
+  value?: string | number
   /** Minimum value for the `input` element */
   min?: number | string
   /** Maximum value for the `input` element */
@@ -43,6 +43,8 @@ type NumberAdornmentProps = {
   classes: Record<string, string>
   disabled?: boolean
 }
+
+const DEFAULT_NUMBER_INPUT_VALUE = 0
 
 const nativeInputValueSetter = (Object.getOwnPropertyDescriptor(
   window.HTMLInputElement.prototype,
@@ -201,6 +203,7 @@ export const NumberInput = forwardRef<HTMLInputElement, Props>(
 
 NumberInput.defaultProps = {
   onChange: () => {},
+  value: DEFAULT_NUMBER_INPUT_VALUE,
   step: 1,
   min: -Infinity,
   max: Infinity,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -33,7 +33,8 @@
     }
   },
   "include": [
-    "packages/picasso/src/**/*"
+    "packages/picasso/src/**/*",
+    "packages/picasso-forms/src/**/*"
   ],
   "exclude": ["**/test.jsx", "**/test.tsx", "**/story/index.jsx"]
 }


### PR DESCRIPTION
### Description

We had disabled TS checks for picasso packages, except the main picasso. This PR is a try to enable this check for `picasso-forms` package with necessary fixes.