### PR TITLE
fix(picasso-forms:radio): show initially checked radio of the group

### DIFF
--- a/packages/picasso-forms/src/Form/story/Default.example.tsx
+++ b/packages/picasso-forms/src/Form/story/Default.example.tsx
@@ -26,7 +26,10 @@ const DefaultExample = () => {
   const skillOptions = filterOptions(skillInputValue, skills)
 
   return (
-    <Form onSubmit={values => console.log(values)}>
+    <Form
+      onSubmit={values => console.log(values)}
+      initialValues={{ gender: 'female' }}
+    >
       <Form.Input
         enableReset
         onResetClick={(set: (value: string) => void) => {

--- a/packages/picasso-forms/src/Radio/Radio.tsx
+++ b/packages/picasso-forms/src/Radio/Radio.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { Radio as PicassoRadio, RadioProps } from '@toptal/picasso'
+import { Field } from 'react-final-form'
 
 // Intersection with the type { name?: string } is needed here because of
 // TS compiler issue https://github.com/microsoft/TypeScript/issues/34793
@@ -8,10 +9,15 @@ export type Props = RadioProps & {
 }
 
 const Radio = (props: Props) => (
-  <PicassoRadio
-    // eslint-disable-next-line react/jsx-props-no-spreading
-    {...props}
-  />
+  <Field name={props.name!} type='radio' value={props.value}>
+    {({ input }) => (
+      <PicassoRadio
+        checked={input.checked}
+        // eslint-disable-next-line react/jsx-props-no-spreading
+        {...props}
+      />
+    )}
+  </Field>
 )
 
 export default Radio

--- a/packages/picasso-forms/src/Radio/__snapshots__/test.tsx.snap
+++ b/packages/picasso-forms/src/Radio/__snapshots__/test.tsx.snap
@@ -66,19 +66,20 @@ exports[`FormRadio default render 1`] = `
           >
             <span
               aria-disabled="false"
-              class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root MuiRadio-root Radio-root Radio-withLabel"
+              class="MuiButtonBase-root MuiIconButton-root PrivateSwitchBase-root MuiRadio-root Radio-root Radio-withLabel PrivateSwitchBase-checked Mui-checked"
             >
               <span
                 class="MuiIconButton-label"
               >
                 <input
+                  checked=""
                   class="PrivateSwitchBase-input"
                   name="color"
                   type="radio"
                   value="#ffe4b5"
                 />
                 <div
-                  class="Radio-uncheckedIcon"
+                  class="Radio-checkedIcon"
                 />
               </span>
             </span>

--- a/packages/picasso-forms/src/Radio/test.tsx
+++ b/packages/picasso-forms/src/Radio/test.tsx
@@ -5,7 +5,7 @@ import Form from '../Form/Form'
 
 const renderFormRadio = () => {
   return render(
-    <Form onSubmit={() => {}}>
+    <Form onSubmit={() => {}} initialValues={{ color: '#ffe4b5' }}>
       <Form.RadioGroup
         name='color'
         required

--- a/packages/picasso-forms/src/RadioGroup/RadioGroup.tsx
+++ b/packages/picasso-forms/src/RadioGroup/RadioGroup.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { ReactElement } from 'react'
 import {
   Radio as PicassoRadio,
   RadioProps,
@@ -22,7 +22,11 @@ export const RadioGroup = (props: Props) => {
         return (
           // eslint-disable-next-line react/jsx-props-no-spreading
           <PicassoRadio.Group {...restRadioGroupProps}>
-            {children}
+            {React.Children.map(children, child =>
+              React.cloneElement(child as ReactElement, {
+                name: props.name
+              })
+            )}
           </PicassoRadio.Group>
         )
       }}


### PR DESCRIPTION
### Description

The initial radio group does not show the checked radio.

### How to test

1. Show the form with initial values

### Screenshots

![image](https://user-images.githubusercontent.com/1824723/84399770-e848f500-ac09-11ea-8911-bbd260d30b66.png)


### Review

- [ ] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that visuals specs are green [See the documentation](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
