### PR TITLE
fix(modal): fix modal height on iPhone

### DIFF
--- a/packages/picasso/src/Modal/Modal.tsx
+++ b/packages/picasso/src/Modal/Modal.tsx
@@ -13,6 +13,7 @@ import {
   BaseProps,
   CompoundedComponentWithRef,
   usePicassoRoot,
+  useBreakpoint,
   SizeType
 } from '@toptal/picasso-shared'
 
@@ -170,6 +171,8 @@ export const Modal = forwardRef<HTMLElement, Props>(function Modal(props, ref) {
     }
   }, [open])
 
+  const isSmall = useBreakpoint('small')
+
   return (
     <Dialog
       // eslint-disable-next-line react/jsx-props-no-spreading
@@ -182,6 +185,7 @@ export const Modal = forwardRef<HTMLElement, Props>(function Modal(props, ref) {
       }}
       className={className}
       style={style}
+      fullScreen={isSmall}
       container={container || picassoRootContainer}
       PaperProps={{ ...paperProps, elevation: 2 }}
       hideBackdrop={hideBackdrop}

--- a/packages/picasso/src/Modal/styles.ts
+++ b/packages/picasso/src/Modal/styles.ts
@@ -15,9 +15,6 @@ export default ({ palette, screens }: Theme) =>
       maxWidth,
 
       [screens('small')]: {
-        width: '100vw',
-        height: '100vh',
-        margin: 0,
         maxWidth: 'none',
         maxHeight: 'none'
       }


### PR DESCRIPTION
### Description

100vh is more than the screen height on iPhone so the top part of the modal with the title and the close button is invisible

### How to test

- Open a modal on iPhone

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| ![Screenshot 2020-06-02 at 12 06 08](https://user-images.githubusercontent.com/2437969/83507967-8ed61d00-a4c9-11ea-99e1-b30afb54a9c8.png) | ![Screenshot 2020-06-02 at 16 12 41](https://user-images.githubusercontent.com/2437969/83559605-21e87480-a515-11ea-88ba-b77cdadf9434.png) |

### Review

- [ ] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that visuals specs are green [See the documentation](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
