### PR TITLE
fix(select): reset highlighted option on toggle

### DIFF
--- a/packages/picasso/src/Autocomplete/useAutocomplete.ts
+++ b/packages/picasso/src/Autocomplete/useAutocomplete.ts
@@ -95,7 +95,7 @@ const useAutocomplete = ({
 
   useLayoutEffect(() => {
     setHighlightedIndex(null)
-  }, [value])
+  }, [value, isOpen])
 
   const shouldShowOtherOption =
     showOtherOption &&

--- a/packages/picasso/src/Select/useSelect.ts
+++ b/packages/picasso/src/Select/useSelect.ts
@@ -122,7 +122,7 @@ const useSelect = ({
 
   useLayoutEffect(() => {
     setHighlightedIndex(null)
-  }, [value])
+  }, [value, isOpen])
 
   const handleChange = (newValue: string) => {
     if (newValue !== value) {


### PR DESCRIPTION
No ticket.

### Description

Right now, when we highlight an option and close the select/autocomplete, it keeps the same highlighted option when you open it again. This isn't good as it might confuse users. [See this example](https://share.getcloudapp.com/wbu0BbPj).

### How to test

- Open a select/autocomplete box;
- Hover some item;
- Close the box;
- See no highlighted option when opening again.

### Review

- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that visuals specs are green [See the documentation](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
