### PR TITLE
fix: autocomplete custom render example

### DIFF
--- a/packages/picasso/src/Autocomplete/story/CustomOptionRenderer.example.tsx
+++ b/packages/picasso/src/Autocomplete/story/CustomOptionRenderer.example.tsx
@@ -1,9 +1,10 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { Item } from '@toptal/picasso/Autocomplete'
 import { Typography, Container, Autocomplete } from '@toptal/picasso'
+import { isSubstring } from '@toptal/picasso/utils'
 
 const renderOtherOption = (value: string) => (
-  <Typography size='medium' color='inherit' weight='semibold'>
+  <Typography size='medium' color='dark-grey' weight='semibold'>
     Search for: {value}
   </Typography>
 )
@@ -14,7 +15,9 @@ interface Country extends Item {
   code: string
 }
 
-const options: Country[] = [
+const EMPTY_INPUT_VALUE = ''
+
+const allOptions: Country[] = [
   { country: 'Belarus', capital: 'Minsk', code: 'BE' },
   { country: 'Croatia', capital: 'Zagreb', code: 'HR' },
   { country: 'Lithuania', capital: 'Vilnius', code: 'LU' },
@@ -22,33 +25,58 @@ const options: Country[] = [
   { country: 'Ukraine', capital: 'Kyiv', code: 'UA' }
 ]
 
-const CustomOptionRenderer = () => (
-  <div>
-    <Autocomplete
-      value=''
-      placeholder='Start typing country...'
-      options={options}
-      onSelect={(item: Item) => {
-        window.console.log('onSelect returns item object:', item)
-        window.console.log('selected capital:', item.capital)
-      }}
-      getKey={(item: Item) => (item as Country).code}
-      getDisplayValue={(item: Item | null) =>
-        (item && (item as Country).country) || ''
-      }
-      renderOption={(option: Partial<Country>, index) => (
-        <Container>
-          <Typography size='medium' weight='semibold'>
-            {option.country}
-          </Typography>
-          <Typography size='inherit' style={{ fontSize: '12px' }}>
-            {option.capital} ({index})
-          </Typography>
-        </Container>
-      )}
-      renderOtherOption={renderOtherOption}
-    />
-  </div>
-)
+const getDisplayValue = (item: Item | null) =>
+  (item && (item as Country).country) || ''
+
+const filterOptions = (str: string) =>
+  str !== ''
+    ? allOptions.filter(option => isSubstring(str, getDisplayValue(option)))
+    : allOptions
+
+const CustomOptionRenderer = () => {
+  const [value, setValue] = useState(EMPTY_INPUT_VALUE)
+  const [options, setOptions] = useState(allOptions)
+
+  return (
+    <div>
+      <Autocomplete
+        showOtherOption
+        value={value}
+        placeholder='Start typing country...'
+        options={options}
+        getKey={(item: Item) => (item as Country).code}
+        renderOption={(option: Partial<Country>, index) => (
+          <Container>
+            <Typography size='medium' weight='semibold'>
+              {option.country}
+            </Typography>
+            <Typography size='inherit' style={{ fontSize: '12px' }}>
+              {option.capital} ({index})
+            </Typography>
+          </Container>
+        )}
+        renderOtherOption={renderOtherOption}
+        onSelect={(option: Partial<Country>) => {
+          window.console.log('onSelect returns item object:', option)
+          window.console.log('selected capital:', option.capital)
+
+          const itemValue = getDisplayValue(option)
+
+          if (value !== itemValue) {
+            setValue(itemValue)
+          }
+        }}
+        onOtherOptionSelect={newValue => {
+          setValue(newValue)
+          setOptions(filterOptions(newValue))
+        }}
+        onChange={newValue => {
+          setOptions(filterOptions(newValue))
+          setValue(newValue)
+        }}
+      />
+    </div>
+  )
+}
 
 export default CustomOptionRenderer


### PR DESCRIPTION
### Description

Make [Custom options rendering](https://picasso.toptal.net/?path=/story/forms-folder--autocomplete#custom-options-rendering) example work to demonstrate the `renderOtherOption` prop

### How to test

- Go to Autocomplete page
- Scroll to Custom option rendering example
- Type in something

### Screenshots

![image](https://user-images.githubusercontent.com/18625278/95312481-2ead1880-08b9-11eb-8ab4-b4fbbbb5f3d8.png)

### Review

- [ ] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/api-principles.md)
- [ ] Make sure you've converted all `js/jsx` file into `ts/tsx` in your PR
- [ ] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that unit tests pass by running `yarn test`
- [ ] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run  whole pipeline
- `@toptal-bot run danger` - Danger checks
- `@toptal-bot run lint` - Run linter
- `@toptal-bot run test` - Run jest
- `@toptal-bot run build` - Check build
- `@toptal-bot run test:visual` or `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation


</details>
