### PR TITLE
chore: upgrade picasso-charts for analytics

### DIFF
--- a/packages/topkit-analytics-charts/package.json
+++ b/packages/topkit-analytics-charts/package.json
@@ -20,7 +20,7 @@
     "url": "https://github.com/toptal/picasso/issues"
   },
   "peerDependencies": {
-    "@toptal/picasso-charts": "^0.3.4"
+    "@toptal/picasso-charts": "^0.4.0"
   },
   "devDependencies": {
     "cross-env": "^6.0.3",


### PR DESCRIPTION
No JIRA ticket.

### Description

The version of `picasso-charts` needs to be updated for `@topkit/analytics-charts` to use the latest changes from https://github.com/toptal/picasso/pull/1323.

### How to test

- make sure that the build succeeds, so the version bump does not break anything.

### Screenshots

No screenshots for chore PR.

### Review

- [ ] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure that visuals specs are green [See the documentation](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
