### PR TITLE
feat(Helpbox): design changes in Helpbox component

### DIFF
--- a/packages/picasso/src/Helpbox/Helpbox.tsx
+++ b/packages/picasso/src/Helpbox/Helpbox.tsx
@@ -3,6 +3,7 @@ import { makeStyles, Theme } from '@material-ui/core/styles'
 import cx from 'classnames'
 import {
   BaseProps,
+  SpacingType,
   PicassoComponentWithRef,
   CompoundedComponentWithRef
 } from '@toptal/picasso-shared'
@@ -21,6 +22,8 @@ export interface Props extends BaseProps, HTMLAttributes<HTMLDivElement> {
   children: ReactNode
   /** Color variant of Helpbox */
   variant?: ContainerVariantType
+  /** padding for the container transformed to `em` */
+  padded?: SpacingType
   /** Callback invoked when close is clicked */
   onClose?: (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void
 }
@@ -41,7 +44,15 @@ export const Helpbox = forwardRef<HTMLDivElement, Props>(function Helpbox(
   ref
 ) {
   const classes = useStyles(props)
-  const { className, style, children, variant, onClose, ...rest } = props
+  const {
+    className,
+    style,
+    children,
+    variant,
+    padded,
+    onClose,
+    ...rest
+  } = props
 
   return (
     <Container
@@ -52,7 +63,7 @@ export const Helpbox = forwardRef<HTMLDivElement, Props>(function Helpbox(
       style={style}
       bordered={!variant || variant === 'white'}
       variant={variant}
-      padded='large'
+      padded={padded}
     >
       <HelpboxContext.Provider value={{ closeable: Boolean(onClose) }}>
         {children}
@@ -69,7 +80,9 @@ export const Helpbox = forwardRef<HTMLDivElement, Props>(function Helpbox(
   )
 }) as CompoundedComponentWithRef<Props, HTMLDivElement, StaticProps>
 
-Helpbox.defaultProps = {}
+Helpbox.defaultProps = {
+  padded: 'large'
+}
 
 Helpbox.displayName = 'Helpbox'
 


### PR DESCRIPTION
[FX-1098]

### Description

Design changes in `Helpbox` component: 
- Padding reduced to 24px
- Rounded borders


### How to test

- FIXME: Add the steps describing how to verify your changes

### Screenshots

N/A

### Review

- [ ] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that visuals specs are green [See the documentation](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)


[SPT-818]: https://toptal-core.atlassian.net/browse/SPT-818

[FX-1098]: https://toptal-core.atlassian.net/browse/FX-1098