### PR TITLE
fix(radiogroup): remove invalid elements on clone

### DIFF
--- a/packages/picasso-forms/src/RadioGroup/RadioGroup.tsx
+++ b/packages/picasso-forms/src/RadioGroup/RadioGroup.tsx
@@ -22,11 +22,13 @@ export const RadioGroup = (props: Props) => {
         return (
           // eslint-disable-next-line react/jsx-props-no-spreading
           <PicassoRadio.Group {...restRadioGroupProps}>
-            {React.Children.map(children, child =>
-              React.cloneElement(child as ReactElement, {
-                name: props.name
-              })
-            )}
+            {React.Children.toArray(children)
+              .filter(React.isValidElement)
+              .map(child =>
+                React.cloneElement(child as ReactElement, {
+                  name: props.name
+                })
+              )}
           </PicassoRadio.Group>
         )
       }}


### PR DESCRIPTION
### Description

While using the `Form.RadioGroup`, we faced a strange error when conditionally showing elements. This:

```ts
<Form.RadioGroup name='group' required>
  {someFalsyCondition && (
    <div></div> // code omitted for brevity sake
  )}
</Form.RadioGroup>
```

Was yielding the following error:

`React.cloneElement(...): The argument must be a React element, but you passed null.`

This PR fixes this problem. You cannot clone something that is not an element: `React.cloneElement(null)` doesn't work.

Environment:

```ts
typescript@3.9.7
@toptal/picasso@4.69.2
@toptal/picasso-forms@0.18.2
```

### Review

- (n/a) Annotate all `props` in component with documentation
- (n/a) Create `examples` for component
- (n/a) Ensure that deployed demo has expected results and good examples
- [ ] Ensure that visuals specs are green [See the documentation](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
