### PR TITLE
fix: add interactive to TypographyOverflow

### DIFF
--- a/packages/picasso-lab/src/TypographyOverflow/TypographyOverflow.tsx
+++ b/packages/picasso-lab/src/TypographyOverflow/TypographyOverflow.tsx
@@ -20,7 +20,7 @@ export const TypographyOverflow = ({ children, noWrap, ...rest }: Props) => {
   return (
     <Ellipsis
       renderWhenEllipsis={child => (
-        <Tooltip content={children} placement='top' interactive preventOverflow>
+        <Tooltip content={children} placement='top' interactive>
           {child}
         </Tooltip>
       )}


### PR DESCRIPTION
[SPT-955](https://toptal-core.atlassian.net/browse/SPT-955)

### Description

Add `interactive` as default for `TypographyOverflow` so users can always see can copy the text in the tooltip.

### How to test

- Go to `TypographyOverflow` story
- All tooltip should be interactive and visible

### Screenshots

![image](https://user-images.githubusercontent.com/18625278/93962071-17800e00-fd84-11ea-8899-3f023c448d71.png)

### Review

- [ ] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/api-principles.md)
- [ ] Make sure you've converted all `js/jsx` file into `ts/tsx` in your PR
- [ ] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that unit tests pass by running `yarn test`
- [ ] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run  whole pipeline
- `@toptal-bot run danger` - Danger checks
- `@toptal-bot run lint` - Run linter
- `@toptal-bot run test` - Run jest
- `@toptal-bot run build` - Check build
- `@toptal-bot run test:visual` or `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation


</details>
