### PR TITLE
fix(Form): improve form errors scrolling

### DIFF
--- a/packages/picasso-forms/src/Form/Form.tsx
+++ b/packages/picasso-forms/src/Form/Form.tsx
@@ -67,14 +67,13 @@ export const Form = <T extends any = AnyObject>(props: Props<T>) => {
     onSubmit,
     successSubmitMessage,
     failedSubmitMessage,
-    scrollOffsetTop,
     decorators = [],
     ...rest
   } = props
   const { showSuccess, showError } = useNotifications()
   const scrollToErrorDecorator = useMemo(
-    () => createScrollToErrorDecorator({ scrollOffsetTop }),
-    [scrollOffsetTop]
+    () => createScrollToErrorDecorator(),
+    []
   )
 
   const validationObject = useRef<FormContextProps>(createFormContext())

--- a/packages/picasso-forms/src/Form/story/index.jsx
+++ b/packages/picasso-forms/src/Form/story/index.jsx
@@ -104,7 +104,7 @@ page
         name: 'scrollOffsetTop',
         type: 'number',
         description:
-          'Offset from the viewport for inputs to focus on, defaults to the center of the window'
+          'Offset from the viewport for inputs to focus on, defaults to the center of the window (deprecated, will not have any effect)'
       }
     }
   })

--- a/packages/picasso-forms/src/utils/scroll-to-error-decorator.ts
+++ b/packages/picasso-forms/src/utils/scroll-to-error-decorator.ts
@@ -2,19 +2,6 @@ import { FormApi, getIn } from 'final-form'
 
 import flatMap from './flat-map'
 
-const getDefaultScrollOffsetTop = () => {
-  if (!window) return 0
-  return window.innerHeight / 2 - 50
-}
-
-const scrollTo = (options: ScrollToOptions) => {
-  try {
-    window.scrollTo(options)
-  } catch {
-    window.scrollTo(options.left ?? 0, options.top ?? 0)
-  }
-}
-
 const formInputs = (form: HTMLFormElement) =>
   Array.from(form.elements).filter(
     element =>
@@ -29,21 +16,15 @@ const getInputs = (): HTMLInputElement[] => {
 const findInputWithError = (inputs: HTMLInputElement[], errors: {}) =>
   inputs.find(input => input.name && getIn(errors, input.name))
 
-const scrollToError = (offsetTop: number, errors: object) => {
+const scrollToError = (errors: object) => {
   const firstInput = findInputWithError(getInputs(), errors)
   if (!firstInput) return
 
   firstInput.focus({ preventScroll: true })
-  const top =
-    firstInput.getBoundingClientRect().top + window.pageYOffset - offsetTop
-  scrollTo({ top, behavior: 'smooth' })
+  firstInput.scrollIntoView({ block: 'center', behavior: 'smooth' })
 }
 
-export default ({
-  scrollOffsetTop = getDefaultScrollOffsetTop()
-}: {
-  scrollOffsetTop?: number
-}) => <T>(form: FormApi<T>) => {
+export default () => <T>(form: FormApi<T>) => {
   const originalSubmit = form.submit
   let state: { errors?: object; submitErrors?: object } = {}
 
@@ -57,9 +38,9 @@ export default ({
   const scrollOnErrors = () => {
     const { errors = {}, submitErrors = {} } = state
     if (Object.keys(errors).length) {
-      scrollToError(scrollOffsetTop, errors)
+      scrollToError(errors)
     } else if (Object.keys(submitErrors).length) {
-      scrollToError(scrollOffsetTop, submitErrors)
+      scrollToError(submitErrors)
     }
   }
 


### PR DESCRIPTION
[SPT-854]

### Description

Error scrolling is broken when error happens inside modal windows. Whole window is being scrolled instead of the modal scrollable area:

![BlackFlagModal_Backgroundscroll](https://user-images.githubusercontent.com/763624/91322938-f9e17800-e7c8-11ea-99ef-9a7fd788a68d.gif)

I've replaced the scrolling logic with `Element.scrollIntoView` method which is very flexible and convinient. I also added ability to pass custom options to this method. I've removed `scrollOffsetTop` setting from the codebase even though I've left it in public API (not to break versioning and just in case). I haven't find any usages of this prop in `staff-portal`, `billing-frontend` and `chronicles-frontend`.

We can control this scrolling offset with `scroll-padding-top` style which should be applied to scrollable element. It is supported by all major browsers and works really nice. (Previously this offset was hardcoded as `50px` value).

Previous default scrolling behavior was preserved. Form will be scrolled so that error input will be located in the center of the viewport.

### Screenshots

![error1](https://user-images.githubusercontent.com/763624/91323329-6fe5df00-e7c9-11ea-87ed-d962a0211cd8.gif)

![error2](https://user-images.githubusercontent.com/763624/91323335-72e0cf80-e7c9-11ea-99af-87496551455e.gif)


### Review

- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/api-principles.md)
- [ ] Make sure you've converted all `js/jsx` file into `ts/tsx` in your PR
- [x] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure that unit tests pass by running `yarn test`
- [x] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run  whole pipeline
- `@toptal-bot run danger` - Danger checks
- `@toptal-bot run lint` - Run linter
- `@toptal-bot run test` - Run jest
- `@toptal-bot run build` - Check build
- `@toptal-bot run test:visual` or `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation


</details>


[SPT-854]: https://toptal-core.atlassian.net/browse/SPT-854