### PR TITLE
feat(TagSelector): add noOptionsText to TagSelector props

### DIFF
--- a/packages/picasso/src/TagSelector/TagSelector.tsx
+++ b/packages/picasso/src/TagSelector/TagSelector.tsx
@@ -43,6 +43,8 @@ export interface Props
   onOtherOptionSelect?: (value: string) => void
   /** Allow to show the other option in the list of options */
   showOtherOption?: boolean
+  /** Label to show when no options were found */
+  noOptionsText?: string
   /** List of options with unique labels */
   options?: Item[] | null
   /** The list of values of the selected options, required for a controlled component. */
@@ -90,6 +92,7 @@ export const TagSelector = forwardRef<HTMLInputElement, Props>(
       otherOptionLabel,
       onOtherOptionSelect,
       showOtherOption,
+      noOptionsText,
       value: values = [],
       getDisplayValue,
       onChange,
@@ -199,6 +202,7 @@ export const TagSelector = forwardRef<HTMLInputElement, Props>(
         width={width}
         showOtherOption={showOtherOption}
         otherOptionText={otherOptionLabel}
+        noOptionsText={noOptionsText}
         enableAutofill={enableAutofill}
         getDisplayValue={getDisplayValue}
         renderOption={renderOption}
@@ -218,6 +222,7 @@ TagSelector.defaultProps = {
   onOtherOptionSelect: () => {},
   options: [],
   otherOptionLabel: 'Add new option: ',
+  noOptionsText: 'No matches found',
   placeholder: '',
   showOtherOption: false
 }


### PR DESCRIPTION
[SPT-702]

### Description

Need to show “No results” text if there is no matching results to be displayed in TagSelector.

### How to test

- FIXME: Add the steps describing how to verify your changes

### Screenshots

N/A

### Review

- [ ] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that visuals specs are green [See the documentation](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)


[SPT-702]: https://toptal-core.atlassian.net/browse/SPT-702