### PR TITLE
fix: ignore titleCase for Select options

### DIFF
--- a/packages/picasso-lab/src/BreadcrumbsItem/BreadcrumbsItem.tsx
+++ b/packages/picasso-lab/src/BreadcrumbsItem/BreadcrumbsItem.tsx
@@ -40,11 +40,18 @@ export const BreadcrumbsItem: OverridableComponent<Props> = forwardRef<
   HTMLElement,
   Props
 >(function BreadcrumbsItem(props, ref) {
-  const { as, active, children, className, ...rest } = props
+  const {
+    as,
+    active,
+    children,
+    className,
+    titleCase: propsTitleCase,
+    ...rest
+  } = props
   const Component = active ? Active : as || 'span'
   const classes = useStyles(props)
 
-  const titleCase = useTitleCase(rest.titleCase)
+  const titleCase = useTitleCase(propsTitleCase)
 
   return (
     // eslint-disable-next-line react/jsx-props-no-spreading

--- a/packages/picasso-lab/src/OverviewBlock/OverviewBlock.tsx
+++ b/packages/picasso-lab/src/OverviewBlock/OverviewBlock.tsx
@@ -70,6 +70,7 @@ export const OverviewBlock: OverridableComponent<Props> & StaticProps =
       as: Component = 'button',
       className,
       onClick,
+      titleCase: propsTitleCase,
       ...rest
     } = props
     const classes = useStyles(props)
@@ -90,7 +91,7 @@ export const OverviewBlock: OverridableComponent<Props> & StaticProps =
 
     const isClickable = Boolean(onClick)
 
-    const titleCase = useTitleCase(rest.titleCase)
+    const titleCase = useTitleCase(propsTitleCase)
 
     return (
       <Component

--- a/packages/picasso/src/Button/Button.tsx
+++ b/packages/picasso/src/Button/Button.tsx
@@ -116,6 +116,7 @@ export const Button = forwardRef<HTMLButtonElement, Props>(function Button(
     value,
     type,
     as,
+    titleCase: propsTitleCase,
     ...rest
   } = props
   const classes = useStyles(props)
@@ -130,7 +131,7 @@ export const Button = forwardRef<HTMLButtonElement, Props>(function Button(
     content: contentClass
   } = classes
 
-  const titleCase = useTitleCase(rest.titleCase)
+  const titleCase = useTitleCase(propsTitleCase)
 
   const finalChildren = [titleCase ? toTitleCase(children) : children]
 

--- a/packages/picasso/src/FormLabel/FormLabel.tsx
+++ b/packages/picasso/src/FormLabel/FormLabel.tsx
@@ -41,13 +41,14 @@ export const FormLabel = forwardRef<HTMLLabelElement, Props>(function FormLabel(
     style,
     inline,
     as: Component = 'label',
+    titleCase: propsTitleCase,
     ...rest
   },
   ref
 ) {
   const isInline = inline || Component === 'span'
 
-  const titleCase = useTitleCase(rest.titleCase)
+  const titleCase = useTitleCase(propsTitleCase)
 
   return (
     <Component

--- a/packages/picasso/src/Label/Label.tsx
+++ b/packages/picasso/src/Label/Label.tsx
@@ -65,13 +65,14 @@ export const Label = forwardRef<HTMLDivElement, Props>(function Label(
     onDelete,
     variant,
     as,
+    titleCase: propsTitleCase,
     ...rest
   } = props
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const { color, ...htmlAttributes } = rest
   const classes = useStyles(props)
 
-  const titleCase = useTitleCase(rest.titleCase)
+  const titleCase = useTitleCase(propsTitleCase)
 
   const handleDelete = (event: MouseEvent) => {
     if (disabled) {

--- a/packages/picasso/src/MenuItem/MenuItem.tsx
+++ b/packages/picasso/src/MenuItem/MenuItem.tsx
@@ -84,6 +84,7 @@ export const MenuItem = forwardRef<HTMLElement, Props>(function MenuItem(
     value,
     variant,
     size,
+    titleCase: propsTitleCase,
     ...rest
   },
   ref
@@ -91,7 +92,7 @@ export const MenuItem = forwardRef<HTMLElement, Props>(function MenuItem(
   const { push, refresh } = useContext<MenuContextProps>(MenuContext)
   const key = useMemo(generateKey, [])
 
-  const titleCase = useTitleCase(rest.titleCase)
+  const titleCase = useTitleCase(propsTitleCase)
 
   useEffect(() => {
     if (menu && refresh) {

--- a/packages/picasso/src/Select/Select.tsx
+++ b/packages/picasso/src/Select/Select.tsx
@@ -220,6 +220,7 @@ const SelectOption = React.memo(
 
           onItemSelect(event, option)
         }}
+        titleCase={false}
       >
         {children}
       </MenuItem>

--- a/packages/picasso/src/Select/test.tsx
+++ b/packages/picasso/src/Select/test.tsx
@@ -1,10 +1,18 @@
+/* eslint-disable max-lines */
+
 import React from 'react'
-import { render, fireEvent } from '@toptal/picasso/test-utils'
+import { render, fireEvent, PicassoConfig } from '@toptal/picasso/test-utils'
 import { OmitInternalProps } from '@toptal/picasso-shared'
+import * as titleCaseModule from 'ap-style-title-case'
 
 import Select, { Props } from './Select'
 
-const renderSelect = (props: OmitInternalProps<Props>) => {
+jest.mock('ap-style-title-case')
+
+const renderSelect = (
+  props: OmitInternalProps<Props>,
+  picassoConfig?: PicassoConfig
+) => {
   const {
     options,
     native,
@@ -31,9 +39,19 @@ const renderSelect = (props: OmitInternalProps<Props>) => {
       placeholder={placeholder}
       multiple={multiple}
       onChange={onChange}
-    />
+    />,
+    undefined,
+    picassoConfig
   )
 }
+
+let spiedOnTitleCase: jest.SpyInstance
+beforeEach(() => {
+  spiedOnTitleCase = jest.spyOn(titleCaseModule, 'default')
+})
+afterEach(() => {
+  spiedOnTitleCase.mockReset()
+})
 
 const OPTIONS = [
   {
@@ -360,5 +378,24 @@ describe('multiple select', () => {
 
     expect(checkmarkedOptions.length).toBe(1)
     expect(checkmarkedOptions[0].textContent).toMatch(OPTIONS[2].text)
+  })
+
+  test('should not transform options text to title case when Picasso titleCase property is true', () => {
+    const placeholder = 'Choose an option...'
+    const { getByPlaceholderText } = renderSelect(
+      {
+        options: OPTIONS,
+        value: OPTIONS[0].value,
+        placeholder
+      },
+      {
+        titleCase: true
+      }
+    )
+
+    const input = getByPlaceholderText(placeholder)
+    fireEvent.focus(input)
+
+    expect(spiedOnTitleCase).toBeCalledTimes(0)
   })
 })

--- a/packages/picasso/src/SidebarItem/SidebarItem.tsx
+++ b/packages/picasso/src/SidebarItem/SidebarItem.tsx
@@ -66,13 +66,14 @@ export const SidebarItem: OverridableComponent<Props> = memo(
       isExpanded,
       expand,
       index,
+      titleCase: propsTitleCase,
       ...rest
     } = props
 
     const hasIcon = Boolean(icon)
     const hasMenu = Boolean(menu)
 
-    const titleCase = useTitleCase(props.titleCase)
+    const titleCase = useTitleCase(propsTitleCase)
 
     const handleMenuItemClick = (
       event: React.MouseEvent<HTMLElement, MouseEvent>

--- a/packages/picasso/src/StepLabel/StepLabel.tsx
+++ b/packages/picasso/src/StepLabel/StepLabel.tsx
@@ -30,9 +30,10 @@ export const StepLabel: FunctionComponent<Props> = ({
   completed,
   hideLabel,
   style,
+  titleCase: propsTitleCase,
   ...rest
 }) => {
-  const titleCase = useTitleCase(rest.titleCase)
+  const titleCase = useTitleCase(propsTitleCase)
   return (
     <MUIStepLabel
       // eslint-disable-next-line react/jsx-props-no-spreading

--- a/packages/picasso/src/Tab/Tab.tsx
+++ b/packages/picasso/src/Tab/Tab.tsx
@@ -42,10 +42,20 @@ export interface Props
 }
 
 export const Tab = forwardRef<HTMLDivElement, Props>(function Tab(
-  { disabled, value, label, icon, selected, onChange, onClick, ...rest },
+  {
+    disabled,
+    value,
+    label,
+    icon,
+    selected,
+    onChange,
+    onClick,
+    titleCase: propsTitleCase,
+    ...rest
+  },
   ref
 ) {
-  const titleCase = useTitleCase(rest.titleCase)
+  const titleCase = useTitleCase(propsTitleCase)
 
   return (
     <MUITab

--- a/packages/picasso/src/TableCell/TableCell.tsx
+++ b/packages/picasso/src/TableCell/TableCell.tsx
@@ -26,12 +26,21 @@ export interface Props
 
 export const TableCell = forwardRef<HTMLTableCellElement, Props>(
   function TableCell(
-    { align, classes, className, style, children, colSpan, ...rest },
+    {
+      align,
+      classes,
+      className,
+      style,
+      children,
+      colSpan,
+      titleCase: propsTitleCase,
+      ...rest
+    },
     ref
   ) {
     const tableSection = useContext(TableSectionContext)
 
-    const titleCase = useTitleCase(rest.titleCase)
+    const titleCase = useTitleCase(propsTitleCase)
 
     return (
       <MUITableCell


### PR DESCRIPTION
No JIRA ticket.

### Description

The `Select` component automatically transforms the options text into `titleCase` if the `titleCase` setting is globally enabled. This behavior is unwanted and should be disabled.

Also, this PR fixes warning like the one below:

```
 console.error
   Warning: React does not recognize the `titleCase` prop on a DOM element. If you intentionally want it to appear in t
e DOM as a custom attribute, spell it as lowercase `titlecase` instead. If you accidentally passed it from a parent com
onent, remove it from the DOM element.
       in li (created by ForwardRef(ButtonBase))
       in ForwardRef(ButtonBase) (created by WithStyles(ForwardRef(ButtonBase)))
       in WithStyles(ForwardRef(ButtonBase)) (created by ForwardRef(ListItem))
       in ForwardRef(ListItem) (created by WithStyles(ForwardRef(ListItem)))
       ...

     at warningWithoutStack (node_modules/react-dom/cjs/react-dom.development.js:530:32)
     at warning (node_modules/react-dom/cjs/react-dom.development.js:1018:27)
     at validateProperty$1 (node_modules/react-dom/cjs/react-dom.development.js:7462:7)
     at warnUnknownProperties (node_modules/react-dom/cjs/react-dom.development.js:7505:19)
     at validateProperties$2 (node_modules/react-dom/cjs/react-dom.development.js:7528:3)
     at validatePropertiesInDevelopment (node_modules/react-dom/cjs/react-dom.development.js:7575:5)
     at setInitialProperties (node_modules/react-dom/cjs/react-dom.development.js:7860:5)
```

### How to test

- make sure that CI log does not contain the `React does not recognize the ...` warnings;
- try the code below at https://picasso.toptal.net/?path=/story/forms-folder--select and at the PR's temploy

```
import React, { useState } from 'react'
import { Select, default as Picasso } from '@toptal/picasso'

const Example = () => {
  const [value, setValue] = useState()

  const handleChange = event => {
    console.log('Select value:', event.target.value)
    setValue(event.target.value)
  }

  return (
    <Picasso titleCase>
    <Select
      onChange={handleChange}
      renderOption={option => option.text}
      options={OPTIONS}
      value={value}
      placeholder='Choose an option...'
      width='auto'
    />
    </Picasso>
  )
}

const OPTIONS = [
  { value: '1', text: 'Option text 1' },
  { value: '2', text: 'Option text 2' },
]

export default Example
```

### Screenshots

Before:

<img width="464" alt="Screenshot 2020-07-14 at 14 00 25" src="https://user-images.githubusercontent.com/1390758/87390011-80a41200-c5da-11ea-9641-86cec6fd7b25.png">

After:

<img width="462" alt="Screenshot 2020-07-14 at 14 00 50" src="https://user-images.githubusercontent.com/1390758/87390014-839f0280-c5da-11ea-9e60-53a45aa1dfc8.png">


### Review

- [x] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that visuals specs are green [See the documentation](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
