### PR TITLE
feat(Autocomplete): pass event in Autocomplete onSelect

### DIFF
--- a/packages/picasso/src/Autocomplete/Autocomplete.tsx
+++ b/packages/picasso/src/Autocomplete/Autocomplete.tsx
@@ -7,7 +7,8 @@ import React, {
   ReactNode,
   ComponentType,
   useRef,
-  FocusEventHandler
+  FocusEventHandler,
+  MouseEvent
 } from 'react'
 import { withStyles } from '@material-ui/core/styles'
 import capitalize from '@material-ui/core/utils/capitalize'
@@ -37,9 +38,12 @@ export interface Props
   /** The value of the selected option, required for a controlled component. */
   value: string
   /**  Callback invoked when selection changes */
-  onSelect?: (item: Item) => void
+  onSelect?: (item: Item, event: MouseEvent | KeyboardEvent) => void
   /**  Callback invoked when other option selected */
-  onOtherOptionSelect?: (value: string) => void
+  onOtherOptionSelect?: (
+    value: string,
+    event: MouseEvent | KeyboardEvent
+  ) => void
   /** Placeholder for value */
   placeholder?: string
   /** Text prefix for other option */

--- a/packages/picasso/src/Autocomplete/test.tsx
+++ b/packages/picasso/src/Autocomplete/test.tsx
@@ -30,6 +30,7 @@ const renderAutocomplete = (
 }
 
 let spiedOnTitleCase: jest.SpyInstance
+
 beforeEach(() => {
   spiedOnTitleCase = jest.spyOn(titleCaseModule, 'default')
 })
@@ -115,13 +116,14 @@ describe('Autocomplete', () => {
       const input = getByPlaceholderText(placeholder) as HTMLInputElement
 
       fireEvent.focus(input)
+
       fireEvent.click(getByText('Slovakia'))
 
       const optionSlovakia = testOptions.find(
         option => option.text === 'Slovakia'
       )
 
-      expect(onSelect).toBeCalledWith(optionSlovakia)
+      expect(onSelect).toBeCalledWith(optionSlovakia, expect.anything())
       expect(onChange).toBeCalledWith('Slovakia', { isSelected: true })
     })
 
@@ -223,7 +225,10 @@ describe('Autocomplete', () => {
           key: 'Enter'
         })
 
-        expect(onOtherOptionSelect).toBeCalledWith('Other option!')
+        expect(onOtherOptionSelect).toBeCalledWith(
+          'Other option!',
+          expect.anything()
+        )
       })
     })
   })
