### PR TITLE
feat: add disable portal for slider

### DIFF
--- a/packages/picasso/src/Slider/Slider.tsx
+++ b/packages/picasso/src/Slider/Slider.tsx
@@ -40,6 +40,8 @@ export interface Props extends SliderProps {
   tooltip?: ValueLabelDisplay
   /** The format function the value tooltip's value. */
   tooltipFormat?: string | ((value: number, index: number) => React.ReactNode)
+  /** Disable the portal behavior of the tooltip. The children stay within it's parent */
+  disablePortal?: boolean
   /** Callback invoked when slider changes its state. */
   onChange?: (event: ChangeEvent<{}>, value: Value) => void
 }
@@ -50,7 +52,8 @@ type ValueLabelComponentProps = ValueLabelProps & {
 }
 
 const DefaultTooltip = (
-  isTooltipAlwaysVisible: boolean
+  isTooltipAlwaysVisible: boolean,
+  disablePortal?: boolean
 ): React.FunctionComponent<ValueLabelComponentProps> => ({
   children,
   open,
@@ -68,6 +71,7 @@ const DefaultTooltip = (
       open={open || valueLabelDisplay === 'on'}
       placement={isTooltipAlwaysVisible ? 'right' : 'top'}
       preventOverflow={isTooltipAlwaysVisible}
+      disablePortal={disablePortal}
     >
       {children}
     </Tooltip>
@@ -89,13 +93,17 @@ export const Slider = forwardRef<HTMLElement, Props>(function Slider(
     TooltipComponent: UserDefinedTooltip,
     step,
     disabled,
+    disablePortal,
     onChange,
     ...rest
   } = props
   const { wrapper, markTrack, ...classes } = useStyles(props)
   const isTooltipAlwaysVisible = tooltip === 'on'
   const ValueLabelComponent = (UserDefinedTooltip ||
-    DefaultTooltip(isTooltipAlwaysVisible)) as typeof UserDefinedTooltip
+    DefaultTooltip(
+      isTooltipAlwaysVisible,
+      disablePortal
+    )) as typeof UserDefinedTooltip
 
   return (
     <div className={wrapper}>
@@ -134,7 +142,8 @@ Slider.defaultProps = {
   defaultValue: 0,
   min: 0,
   max: 100,
-  tooltip: 'off'
+  tooltip: 'off',
+  disablePortal: false
 }
 
 export default Slider

--- a/packages/picasso/src/Tooltip/Tooltip.tsx
+++ b/packages/picasso/src/Tooltip/Tooltip.tsx
@@ -40,6 +40,8 @@ export interface Props extends StandardProps, HTMLAttributes<HTMLDivElement> {
   disableListeners?: boolean
   /** Allows tooltip to change its placement when it overflows */
   preventOverflow?: boolean
+  /** Disable the portal behavior. The children stay within it's parent */
+  disablePortal?: boolean
 }
 
 export const Tooltip: FunctionComponent<Props> = ({
@@ -57,6 +59,7 @@ export const Tooltip: FunctionComponent<Props> = ({
   variant,
   disableListeners,
   preventOverflow,
+  disablePortal,
   ...rest
 }) => {
   const [arrowRef, setArrowRef] = useState<HTMLSpanElement | null>(null)
@@ -77,6 +80,7 @@ export const Tooltip: FunctionComponent<Props> = ({
       {...rest}
       PopperProps={{
         container,
+        disablePortal,
         popperOptions: {
           modifiers: {
             arrow: {
@@ -122,7 +126,8 @@ Tooltip.defaultProps = {
   arrow: true,
   preventOverflow: false,
   placement: 'top',
-  variant: 'dark'
+  variant: 'dark',
+  disablePortal: false
 }
 
 export default withStyles(styles)(Tooltip)


### PR DESCRIPTION
[SPT-812](https://toptal-core.atlassian.net/browse/SPT-812)

### Description

Add the `disabledPortal` for tooltip and slider to help us to change the popper `zIndex` in the staff-portal, based on need.
Please check, [SPT-812](https://toptal-core.atlassian.net/browse/SPT-812) for more info.

### How to test

- FIXME: Add the steps describing how to verify your changes

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| Insert screenshots or screen recordings | Insert screenshots or screen recordings |

### Review

- [x] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [x] Ensure that visuals specs are green [See the documentation](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
