### PR TITLE
fix: typo in the documentation

### DIFF
--- a/docs/contribution/visual-testing.md
+++ b/docs/contribution/visual-testing.md
@@ -8,7 +8,7 @@ Storing/Updating snapshots has the same logic as `jest` snapshots. Therefore in 
 
 ## Fixing broken visual tests inside a PR
 
-In order to have a good tracking on visual changes which were applied in each PR, we run visual snapshot comparision inside each pull request. `Jenkins` is automatically trying to take snapshot of each component and compare the result to a previous state. Logic behind this is similar as running `jest` snapshots, therefore when your PR has failing visual tests you need to update them.
+In order to have a good tracking on visual changes which were applied in each PR, we run visual snapshot comparison inside each pull request. `Jenkins` is automatically trying to take snapshot of each component and compare the result to a previous state. Logic behind this is similar as running `jest` snapshots, therefore when your PR has failing visual tests you need to update them.
 
 1. Check the report on jenkins which are linked to the PR status.
 2. Manually check the differences by eye and ensure that the current state of the screenshot is the expected state.


### PR DESCRIPTION
### Review

- [ ] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/api-principles.md)
- [ ] Make sure you've converted all `js/jsx` file into `ts/tsx` in your PR
- [ ] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that unit tests pass by running `yarn test`
- [ ] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run  whole pipeline
- `@toptal-bot run danger` - Danger checks
- `@toptal-bot run lint` - Run linter
- `@toptal-bot run test` - Run jest
- `@toptal-bot run build` - Check build
- `@toptal-bot run test:visual` or `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation


</details>
