### PR TITLE
fix(treeview): set the TreeView center by default

### DIFF
--- a/packages/picasso-lab/src/TreeView/useZoom.ts
+++ b/packages/picasso-lab/src/TreeView/useZoom.ts
@@ -50,6 +50,10 @@ export const useZoom = <ZoomRefElement extends ZoomedElementBaseType>({
         .call(zoom)
         .call(zoom.transform, d3.zoomIdentity.scale(initialScale))
 
+      if (center) {
+        d3.select(rootRef.current).call(zoom.translateTo, center.x, center.y)
+      }
+
       setInitialized(true)
     } else if (center) {
       d3.select(rootRef.current)


### PR DESCRIPTION
### Description

We need to set the center by default, without animation

### How to test

- Go to Picasso's TreeView component
- Change something, like the css attributes
- The TreeView component will be scrolling to the center with animation

### Review

- [ ] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that visuals specs are green [See the documentation](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
