### PR TITLE
fix(popper): fix width calculation for Popper

### DIFF
--- a/packages/picasso/src/utils/use-width-of.ts
+++ b/packages/picasso/src/utils/use-width-of.ts
@@ -1,6 +1,7 @@
 import { useLayoutEffect, useState } from 'react'
 
 export interface ReferenceObject {
+  offsetParent?: Element
   getBoundingClientRect(): ClientRect
 }
 
@@ -14,7 +15,7 @@ const useWidthOf = <T extends ReferenceObject>(element: T | null) => {
     const { width } = element.getBoundingClientRect()
 
     setMenuWidth(`${width}px`)
-  }, [element])
+  }, [element, element?.offsetParent])
 
   return menuWidth
 }


### PR DESCRIPTION
### Description

Engaged issue:
https://github.com/toptal/picasso/issues/1336

<img width="720" alt="Picasso | Select 2020-05-26 14-39-58" src="https://user-images.githubusercontent.com/1824723/82896618-eff87080-9f5e-11ea-92c5-80edceecfe8a.png">

The found out solution is based on `offsetParent` attribute: https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/offsetParent

Checked locally.

### Review

- [ ] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that visuals specs are green [See the documentation](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
