### PR TITLE
fix: documentation for weekStartsOn

### DIFF
--- a/packages/picasso-lab/src/DatePicker/DatePicker.tsx
+++ b/packages/picasso-lab/src/DatePicker/DatePicker.tsx
@@ -63,7 +63,7 @@ export interface Props
   /** Function to override default markup to show Date */
   renderDay?: (args: DayProps) => ReactNode
   popperContainer?: HTMLElement
-  /** Index of the first day of the week (0 - Sunday). Default is 0 */
+  /** Index of the first day of the week (0 - Sunday). Default is 1 - Monday */
   weekStartsOn?: number
 }
 


### PR DESCRIPTION
No JIRA ticket.

### Description

The `weekStartsOn` property is described as `the index of the first day of the week (0 - Sunday). Default is 0`, but the actual source code at https://github.com/toptal/simple-react-calendar/blob/master/src/calendar/calendar.tsx#L115 has

```
export default class Calendar extends Component<Props, State> {
  static defaultProps = {
    ...
    weekStartsOn: 1
  }
  ...
}
```

ℹ️ Corresponding change in Simple React Calendar – https://github.com/toptal/simple-react-calendar/pull/208

### How to test

No testing for documentation change.

### Screenshots

No screenshots for documentation change.

### Review

- [x] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that visuals specs are green [See the documentation](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
