### PR TITLE
feat: extend typography overflow

### DIFF
--- a/packages/picasso-lab/src/TypographyOverflow/TypographyOverflow.tsx
+++ b/packages/picasso-lab/src/TypographyOverflow/TypographyOverflow.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, ReactText } from 'react'
+import React, { ReactNode } from 'react'
 import { BaseProps } from '@toptal/picasso-shared'
 import { Tooltip, Typography, TypographyProps } from '@toptal/picasso'
 
@@ -6,7 +6,7 @@ import Ellipsis from '../Ellipsis'
 
 export interface Props extends BaseProps, TypographyProps {
   /** A typography which can possibly overflow */
-  children?: ReactText
+  children?: ReactNode
   /** A content to show in tooltip when typography overflows. By default, TypographyOverflow's children are used. */
   tooltipContent?: ReactNode
 }


### PR DESCRIPTION
[SPC-551]

### Description

TypographyOverflow now accepts ReactNode instead ReactText. This will enabled us to pass <Link /> and any other component as children.

### Review

- [ ] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/api-principles.md)
- [ ] Make sure you've converted all `js/jsx` file into `ts/tsx` in your PR
- [ ] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that unit tests pass by running `yarn test`
- [ ] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run  whole pipeline
- `@toptal-bot run danger` - Danger checks
- `@toptal-bot run lint` - Run linter
- `@toptal-bot run test` - Run jest
- `@toptal-bot run build` - Check build
- `@toptal-bot run test:visual` or `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>


[SPC-551]: https://toptal-core.atlassian.net/browse/SPC-551