### PR TITLE
fix: pass id to wrapped form fields

### DIFF
--- a/packages/picasso-forms/src/FieldWrapper/FieldWrapper.tsx
+++ b/packages/picasso-forms/src/FieldWrapper/FieldWrapper.tsx
@@ -170,6 +170,7 @@ const FieldWrapper = <
   })
 
   const childProps: Record<string, unknown> = {
+    id,
     ...rest,
     ...input,
     ...getProps({ hideFieldLabel, error, label, required }),

--- a/packages/picasso-forms/src/Form/__snapshots__/test.tsx.snap
+++ b/packages/picasso-forms/src/Form/__snapshots__/test.tsx.snap
@@ -16,6 +16,7 @@ exports[`FormInput default render 1`] = `
             aria-invalid="false"
             autocomplete="none"
             class="MuiInputBase-input MuiOutlinedInput-input OutlinedInput-input OutlinedInput-inputMedium MuiInputBase-inputAdornedStart MuiOutlinedInput-inputAdornedStart MuiInputBase-inputAdornedEnd MuiOutlinedInput-inputAdornedEnd"
+            id="test"
             name="test"
             placeholder="test input"
             type="text"

--- a/packages/picasso-forms/src/Radio/__snapshots__/test.tsx.snap
+++ b/packages/picasso-forms/src/Radio/__snapshots__/test.tsx.snap
@@ -26,6 +26,7 @@ exports[`FormRadio default render 1`] = `
         </label>
         <div
           class="MuiFormGroup-root"
+          id="color"
           role="radiogroup"
           type="radio"
         >


### PR DESCRIPTION
No JIRA ticket (the problem was discovered in [SPC-343](https://toptal-core.atlassian.net/browse/SPC-343)).

### Description

Right now the `id` attribute is not passed to wrapped fields, so the `htmlFor` attribute for labels is not really useful. This PR provides `id` attribute to wrapped components, so the actual input could be located via `getByLabelText()` in React Testing Library.

### How to test

- make sure that the wrapped field inputs have the same identifier as the `htmlFor` attribute

### Screenshots

<img width="858" alt="Screenshot 2020-06-09 at 19 06 54" src="https://user-images.githubusercontent.com/1390758/84140630-7eeba980-aa84-11ea-896d-77ac3ca93450.png">

### Review

- [ ] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that visuals specs are green [See the documentation](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
