### PR TITLE
fix(Slider): add missing field in ValueLabelProps interface

### DIFF
--- a/packages/picasso/src/Slider/Slider.tsx
+++ b/packages/picasso/src/Slider/Slider.tsx
@@ -29,8 +29,9 @@ export interface Props extends SliderProps {
   marks?: boolean
   /** Whether component is disabled or not */
   disabled?: boolean
+  // Workaround for https://github.com/mui-org/material-ui/issues/21889
   /** The tooltip component. */
-  TooltipComponent?: React.ElementType<ValueLabelProps>
+  TooltipComponent?: React.ElementType<ValueLabelProps & { index: number }>
   /** Controls when tooltip is displayed:
   - **auto** the value tooltip will display when the thumb is hovered or focused.
   - **on** will display persistently.
@@ -115,7 +116,10 @@ export const Slider = forwardRef<HTMLElement, Props>(function Slider(
             [markTrack]: marks
           })
         }}
-        ValueLabelComponent={ValueLabelComponent}
+        ValueLabelComponent={
+          // From Workaround for https://github.com/mui-org/material-ui/issues/21889
+          ValueLabelComponent as React.ElementType<ValueLabelProps>
+        }
         valueLabelFormat={tooltipFormat}
         valueLabelDisplay={tooltip}
         onChange={onChange}


### PR DESCRIPTION
Related to [SPC-452]

### Description

`ValueLabelProps` interface from `Slider` is missing some fields in MUI. Here we patch this interface at the corresponding prop `TooltipComponent`.
It also contains a reference to the issue created in Material UI repo (https://github.com/mui-org/material-ui/issues/21889)

### How to test

- Use the prop `index` for a custom `TooltipComponent` in `Slider`. There should be no TS errror.

### Review

- [ ] ~Annotate all `props` in component with documentation~
- [ ] ~Create `examples` for component~
- [x] Ensure that deployed demo has expected results and good examples
- [ ] ~Ensure that visuals specs are green [See the documentation](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)~


[SPC-452]: https://toptal-core.atlassian.net/browse/SPC-452