### PR TITLE
feat: set default tooltip delay

### DIFF
--- a/packages/picasso-lab/src/DatePicker/test.tsx
+++ b/packages/picasso-lab/src/DatePicker/test.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { render, fireEvent } from '@toptal/picasso/test-utils'
+import { render, fireEvent, wait } from '@toptal/picasso/test-utils'
 import { Tooltip } from '@toptal/picasso'
 
 import DatePicker from './DatePicker'
@@ -38,9 +38,16 @@ describe('DatePicker', () => {
     // this line leads to a warning, wrapping into `act` doesn't help
     fireEvent.mouseOver(day15)
 
-    const tooltip = getByText('tooltip content')
-
-    expect(tooltip).toBeInTheDocument()
+    /**
+     * Wait for Tooltips' "enterDelay" of .5 seconds
+     */
+    wait(
+      () => {
+        const tooltip = getByText('tooltip content')
+        expect(tooltip).toBeInTheDocument()
+      },
+      { timeout: 600 }
+    )
   })
 
   test('custom day rendering', () => {

--- a/packages/picasso/src/Tooltip/Tooltip.tsx
+++ b/packages/picasso/src/Tooltip/Tooltip.tsx
@@ -69,6 +69,8 @@ export const Tooltip: FunctionComponent<Props> = ({
     </>
   )
 
+  const defaultDelay = 500
+
   return (
     <MUITooltip
       // eslint-disable-next-line react/jsx-props-no-spreading
@@ -109,7 +111,8 @@ export const Tooltip: FunctionComponent<Props> = ({
       disableHoverListener={disableListeners}
       disableFocusListener={disableListeners}
       disableTouchListener
-      enterDelay={0}
+      enterDelay={defaultDelay}
+      leaveDelay={defaultDelay}
     >
       {children as ReactElement}
     </MUITooltip>


### PR DESCRIPTION
[SPC-379]

### Description

Delay showing and hiding tooltips to mimic the default `title` attribute experience. See Slack discussion https://toptal-core.slack.com/archives/CM8KE183V/p1591790386361600.

### How to test

- Hover elements with tooltip and observe a .5 second delay
- Quickly hover over and out of elements with a tooltip, and observe that the tooltip does NOT show up (default Material UI behavior, that mimics the default `title` attribute behavior), which is exactly what we want
- I also observed that if you hover over an element, in the sub-sequence hovers the tooltip show up immediately - again, this is also the default browser `title` attribute behavior.
- Note that I added both enter and leave delay - let me know if leave delay also makes sense, otherwise, we can easily change it accordingly (remove, make the "leave" delay shorter or even longer).


[SPC-379]: https://toptal-core.atlassian.net/browse/SPC-379