@@ -300,6 +305,7 @@ describe('Autocomplete', () => {
     )
 
     const input = getByPlaceholderText(placeholder)
+
     fireEvent.focus(input)
 
     expect(spiedOnTitleCase).toBeCalledTimes(0)

--- a/packages/picasso/src/Autocomplete/useAutocomplete.ts
+++ b/packages/picasso/src/Autocomplete/useAutocomplete.ts
@@ -1,6 +1,7 @@
 /* eslint-disable complexity, max-statements */ // Squiggly lines makes code difficult to work with
 
 import {
+  MouseEvent,
   KeyboardEvent,
   useState,
   ChangeEvent,
@@ -20,6 +21,7 @@ const normalizeArrowKey = (event: KeyboardEvent<HTMLInputElement>) => {
   if (keyCode >= 37 && keyCode <= 40 && key.indexOf('Arrow') !== 0) {
     return `Arrow${key}`
   }
+
   return key
 }
 
@@ -63,8 +65,11 @@ const getNextWrappingIndex = (
 interface Props {
   value: string
   options?: Item[] | null
-  onSelect?: (item: Item) => void
-  onOtherOptionSelect?: (value: string) => void
+  onSelect?: (item: Item, event: MouseEvent | KeyboardEvent) => void
+  onOtherOptionSelect?: (
+    value: string,
+    event: MouseEvent | KeyboardEvent
+  ) => void
   onChange?: (value: string, options: ChangedOptions) => void
   onKeyDown?: (
     event: KeyboardEvent<HTMLInputElement>,
@@ -109,14 +114,17 @@ const useAutocomplete = ({
     }
   }
 
-  const handleSelect = (item: Item | null) => {
+  const handleSelect = (
+    item: Item | null,
+    event: MouseEvent | KeyboardEvent
+  ) => {
     const displayValue = getDisplayValue(item)
 
     if (item === null || displayValue === null) {
       return
     }
 
-    onSelect(item)
+    onSelect(item, event)
   }
 
   const getBaseItemProps = (index: number) => ({
@@ -140,18 +148,18 @@ const useAutocomplete = ({
 
   const getItemProps = (index: number, item: Item) => ({
     ...getBaseItemProps(index),
-    onClick: () => {
+    onClick: (event: MouseEvent) => {
       setOpen(false)
       handleChange(getDisplayValue(item), true)
-      handleSelect(item)
+      handleSelect(item, event)
     }
   })
 
   const getOtherItemProps = (index: number, newValue: string) => ({
     ...getBaseItemProps(index),
-    onClick: () => {
+    onClick: (event: MouseEvent) => {
       setOpen(false)
-      onOtherOptionSelect(newValue)
+      onOtherOptionSelect(newValue, event)
     }
   })
 
@@ -237,9 +245,9 @@ const useAutocomplete = ({
 
         if (selectedItem) {
           handleChange(getDisplayValue(selectedItem), true)
-          handleSelect(selectedItem)
+          handleSelect(selectedItem, event)
         } else if (value) {
-          onOtherOptionSelect(value)
+          onOtherOptionSelect(value, event)
         }
       }
 


### PR DESCRIPTION
No FX JIRA ticket. Staff Portal ticket: [SPC-521](https://toptal-core.atlassian.net/browse/SPC-521)

### Description

The `onSelect` callback in `Autocomplete` needs to have an original event passed. The Staff Portal `UserSearch` autocomplete results are supposed to respond to the following events:
- regular click (navigating to the result’s page)
- a middle button click (opening result’s page in a separate tab)
- ctrl / command + click (opening result’s page in a separate tab)
- enter pressing (navigating to the result’s page)
This way the actual redirect has to happen in `onSelect` handler to support all of the events, but the information about the actual event that triggered the selection is missing (the `KeyboardEvent` or `MouseEvent` might help with determining the actual combination that was used).

This way the `Autocomplete` needs to pass the event parameter.

This topic was also discussed in https://toptal-core.slack.com/archives/CERF5NHT3/p1599140092387100.

### How to test

- [open the Storybook](https://picasso.toptal.net/pass-events-to-onSelect/?path=/story/forms-folder--autocomplete);
- make sure that the following code logs the `Mouse` or `Keyboard` event on `Autocomplete` option selection:

```
import React, { useState } from 'react'
import { Autocomplete, Form } from '@toptal/picasso'
import { isSubstring } from '@toptal/picasso/utils'

const allOptions = [
  { text: 'Belarus' },
  { text: 'Croatia' }
]

const EMPTY_INPUT_VALUE = ''
const getDisplayValue = item => (item ? item.text : EMPTY_INPUT_VALUE)

const Example = () => {
  const [value, setValue] = useState(EMPTY_INPUT_VALUE)
  const [options, setOptions] = useState(allOptions)

  return (
    <div>
      <Form autoComplete='off'>
        <Autocomplete
          value={value}
          options={options}
          onSelect={(item, event) => {
            console.log('onSelect returns item object and event:', item, event)

            const itemValue = getDisplayValue(item)
            if (value !== itemValue) {
              setValue(itemValue)
            }
          }}
          onChange={setValue}
          getDisplayValue={getDisplayValue}
        />
      </Form>
    </div>
  )
}

export default Example
```

MouseEvent:

<img width="646" alt="Screenshot 2020-09-04 at 12 01 03" src="https://user-images.githubusercontent.com/1390758/92198196-5702bb00-eea6-11ea-972e-1d8dd6bb97bd.png">

KeyboardEvent:

<img width="639" alt="Screenshot 2020-09-04 at 12 01 08" src="https://user-images.githubusercontent.com/1390758/92198199-58cc7e80-eea6-11ea-9fa5-e67683e91c64.png">

### Screenshots

No visual or behavior changes.

### Review

- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/api-principles.md)
- [x] Make sure you've converted all `js/jsx` file into `ts/tsx` in your PR
- [x] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure that unit tests pass by running `yarn test`
- [ ] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run  whole pipeline
- `@toptal-bot run danger` - Danger checks
- `@toptal-bot run lint` - Run linter
- `@toptal-bot run test` - Run jest
- `@toptal-bot run build` - Check build
- `@toptal-bot run test:visual` or `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation


</details>
