### PR TITLE
fix(Select): remove onMouseEnter for SelectOption

### DIFF
--- a/packages/picasso/src/Select/Select.tsx
+++ b/packages/picasso/src/Select/Select.tsx
@@ -186,8 +186,6 @@ interface SelectOptionProps {
   checkmarked: boolean
   multiple?: boolean
   size?: SizeType<'small' | 'medium'>
-  index: number
-  setHighlightedIndex: OptionsProps['setHighlightedIndex']
   onItemSelect: OptionsProps['onItemSelect']
   option: Option
 }
@@ -199,8 +197,6 @@ const SelectOption = React.memo(
     onMouseDown,
     selected,
     checkmarked,
-    setHighlightedIndex,
-    index,
     onItemSelect,
     multiple,
     children,
@@ -215,13 +211,6 @@ const SelectOption = React.memo(
         selected={selected}
         checkmarked={checkmarked}
         onMouseDown={onMouseDown}
-        onMouseEnter={() => {
-          if (selected) {
-            return
-          }
-
-          setHighlightedIndex(index)
-        }}
         onClick={(event: React.MouseEvent) => {
           if (!multiple) {
             close()
@@ -305,7 +294,6 @@ const renderOptions = ({
   options,
   renderOption,
   highlightedIndex,
-  setHighlightedIndex,
   onItemSelect,
   getItemProps,
   value,
@@ -338,8 +326,6 @@ const renderOptions = ({
           highlightedIndex === currentIndex
         }
         checkmarked={selection.isOptionCheckmarked(option)}
-        setHighlightedIndex={setHighlightedIndex}
-        index={currentIndex}
         multiple={multiple}
         close={close}
         onItemSelect={onItemSelect}

--- a/packages/picasso/src/Select/useSelect.ts
+++ b/packages/picasso/src/Select/useSelect.ts
@@ -12,7 +12,6 @@ import { Option } from './types'
 export type ItemProps = {
   role: string
   'aria-selected': boolean
-  onMouseEnter: () => void
   onMouseDown: (event: React.MouseEvent) => void
   close: () => void
   onClick: (event: React.MouseEvent) => void
@@ -142,13 +141,6 @@ const useSelect = ({
   const getItemProps = (index: number, item: Option): ItemProps => ({
     role: 'option',
     'aria-selected': highlightedIndex === index,
-    onMouseEnter: () => {
-      if (index === highlightedIndex) {
-        return
-      }
-
-      setHighlightedIndex(index)
-    },
     onMouseDown,
     close,
     onClick: (event: React.MouseEvent) => {


### PR DESCRIPTION
[SP-1033](https://toptal-core.atlassian.net/browse/SP-1033)

### Description

Fix scrolling in select options. Please check the screencasts.

I found that `onMouseEnter` handler is not needed as we already show hover state using css in `MenuItem` component. So it was removed to reduce extra rendering upon `mouseenter` event when we scroll inside the options list.

### How to test

- Go to `Select` story
- Update the Default example with a list of long options
- Check the scrolling

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| ![brokenselect](https://user-images.githubusercontent.com/18625278/91698151-721ab580-eb9c-11ea-88b8-13b7c1f4353f.gif) | ![fixedselect](https://user-images.githubusercontent.com/18625278/91698171-7941c380-eb9c-11ea-909e-e99a3be431a6.gif) |

### Review

- [ ] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/api-principles.md)
- [ ] Make sure you've converted all `js/jsx` file into `ts/tsx` in your PR
- [ ] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that unit tests pass by running `yarn test`
- [ ] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run  whole pipeline
- `@toptal-bot run danger` - Danger checks
- `@toptal-bot run lint` - Run linter
- `@toptal-bot run test` - Run jest
- `@toptal-bot run build` - Check build
- `@toptal-bot run test:visual` or `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation


</details>
