### PR TITLE
fix(tooltip): revert the enter delay fix

### DIFF
--- a/packages/picasso/src/Tooltip/Tooltip.tsx
+++ b/packages/picasso/src/Tooltip/Tooltip.tsx
@@ -220,7 +220,7 @@ export const Tooltip: FunctionComponent<Props> = props => {
       disableFocusListener={disableListeners}
       disableTouchListener
       enterDelay={delayDuration}
-      enterNextDelay={interactive ? 0 : delayDuration}
+      enterNextDelay={delayDuration}
     >
       {children as ReactElement}
     </MUITooltip>


### PR DESCRIPTION
This reverts commit 91086eefb89115b5d761d30f4e7cd3bbcd8ada83.

https://toptal-core.slack.com/archives/CCC3GP6CC/p1602583641300900

### Description

We don't want to change the delay behavior and instead make the tooltip non-interactive when it starts to hide.

### How to test

- See the interactive tooltip example still working

### Review

- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/api-principles.md)
- n/a Make sure you've converted all `js/jsx` file into `ts/tsx` in your PR
- n/a Annotate all `props` in component with documentation
- n/a Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that unit tests pass by running `yarn test`
- [ ] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run  whole pipeline
- `@toptal-bot run danger` - Danger checks
- `@toptal-bot run lint` - Run linter
- `@toptal-bot run test` - Run jest
- `@toptal-bot run build` - Check build
- `@toptal-bot run test:visual` or `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>
