### PR TITLE
fix(treeview): do not scroll to the center by default

### DIFF
--- a/packages/picasso-lab/src/TreeView/TreeView.tsx
+++ b/packages/picasso-lab/src/TreeView/TreeView.tsx
@@ -51,14 +51,15 @@ export const TreeView = (props: Props) => {
   const classes = useStyles(props)
   const rootRef = createRef<SVGSVGElement>()
   const { nodes, links, selectedNode } = useTree({ data })
-  const center = useMemo<{ x: number; y: number }>(() => {
-    const { x: xPosition, y: yPosition, data } = selectedNode || nodes[0]
+  const center = useMemo<{ x: number; y: number } | undefined>(() => {
+    if (!selectedNode) return undefined
+    const { x: xPosition, y: yPosition, data } = selectedNode
 
     return {
       x: xPosition + (data.selectedOffset?.x || 0),
       y: yPosition + (data.selectedOffset?.y || 0)
     }
-  }, [selectedNode, nodes])
+  }, [selectedNode])
   const { handleZoom, zoom } = useZoom<SVGSVGElement>({
     rootRef,
     scaleExtent,

--- a/packages/picasso-lab/src/TreeView/story/CustomZoom.example.tsx
+++ b/packages/picasso-lab/src/TreeView/story/CustomZoom.example.tsx
@@ -39,6 +39,7 @@ const createTreeNode = (
 const createTree = (): TreeNodeInterface => {
   return createTreeNode({
     id: '1',
+    selected: true,
     info: {
       name: 'NODE+1'
     },

--- a/packages/picasso-lab/src/TreeView/story/Default.example.tsx
+++ b/packages/picasso-lab/src/TreeView/story/Default.example.tsx
@@ -34,6 +34,7 @@ const createTreeNode = (
 const createTree = (): TreeNodeInterface => {
   return createTreeNode({
     id: '1',
+    selected: true,
     info: {
       name: 'NODE+1'
     },

--- a/packages/picasso-lab/src/TreeView/story/Modal.example.tsx
+++ b/packages/picasso-lab/src/TreeView/story/Modal.example.tsx
@@ -34,6 +34,7 @@ const createTreeNode = (
 const createTree = (): TreeNodeInterface => {
   return createTreeNode({
     id: '1',
+    selected: true,
     info: {
       name: 'NODE+1'
     },

--- a/packages/picasso-lab/src/TreeView/story/Selected.example.tsx
+++ b/packages/picasso-lab/src/TreeView/story/Selected.example.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react'
 import { TreeView, TreeNodeInterface } from '@toptal/picasso-lab'
-import { Container, UserBadge } from '@toptal/picasso'
+import { Button, Container, UserBadge } from '@toptal/picasso'
 import { HierarchyPointNode } from 'd3-hierarchy'
 import styled from 'styled-components'
 import { palette } from '@toptal/picasso/utils'
@@ -154,7 +154,7 @@ const data: DataItem = {
 
 const convertToNode = (
   data: DataItem,
-  selectedId: string
+  selectedId: string | null
 ): TreeNodeInterface => {
   return {
     id: data.content.name,
@@ -175,12 +175,12 @@ const convertToNode = (
   }
 }
 
-const createTree = (selectedId: string): TreeNodeInterface => {
+const createTree = (selectedId: string | null): TreeNodeInterface => {
   return convertToNode(data, selectedId)
 }
 
 const Example = () => {
-  const [selectedId, setSelectedId] = useState('Name Surname 1')
+  const [selectedId, setSelectedId] = useState<string | null>('Name Surname 1')
 
   const rootNode = createTree(selectedId)
 
@@ -211,7 +211,14 @@ const Example = () => {
     )
   }
 
-  return <TreeView data={rootNode} renderNode={renderNode} initialScale={0.5} />
+  return (
+    <Container>
+      <Button size='small' onClick={() => setSelectedId(null)}>
+        Reset selection
+      </Button>
+      <TreeView data={rootNode} renderNode={renderNode} initialScale={0.5} />
+    </Container>
+  )
 }
 
 export default Example


### PR DESCRIPTION
### Description

We don't need to scroll to the root of the Tree if no one node is selected. Keep the Tree as is.


### Screenshots

<img width="720" alt="Picasso | TreeView 2020-07-08 11-27-44" src="https://user-images.githubusercontent.com/1824723/86896072-1b4dae00-c10e-11ea-91e2-9773fe677ded.png">

### Review

- [ ] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that visuals specs are green [See the documentation](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
