### PR TITLE
fix(button): eliminate circular dependency on utils

### DIFF
--- a/packages/picasso/src/Button/Button.tsx
+++ b/packages/picasso/src/Button/Button.tsx
@@ -21,8 +21,8 @@ import Loader from '../Loader'
 import Container from '../Container'
 import Group from '../ButtonGroup'
 import kebabToCamelCase from '../utils/kebab-to-camel-case'
+import toTitleCase from '../utils/to-title-case'
 import styles from './styles'
-import { toTitleCase } from '../utils'
 
 export type VariantType =
   | 'primary-blue'


### PR DESCRIPTION
### Description

Test runner jest breaks when we mock modules with circular dependencies.

### How to test

- Check out https://github.com/toptal/talent-portal-frontend/pull/807
- See that the tests are failing
- Apply this patch to picasso button
- See green tests

### Review

- n/a Annotate all `props` in component with documentation
- n/a Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that visuals specs are green [See the documentation](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
