### PR TITLE
fix(treeview): adjust zoom to support linear transition

### DIFF
--- a/packages/picasso-lab/src/TreeView/TreeViewContainer.tsx
+++ b/packages/picasso-lab/src/TreeView/TreeViewContainer.tsx
@@ -1,5 +1,6 @@
 import React, { FC, useState } from 'react'
-import * as d3 from 'd3'
+import * as d3 from 'd3' // eslint-disable-line import/no-duplicates
+import { zoomTransform } from 'd3' // eslint-disable-line import/no-duplicates
 
 import { TreeViewContextProps } from './types'
 
@@ -32,7 +33,21 @@ export const TreeViewContainer: FC = ({ children }) => {
 
     d3.select(state.ref)
       .transition()
-      .call(state.zoom.scaleBy, step)
+      .call(state.zoom.scaleTo, function (
+        this: SVGSVGElement,
+        datum: unknown,
+        index: number,
+        groups: any
+      ) {
+        const defaultExtent = state.zoom!.extent()
+        const k0 = zoomTransform(this).k
+        const extent = defaultExtent.apply(this, [datum, index, groups])
+        const width = extent[1][0]
+        // support backward compatibility for the `step` argument
+        const k1 = step > 1 ? step - 1 : -step
+
+        return (width * k0 + width * k1) / width
+      })
   }
 
   return (


### PR DESCRIPTION
### Description

We had to implement linear transition for the custom `Zoom` Component.

Before if the decrease step was `10%`, the set was: `100px, 90px, 81px, 72,9px, 65,61px`
not it' more consistent: `100px, 90px, 80px, 70px, 60px ...`

### How to test

Just check the `Custom Zoom` example

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| Insert screenshots or screen recordings | Insert screenshots or screen recordings |

### Review

- [ ] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that visuals specs are green [See the documentation](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
