### PR TITLE
feat: add allowTooltipEscapeViewBox prop to charts

### DIFF
--- a/packages/picasso-charts/src/LineChart/LineChart.tsx
+++ b/packages/picasso-charts/src/LineChart/LineChart.tsx
@@ -60,6 +60,7 @@ export type BaseChartProps = {
   height?: number
   tooltip?: boolean
   customTooltip?: ReactElement
+  allowTooltipEscapeViewBox?: boolean
   className?: string
   children?: ReactNode
 }
@@ -165,6 +166,7 @@ export const LineChart = ({
   height,
   tooltip,
   customTooltip,
+  allowTooltipEscapeViewBox,
   highlights,
   referenceLines,
   children
@@ -247,7 +249,14 @@ export const LineChart = ({
           {lineGraphs}
           {children}
 
-          {tooltip && <Tooltip content={customTooltip} />}
+          {tooltip && (
+            <Tooltip
+              allowEscapeViewBox={
+                allowTooltipEscapeViewBox ? { x: true, y: true } : undefined
+              }
+              content={customTooltip}
+            />
+          )}
 
           {highlightedAreas}
         </ComposedChart>
@@ -260,6 +269,7 @@ LineChart.defaultProps = {
   height: 200,
   unit: 'd',
   tooltip: false,
+  allowTooltipEscapeViewBox: false,
   xAxisKey: 'x'
 }
 

--- a/packages/picasso-charts/src/LineChart/story/index.jsx
+++ b/packages/picasso-charts/src/LineChart/story/index.jsx
@@ -47,6 +47,12 @@ export const sharedChartDocs = {
     name: 'customTooltip',
     type: 'ReactElement',
     description: 'Requires `tooltip` to be `true`'
+  },
+  allowTooltipEscapeViewBox: {
+    name: 'allowTooltipEscapeViewBox',
+    type: 'boolean',
+    description:
+      'Allows the tooltip to extend beyond the viewBox of the chart itself'
   }
 }
 


### PR DESCRIPTION
No JIRA ticket.

### Description

[_Non-breaking change_] Sometimes when the custom chart tooltip takes a lot of space it covers the entire chart view box. In order to avoid this, optional `allowTooltipEscapeViewBox` (default is false) was added (originated from https://toptal-core.atlassian.net/browse/SPC-316).

### How to test

- visit the [temploy](https://picasso.toptal.net/add-allowEscapeViewBox-prop-to-analytics-chart/?59a717b768345a0657c334e2e492d0d28e546658) and use the code below to create big tooltip for `LineChart > Default` example:

```
const Example = () => (
  <LineChart
    data={CHART_DATA}
    highlights={HIGHLIGHTS}
    lineConfig={{
      talents: { color: palette.blue.main }
    }}
    allowTooltipEscapeViewBox={true}
    tooltip
    customTooltip={
      <div style={{border: '1px solid black', backgroundColor: 'white', padding: '10px'}}>
        <h1>Extra # # # # # # # # # # # wide</h1>
        <h1>And</h1>
        <h1>Very</h1>
        <h1>Tall Tooltip</h1>
      </div>
    }
  />
)
```

### Screenshots

Before:

![tooltip_old_1](https://user-images.githubusercontent.com/1390758/82530354-acbd8c80-9b6f-11ea-9905-cc716214aba8.gif)

After:

![tooltip_new_1](https://user-images.githubusercontent.com/1390758/82530359-af1fe680-9b6f-11ea-96a3-a03903a40073.gif)

### Review

- [x] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure that visuals specs are green [See the documentation](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
