### PR TITLE
fix: the select menu is visible after the disabled property is removed

### DIFF
--- a/packages/picasso/src/Select/Select.tsx
+++ b/packages/picasso/src/Select/Select.tsx
@@ -511,6 +511,7 @@ export const Select = documentable(
       } = useSelect({
         value: inputValue,
         options,
+        disabled,
         onSelect: handleSelect,
         onChange: handleChange,
         onBlur: handleBlur,

--- a/packages/picasso/src/Select/useSelect.ts
+++ b/packages/picasso/src/Select/useSelect.ts
@@ -73,6 +73,7 @@ interface Props {
   options?: Option[]
   enableAutofill?: boolean
   autoComplete?: any
+  disabled?: boolean
   onSelect?: (event: React.SyntheticEvent, item: Option | null) => void
   onChange?: (value: string) => void
   onKeyDown?: (
@@ -109,6 +110,7 @@ interface UseSelectOutput {
 const useSelect = ({
   value,
   options = [],
+  disabled = false,
   onChange = () => {},
   onKeyDown = () => {},
   onSelect = () => {},
@@ -160,7 +162,7 @@ const useSelect = ({
       | React.FocusEvent<HTMLInputElement>
       | React.MouseEvent<HTMLInputElement>
   ) => {
-    if (!isOpen) {
+    if (!isOpen && !disabled) {
       onFocus(event as React.FocusEvent<HTMLInputElement>)
       setOpen(true)
     }


### PR DESCRIPTION
[SPT-764](https://toptal-core.atlassian.net/browse/SPT-764)

### Description

Now, when you click on a disabled select and after that, you enable the select, the menu will be visible, without clicking again on the select.

This is because, when you click or focus a select, the disabled property is not checked. 

![7940eadb-5e84-4caf-9a97-f1bc00e617fb](https://user-images.githubusercontent.com/2583281/89298645-40323400-d66e-11ea-806e-552747846e1c.gif)


### How to test

```
import React, { useState } from 'react'
import { Select, Button, Container } from '@toptal/picasso'

const Example = () => {
  const [value, setValue] = useState()
  const [disabled, setDisabled] = useState(false)

  const handleChange = event => {
    console.log('Select value:', event.target.value)
    setValue(event.target.value)
  }

  return (
    <>
    <Select
      disabled={disabled}
      onChange={handleChange}
      options={OPTIONS}
      value={value}
      placeholder='Choose an option...'
      width='auto'
    />
    <Container inline left='small'>
      <Button onClick={() => setDisabled(!disabled)}>Toggle disabled</Button>
    </Container>
    </>
  )
}

const OPTIONS = [
  { value: '1', text: 'Option 1' },
  { value: '2', text: 'Option 2' },
]

export default Example

```

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
|![select-master](https://user-images.githubusercontent.com/2583281/89297996-660b0900-d66d-11ea-89d1-8e83fa519cf9.gif)|![fix-select](https://user-images.githubusercontent.com/2583281/89297791-1fb5aa00-d66d-11ea-9639-2d4f48f45f9f.gif)|

### Review

- [x] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure that visuals specs are green [See the documentation](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
