### PR TITLE
fix(OverviewBlock): alignment on Firefox

### DIFF
--- a/packages/picasso-lab/src/OverviewBlock/styles.ts
+++ b/packages/picasso-lab/src/OverviewBlock/styles.ts
@@ -10,7 +10,8 @@ export default ({ palette }: Theme) =>
       padding: '0.5rem 1rem',
       minWidth: rem('150px'),
       border: 'none',
-      textDecoration: 'none'
+      textDecoration: 'none',
+      alignItems: 'flex-start'
     },
     clickable: {
       cursor: 'pointer',


### PR DESCRIPTION
[FX-NNNN]

### Description

Alignment of OverviewBlock does not match the one in Chrome because of the default user agent style is different, so I added a style to force it to work like in Chrome default user agent 

Chrome user agent style
![image](https://user-images.githubusercontent.com/18625278/86214902-0a4cec00-bba6-11ea-98a5-d5392c22f14d.png)

### How to test

- Open Firefox
- Go to OverviewBlock page

### Screenshots

![image](https://user-images.githubusercontent.com/18625278/86214742-c0fc9c80-bba5-11ea-8612-19bce2633e1a.png)


### Review

- [ ] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that visuals specs are green [See the documentation](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
