### PR TITLE
feat(TreeNodeAvatar): add size variant to component

### DIFF
--- a/packages/picasso-lab/src/TreeView/PointNode/TreeNodeAvatar.tsx
+++ b/packages/picasso-lab/src/TreeView/PointNode/TreeNodeAvatar.tsx
@@ -1,7 +1,7 @@
 import React, { FC } from 'react'
 import { Theme, makeStyles } from '@material-ui/core/styles'
 import getNameInitials from '@toptal/picasso/utils/get-name-initials'
-import { JssProps } from '@toptal/picasso-shared'
+import { JssProps, SizeType } from '@toptal/picasso-shared'
 
 import styles from './styles'
 
@@ -10,6 +10,8 @@ export interface Props {
   name: string
   /** Photo url */
   src?: string
+  /** A avatar can have different sizes */
+  size?: SizeType<'xxsmall' | 'xsmall' | 'small' | 'medium' | 'large'>
 }
 
 const useStyles = makeStyles<Theme, Props>(styles, {
@@ -35,12 +37,21 @@ const renderInitials = ({ src, name, classes }: Partial<Props> & JssProps) => {
   )
 }
 
+const sizeValues = {
+  xxsmall: '32',
+  xsmall: '40',
+  small: '80',
+  medium: '120',
+  large: '160'
+}
+
 export const TreeNodeAvatar: FC<Props> = props => {
   const classes = useStyles(props)
-  const { name, src } = props
+  const { name, src, size } = props
+  const sizeValue = sizeValues[size!]
 
   return (
-    <svg width='40' height='40'>
+    <svg width={sizeValue} height={sizeValue} viewBox='0 0 40 40'>
       <g>
         {src && (
           <image
@@ -62,3 +73,9 @@ export const TreeNodeAvatar: FC<Props> = props => {
     </svg>
   )
 }
+
+TreeNodeAvatar.defaultProps = {
+  size: 'xxsmall'
+}
+
+TreeNodeAvatar.displayName = 'TreeNodeAvatar'

--- a/packages/picasso-lab/src/TreeView/story/AvatarSize.example.tsx
+++ b/packages/picasso-lab/src/TreeView/story/AvatarSize.example.tsx
@@ -1,0 +1,104 @@
+import React from 'react'
+import {
+  TreeView,
+  TreeNodeInterface,
+  TreeNodeAvatar
+} from '@toptal/picasso-lab'
+import { Container, UserBadge } from '@toptal/picasso'
+import { HierarchyPointNode } from 'd3-hierarchy'
+import styled from 'styled-components'
+import { palette } from '@toptal/picasso/utils'
+
+const NodeContainer = styled<typeof Container>(Container)<{
+  selected?: boolean
+}>`
+  display: flex;
+  alignitems: center;
+  width: 236px;
+  padding: 0.5rem;
+  ${({ selected }) =>
+    `border: 1px solid ${selected ? palette.blue.main : palette.grey.light};`}
+`
+
+const createTreeNode = (
+  override: Partial<TreeNodeInterface> = {}
+): TreeNodeInterface => {
+  return {
+    id: '1',
+    disabled: false,
+    selected: false,
+    children: [],
+    info: {
+      name: 'NODE+NAME+1'
+    },
+    ...override
+  }
+}
+
+const rootNode = createTreeNode({
+  id: '1',
+  selected: true,
+  selectedOffset: {
+    y: 150
+  },
+  info: {
+    name: 'NODE+1',
+    size: 'xxsmall'
+  },
+  children: [
+    createTreeNode({
+      id: '1.2',
+      info: {
+        name: 'NODE+2',
+        size: 'xsmall'
+      }
+    }),
+    createTreeNode({
+      id: '1.3',
+      info: {
+        name: 'NODE+3',
+        size: 'small'
+      }
+    }),
+    createTreeNode({
+      id: '1.4',
+      info: {
+        name: 'NODE+4',
+        size: 'medium'
+      }
+    }),
+    createTreeNode({
+      id: '1.5',
+      info: {
+        name: 'NODE+5',
+        size: 'large'
+      }
+    })
+  ]
+})
+
+const renderNode = (pointNode: HierarchyPointNode<TreeNodeInterface>) => {
+  return (
+    <NodeContainer>
+      <UserBadge
+        name={pointNode.data.info.size}
+        avatar={
+          <TreeNodeAvatar
+            name={pointNode.data.info.name}
+            size={pointNode.data.info.size}
+          />
+        }
+      />
+    </NodeContainer>
+  )
+}
+
+const Example = () => (
+  <div>
+    <Container style={{ height: '300px' }}>
+      <TreeView data={rootNode} renderNode={renderNode} initialScale={0.8} />
+    </Container>
+  </div>
+)
+
+export default Example

--- a/packages/picasso-lab/src/TreeView/story/Default.example.tsx
+++ b/packages/picasso-lab/src/TreeView/story/Default.example.tsx
@@ -172,7 +172,9 @@ const renderNode = (pointNode: HierarchyPointNode<TreeNodeInterface>) => {
     <NodeContainer>
       <UserBadge
         name={pointNode.data.info.name}
-        avatar={<TreeNodeAvatar name={pointNode.data.info.name} />}
+        avatar={
+          <TreeNodeAvatar name={pointNode.data.info.name} size='xsmall' />
+        }
       />
     </NodeContainer>
   )

--- a/packages/picasso-lab/src/TreeView/story/index.tsx
+++ b/packages/picasso-lab/src/TreeView/story/index.tsx
@@ -22,3 +22,4 @@ page
   })
   .addExample('TreeView/story/Modal.example.tsx', 'With Modal')
   .addExample('TreeView/story/CustomZoom.example.tsx', 'Custom Zoom')
+  .addExample('TreeView/story/AvatarSize.example.tsx', 'Avatar Size')


### PR DESCRIPTION
[SPC-511]

### Description

This component is only used inside a `TreeView`. Sizes are similar to the `Avatar` component.

### How to test

- Check `TreeNodeAvatar` sizes on [TreeView examples](https://picasso.toptal.net/add-size-variant-tree-node-avatar/?path=/story/lab-folder--treeview#avatar-size)

### Screenshots
N/A

### Review

- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/api-principles.md)
- [x] Make sure you've converted all `js/jsx` file into `ts/tsx` in your PR
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [x] Ensure that unit tests pass by running `yarn test`
- [ ] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run  whole pipeline
- `@toptal-bot run danger` - Danger checks
- `@toptal-bot run lint` - Run linter
- `@toptal-bot run test` - Run jest
- `@toptal-bot run build` - Check build
- `@toptal-bot run test:visual` or `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation


</details>


[SPC-511]: https://toptal-core.atlassian.net/browse/SPC-511