### PR TITLE
chore(datepicker): fix date object created in the datepicker example

### DIFF
--- a/packages/picasso-lab/src/DatePicker/story/WithTimezone.example.tsx
+++ b/packages/picasso-lab/src/DatePicker/story/WithTimezone.example.tsx
@@ -4,7 +4,7 @@ import { Search16 } from '@toptal/picasso'
 
 const WithTimezoneExample = () => {
   const timezone = 'Asia/Tokyo'
-  const [value, setValue] = useState(new Date('2015-12-12 16:00:00'))
+  const [value, setValue] = useState(new Date('2015-12-12T16:00:00'))
 
   return (
     <div style={{ height: '50vh', width: '100%' }}>


### PR DESCRIPTION
### Description

Mobile Safari does not recognize the date time format without the T separator

### How to test

- See the examples of Datepicker still working

### Screenshots
![Screenshot 2020-08-17 at 15 50 26](https://user-images.githubusercontent.com/2437969/90403797-c18fba80-e0a1-11ea-854b-25fe85b304ef.png)
