### PR TITLE
feat: change Form.SubmitButton to be enabled on submit

### DIFF
--- a/packages/picasso-forms/src/SubmitButton/SubmitButton.tsx
+++ b/packages/picasso-forms/src/SubmitButton/SubmitButton.tsx
@@ -13,7 +13,6 @@ export const SubmitButton = (props: Props) => {
   return (
     <Button
       type='submit'
-      disabled={submitting}
       loading={submitting}
       // eslint-disable-next-line react/jsx-props-no-spreading
       {...props}


### PR DESCRIPTION
[SP-976]

### Description

While the `<Button />` component's `loading` property is true, click events are "ignored". With that, we no longer need to also make it disabled, which is what `<Form.SubmitButton />` was doing. So, when "fast form" was "submitting" `Form.SubmitButton` was setting both loading and disabled on `<Button />`.

See Aleks' changes for more details on this https://github.com/toptal/picasso/pull/1319.

[SP-976]: https://toptal-core.atlassian.net/browse/SP-976