### PR TITLE
fix(alert): expose variant type

### DIFF
--- a/packages/picasso-lab/src/Alert/index.ts
+++ b/packages/picasso-lab/src/Alert/index.ts
@@ -4,3 +4,4 @@ import { Props } from './Alert'
 
 export { default } from './Alert'
 export type AlertProps = OmitInternalProps<Props>
+export * from './Alert'


### PR DESCRIPTION
No ticket.

### Description

Just a small fix to expose other exports from the `Alert` component, as `VariantType`.

### Screenshots
N/A

### Review
N/A

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run  whole pipeline
- `@toptal-bot run danger` - Danger checks
- `@toptal-bot run lint` - Run linter
- `@toptal-bot run test` - Run jest
- `@toptal-bot run build` - Check build
- `@toptal-bot run test:visual` or `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>
