### PR TITLE
fix: increase jest async callback timeout

### DIFF
--- a/jest-setup.ts
+++ b/jest-setup.ts
@@ -1,1 +1,8 @@
 import '@testing-library/jest-dom/extend-expect'
+
+/**
+ * Increase async callback timeout to address
+ * this issue  https://github.com/facebook/jest/issues/9881
+ * which is causing visual tests to fail in Jenkins
+ */
+jest.setTimeout(15000)


### PR DESCRIPTION
### Description

Visual tests are failing in Jenkins because they are taking more than 5 seconds, and causing jest to fail. This is a straight forward attempt to fix the issue. 

### How to test

Visual tests should timeout after 15 seconds now, instead of 5 seconds.

### Review

- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that visuals specs are green [See the documentation](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
