### PR TITLE
fix(Symlinking): allow specifying target project

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,37 +149,22 @@ After Picasso will be released with your changes you can start using your Icon a
 ## Linking with other projects
 
 In order to develop or debug Picasso in parallel with your project without the need to publish new Picasso versions, you need to link Picasso to your project. And once finished unlink it.
-You will probably notice that linking process links `@toptal/picasso` and `react`. It is due to React restriction of only once instance used in the project [[1]](https://github.com/facebook/react/issues/14257#issuecomment-439967377) [[2]](https://github.com/facebook/react/issues/13991#issuecomment-463486871), so we link to Picasso's `react` version.
+Please use custom `yarn symlink TARGET_PROJECT_PATH` script that will create links for all Picasso packages, `react` and `@types/react` (**please don't use default `yarn link` script, it is not enough**). React has to be linked due to restriction of only single React instance used in the project [[1]](https://github.com/facebook/react/issues/14257#issuecomment-439967377) [[2]](https://github.com/facebook/react/issues/13991#issuecomment-463486871). React typings are also have to be linked because of the type incompatiblity issues.
 
 ### Link
 
 To link Picasso follow these steps:
 
-In Picasso project directory:
-
 1. Checkout Picasso project from [Github](https://github.com/toptal/picasso)
 2. Install Picasso dependencies with `yarn install`
-3. Build Picasso inside Picasso package folder (`./packages/picasso/`) with `yarn build:dist`
-4. Create a link with running in the root path `yarn symlink` (creates all links to Picasso packages and React link)
+3. Build Picasso with `yarn build:dist`
+4. Link target project to local Picasso by running `yarn symlink TARGET_PROJECT_PATH` from Picasso root folder (e.g. `yarn symlink ~/projects/staff-portal`)
 
-In your project directory:
-
-1. Link Picasso and React with `yarn link @toptal/picasso react`
-2. Start your project and changes in Picasso will be visible in your project!
+From that point you can rebuild local Picasso with `yarn build:dist` and it'll be automatically updated in your target project.
 
 ### Unlink
 
-To unlink Picasso follow these steps:
-
-In your project directory:
-
-1. Unlink Picasso with `yarn unlink @toptal/picasso react`
-2. Re-install dependencies with `yarn install --force`
-
-(Optional) In Picasso project directory:
-
-1. Unlink with `yarn symlink:off`
-2. Re-install dependencies with `yarn install --force`
+To unlink target project from local Picasso use `yarn symlink:off TARGET_PROJECT_PATH` (e.g. `yarn symlink:off ~/projects/staff-portal`)
 
 ### Tree shaking
 

--- a/bin/symlink
+++ b/bin/symlink
@@ -1,23 +1,26 @@
 #!/usr/bin/env node
 
 const path = require('path')
-const { readdirSync } = require('fs')
+const { readdirSync, lstatSync } = require('fs')
 const yargs = require('yargs').argv
 const exec = require('child_process').execSync
 
 const { log } = require('./utils')
 
 const PACKAGES_DIR = path.join(__dirname, '../packages/')
+const picassoRoot = __dirname
 
-const link = function(name) {
+const link = function(name, cwd) {
   exec(`yarn link ${name}`, {
+    cwd,
     stdio: 'inherit'
   })
 }
 
-const unlink = function(name) {
+const unlink = function(name, cwd) {
   try {
     exec(`yarn unlink ${name}`, {
+      cwd,
       stdio: 'ignore',
       stderr: 'ignore'
     })
@@ -47,7 +50,17 @@ const removeLink = function(name, cwd) {
   }
 }
 
-const getPicassoPackages = () => readdirSync(PACKAGES_DIR)
+const createReactLinks = function() {
+  createLink('react', './node_modules/react')
+  createLink('@types/react', './node_modules/@types/react')
+}
+
+const removeReactLinks = function() {
+  removeLink('react', './node_modules/react')
+  removeLink('@types/react', './node_modules/@types/react')
+}
+
+const getPicassoPackages = () => readdirSync(PACKAGES_DIR).filter(dir => lstatSync(path.join(PACKAGES_DIR, dir)).isDirectory())
 const getPackageTsConfig = packageName => {
   const tsConfigPath = path.join(PACKAGES_DIR, packageName, './tsconfig.build.json')
   return require(tsConfigPath)
@@ -74,36 +87,63 @@ const setup = function() {
   })
 
   if (yargs.link) {
-    log('Firt build dist versions of all the packages')
+    if (!yargs.link.length || !yargs.link.trim()) {
+      throw new Error('Please specify target project for linking, e.g.: `yarn symlink ~/projects/staff-portal`')
+    }
 
-    exec('yarn build:dist', { stdio: 'inherit' })
+    const destinationDir = yargs.link.trim()
 
-    log('Linking process started...')
+    log('Creating Picasso links...')
 
     linkPackages.forEach(({ name, outputDir }) => removeLink(name, outputDir))
-    removeLink('react', './node_modules/react')
+    removeReactLinks()
 
     linkPackages.forEach(({ name, outputDir }) => createLink(name, outputDir))
-    createLink('react', './node_modules/react')
+    createReactLinks()
+
     // because we are using yarn workspaces
     // we have default symlinks set up to /src folders of packages
     // so we need to override them and reffer to /build folders
-    linkPackages.forEach(({ name }) => link(name))
+    linkPackages.forEach(({ name }) => link(name, picassoRoot))
 
-    log('Linking process finished.')
+    log('Links are created. Linking the target project...')
+
+    const packageNames = linkPackages.map(({ name }) => `"${name}"`);
+    ['react', '@types/react', ...packageNames].forEach(name => link(name, destinationDir))
+
+    log(`Successfully linked ${destinationDir} to local version of Picasso.`)
   }
 
   if (yargs.unlink) {
-    log('Unlinking process started...')
+    if (!yargs.unlink.length || !yargs.unlink.trim()) {
+      throw new Error('Please specify target project for unlinking, e.g.: `yarn symlink:off ~/projects/staff-portal`')
+    }
 
-    linkPackages.forEach(({ name }) => unlink(name))
+    const destinationDir = yargs.unlink.trim()
+
+    log('Unlinking Picasso packages...')
+    linkPackages.forEach(({ name }) => unlink(name, picassoRoot))
+
+    log('Removing links...')
     linkPackages.forEach(({ name, outputDir }) => removeLink(name, outputDir))
-    removeLink('react', './node_modules/react')
+    removeReactLinks()
 
     log('Re-running "yarn install" to restore links for workspaces...')
     exec('yarn install --force')
 
-    log('Unlinking process finished.')
+    log('Unlinking the target project...')
+
+    const packageNames = linkPackages.map(({ name }) => `"${name}"`);
+    ['react', '@types/react', ...packageNames].forEach(name => unlink(name, destinationDir))
+
+    log('Restoring packages on target project...')
+    exec('yarn install --force', {
+      cwd: destinationDir,
+      stderr: 'inherit',
+      stdio: 'inherit'
+    })
+
+    log(`Successfully unlinked ${destinationDir} from local version of Picasso.`)
   }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7904,7 +7904,7 @@ debug@^3.0.0, debug@^3.1.0, debug@^3.1.1, debug@^3.2.5, debug@^3.2.6:
   dependencies:
     ms "^2.1.1"
 
-debuglog@*, debuglog@^1.0.1:
+debuglog@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/debuglog/-/debuglog-1.0.1.tgz#aa24ffb9ac3df9a2351837cfb2d279360cd78492"
 
@@ -10830,7 +10830,7 @@ import-local@^3.0.2:
     pkg-dir "^4.2.0"
     resolve-cwd "^3.0.0"
 
-imurmurhash@*, imurmurhash@^0.1.4:
+imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
 
@@ -13203,11 +13203,6 @@ lodash-es@^4.17.15:
   resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.15.tgz#21bd96839354412f23d7a10340e5eac6ee455d78"
   integrity sha512-rlrc3yU3+JNOpZ9zj5pQtxnx2THmvRykwL4Xlxoa8I9lHBlVbbyPhgyPMioxVZ4NqyxaVVtaJnzsyOidQIhyyQ==
 
-lodash._baseindexof@*:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz#fe52b53a1c6761e42618d654e4a25789ed61822c"
-  integrity sha1-/lK1OhxnYeQmGNZU5KJXie1hgiw=
-
 lodash._baseuniq@~4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash._baseuniq/-/lodash._baseuniq-4.6.0.tgz#0ebb44e456814af7905c6212fa2c9b2d51b841e8"
@@ -13215,31 +13210,9 @@ lodash._baseuniq@~4.6.0:
     lodash._createset "~4.0.0"
     lodash._root "~3.0.0"
 
-lodash._bindcallback@*:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz#e531c27644cf8b57a99e17ed95b35c748789392e"
-  integrity sha1-5THCdkTPi1epnhftlbNcdIeJOS4=
-
-lodash._cacheindexof@*:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz#3dc69ac82498d2ee5e3ce56091bafd2adc7bde92"
-  integrity sha1-PcaayCSY0u5ePOVgkbr9Ktx73pI=
-
-lodash._createcache@*:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/lodash._createcache/-/lodash._createcache-3.1.2.tgz#56d6a064017625e79ebca6b8018e17440bdcf093"
-  integrity sha1-VtagZAF2JeeevKa4AY4XRAvc8JM=
-  dependencies:
-    lodash._getnative "^3.0.0"
-
 lodash._createset@~4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/lodash._createset/-/lodash._createset-4.0.3.tgz#0f4659fbb09d75194fa9e2b88a6644d363c9fe26"
-
-lodash._getnative@*, lodash._getnative@^3.0.0:
-  version "3.9.1"
-  resolved "https://registry.yarnpkg.com/lodash._getnative/-/lodash._getnative-3.9.1.tgz#570bc7dede46d61cdcde687d65d3eecbaa3aaff5"
-  integrity sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=
 
 lodash._reinterpolate@^3.0.0:
   version "3.0.0"
@@ -13347,11 +13320,6 @@ lodash.once@^4.0.0, lodash.once@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/lodash.once/-/lodash.once-4.1.1.tgz#0dd3971213c7c56df880977d504c88fb471a97ac"
   integrity sha1-DdOXEhPHxW34gJd9UEyI+0cal6w=
-
-lodash.restparam@*:
-  version "3.6.1"
-  resolved "https://registry.yarnpkg.com/lodash.restparam/-/lodash.restparam-3.6.1.tgz#936a4e309ef330a7645ed4145986c85ae5b20805"
-  integrity sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=
 
 lodash.set@^4.3.2:
   version "4.3.2"
@@ -14760,7 +14728,6 @@ npm@5.1.0, npm@^5.7.1:
     cmd-shim "~2.0.2"
     columnify "~1.5.4"
     config-chain "~1.1.11"
-    debuglog "*"
     detect-indent "~5.0.0"
     detect-newline "^2.1.0"
     dezalgo "~1.0.3"
@@ -14774,7 +14741,6 @@ npm@5.1.0, npm@^5.7.1:
     has-unicode "~2.0.1"
     hosted-git-info "^2.6.0"
     iferr "~0.1.5"
-    imurmurhash "*"
     inflight "~1.0.6"
     inherits "~2.0.3"
     ini "^1.3.5"
@@ -14786,14 +14752,8 @@ npm@5.1.0, npm@^5.7.1:
     libnpx "^10.2.0"
     lock-verify "^2.0.2"
     lockfile "^1.0.4"
-    lodash._baseindexof "*"
     lodash._baseuniq "~4.6.0"
-    lodash._bindcallback "*"
-    lodash._cacheindexof "*"
-    lodash._createcache "*"
-    lodash._getnative "*"
     lodash.clonedeep "~4.5.0"
-    lodash.restparam "*"
     lodash.union "~4.6.0"
     lodash.uniq "~4.5.0"
     lodash.without "~4.4.0"
@@ -14831,7 +14791,6 @@ npm@5.1.0, npm@^5.7.1:
     read-package-json "^2.0.13"
     read-package-tree "^5.2.1"
     readable-stream "^2.3.6"
-    readdir-scoped-modules "*"
     request "^2.85.0"
     retry "^0.12.0"
     rimraf "~2.6.2"
@@ -17109,7 +17068,7 @@ readable-stream@~1.1.10:
     isarray "0.0.1"
     string_decoder "~0.10.x"
 
-readdir-scoped-modules@*, readdir-scoped-modules@^1.0.0:
+readdir-scoped-modules@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/readdir-scoped-modules/-/readdir-scoped-modules-1.1.0.tgz#8d45407b4f870a0dcaebc0e28670d18e74514309"
   integrity sha512-asaikDeqAQg7JifRsZn1NJZXo9E+VwlyCfbkZhwyISinqk5zNS6266HS5kah6P0SaQKGF6SkNnZVHUzHFYxYDw==


### PR DESCRIPTION
[FX-X]

### Description

Symlinking to local version of Picasso is broken. This PR addresses the issue:

1) React types have to be linked too, without this types are incompatible and a lot of type errors pop up
2) We have to link all of the Picasso packages. In either way we get a successful build, but Material UI library is going to be included twice from different locations and UI will be broken with the following error:

<img width="679" alt="Снимок экрана 2020-08-25 в 18 12 07" src="https://user-images.githubusercontent.com/763624/91224992-8e959880-e72b-11ea-9597-371454601dc3.png">

We simplify the whole process by allowing to specify target project when using `yarn symlink` script (by analogy with `billing-frontend` repo). This way we perform all symlinking with a single command (e.g. `yarn symlink ~projects/staff-portal`).

One more thing. I've removed build stage from symlinking command to make it faster and to make emphasize on separate usage of `yarn build:dist` command which may be used once packages are built and symlinked the very first time. **upd: last statement is false, subsequent build are still problematic**

### Review

- [ ] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/api-principles.md)
- [ ] Make sure you've converted all `js/jsx` file into `ts/tsx` in your PR
- [ ] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that unit tests pass by running `yarn test`
- [ ] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run  whole pipeline
- `@toptal-bot run danger` - Danger checks
- `@toptal-bot run lint` - Run linter
- `@toptal-bot run test` - Run jest
- `@toptal-bot run build` - Check build
- `@toptal-bot run test:visual` or `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation


</details>
