### PR TITLE
fix(autocomplete): fix size of the dropdown for full width autocomplete

### DIFF
--- a/packages/picasso/src/Autocomplete/Autocomplete.tsx
+++ b/packages/picasso/src/Autocomplete/Autocomplete.tsx
@@ -245,7 +245,7 @@ export const Autocomplete = forwardRef<HTMLInputElement, Props>(
           />
         </Container>
         <div role='listbox'>
-          {inputWrapperRef.current && optionsMenu && (
+          {isOpen && inputWrapperRef.current && optionsMenu && (
             <Popper
               autoWidth
               open={isOpen && !loading}


### PR DESCRIPTION
### Description

Force re-render of the dropdown when it's open to recalculate the width of the dropdown


### How to test

- Update the default example to have `width='full'`
- Type b
- See that Belarus item has good width
- Click away to close the input
- Resize the window size
- Focus on the input again

### Screenshots

#### Before
![screencast 2020-05-18 16-07-51 2020-05-18 16_10_10](https://user-images.githubusercontent.com/2437969/82222829-1e080000-9922-11ea-942f-779f4584a603.gif)


#### After
![screencast 2020-05-18 16-19-16 2020-05-18 16_23_35](https://user-images.githubusercontent.com/2437969/82224293-f87bf600-9923-11ea-8545-326f51d09913.gif)


### Review

- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure that visuals specs are green [See the documentation](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
