### PR TITLE
fix(tooltip): get rid of blinking from interactive tooltips

### DIFF
--- a/packages/picasso/src/Tooltip/Tooltip.tsx
+++ b/packages/picasso/src/Tooltip/Tooltip.tsx
@@ -220,7 +220,7 @@ export const Tooltip: FunctionComponent<Props> = props => {
       disableFocusListener={disableListeners}
       disableTouchListener
       enterDelay={delayDuration}
-      enterNextDelay={delayDuration}
+      enterNextDelay={interactive ? 0 : delayDuration}
     >
       {children as ReactElement}
     </MUITooltip>


### PR DESCRIPTION
fixes #1616

### Description

Reduce the next delay when tooltip is interactive to prevent poor UX when tooltip content is
hovered.

### How to test

- Change the content of interactive tooltip to some lengthy text

### Screenshots



### Review

- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/api-principles.md)
- [x] Make sure you've converted all `js/jsx` file into `ts/tsx` in your PR
- [x] Annotate all `props` in component with documentation
- n/a Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure that unit tests pass by running `yarn test`
- [x] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run  whole pipeline
- `@toptal-bot run danger` - Danger checks
- `@toptal-bot run lint` - Run linter
- `@toptal-bot run test` - Run jest
- `@toptal-bot run build` - Check build
- `@toptal-bot run test:visual` or `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>
