### PR TITLE
fix(popper): disable compact mode for Autocomplete and Select

### DIFF
--- a/packages/picasso-lab/src/DatePicker/DatePicker.tsx
+++ b/packages/picasso-lab/src/DatePicker/DatePicker.tsx
@@ -276,6 +276,7 @@ export const DatePicker = (props: Props) => {
           open={calendarIsShown}
           anchorEl={inputWrapperRef.current}
           autoWidth={false}
+          enableCompactMode
           container={popperContainer}
           ref={popperRef}
         >

--- a/packages/picasso/src/Dropdown/Dropdown.tsx
+++ b/packages/picasso/src/Dropdown/Dropdown.tsx
@@ -223,6 +223,7 @@ export const Dropdown = forwardRef<HTMLDivElement, Props>(function Dropdown(
           style={paperMargins}
           disablePortal={disablePortal}
           autoWidth={false}
+          enableCompactMode
           container={popperContainer}
         >
           <ClickAwayListener onClickAway={handleClickAway}>

--- a/packages/picasso/src/Popper/Popper.tsx
+++ b/packages/picasso/src/Popper/Popper.tsx
@@ -47,6 +47,8 @@ export interface Props extends BaseProps {
   autoWidth?: boolean
   /** Popper width */
   width?: string
+  /** Take full window width on small and medium screens */
+  enableCompactMode?: boolean
 }
 
 const useStyles = makeStyles<Theme, Props>(styles, { name: 'PicassoPopper' })
@@ -105,6 +107,7 @@ export const Popper = forwardRef<PopperJs, Props>(function Popper(props, ref) {
     popperOptions,
     autoWidth,
     width,
+    enableCompactMode,
     disablePortal,
     style,
     ...rest
@@ -113,7 +116,8 @@ export const Popper = forwardRef<PopperJs, Props>(function Popper(props, ref) {
   const picassoRootContainer = usePicassoRoot()
 
   const classes = useStyles(props)
-  const isCompactLayout = useBreakpoint(['small', 'medium'])
+  const isCompactLayoutResolution = useBreakpoint(['small', 'medium'])
+  const isCompactLayout = enableCompactMode && isCompactLayoutResolution
   const widthStyle = useWidthStyle({ autoWidth, width, anchorEl })
   const anchorElWidthStyle = !isCompactLayout && widthStyle
 


### PR DESCRIPTION
[TEA-1288]

### Description

Dropdown displayed under inputs should respect the input size even on small and medium screens.

Confirmed with #-base-core channel 
https://toptal-core.slack.com/archives/CCC3GP6CC/p1589805497366400
https://toptal-core.slack.com/archives/CCC3GP6CC/p1589873210378000

### How to test

- Resize the window to small or medium breakpoint
- See that the Select and Autocomplete dropdown respects the input width instead of going full width

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| ![Screenshot 2020-05-19 at 10 34 47](https://user-images.githubusercontent.com/2437969/82304298-6ffd6400-99bc-11ea-96ff-f2d84900c9de.png) | ![Screenshot 2020-05-19 at 10 35 04](https://user-images.githubusercontent.com/2437969/82304322-77bd0880-99bc-11ea-8000-49cc7e90bd48.png) |

### Review

- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure that visuals specs are green [See the documentation](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)


[TEA-1288]: https://toptal-core.atlassian.net/browse/TEA-1288