### PR TITLE
fix: documentation for Button

### DIFF
--- a/packages/picasso/src/Button/story/index.jsx
+++ b/packages/picasso/src/Button/story/index.jsx
@@ -68,7 +68,6 @@ page
         description: 'Disables button',
         defaultValue: 'false'
       },
-
       fullWidth: {
         name: 'fullWidth',
         type: 'boolean',
@@ -172,6 +171,11 @@ page
           enums: ['button', 'reset', 'submit']
         },
         defaultValue: 'button'
+      },
+      titleCase: {
+        name: 'titleCase',
+        description: 'Defines if the text should be transformed to title case',
+        type: 'boolean'
       }
     },
     name: 'Button'


### PR DESCRIPTION
No JIRA ticket.

### Description

The `<Button/>` component documentation did not have the `titleCase` property described (please see the https://picasso.toptal.net/?path=/story/components-folder--button). This PR adds the missing documentation.

### How to test

- please see the temploy to make sure that prop description was added.

### Screenshots

<img width="588" alt="Screenshot 2020-06-22 at 18 30 43" src="https://user-images.githubusercontent.com/1390758/85277774-7f3d6900-b4b6-11ea-8b93-2d80331e0da8.png">

### Review

- [x] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure that visuals specs are green [See the documentation](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
