### PR TITLE
fix(treeview): fix treeview appearance on the FF

### DIFF
--- a/packages/picasso-lab/src/TreeView/PointNode/PointNode.tsx
+++ b/packages/picasso-lab/src/TreeView/PointNode/PointNode.tsx
@@ -30,15 +30,13 @@ export const PointNode = forwardRef<any, Props>(
 
     useLayoutEffect(() => {
       if (nodeRef.current) {
-        const { scrollWidth, scrollHeight } = nodeRef.current
+        const { offsetWidth: width, offsetHeight: height } = node.ref.current!
+          .firstElementChild!.firstElementChild! as HTMLElement
 
-        if (
-          dimensions.height !== scrollHeight ||
-          dimensions.width !== scrollWidth
-        ) {
+        if (dimensions.height !== height || dimensions.width !== width) {
           setDimensions({
-            width: scrollWidth,
-            height: scrollHeight
+            width,
+            height
           })
         }
       }

--- a/packages/picasso-lab/src/TreeView/useNodes.ts
+++ b/packages/picasso-lab/src/TreeView/useNodes.ts
@@ -26,10 +26,8 @@ const updateNodesYPosition = (
     .map(node => {
       if (!node.ref.current) return node
 
-      const {
-        scrollWidth: width,
-        scrollHeight: height
-      } = node.ref.current!.firstElementChild!
+      const { offsetWidth: width, offsetHeight: height } = node.ref.current!
+        .firstElementChild!.firstElementChild! as HTMLElement
 
       if (!height || !width) {
         return node


### PR DESCRIPTION
### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
|    <img width="720" alt="Picasso TreeView 2020-07-02 15-45-55" src="https://user-images.githubusercontent.com/1824723/86365586-5ec59980-bc82-11ea-869a-51e989575454.png"> |  <img width="720" alt="Picasso TreeView 2020-07-02 16-36-33" src="https://user-images.githubusercontent.com/1824723/86365607-66853e00-bc82-11ea-946f-3b5cf468b9c4.png"> |

### Review

- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that visuals specs are green [See the documentation](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
