### PR TITLE
fix(SubmitButton): subscribe only to important part of the form state

### DIFF
--- a/packages/picasso-forms/src/SubmitButton/SubmitButton.tsx
+++ b/packages/picasso-forms/src/SubmitButton/SubmitButton.tsx
@@ -9,7 +9,7 @@ export type Props = Omit<ButtonProps, 'type'> & {
 }
 
 export const SubmitButton = (props: Props) => {
-  const { submitting } = useFormState()
+  const { submitting } = useFormState({ subscription: { submitting: true } })
   return (
     <Button
       type='submit'


### PR DESCRIPTION
### Description

While working on a task for Talent Activation team I noticed that `SubmitButton` is calling `formState` only to get changes on `submitting` but subscribing to any change, thus causing unncessary renderings of the component.

It's not a bug nor a big deal but we could avoid these behaviour with this change.

More on this on [ReactFinalForm#subscription](https://final-form.org/docs/react-final-form/types/FormProps#subscription)

### How to test

- FIXME: Add the steps describing how to verify your changes

### Review

- ~Annotate all `props` in component with documentation~
- ~Create `examples` for component~
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure that visuals specs are green [See the documentation](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
