### PR TITLE
chore: skip chromium download

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,10 @@ ENV APK_BRANCH ${APK_BRANCH}
 
 ENV PATH="${PATH}:/app/node_modules/.bin"
 
+# TODO replace with puppeteer-core
+ARG PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
+ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD ${PUPPETEER_SKIP_CHROMIUM_DOWNLOAD}
+
 # Installs Chromium (77) package.
 ENV CHROME_BIN /usr/bin/chromium-browser
 


### PR DESCRIPTION
No ticket

By default `puppeteer` package expects that chrome is not installed and downloads it from network. Since we have Chromium installed, we can avoid downloading and keeping it in node_modules and save some bandwidth. 

Proper solution will be to update to `puppeteer-core` package in the future - it doesn't download Chromium by itself

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| ![image](https://user-images.githubusercontent.com/1291032/86335260-f0b7ad00-bc56-11ea-9dc7-743de36313d0.png) | ![image](https://user-images.githubusercontent.com/1291032/86336280-55bfd280-bc58-11ea-8f86-4e8a3377ba8c.png) |

![image](https://user-images.githubusercontent.com/1291032/86336574-b51de280-bc58-11ea-86c4-734472d30f26.png)


### Review

- [ ] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that visuals specs are green [See the documentation](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
