### PR TITLE
fix(forms): fix wrong references in types in picasso-forms

### DIFF
--- a/packages/picasso-forms/src/Radio/Radio.tsx
+++ b/packages/picasso-forms/src/Radio/Radio.tsx
@@ -1,3 +1,17 @@
-import { Radio } from '@toptal/picasso'
+import React from 'react'
+import { Radio as PicassoRadio, RadioProps } from '@toptal/picasso'
+
+// Intersection with the type { name?: string } is needed here because of
+// TS compiler issue https://github.com/microsoft/TypeScript/issues/34793
+export type Props = RadioProps & {
+  name?: string
+}
+
+const Radio = (props: Props) => (
+  <PicassoRadio
+    // eslint-disable-next-line react/jsx-props-no-spreading
+    {...props}
+  />
+)
 
 export default Radio

--- a/packages/picasso-forms/src/SubmitButton/SubmitButton.tsx
+++ b/packages/picasso-forms/src/SubmitButton/SubmitButton.tsx
@@ -1,8 +1,12 @@
 import React from 'react'
-import { Button, Props as ButtonProps } from '@toptal/picasso/Button'
+import { Button, ButtonProps } from '@toptal/picasso'
 import { useFormState } from 'react-final-form'
 
-export type Props = Omit<ButtonProps, 'type'>
+// Intersection with the type { id?: string } is needed here because of
+// TS compiler issue https://github.com/microsoft/TypeScript/issues/34793
+export type Props = Omit<ButtonProps, 'type'> & {
+  id?: string
+}
 
 export const SubmitButton = (props: Props) => {
   const { submitting } = useFormState()

--- a/packages/picasso/src/Button/Button.tsx
+++ b/packages/picasso/src/Button/Button.tsx
@@ -36,7 +36,7 @@ export type VariantType =
   | 'transparent-white'
   | 'transparent-blue'
 
-type IconPositionType = 'left' | 'right'
+export type IconPositionType = 'left' | 'right'
 
 export interface Props extends BaseProps, ButtonOrAnchorProps {
   /** Show button in the active state (left mouse button down) */

--- a/packages/picasso/src/Button/index.ts
+++ b/packages/picasso/src/Button/index.ts
@@ -1,7 +1,5 @@
-import { OmitInternalProps } from '@toptal/picasso-shared'
-
 import { Props } from './Button'
 
 export { default } from './Button'
-export type ButtonProps = OmitInternalProps<Props>
+export type ButtonProps = Props
 export * from './Button'


### PR DESCRIPTION
### Description

We have currently an issue in the types of `picasso-forms`, that come types are imported incorrectly from `@toptal/picasso/src/**`. Looks like this is happening because of an issue in `tsc` - https://github.com/microsoft/TypeScript/issues/34793.

So currently this code:

```
import { ButtonProps } from '@toptal/picasso'
export type Props = Omit<ButtonProps, 'type'>
export const SubmitButton = (props: Props) => {
```

got transformed by `tsc` into:

```
import { ButtonProps } from '@toptal/picasso';
export declare type Props = Omit<ButtonProps, 'type'>;
export declare const SubmitButton: {
    (props: Pick<Pick<import("@toptal/picasso/src/Button").Props, "color" | "hidden" | "size" | "style" | "icon" | "active" | "disabled" | "children", ...
```

which is wrong. But after modifying `ButtonProps` somehow - looks like `tsc` understand better what we want from it. I haven't found yet a better fix