### PR TITLE
fix: ignore titleCase for Autocomplete options

### DIFF
--- a/packages/picasso/src/Autocomplete/Autocomplete.tsx
+++ b/packages/picasso/src/Autocomplete/Autocomplete.tsx
@@ -171,6 +171,7 @@ export const Autocomplete = forwardRef<HTMLInputElement, Props>(
             key={getKey(option)}
             /* eslint-disable-next-line react/jsx-props-no-spreading */
             {...getItemProps(index, option)}
+            titleCase={false}
           >
             {renderOption
               ? renderOption(option, index)
@@ -186,6 +187,7 @@ export const Autocomplete = forwardRef<HTMLInputElement, Props>(
             })}
             /* eslint-disable-next-line react/jsx-props-no-spreading */
             {...getOtherItemProps(optionsLength, value)}
+            titleCase={false}
           >
             <span className={classes.stringContent}>
               <Typography as='span' color='dark-grey'>
@@ -197,7 +199,9 @@ export const Autocomplete = forwardRef<HTMLInputElement, Props>(
         )}
 
         {!optionsLength && !shouldShowOtherOption && (
-          <Menu.Item disabled>{noOptionsText}</Menu.Item>
+          <Menu.Item titleCase={false} disabled>
+            {noOptionsText}
+          </Menu.Item>
         )}
       </ScrollMenu>
     )

--- a/packages/picasso/src/Autocomplete/test.tsx
+++ b/packages/picasso/src/Autocomplete/test.tsx
@@ -1,8 +1,11 @@
 import React from 'react'
-import { render, fireEvent } from '@toptal/picasso/test-utils'
+import { render, fireEvent, PicassoConfig } from '@toptal/picasso/test-utils'
 import { OmitInternalProps } from '@toptal/picasso-shared'
+import * as titleCaseModule from 'ap-style-title-case'
 
 import Autocomplete, { Props } from './Autocomplete'
+
+jest.mock('ap-style-title-case')
 
 const testOptions = [
   { text: 'Belarus', value: 'BY' },
@@ -12,14 +15,27 @@ const testOptions = [
   { text: 'Ukraine', value: 'UA' }
 ]
 
-const renderAutocomplete = (props: OmitInternalProps<Props>) => {
+const renderAutocomplete = (
+  props: OmitInternalProps<Props>,
+  picassoConfig?: PicassoConfig
+) => {
   return render(
     <Autocomplete
       /* eslint-disable-next-line react/jsx-props-no-spreading */
       {...props}
-    />
+    />,
+    undefined,
+    picassoConfig
   )
 }
+
+let spiedOnTitleCase: jest.SpyInstance
+beforeEach(() => {
+  spiedOnTitleCase = jest.spyOn(titleCaseModule, 'default')
+})
+afterEach(() => {
+  spiedOnTitleCase.mockReset()
+})
 
 const placeholder = 'Placeholder text'
 
@@ -268,6 +284,25 @@ describe('Autocomplete', () => {
 
     fireEvent.focus(input)
     expect(api.baseElement.textContent).toContain('Custom renderer')
+  })
+
+  test('should not transform options text to title case when Picasso titleCase property is true', () => {
+    const placeholder = 'Choose an option...'
+    const { getByPlaceholderText } = renderAutocomplete(
+      {
+        options: testOptions,
+        value: '',
+        placeholder
+      },
+      {
+        titleCase: true
+      }
+    )
+
+    const input = getByPlaceholderText(placeholder)
+    fireEvent.focus(input)
+
+    expect(spiedOnTitleCase).toBeCalledTimes(0)
   })
 
   describe('Autofill', () => {


### PR DESCRIPTION
No JIRA ticket.

### Description

The `Autocomplete` component automatically transforms the options text into `titleCase` if the `titleCase` setting is globally enabled. This behavior is unwanted and should be disabled.

### How to test

- try the code below at https://picasso.toptal.net/?path=/story/forms-folder--select and at the PR's temploy

```
import React, { useState } from 'react'
import { default as Picasso, Autocomplete, Form } from '@toptal/picasso'
import { isSubstring } from '@toptal/picasso/utils'

const allOptions = [
  { text: 'option one' },
  { text: 'option two' }
]

const EMPTY_INPUT_VALUE = ''
const getDisplayValue = item => (item ? item.text : EMPTY_INPUT_VALUE)
const filterOptions = (str = '') => {
  if (str === '') {
    return allOptions
  }

  const result = allOptions.filter(option =>
    isSubstring(str, getDisplayValue(option))
  )

  return result.length > 0 ? result : null
}

const Example = () => {
  const [value, setValue] = useState(EMPTY_INPUT_VALUE)
  const [options, setOptions] = useState(allOptions)

  return (
    <Picasso titleCase>
      <Form autoComplete='off'>
        <Autocomplete
          placeholder='Start typing country...'
          value={value}
          options={options}
          onSelect={item => {
            console.log('onSelect returns item object:', item)

            const itemValue = getDisplayValue(item)

            if (value !== itemValue) {
              setValue(itemValue)
            }
          }}
          onChange={newValue => {
            console.log('onChange returns just item value:', newValue)

            setOptions(filterOptions(newValue))
            setValue(newValue)
          }}
          getDisplayValue={getDisplayValue}
        />
      </Form>
    </Picasso>
  )
}

export default Example
```

### Screenshots

Before:

<img width="532" alt="Screenshot 2020-07-14 at 18 39 00" src="https://user-images.githubusercontent.com/1390758/87416608-852ff100-c601-11ea-81d9-0d006a94e843.png">

After:

<img width="533" alt="Screenshot 2020-07-14 at 18 49 56" src="https://user-images.githubusercontent.com/1390758/87417511-e3a99f00-c602-11ea-9b99-0338e60239d0.png">

### Review

- [x] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that visuals specs are green [See the documentation](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
