### PR TITLE
fix(input): set background color to white

### DIFF
--- a/packages/picasso/src/Input/styles.ts
+++ b/packages/picasso/src/Input/styles.ts
@@ -8,7 +8,8 @@ import '../InputAdornment/styles'
 export default ({ palette }: Theme) =>
   createStyles({
     root: {
-      fontSize: '1rem'
+      fontSize: '1rem',
+      backgroundColor: palette.common.white
     },
     rootMultiline: {
       height: 'auto'


### PR DESCRIPTION
re #1368

### Description

Ensure the input has a white background color even if it's rendered with the colored parent element.

Related question: https://toptal-core.slack.com/archives/CCC3GP6CC/p1591691035024900

### How to test

1. Go to https://picasso.toptal.net/?path=/story/forms-folder--input#default
2. Update the example code to 
```
import React, { useState } from 'react'
import { Input } from '@toptal/picasso'

const Example = () => {
  const [value, setValue] = useState('Text')

  const handleChange = event => {
    setValue(event.target.value)
  }

  return (
    <div style={{backgroundColor: 'red', padding: 20}}>
    <Input value={value} placeholder='Placeholder' onChange={handleChange} />
    </div>
  )
}

export default Example
```
3. See the input with red background

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| ![Screenshot 2020-06-09 at 09 48 06](https://user-images.githubusercontent.com/2437969/84126258-f64a1a80-aa3d-11ea-8e4b-379276bf363a.png) | ![Screenshot 2020-06-09 at 10 46 46](https://user-images.githubusercontent.com/2437969/84126714-92742180-aa3e-11ea-8eac-eeb5cf482f12.png)  |

### Review

- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure that visuals specs are green [See the documentation](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
