### PR TITLE
fix: add white Container variant

### DIFF
--- a/packages/picasso/src/Container/styles.ts
+++ b/packages/picasso/src/Container/styles.ts
@@ -124,7 +124,9 @@ export default ({ palette }: Theme) =>
       display: 'inline-block'
     },
 
-    whiteVariant: colorVariant(),
+    whiteVariant: createPropertiesStyles({
+      backgroundColor: palette.common.white
+    }),
 
     redVariant: colorVariant(palette.red),
 


### PR DESCRIPTION
No JIRA ticket (encountered in https://github.com/toptal/staff-portal/pull/1043).

### Description

The `variant: white` for `Container` is not working.

### How to test

- try the code below in the PR temploy:

```
import React from 'react'
import { Container } from '@toptal/picasso'

const Example = () => (
  <div>
    <Container padded='medium' variant='red'>
      Red container
      <Container padded='medium' variant='white'>White container</Container>
    </Container>
    
  </div>
)

export default Example
```

### Screenshots

Before:

![container](https://user-images.githubusercontent.com/1390758/86218963-16d84100-bbb4-11ea-87e7-288f5aeffdb4.gif)

After:

![container-2](https://user-images.githubusercontent.com/1390758/86221434-7b48cf80-bbb7-11ea-89f2-19ed56ea97a2.gif)

### Review

- [ ] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure that visuals specs are green [See the documentation](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
