### PR TITLE
feat: do not wrap non-text labels for forms

### DIFF
--- a/packages/picasso-forms/src/FieldWrapper/FieldWrapper.tsx
+++ b/packages/picasso-forms/src/FieldWrapper/FieldWrapper.tsx
@@ -40,6 +40,7 @@ export type Props<
     type?: string
     hideFieldLabel?: boolean
     fieldType?: string
+    wrapFieldLabel?: boolean
     children: (props: any) => React.ReactNode
   }
 
@@ -110,6 +111,7 @@ const FieldWrapper = <
   const {
     type,
     hideFieldLabel,
+    wrapFieldLabel = true,
     hint,
     label,
     required,
@@ -199,11 +201,15 @@ const FieldWrapper = <
 
   return (
     <PicassoForm.Field error={error} hint={hint}>
-      {!hideFieldLabel && label && (
-        <PicassoForm.Label required={required} htmlFor={id}>
-          {label}
-        </PicassoForm.Label>
-      )}
+      {!hideFieldLabel &&
+        label &&
+        (wrapFieldLabel ? (
+          <PicassoForm.Label required={required} htmlFor={id}>
+            {label}
+          </PicassoForm.Label>
+        ) : (
+          label
+        ))}
       {children(childProps)}
     </PicassoForm.Field>
   )


### PR DESCRIPTION
No JIRA ticket (the original Staff Portal PR is https://github.com/toptal/staff-portal/pull/1024).

### Description

When the field label is `ReactNode` it should not be wrapped in `Form.Label` as there can be situations like this (blue is the `ReactNode` which was passed as `label` property):

<img width="606" alt="Screenshot 2020-06-25 at 13 49 53" src="https://user-images.githubusercontent.com/1390758/85662922-112db780-b6eb-11ea-9b37-ddc7d7654ca5.png">

In order to avoid this, the `FieldWrapper` consumer needs to have an option to disable wrapping of the label.

### How to test

Please use the following code to observe the change:

```
import React, { useState } from 'react'
import { Container, Form as RegularPicassoForm } from '@toptal/picasso'
import { Item } from '@toptal/picasso/Autocomplete'
import { Form } from '@toptal/picasso-forms'

const DefaultExample = () => {
  return (
    <Form
      onSubmit={values => console.log(values)}
      initialValues={{  }}
    >
      <Form.Input
        enableReset
        onResetClick={(set: (value: string) => void) => {
          set('')
        }}
        required
        name='firstName'
        wrapFieldLabel={false}
        label={<h1><RegularPicassoForm.Label required>Some complex label with <button>button</button></RegularPicassoForm.Label></h1>}
        placeholder='e.g. Bruce'
      />
    
      <Container top='small'>
        <Form.SubmitButton>Submit</Form.SubmitButton>
      </Container>
    </Form>
  )
}

export default DefaultExample
```

### Screenshots

![label](https://user-images.githubusercontent.com/1390758/85670176-36262880-b6f3-11ea-8d42-7de3a963452c.gif)

### Review

- [ ] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that visuals specs are green [See the documentation](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
