### PR TITLE
feat(treeview): add a scroll offset for each node

### DIFF
--- a/packages/picasso-lab/src/TreeView/TreeView.tsx
+++ b/packages/picasso-lab/src/TreeView/TreeView.tsx
@@ -3,7 +3,8 @@ import React, {
   ReactNode,
   useContext,
   useEffect,
-  useState
+  useState,
+  useMemo
 } from 'react'
 import { HierarchyPointNode } from 'd3' // eslint-disable-line import/no-duplicates
 import { Theme, makeStyles } from '@material-ui/core/styles'
@@ -50,10 +51,18 @@ export const TreeView = (props: Props) => {
   const classes = useStyles(props)
   const rootRef = createRef<SVGSVGElement>()
   const { nodes, links, selectedNode } = useTree({ data })
+  const center = useMemo<{ x: number; y: number }>(() => {
+    const { x: xPosition, y: yPosition, data } = selectedNode || nodes[0]
+
+    return {
+      x: xPosition + (data.selectedOffset?.x || 0),
+      y: yPosition + (data.selectedOffset?.y || 0)
+    }
+  }, [selectedNode, nodes])
   const { handleZoom, zoom } = useZoom<SVGSVGElement>({
     rootRef,
     scaleExtent,
-    center: selectedNode || nodes[0],
+    center,
     initialScale
   })
   const [initialized, setInitialized] = useState(false)

--- a/packages/picasso-lab/src/TreeView/story/Selected.example.tsx
+++ b/packages/picasso-lab/src/TreeView/story/Selected.example.tsx
@@ -16,131 +16,171 @@ const NodeContainer = styled<typeof Container>(Container)<{
     `border: 1px solid ${selected ? palette.blue.main : palette.grey.light};`}
 `
 
-const createTreeNode = (
-  override: Partial<TreeNodeInterface> = {}
+interface DataItem {
+  content: {
+    name: string
+    type: 'card' | 'group'
+    members?: {
+      name: string
+    }[]
+  }
+  children: DataItem[]
+}
+
+const data: DataItem = {
+  content: {
+    name: 'Name Surname 1',
+    type: 'card'
+  },
+  children: [
+    {
+      content: {
+        name: 'Name Surname 2',
+        type: 'card'
+      },
+      children: [
+        {
+          content: {
+            name: 'Name Surname 3',
+            type: 'group',
+            members: [
+              {
+                name: 'Name Surname 4'
+              },
+              {
+                name: 'Name Surname 5'
+              },
+              {
+                name: 'Name Surname 6'
+              },
+              {
+                name: 'Name Surname 7'
+              },
+              {
+                name: 'Name Surname 8'
+              }
+            ]
+          },
+          children: []
+        },
+        {
+          content: {
+            name: 'Name Surname 9',
+            type: 'card'
+          },
+          children: [
+            {
+              content: {
+                name: 'Name Surname 10',
+                type: 'group',
+                members: [
+                  {
+                    name: 'Name Surname 11'
+                  },
+                  {
+                    name: 'Name Surname 12'
+                  },
+                  {
+                    name: 'Name Surname 13'
+                  },
+                  {
+                    name: 'Name Surname 14'
+                  },
+                  {
+                    name: 'Name Surname 15'
+                  }
+                ]
+              },
+              children: []
+            }
+          ]
+        }
+      ]
+    },
+    {
+      content: {
+        name: 'Name Surname 16',
+        type: 'card'
+      },
+      children: [
+        {
+          content: {
+            name: 'Name Surname 17',
+            type: 'group',
+            members: [
+              {
+                name: 'Name Surname 18'
+              },
+              {
+                name: 'Name Surname 19'
+              },
+              {
+                name: 'Name Surname 20'
+              },
+              {
+                name: 'Name Surname 21'
+              },
+              {
+                name: 'Name Surname 22'
+              },
+              {
+                name: 'Name Surname 23'
+              },
+              {
+                name: 'Name Surname 24'
+              },
+              {
+                name: 'Name Surname 25'
+              },
+              {
+                name: 'Name Surname 26'
+              },
+              {
+                name: 'Name Surname 27'
+              },
+              { name: 'Name Surname 28' },
+              { name: 'Name Surname 29' },
+              { name: 'Name Surname 30' },
+              { name: 'Name Surname 31' },
+              { name: 'Name Surname 32' }
+            ]
+          },
+          children: []
+        }
+      ]
+    }
+  ]
+}
+
+const convertToNode = (
+  data: DataItem,
+  selectedId: string
 ): TreeNodeInterface => {
   return {
-    id: '1',
+    id: data.content.name,
+    selected: data.content.name === selectedId,
+    selectedOffset:
+      data.content.type === 'group'
+        ? {
+            y: 150
+          }
+        : undefined,
     disabled: false,
-    selected: false,
-    children: [],
     info: {
-      name: 'NODE+NAME+1'
+      name: data.content.name,
+      type: data.content.type,
+      members: data.content.members
     },
-    ...override
+    children: data.children.map(child => convertToNode(child, selectedId))
   }
 }
 
-const createTree = (seletedId?: string): TreeNodeInterface => {
-  return createTreeNode({
-    id: '1',
-    selected: seletedId === '1',
-    info: {
-      name: 'NODE+1'
-    },
-    children: [
-      createTreeNode({
-        id: '2',
-        selected: seletedId === '2',
-        info: {
-          name: 'NODE+2'
-        },
-        children: [
-          createTreeNode({
-            id: '3',
-            selected: seletedId === '3',
-            info: {
-              name: 'NODE+3'
-            },
-            children: [
-              createTreeNode({
-                id: '3.1',
-                selected: seletedId === '3.1',
-                info: {
-                  name: 'NODE+3.1'
-                },
-                children: [
-                  createTreeNode({
-                    id: '3.1.1',
-                    selected: seletedId === '3.1.1',
-                    info: {
-                      name: 'NODE+3.1.1'
-                    }
-                  }),
-                  createTreeNode({
-                    id: '3.1.2',
-                    selected: seletedId === '3.1.2',
-                    info: {
-                      name: 'NODE+3.1.2'
-                    }
-                  })
-                ]
-              }),
-              createTreeNode({
-                id: '3.2',
-                selected: seletedId === '3.2',
-                info: {
-                  name: 'NODE+3.2'
-                },
-                children: [
-                  createTreeNode({
-                    id: '3.2.1',
-                    selected: seletedId === '3.2.1',
-                    info: {
-                      name: 'NODE+3.2.1'
-                    }
-                  }),
-                  createTreeNode({
-                    id: '3.2.2',
-                    selected: seletedId === '3.2.2',
-                    info: {
-                      name: 'NODE+3.2.2'
-                    }
-                  })
-                ]
-              })
-            ]
-          })
-        ]
-      }),
-      createTreeNode({
-        id: '4',
-        selected: seletedId === '4',
-        info: {
-          name: 'NODE+4'
-        },
-        children: [
-          createTreeNode({
-            id: '4.1',
-            selected: seletedId === '4.1',
-            info: {
-              name: 'NODE+4.1'
-            },
-            children: [
-              createTreeNode({
-                id: '4.1.1',
-                selected: seletedId === '4.1.1',
-                info: {
-                  name: 'NODE+4.1.1'
-                }
-              }),
-              createTreeNode({
-                id: '4.1.2',
-                selected: seletedId === '4.1.2',
-                info: {
-                  name: 'NODE+4.1.2'
-                }
-              })
-            ]
-          })
-        ]
-      })
-    ]
-  })
+const createTree = (selectedId: string): TreeNodeInterface => {
+  return convertToNode(data, selectedId)
 }
 
 const Example = () => {
-  const [selectedId, setSelectedId] = useState('3.1.2')
+  const [selectedId, setSelectedId] = useState('Name Surname 1')
 
   const rootNode = createTree(selectedId)
 
@@ -149,15 +189,13 @@ const Example = () => {
   }
 
   const renderNode = (pointNode: HierarchyPointNode<TreeNodeInterface>) => {
-    if (pointNode.data.id === '2') {
+    if (pointNode.data.info.type === 'group') {
       return (
-        <NodeContainer>
+        <NodeContainer onClick={() => onClick(pointNode.data.id)}>
           <div>
-            <UserBadge name='QQQQQQQQ QQQQQQQQ' />
-            <UserBadge name='QQQQQQQQ QQQQQQQQ' />
-            <UserBadge name='QQQQQQQQ QQQQQQQQ' />
-            <UserBadge name='QQQQQQQQ QQQQQQQQ' />
-            <UserBadge name='QQQQQQQQ QQQQQQQQ' />
+            {pointNode.data.info.members.map((member: { name: string }) => (
+              <UserBadge name={member.name} key={member.name} />
+            ))}
           </div>
         </NodeContainer>
       )

--- a/packages/picasso-lab/src/TreeView/story/index.tsx
+++ b/packages/picasso-lab/src/TreeView/story/index.tsx
@@ -18,7 +18,7 @@ page
   .addExample('TreeView/story/Selected.example.tsx', {
     title: 'With selected node',
     description:
-      "To set the particular node selected, you need to set `node`'s attribute *selected* to `true`"
+      "To set the particular node selected, you need to set `node`'s attribute *selected* to `true`. Also there is additional attribute `selectedOffset` for adding an scroll offset for particular node"
   })
   .addExample('TreeView/story/Modal.example.tsx', 'With Modal')
   .addExample('TreeView/story/CustomZoom.example.tsx', 'Custom Zoom')

--- a/packages/picasso-lab/src/TreeView/types.ts
+++ b/packages/picasso-lab/src/TreeView/types.ts
@@ -11,6 +11,10 @@ export interface TreeViewContextProps {
 export interface TreeNodeInterface {
   id: string
   selected: boolean
+  selectedOffset?: {
+    x?: number
+    y?: number
+  }
   disabled: boolean
   children?: TreeNodeInterface[]
   info: Record<string, any>

--- a/packages/picasso-lab/src/TreeView/useNodes.ts
+++ b/packages/picasso-lab/src/TreeView/useNodes.ts
@@ -1,0 +1,97 @@
+import { createRef, useMemo, useLayoutEffect, useState } from 'react'
+import { TreeNodeInterface } from '@toptal/picasso-lab'
+import { HierarchyPointNode } from 'd3-hierarchy'
+
+import { DynamicPointNode } from './types'
+import { VERTICAL_MARGIN } from './variables'
+
+const getDynamicNodes = (
+  nodes: HierarchyPointNode<TreeNodeInterface>[]
+): DynamicPointNode[] => {
+  return nodes.map(node => {
+    return Object.assign(node, {
+      ref: createRef<HTMLElement>(),
+      rect: {
+        width: 0,
+        height: 0
+      }
+    })
+  })
+}
+
+const updateNodesYPosition = (
+  nodes: DynamicPointNode[]
+): DynamicPointNode[] => {
+  return nodes
+    .sort((left, right) => left.depth - right.depth)
+    .map(node => {
+      if (!node.ref.current) return node
+
+      const {
+        scrollWidth: width,
+        scrollHeight: height
+      } = node.ref.current!.firstElementChild!
+
+      if (!height || !width) {
+        return node
+      }
+
+      node.y = 0
+      node.rect = {
+        width,
+        height
+      }
+
+      if (node.parent) {
+        node.y = node.parent.y + node.parent.rect.height + VERTICAL_MARGIN
+      }
+
+      return node
+    })
+}
+
+/**
+ * That hook expects the rootNode of the tree and returns the list of nodes with predefined position values
+ * Coz, the exact node contains the ReactElement, so it's not clear the real sizes of the node before the rendering.
+ * That hook handles that problem by listening the changes from the render and recalculating positions.
+ * Also, the data of the `rootNode` can be changed — that hook handles it as well.
+ */
+export const useNodes = (
+  rootNode: HierarchyPointNode<TreeNodeInterface>
+): DynamicPointNode[] => {
+  const [initialized, setInitializedState] = useState<boolean>(false)
+  const initialNodes = useMemo(() => {
+    return getDynamicNodes(rootNode.descendants())
+  }, [])
+  const dynamicNodes = useMemo(() => {
+    const latestNodes = rootNode.descendants()
+    return initialNodes.map<DynamicPointNode>(node => {
+      const foundNode = latestNodes.find(
+        (latestNode: HierarchyPointNode<TreeNodeInterface>) =>
+          latestNode.data.id === node.data.id
+      )
+
+      if (!foundNode) return node
+
+      return Object.assign(node, {
+        data: foundNode.data
+      })
+    })
+  }, [rootNode, initialNodes])
+
+  // we have to render nodes twice: first for the initial showing data, and the second one — with the correct positions.
+  const nodes = useMemo<DynamicPointNode[]>(() => {
+    return updateNodesYPosition(dynamicNodes)
+  }, [dynamicNodes, initialized])
+
+  useLayoutEffect(() => {
+    if (!dynamicNodes[0].ref.current || initialized) {
+      return
+    }
+
+    // as soon as `ref.current` appears, we can take positions for each node
+    setInitializedState(true)
+  }, [dynamicNodes, initialized])
+
+  return nodes
+}

--- a/packages/picasso-lab/src/TreeView/useTree.ts
+++ b/packages/picasso-lab/src/TreeView/useTree.ts
@@ -1,17 +1,14 @@
-import { createRef, useLayoutEffect, useMemo, useState } from 'react'
+import { useMemo } from 'react'
 import * as d3 from 'd3' // eslint-disable-line import/no-duplicates
 import { HierarchyPointNode } from 'd3' // eslint-disable-line import/no-duplicates
 
-import {
-  DEFAULT_HEIGHT,
-  DEFAULT_WIDTH,
-  HORIZONTAL_MARGIN,
-  VERTICAL_MARGIN
-} from './variables'
+import { useNodes } from './useNodes'
+import { DEFAULT_HEIGHT, DEFAULT_WIDTH, HORIZONTAL_MARGIN } from './variables'
 import { DynamicPointLink, DynamicPointNode, TreeNodeInterface } from './types'
 
 export interface UseTreeArguments {
   data: TreeNodeInterface
+  nodeWidth?: number
 }
 
 export interface UseTreeResponse {
@@ -20,126 +17,73 @@ export interface UseTreeResponse {
   selectedNode: DynamicPointNode | undefined
 }
 
-export interface LevelInfo {
-  top: number
-  width: number
-  height: number
+const calculateNodeXPosition = (
+  node: HierarchyPointNode<TreeNodeInterface>,
+  {
+    leaves,
+    nodeWidth
+  }: { leaves: HierarchyPointNode<TreeNodeInterface>[]; nodeWidth: number }
+) => {
+  if (!node.children || !node.children.length) {
+    const index = leaves.findIndex(leaf => leaf === node)
+
+    node.x = Math.floor(index - leaves.length / 2) * nodeWidth
+  } else {
+    node.x =
+      node.children.reduce((acc, child) => {
+        calculateNodeXPosition(child, { leaves, nodeWidth })
+
+        acc += child.x
+
+        return acc
+      }, 0) / node.children.length
+  }
+
+  return node
 }
 
-const updatePositions = (nodes: DynamicPointNode[]) => {
-  const levels: Record<number, LevelInfo> = {}
+export const useTree = ({
+  data,
+  nodeWidth = DEFAULT_WIDTH
+}: UseTreeArguments): UseTreeResponse => {
+  const fullNodeWidth = nodeWidth + 2 * HORIZONTAL_MARGIN
 
-  nodes
-    .sort((left, right) => left.depth - right.depth)
-    .forEach(node => {
-      const {
-        scrollWidth: width,
-        scrollHeight: height
-      } = node.ref.current!.firstElementChild!
-
-      if (!height || !width) {
-        return
-      }
-
-      node.y = 0
-      node.rect = {
-        width,
-        height
-      }
-
-      if (!node.parent) {
-        levels[node.depth] = {
-          width,
-          height,
-          top: 0
-        }
-      } else {
-        const previousLevel = levels[node.depth - 1]
-
-        node.y = previousLevel.top + previousLevel.height + VERTICAL_MARGIN
-
-        levels[node.depth] = {
-          width,
-          height: Math.max(levels[node.depth]?.height || 0, height),
-          top: previousLevel.top + previousLevel.height + VERTICAL_MARGIN
-        }
-      }
-    })
-
-  return levels
-}
-
-const getDynamicNodes = (
-  nodes: HierarchyPointNode<TreeNodeInterface>[]
-): DynamicPointNode[] => {
-  return nodes.map(node => {
-    return Object.assign(node, {
-      ref: createRef<HTMLElement>(),
-      rect: {
-        width: 0,
-        height: 0
-      }
-    })
-  })
-}
-
-export const useTree = ({ data }: UseTreeArguments): UseTreeResponse => {
-  const [levels, setLevels] = useState<Record<number, LevelInfo>>()
   const rootNode = useMemo(() => {
     const root = d3.hierarchy(data)
 
-    return d3
+    const rootNode = d3
       .tree<TreeNodeInterface>()
-      .nodeSize([DEFAULT_WIDTH + 2 * HORIZONTAL_MARGIN, DEFAULT_HEIGHT])(root)
-  }, [data])
-  // create a dynamic nodes
-  const dynamicNodes = useMemo(() => getDynamicNodes(rootNode.descendants()), [
-    rootNode
-  ])
-  // `nodes` depend on levels and dynamicNodes, so it's another entity
-  const nodes = useMemo<DynamicPointNode[]>(() => {
-    if (!levels) {
-      return dynamicNodes
-    }
+      .nodeSize([fullNodeWidth, DEFAULT_HEIGHT])(root)
+    const leaves = rootNode.leaves()
 
-    return dynamicNodes.map(node => {
-      const previousLevel = levels[node.depth - 1]
-
-      if (previousLevel) {
-        node.y = previousLevel.top + previousLevel.height + VERTICAL_MARGIN
-      }
-
-      return node
+    return calculateNodeXPosition(rootNode, {
+      leaves,
+      nodeWidth: fullNodeWidth
     })
-  }, [dynamicNodes, levels])
+  }, [data])
+
+  const nodes = useNodes(rootNode)
 
   const links = useMemo(
     () =>
-      nodes.reduce<DynamicPointLink[]>((acc, nodePoint) => {
-        if (nodePoint.parent) {
-          acc.push({
-            source: nodePoint.parent,
-            target: nodePoint
-          })
-        }
-        return acc
-      }, []),
+      nodes.reduce<DynamicPointLink[]>(
+        (acc: DynamicPointLink[], nodePoint: DynamicPointNode) => {
+          if (nodePoint.parent) {
+            acc.push({
+              source: nodePoint.parent,
+              target: nodePoint
+            })
+          }
+          return acc
+        },
+        []
+      ),
     [nodes]
   )
 
   const selectedNode = useMemo(() => nodes.find(node => node.data.selected), [
     nodes
   ])
-
-  useLayoutEffect(() => {
-    const rootNode = dynamicNodes[0]
-
-    if (!rootNode.ref.current) {
-      return
-    }
-
-    setLevels(updatePositions(dynamicNodes))
-  }, [dynamicNodes])
 
   return {
     nodes,


### PR DESCRIPTION
[FX-1028](https://toptal-core.atlassian.net/browse/FX-1028)


### Description

We need to fix visual issues and bugs, desribed in the task. Also, there is a one feature: user wants to have possibility to scroll to particulat subgroup in the group node. I added a `selectedOffset: {x: number, y: number}` for each node. It provides possibility to fix scroll position.


### Screenshots

<img width="720" alt="Storybook 2020-06-30 19-19-24" src="https://user-images.githubusercontent.com/1824723/86150908-b212dd00-bb06-11ea-9e7c-dd1eecf94346.png">



### Review

- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that visuals specs are green [See the documentation](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
