### PR TITLE
fix(Select): fix select behavior on-blur

### DIFF
--- a/packages/picasso/src/Select/Select.tsx
+++ b/packages/picasso/src/Select/Select.tsx
@@ -13,6 +13,7 @@ import NativeSelect from '@material-ui/core/NativeSelect'
 import { Theme, makeStyles } from '@material-ui/core/styles'
 import capitalize from '@material-ui/core/utils/capitalize'
 import { BaseProps, SizeType } from '@toptal/picasso-shared'
+import PopperJs from 'popper.js'
 
 import OutlinedInput from '../OutlinedInput'
 import Popper from '../Popper'
@@ -416,6 +417,7 @@ export const Select = documentable(
       )
 
       const inputWrapperRef = useRef<HTMLDivElement>(null)
+      const popperRef = useRef<PopperJs>(null)
       const [selectedOptions, setSelectedOptions] = useState(
         allOptions.filter(option =>
           Array.isArray(value)
@@ -454,6 +456,14 @@ export const Select = documentable(
       }
 
       const readOnlyInput = multiple || allOptions.length <= searchThreshold!
+
+      const isInsideSelect = (node: Node) => {
+        return (
+          popperRef.current?.popper.contains(node) ||
+          inputWrapperRef.current?.contains(node) ||
+          false
+        )
+      }
 
       const handleFocus = (
         event: React.FocusEvent<HTMLInputElement | HTMLDivElement>
@@ -550,7 +560,8 @@ export const Select = documentable(
         onSelect: handleSelect,
         onChange: handleChange,
         onBlur: handleBlur,
-        onFocus: handleFocus
+        onFocus: handleFocus,
+        isInsideSelect
       })
 
       const iconAdornment = icon ? (
@@ -690,6 +701,7 @@ export const Select = documentable(
           {!disabled && (
             <Popper
               autoWidth
+              ref={popperRef}
               width={menuWidth}
               placement='bottom-start'
               open={isOpen}

--- a/packages/picasso/src/Select/story/DynamicOptionsInModal.example.tsx
+++ b/packages/picasso/src/Select/story/DynamicOptionsInModal.example.tsx
@@ -1,0 +1,123 @@
+import React, { useState, ChangeEvent, useCallback } from 'react'
+import debounce from 'debounce'
+import { Modal, Button, Select, SelectOption } from '@toptal/picasso'
+import { useModals, isSubstring } from '@toptal/picasso/utils'
+
+const OPTIONS = [
+  { value: '1', text: 'Option 1' },
+  { value: '2', text: 'Option 2' },
+  { value: '3', text: 'Option 3' },
+  { value: '4', text: 'Option 4' },
+  { value: '5', text: 'Option 5' },
+  { value: '6', text: 'Option 6' },
+  { value: '7', text: 'Option 7' },
+  { value: '8', text: 'Option 8' },
+  { value: '9', text: 'Option 9' },
+  { value: '10', text: 'Option 10' },
+  { value: '11', text: 'Option 11' },
+  { value: '12', text: 'Option 12' },
+  { value: '13', text: 'Option 13' },
+  { value: '14', text: 'Option 14' },
+  { value: '24', text: 'Option 24' },
+  { value: '34', text: 'Option 34' },
+  { value: '44', text: 'Option 44' },
+  { value: '54', text: 'Option 54' },
+  { value: '64', text: 'Option 64' },
+  { value: '74', text: 'Option 74' },
+  { value: '84', text: 'Option 84' },
+  { value: '94', text: 'Option 94' },
+  { value: '104', text: 'Option 104' }
+]
+
+const loadOptions = (value: string): Promise<SelectOption[]> =>
+  new Promise(resolve => {
+    const filteredOptions = value
+      ? OPTIONS.filter(({ text }) => isSubstring(value, text))
+      : []
+
+    const result = filteredOptions.length ? filteredOptions : []
+
+    setTimeout(() => resolve(result), 1000)
+  })
+
+const Example = () => {
+  const { showModal, hideModal } = useModals()
+
+  const ModalDialog = ({
+    modalId,
+    hideModal
+  }: {
+    modalId: string
+    hideModal: (modalId: string) => void
+  }) => {
+    const [value, setValue] = useState<string | number>()
+    const [loading, setLoading] = useState(false)
+    const [options, setOptions] = useState<SelectOption[]>([])
+
+    const handleSearchChangeDebounced = useCallback(
+      debounce(async (searchValue: string) => {
+        const newOptions = await loadOptions(searchValue)
+
+        setLoading(false)
+        setOptions(newOptions)
+      }, 500),
+      []
+    )
+
+    const handleSearchChange = (searchValue: string) => {
+      setLoading(true)
+      setOptions([])
+      handleSearchChangeDebounced(searchValue)
+    }
+
+    const handleChange = (
+      event: ChangeEvent<{
+        name?: string | undefined
+        value: string | number
+      }>
+    ) => {
+      console.log('Select value:', event.target.value)
+      setValue(event.target.value)
+      setOptions([])
+    }
+
+    return (
+      <Modal onClose={() => hideModal(modalId)} open>
+        <Modal.Title>Select With Dynamic Options In Modal</Modal.Title>
+        <Modal.Content>
+          <Select
+            searchThreshold={-1}
+            onSearchChange={handleSearchChange}
+            loading={loading}
+            onChange={handleChange}
+            options={options}
+            value={value}
+            placeholder='Choose an option...'
+            width='auto'
+          />
+        </Modal.Content>
+        <Modal.Actions>
+          <Button variant='flat' onClick={() => hideModal(modalId)}>
+            Cancel
+          </Button>
+        </Modal.Actions>
+      </Modal>
+    )
+  }
+
+  const handleClick = () => {
+    const modalId = showModal(() => (
+      <ModalDialog modalId={modalId} hideModal={hideModal} />
+    ))
+  }
+
+  return (
+    <div id='modal-container'>
+      <Button data-testid='open' onClick={handleClick}>
+        Open
+      </Button>
+    </div>
+  )
+}
+
+export default Example

--- a/packages/picasso/src/Select/story/index.jsx
+++ b/packages/picasso/src/Select/story/index.jsx
@@ -124,3 +124,7 @@ number of options greater than specified in \`searchThreshold\` prop.
   .addExample('Select/story/ResetButton.example.jsx', 'With reset button') // picasso-skip-visuals
   .addExample('Select/story/Autofill.example.tsx', 'Disabling autofilling') // picasso-skip-visuals
   .addExample('Select/story/DynamicOptions.example.tsx', 'Dynamic options') // picasso-skip-visuals
+  .addExample(
+    'Select/story/DynamicOptionsInModal.example.tsx',
+    'Dynamic options in Modal'
+  ) // picasso-skip-visuals

--- a/packages/picasso/src/Select/useSelect.ts
+++ b/packages/picasso/src/Select/useSelect.ts
@@ -85,6 +85,7 @@ interface Props {
   ) => void
   onBlur?: FocusEventType
   onFocus?: FocusEventType
+  isInsideSelect: (node: Node) => boolean
 }
 
 type GetInputProps = ({
@@ -118,7 +119,8 @@ const useSelect = ({
   onKeyDown = () => {},
   onSelect = () => {},
   onBlur = () => {},
-  onFocus = () => {}
+  onFocus = () => {},
+  isInsideSelect
 }: Props): UseSelectOutput => {
   const [isOpen, setOpen] = useState<boolean>(false)
   const [highlightedIndex, setHighlightedIndex] = useState<number | null>(null)
@@ -172,7 +174,12 @@ const useSelect = ({
   }
 
   const handleBlur = (event: React.FocusEvent<HTMLInputElement>) => {
-    if (event.relatedTarget) return
+    const isFocusedInsideSelect = isInsideSelect(event.relatedTarget as Node)
+
+    if (isFocusedInsideSelect) {
+      return
+    }
+
     setOpen(false)
     onBlur(event)
   }


### PR DESCRIPTION
[SPT-951](https://toptal-core.atlassian.net/browse/SPT-951)

### Description

**Problem** 

In Modal window Dropdown for a Select not being closed, when user click on the modal window. In this case sometimes impossible to work with other inputs.

**Explanation** 

- Select has 2 parts. `Input` and `dropdown` -- aka `Select group`
- [Previously there was a bug](https://github.com/toptal/picasso/pull/1547). When you have a long options list and try to scroll via mouse then dropdown is closed. It was because `Input` lost his focus and `onBlur` event did hiding of the dropdown. It was a bad case.
- There was an attempt fix the bug, via defining if a mouse event is related to the `Select group` via `relatedTarget` object. Unfortunately not for all cases this solution worked.
- We had to find another approach.

**Solution**

:warning: This PR provides the solution which was already done for **DatePicker** 

https://github.com/toptal/picasso/blob/59ebdff726d7d98d5cf944ae8f27f018e928883e/packages/picasso-lab/src/DatePicker/DatePicker.tsx#L165

### How to test

- Go to the [Test Case](https://picasso.toptal.net/SPT-951-fix-select-onblur/?path=/story/forms-folder--select)
- Type `4` to have a long list of options

![Screenshot from 2020-09-22 23-02-22](https://user-images.githubusercontent.com/496713/93931746-df4ae200-fd27-11ea-8846-f5595c55be60.png)

**Acceptance criteria**

- it's possible to scroll via mouse. Dropdown getting the focus, but not being closed.
- it's possible to close dropdown via clicking the modal's body (:beetle: didnt't work before)
- it's possible to close dropdown via clicking on page's space


### Review

-  Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/api-principles.md)
-  Make sure you've converted all `js/jsx` file into `ts/tsx` in your PR
-  Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure that unit tests pass by running `yarn test`
- [x] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run  whole pipeline
- `@toptal-bot run danger` - Danger checks
- `@toptal-bot run lint` - Run linter
- `@toptal-bot run test` - Run jest
- `@toptal-bot run build` - Check build
- `@toptal-bot run test:visual` or `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation


</details>
