### PR TITLE
feat(tooltip): add delay prop to the Tooltip component

### DIFF
--- a/packages/picasso/src/Tooltip/Tooltip.tsx
+++ b/packages/picasso/src/Tooltip/Tooltip.tsx
@@ -17,6 +17,13 @@ type VariantType = 'light' | 'dark'
 
 type PlacementType = 'bottom' | 'left' | 'right' | 'top'
 
+type DelayType = 'short' | 'long'
+
+const delayDurations: { [k in DelayType]: number } = {
+  short: 200,
+  long: 500
+}
+
 export interface Props extends StandardProps, HTMLAttributes<HTMLDivElement> {
   /** Trigger element for tooltip */
   children: ReactNode
@@ -42,6 +49,8 @@ export interface Props extends StandardProps, HTMLAttributes<HTMLDivElement> {
   preventOverflow?: boolean
   /** Disable the portal behavior. The children stay within it's parent */
   disablePortal?: boolean
+  /** A delay in showing the tooltip */
+  delay?: DelayType
 }
 
 export const Tooltip: FunctionComponent<Props> = ({
@@ -60,6 +69,7 @@ export const Tooltip: FunctionComponent<Props> = ({
   disableListeners,
   preventOverflow,
   disablePortal,
+  delay = 'short',
   ...rest
 }) => {
   const [arrowRef, setArrowRef] = useState<HTMLSpanElement | null>(null)
@@ -72,7 +82,7 @@ export const Tooltip: FunctionComponent<Props> = ({
     </>
   )
 
-  const defaultDelay = 500
+  const delayDuration = delayDurations[delay]
 
   return (
     <MUITooltip
@@ -115,7 +125,8 @@ export const Tooltip: FunctionComponent<Props> = ({
       disableHoverListener={disableListeners}
       disableFocusListener={disableListeners}
       disableTouchListener
-      enterDelay={defaultDelay}
+      enterDelay={delayDuration}
+      enterNextDelay={delayDuration}
     >
       {children as ReactElement}
     </MUITooltip>

--- a/packages/picasso/src/Tooltip/story/Delay.example.tsx
+++ b/packages/picasso/src/Tooltip/story/Delay.example.tsx
@@ -1,0 +1,19 @@
+import React from 'react'
+import { Tooltip, Button, Container } from '@toptal/picasso'
+
+const Example = () => (
+  <div style={{ textAlign: 'center' }}>
+    <Container top='large' bottom='large' left='large' right='large' inline>
+      <Tooltip content='Short delay is 200ms' delay='short' placement='top'>
+        <Button>Short delay</Button>
+      </Tooltip>
+    </Container>
+    <Container top='large' bottom='large' left='large' right='large' inline>
+      <Tooltip content='Long delay is 500ms' delay='long' placement='top'>
+        <Button>Long delay</Button>
+      </Tooltip>
+    </Container>
+  </div>
+)
+
+export default Example

--- a/packages/picasso/src/Tooltip/story/index.jsx
+++ b/packages/picasso/src/Tooltip/story/index.jsx
@@ -19,6 +19,10 @@ page
       variant: {
         type: 'enum',
         enums: ['light', 'dark']
+      },
+      delay: {
+        type: 'enum',
+        enums: ['short', 'long']
       }
     }
   })
@@ -41,3 +45,4 @@ page
     'Tooltip/story/DisabledElement.example.tsx',
     'Tooltip on disabled element'
   ) // picasso-skip-visuals
+  .addExample('Tooltip/story/Delay.example.tsx', 'Delay') // picasso-skip-visuals


### PR DESCRIPTION
### Description

A while ago a default 500ms delay was introduced inside Tooltip component. We need to have an ability to specify a shorter delay.

### How to test

- `yarn start` 
- Ensure Delay works as expected https://picasso.toptal.net/add-enter-delay-prop-to-tooltip/?path=/story/overlays-folder--tooltip#delay

### Screenshots

N/A

### Review

- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure that visuals specs are green [See the documentation](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
