### PR TITLE
fix(Select): fix scrolling on hover of the bottom element

### DIFF
--- a/packages/picasso/src/ScrollMenu/ScrollMenu.tsx
+++ b/packages/picasso/src/ScrollMenu/ScrollMenu.tsx
@@ -21,6 +21,20 @@ enum Direction {
   DOWN
 }
 
+const getMoveDirection = (
+  selectedIndex: number,
+  prevSelectedIndex: number | null | undefined,
+  bottomVisibleItem: number
+) => {
+  if (prevSelectedIndex != null) {
+    return prevSelectedIndex <= selectedIndex ? Direction.DOWN : Direction.UP
+  }
+
+  return selectedIndex === Math.ceil(bottomVisibleItem)
+    ? Direction.DOWN
+    : Direction.UP
+}
+
 const ScrollMenu: FunctionComponent<Props> = ({
   selectedIndex,
   classes,
@@ -52,11 +66,6 @@ const ScrollMenu: FunctionComponent<Props> = ({
     const itemHeight = firstItemRef.current.offsetHeight
     const scrollViewHeight = menuRef.current.offsetHeight
 
-    const moveDirection =
-      prevSelectedIndex != null && prevSelectedIndex <= selectedIndex
-        ? Direction.DOWN
-        : Direction.UP
-
     const countItemsOnScrollView = scrollViewHeight / itemHeight
     const topVisibleItem = currentScrollTop / itemHeight
     const bottomVisibleItem = topVisibleItem + countItemsOnScrollView - 1
@@ -65,6 +74,11 @@ const ScrollMenu: FunctionComponent<Props> = ({
       selectedIndex >= topVisibleItem && selectedIndex <= bottomVisibleItem
 
     if (!isHighlightedItemInScrollView) {
+      const moveDirection = getMoveDirection(
+        selectedIndex,
+        prevSelectedIndex,
+        bottomVisibleItem
+      )
       let scrollTop = 0
 
       if (moveDirection === Direction.UP) {


### PR DESCRIPTION
### Description

When Select is opened so that popover is on the top and user hovers the item in the bottom it incorrectly scrolls:
Scroll jumps from 7 to 13 option: https://share.getcloudapp.com/DOuxgr4g

### How to test

- `yarn start`
- Ensure select works as described https://picasso.toptal.net/fix-select-hover/?path=/story/forms-folder--select

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| https://share.getcloudapp.com/DOuxgr4g | https://share.getcloudapp.com/Jru6v8Gx |

### Review

- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure that visuals specs are green [See the documentation](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
