### PR TITLE
fix(autocomplete): add `isSelect` argument for keyboard selection

### DIFF
--- a/packages/picasso/src/Autocomplete/useAutocomplete.ts
+++ b/packages/picasso/src/Autocomplete/useAutocomplete.ts
@@ -236,7 +236,7 @@ const useAutocomplete = ({
           findSelectedItemUsingIndex() ?? findSelectedItemUsingValue()
 
         if (selectedItem) {
-          handleChange(getDisplayValue(selectedItem))
+          handleChange(getDisplayValue(selectedItem), true)
           handleSelect(selectedItem)
         } else if (value) {
           onOtherOptionSelect(value)


### PR DESCRIPTION
### Description

keyboard selection throws a `onChange` event without passing `isSelect` attribute.

### How to test

- Select option via keyboard and press `Enter`

### Review

- [ ] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that visuals specs are green [See the documentation](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
