### PR TITLE
Revert "fix(Select): fix scrolling for Select (#1539)"

### DIFF
--- a/packages/picasso/src/ScrollMenu/ScrollMenu.tsx
+++ b/packages/picasso/src/ScrollMenu/ScrollMenu.tsx
@@ -12,11 +12,8 @@ import { StandardProps } from '@toptal/picasso-shared'
 import Menu from '../Menu'
 import styles from './styles'
 
-type FocusEventType = (event: React.FocusEvent<HTMLInputElement>) => void
-
 export interface Props extends StandardProps {
   selectedIndex?: number | null
-  onBlur?: FocusEventType
 }
 
 enum Direction {
@@ -40,7 +37,6 @@ const getMoveDirection = (
 
 const ScrollMenu: FunctionComponent<Props> = ({
   selectedIndex,
-  onBlur,
   classes,
   children,
   style
@@ -99,7 +95,7 @@ const ScrollMenu: FunctionComponent<Props> = ({
 
   return (
     <Menu className={classes.menu} style={style}>
-      <div ref={menuRef} className={classes.scrollView} onBlur={onBlur}>
+      <div ref={menuRef} className={classes.scrollView}>
         {renderChildren}
       </div>
     </Menu>

--- a/packages/picasso/src/ScrollMenu/styles.ts
+++ b/packages/picasso/src/ScrollMenu/styles.ts
@@ -8,7 +8,6 @@ export default ({ palette, screens }: Theme) =>
     scrollView: {
       maxHeight: '14.75rem', // 6.5 lines of menu to show
       overflowY: 'auto',
-      outline: 'none',
 
       [screens('small', 'medium')]: {
         maxHeight: '14.75rem' // 6.5 lines of menu to show

--- a/packages/picasso/src/Select/Select.tsx
+++ b/packages/picasso/src/Select/Select.tsx
@@ -24,11 +24,7 @@ import { DropdownArrows16 } from '../Icon'
 import { isSubstring, disableUnsupportedProps } from '../utils'
 import { FeatureOptions } from '../utils/disable-unsupported-props'
 import { Option } from './types'
-import useSelect, {
-  EMPTY_INPUT_VALUE,
-  ItemProps,
-  FocusEventType
-} from './useSelect'
+import useSelect, { EMPTY_INPUT_VALUE, ItemProps } from './useSelect'
 import styles from './styles'
 import { documentable, forwardRef } from '../utils/forward-ref'
 
@@ -146,7 +142,6 @@ type OptionsProps = Pick<
   inputValue: string
   setHighlightedIndex: (index: number | null) => void
   getItemProps: (index: number, option: Option) => ItemProps
-  onBlur?: FocusEventType
   onItemSelect: (event: React.MouseEvent, option: Option) => void
 }
 
@@ -286,7 +281,6 @@ const removeDuplicatedOptions = (options: Option[]) =>
     const innerIndex = options.findIndex(
       innerOption => innerOption.value === option.value
     )
-
     return innerIndex === index
   })
 
@@ -314,7 +308,6 @@ const renderOptions = ({
   setHighlightedIndex,
   onItemSelect,
   getItemProps,
-  onBlur,
   value,
   multiple,
   size,
@@ -334,7 +327,6 @@ const renderOptions = ({
   const optionComponents = options.map((option, currentIndex) => {
     const { close, onMouseDown } = getItemProps(currentIndex, option)
     const selection = getSelection(options, value)
-
     return (
       <SelectOption
         key={option.key || option.value}
@@ -358,9 +350,7 @@ const renderOptions = ({
   })
 
   return (
-    <ScrollMenu onBlur={onBlur} selectedIndex={highlightedIndex}>
-      {optionComponents}
-    </ScrollMenu>
+    <ScrollMenu selectedIndex={highlightedIndex}>{optionComponents}</ScrollMenu>
   )
 }
 
@@ -442,13 +432,11 @@ export const Select = documentable(
       )
 
       const prevValue = useRef(value)
-
       if (prevValue.current !== value) {
         const select = getSelection(
           removeDuplicatedOptions([...allOptions, ...selectedOptions]),
           value
         )
-
         setInputValue(select.display(getDisplayValue!))
         prevValue.current = value
       }
@@ -501,7 +489,6 @@ export const Select = documentable(
         if (isInSelectedValues) {
           return value!.filter(value => value !== option.value)
         }
-
         return [...value, String(option.value)]
       }
       const handleSelect = useCallback(
@@ -637,13 +624,11 @@ export const Select = documentable(
         </NativeSelect>
       )
 
-      const rootProps = getRootProps()
-
       const selectComponent = (
         <>
           <div
             /* eslint-disable-next-line react/jsx-props-no-spreading */
-            {...rootProps}
+            {...getRootProps()}
             className={classes.inputWrapper}
           >
             {!enableAutofill && !native && name && (
@@ -703,9 +688,8 @@ export const Select = documentable(
                   renderOption,
                   highlightedIndex,
                   setHighlightedIndex,
-                  getItemProps,
                   onItemSelect: handleSelect,
-                  onBlur: rootProps.onBlur,
+                  getItemProps,
                   value,
                   getDisplayValue,
                   multiple,

--- a/packages/picasso/src/Select/useSelect.ts
+++ b/packages/picasso/src/Select/useSelect.ts
@@ -28,7 +28,6 @@ const normalizeArrowKey = (event: KeyboardEvent<HTMLInputElement>) => {
   if (keyCode >= 37 && keyCode <= 40 && key.indexOf('Arrow') !== 0) {
     return `Arrow${key}`
   }
-
   return key
 }
 
@@ -69,8 +68,6 @@ const getNextWrappingIndex = (
   return newIndex
 }
 
-export type FocusEventType = (event: React.FocusEvent<HTMLInputElement>) => void
-
 interface Props {
   value: string
   options?: Option[]
@@ -83,8 +80,8 @@ interface Props {
     event: KeyboardEvent<HTMLInputElement>,
     inputValue: string
   ) => void
-  onBlur?: FocusEventType
-  onFocus?: FocusEventType
+  onBlur?: (event: React.FocusEvent<HTMLInputElement>) => void
+  onFocus?: (event: React.FocusEvent<HTMLInputElement>) => void
 }
 
 type GetInputProps = ({
@@ -95,10 +92,10 @@ type GetInputProps = ({
   HTMLAttributes<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>
 >
 
-export type GetRootProps = () => {
-  onFocus: FocusEventType
+type GetRootProps = () => {
+  onFocus: (event: React.FocusEvent<HTMLInputElement>) => void
   onClick: (event: React.MouseEvent<HTMLInputElement>) => void
-  onBlur: FocusEventType
+  onBlur: (event: React.FocusEvent<HTMLInputElement>) => void
 }
 
 interface UseSelectOutput {
@@ -172,7 +169,6 @@ const useSelect = ({
   }
 
   const handleBlur = (event: React.FocusEvent<HTMLInputElement>) => {
-    if (event.relatedTarget) return
     setOpen(false)
     onBlur(event)
   }


### PR DESCRIPTION
This reverts commit e9ba8e470e258934f71e04eb7962f8c49bb43052.

[SPT-888]

### Description

The fix worked well. Mostly.

Unfortunately after the merge we found a bug with using `Tab` button.
If you leave an input with using `Tab` -- a dropdown menu is not being hidden.

[SPT-888]: https://toptal-core.atlassian.net/browse/SPT-888