### PR TITLE
fix(Select): [SPT-888] Fix scroll issue for Select

### DIFF
--- a/packages/picasso/src/ScrollMenu/ScrollMenu.tsx
+++ b/packages/picasso/src/ScrollMenu/ScrollMenu.tsx
@@ -12,8 +12,11 @@ import { StandardProps } from '@toptal/picasso-shared'
 import Menu from '../Menu'
 import styles from './styles'
 
+type FocusEventType = (event: React.FocusEvent<HTMLInputElement>) => void
+
 export interface Props extends StandardProps {
   selectedIndex?: number | null
+  onBlur?: FocusEventType
 }
 
 enum Direction {
@@ -37,6 +40,7 @@ const getMoveDirection = (
 
 const ScrollMenu: FunctionComponent<Props> = ({
   selectedIndex,
+  onBlur,
   classes,
   children,
   style
@@ -95,7 +99,7 @@ const ScrollMenu: FunctionComponent<Props> = ({
 
   return (
     <Menu className={classes.menu} style={style}>
-      <div ref={menuRef} className={classes.scrollView}>
+      <div ref={menuRef} className={classes.scrollView} onBlur={onBlur}>
         {renderChildren}
       </div>
     </Menu>

--- a/packages/picasso/src/ScrollMenu/styles.ts
+++ b/packages/picasso/src/ScrollMenu/styles.ts
@@ -8,6 +8,7 @@ export default ({ palette, screens }: Theme) =>
     scrollView: {
       maxHeight: '14.75rem', // 6.5 lines of menu to show
       overflowY: 'auto',
+      outline: 'none',
 
       [screens('small', 'medium')]: {
         maxHeight: '14.75rem' // 6.5 lines of menu to show

--- a/packages/picasso/src/Select/useSelect.ts
+++ b/packages/picasso/src/Select/useSelect.ts
@@ -28,6 +28,7 @@ const normalizeArrowKey = (event: KeyboardEvent<HTMLInputElement>) => {
   if (keyCode >= 37 && keyCode <= 40 && key.indexOf('Arrow') !== 0) {
     return `Arrow${key}`
   }
+
   return key
 }
 
@@ -68,6 +69,8 @@ const getNextWrappingIndex = (
   return newIndex
 }
 
+export type FocusEventType = (event: React.FocusEvent<HTMLInputElement>) => void
+
 interface Props {
   value: string
   options?: Option[]
@@ -80,8 +83,8 @@ interface Props {
     event: KeyboardEvent<HTMLInputElement>,
     inputValue: string
   ) => void
-  onBlur?: (event: React.FocusEvent<HTMLInputElement>) => void
-  onFocus?: (event: React.FocusEvent<HTMLInputElement>) => void
+  onBlur?: FocusEventType
+  onFocus?: FocusEventType
 }
 
 type GetInputProps = ({
@@ -92,10 +95,10 @@ type GetInputProps = ({
   HTMLAttributes<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>
 >
 
-type GetRootProps = () => {
-  onFocus: (event: React.FocusEvent<HTMLInputElement>) => void
+export type GetRootProps = () => {
+  onFocus: FocusEventType
   onClick: (event: React.MouseEvent<HTMLInputElement>) => void
-  onBlur: (event: React.FocusEvent<HTMLInputElement>) => void
+  onBlur: FocusEventType
 }
 
 interface UseSelectOutput {
@@ -169,6 +172,7 @@ const useSelect = ({
   }
 
   const handleBlur = (event: React.FocusEvent<HTMLInputElement>) => {
+    if (event.relatedTarget) return
     setOpen(false)
     onBlur(event)
   }


### PR DESCRIPTION
[SPT-888]

### Description

Fix scroll issue for Select component

**Problem**

When a list has many options and there is a scroller -- the list is being hidden when you click on the scroller.

### How to test

- Go to `Select` section on StoryBook
- Find the Default Example
- Open the dropdown menu
- Try to scroll

**Acceptance criteria**

- It's possible to scroll
- list is hidden when loses the focus

### Screenshots

<img width="266" alt="Screen Shot 2020-09-01 at 17 30 26" src="https://user-images.githubusercontent.com/496713/91865367-ff800780-ec79-11ea-8765-87913965eb90.png">


### Review

- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/api-principles.md)
-  Make sure you've converted all `js/jsx` file into `ts/tsx` in your PR
-  Annotate all `props` in component with documentation
-  Create `examples` for component
-  Ensure that deployed demo has expected results and good examples
- Ensure that unit tests pass by running `yarn test`
-  Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run  whole pipeline
- `@toptal-bot run danger` - Danger checks
- `@toptal-bot run lint` - Run linter
- `@toptal-bot run test` - Run jest
- `@toptal-bot run build` - Check build
- `@toptal-bot run test:visual` or `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation


</details>


[SPT-888]: https://toptal-core.atlassian.net/browse/SPT-888