### PR TITLE
chore: improve visual tests performance

### DIFF
--- a/bin/test-visual
+++ b/bin/test-visual
@@ -28,7 +28,7 @@ function run_jest() {
   fi
 
   set -x
-  $BIN_PATH/jest --testEnvironment=$JEST_ENV --runInBand --config=$JEST_CONFIG $@ || exit 1
+  $BIN_PATH/jest --verbose --maxWorkers=50% --testEnvironment=$JEST_ENV --config=$JEST_CONFIG $@ || exit 1
   set +x
 }
 

--- a/puppeteer/storyshot.test.jsx
+++ b/puppeteer/storyshot.test.jsx
@@ -23,14 +23,16 @@ stories.forEach(story => {
   story.tests.forEach(({ exampleFilename, options }) => {
     const humanName = createHumanName(story.name, exampleFilename)
 
-    test(
-      humanName,
-      assertVisuals(story.name, exampleFilename, {
-        customSnapshotsDir: snapShotDir(story.file),
-        customSnapshotIdentifier: `${createSnapshotName(humanName)}`,
-        customDiffDir: outputPath,
-        ...options
-      })
-    )
+    describe(`Component ${story.name}`, () => {
+      test(
+        humanName,
+        assertVisuals(story.name, exampleFilename, {
+          customSnapshotsDir: snapShotDir(story.file),
+          customSnapshotIdentifier: `${createSnapshotName(humanName)}`,
+          customDiffDir: outputPath,
+          ...options
+        })
+      )
+    })
   })
 })


### PR DESCRIPTION
### Description

It feels for me that our tests are not treated by Jest as separate tests and run all together at once and they overloading CPU of the machine. Maybe if we try to limit load to 50% it will be smoother