### PR TITLE
fix: export static props to be able to extend via styled

### DIFF
--- a/packages/picasso-lab/src/Breadcrumbs/Breadcrumbs.tsx
+++ b/packages/picasso-lab/src/Breadcrumbs/Breadcrumbs.tsx
@@ -6,7 +6,7 @@ import { Breadcrumbs as MuiBreadcrumbs } from '@material-ui/core'
 import Item from '../BreadcrumbsItem'
 import './styles'
 
-interface StaticProps {
+export interface StaticProps {
   Item: typeof Item
 }
 

--- a/packages/picasso-lab/src/OverviewBlock/OverviewBlock.tsx
+++ b/packages/picasso-lab/src/OverviewBlock/OverviewBlock.tsx
@@ -52,7 +52,7 @@ export type Props = BaseProps &
     onClick?: (event: MouseEvent) => void
   }
 
-interface StaticProps {
+export interface StaticProps {
   Group: FunctionComponent
 }
 

--- a/packages/picasso-lab/src/Subheader/Subheader.tsx
+++ b/packages/picasso-lab/src/Subheader/Subheader.tsx
@@ -17,7 +17,7 @@ export interface Props extends BaseProps {
   rightPadding?: boolean
 }
 
-interface StaticProps {
+export interface StaticProps {
   Title: FunctionComponent
   Breadcrumb: FunctionComponent
   Tabs: FunctionComponent

--- a/packages/picasso/src/Accordion/Accordion.tsx
+++ b/packages/picasso/src/Accordion/Accordion.tsx
@@ -36,7 +36,7 @@ const Details: FunctionComponent<{ className?: string }> = props => {
   return <div className={cx(className, classes.detailsWrapper)}>{children}</div>
 }
 
-interface StaticProps {
+export interface StaticProps {
   Summary: typeof Summary
   Details: typeof Details
 }

--- a/packages/picasso/src/Button/Button.tsx
+++ b/packages/picasso/src/Button/Button.tsx
@@ -78,7 +78,7 @@ export interface Props extends BaseProps, TextLabelProps, ButtonOrAnchorProps {
   type?: 'button' | 'reset' | 'submit'
 }
 
-interface StaticProps {
+export interface StaticProps {
   Group: typeof Group
 }
 

--- a/packages/picasso/src/Checkbox/Checkbox.tsx
+++ b/packages/picasso/src/Checkbox/Checkbox.tsx
@@ -13,7 +13,7 @@ import CheckboxGroup from '../CheckboxGroup'
 import FormControlLabel from '../FormControlLabel'
 import styles from './styles'
 
-interface StaticProps {
+export interface StaticProps {
   Group: typeof CheckboxGroup
 }
 

--- a/packages/picasso/src/Dropdown/Dropdown.tsx
+++ b/packages/picasso/src/Dropdown/Dropdown.tsx
@@ -56,7 +56,7 @@ export interface Props extends BaseProps, HTMLAttributes<HTMLDivElement> {
   popperContainer?: HTMLElement
 }
 
-interface StaticProps {
+export interface StaticProps {
   Arrow: typeof DropdownArrow
   useContext: () => ContextProps
 }

--- a/packages/picasso/src/Form/Form.tsx
+++ b/packages/picasso/src/Form/Form.tsx
@@ -18,7 +18,7 @@ export interface Props extends BaseProps, FormHTMLAttributes<HTMLFormElement> {
   onSubmit?: FormEventHandler<HTMLFormElement>
 }
 
-interface StaticProps {
+export interface StaticProps {
   Field: typeof FormField
   Hint: typeof FormHint
   Label: typeof FormLabel

--- a/packages/picasso/src/Grid/Grid.tsx
+++ b/packages/picasso/src/Grid/Grid.tsx
@@ -31,7 +31,7 @@ export interface Props extends BaseProps, HTMLAttributes<HTMLElement> {
   wrap?: GridWrap
 }
 
-interface StaticProps {
+export interface StaticProps {
   Item: typeof GridItem
 }
 

--- a/packages/picasso/src/Helpbox/Helpbox.tsx
+++ b/packages/picasso/src/Helpbox/Helpbox.tsx
@@ -25,7 +25,7 @@ export interface Props extends BaseProps, HTMLAttributes<HTMLDivElement> {
   onClose?: (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void
 }
 
-interface StaticProps {
+export interface StaticProps {
   Title: typeof HelpboxTitle
   Content: typeof HelpboxContent
   Actions: typeof HelpboxActions

--- a/packages/picasso/src/Label/Label.tsx
+++ b/packages/picasso/src/Label/Label.tsx
@@ -45,7 +45,7 @@ export interface Props extends BaseProps, TextLabelProps, DivOrAnchorProps {
   variant?: VariantType
 }
 
-interface StaticProps {
+export interface StaticProps {
   Group: typeof LabelGroup
 }
 

--- a/packages/picasso/src/Modal/Modal.tsx
+++ b/packages/picasso/src/Modal/Modal.tsx
@@ -48,7 +48,7 @@ export interface Props extends BaseProps, HTMLAttributes<HTMLDivElement> {
   paperProps?: PaperProps
 }
 
-interface StaticProps {
+export interface StaticProps {
   Content: typeof ModalContent
   Actions: typeof ModalActions
   Title: typeof ModalTitle

--- a/packages/picasso/src/Notification/Notification.tsx
+++ b/packages/picasso/src/Notification/Notification.tsx
@@ -46,7 +46,7 @@ export interface Props extends BaseProps, HTMLAttributes<HTMLDivElement> {
   fullWidth?: boolean
 }
 
-interface StaticProps {
+export interface StaticProps {
   Actions: typeof NotificationActions
 }
 

--- a/packages/picasso/src/Page/Page.tsx
+++ b/packages/picasso/src/Page/Page.tsx
@@ -28,7 +28,7 @@ export interface Props extends BaseProps, HTMLAttributes<HTMLDivElement> {
   children: ReactNode
 }
 
-interface StaticProps {
+export interface StaticProps {
   Head: typeof PageHead
   Header: typeof PageHeader
   HeaderMenu: typeof PageHeaderMenu

--- a/packages/picasso/src/PageBanner/PageBanner.tsx
+++ b/packages/picasso/src/PageBanner/PageBanner.tsx
@@ -24,7 +24,7 @@ export interface Props extends BaseProps, HTMLAttributes<HTMLDivElement> {
   icon?: ReactElement
 }
 
-interface StaticProps {
+export interface StaticProps {
   Message: FunctionComponent
   Actions: FunctionComponent
 }

--- a/packages/picasso/src/Sidebar/Sidebar.tsx
+++ b/packages/picasso/src/Sidebar/Sidebar.tsx
@@ -66,7 +66,7 @@ export interface Props extends BaseProps {
   variant?: VariantType
 }
 
-interface StaticProps {
+export interface StaticProps {
   Menu: typeof SidebarMenu
   Item: typeof SidebarItem
   Logo: typeof SidebarLogo

--- a/packages/picasso/src/Table/Table.tsx
+++ b/packages/picasso/src/Table/Table.tsx
@@ -23,7 +23,7 @@ export interface Props
   children: ReactNode
 }
 
-interface StaticProps {
+export interface StaticProps {
   Head: typeof TableHead
   SectionHead: typeof TableSectionHead
   Body: typeof TableBody

--- a/packages/picasso/src/Tabs/Tabs.tsx
+++ b/packages/picasso/src/Tabs/Tabs.tsx
@@ -24,7 +24,7 @@ export interface Props
   value: TabsProps['value']
 }
 
-interface StaticProps {
+export interface StaticProps {
   Tab: typeof Tab
 }
 

--- a/packages/picasso/src/TagSelector/TagSelector.tsx
+++ b/packages/picasso/src/TagSelector/TagSelector.tsx
@@ -76,7 +76,7 @@ export interface Props
   }) => ReactNode
 }
 
-interface StaticProps {
+export interface StaticProps {
   Label: typeof TagSelectorLabel
 }
 


### PR DESCRIPTION
### Description

Need to export all static props types to be able to wrap components with `styled`

<img width="897" alt="Screenshot 2020-07-15 at 11 50 56" src="https://user-images.githubusercontent.com/2836281/87524897-7264fd00-c691-11ea-9d4f-b9a7222ad39a.png">
