### PR TITLE
fix: docker remove useless package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,6 @@ RUN apk update && apk upgrade && \
   curl \
   jq \
   chromium \
-  su-exec \
   openssh-client \
   bash \
   sed \

--- a/jest-puppeteer.config.js
+++ b/jest-puppeteer.config.js
@@ -1,6 +1,6 @@
 module.exports = {
   launch: {
     executablePath: process.env.CHROME_BIN || null,
-    args: ['--no-sandbox']
+    args: ['--no-sandbox', '--disable-dev-shm-usage']
   }
 }


### PR DESCRIPTION
### Description

- Remove `su-exec`, which is not used
- Add `--disable-dev-shm-usage` flag as recommended in https://github.com/puppeteer/puppeteer/blob/main/docs/troubleshooting.md#tips to potentially avoid timeouts for large pages