### PR TITLE
feat: design docs poc

### DIFF
--- a/.storybook/components/PicassoBook/Chapter.tsx
+++ b/.storybook/components/PicassoBook/Chapter.tsx
@@ -146,6 +146,16 @@ class Chapter extends Base {
     return this
   }
 
+  addDesignDocs = (abstract: string) => {
+    this.createSection({
+      sectionFn: () => (
+        <iframe src={abstract} width='1000' height='1200' frameBorder='0' />
+      ),
+      title: 'Design Documentation'
+    })
+
+    return this
+  }
   addExample = (source: string, options: Options | string, module?: string) => {
     const finalOptions: Options =
       typeof options === 'string'

--- a/packages/picasso/src/Accordion/story/index.jsx
+++ b/packages/picasso/src/Accordion/story/index.jsx
@@ -20,6 +20,9 @@ page.createTabChapter('Props').addComponentDocs({
 
 page
   .createChapter()
+  .addDesignDocs(
+    'https://app.abstract.com/embed/636e68ee-2ef4-483d-bdaf-83aef2340477?collectionLayerId=aa49cc2c-6e4e-4d8d-aa3a-3def89e1837f&mode=build'
+  )
 
   .addExample('Accordion/story/Default.example.jsx', {
     title: 'Default',


### PR DESCRIPTION
[FX-NNNN]

### Description

This is a PoC of one way we can integrate [design docs](https://share.goabstract.com/636e68ee-2ef4-483d-bdaf-83aef2340477?collectionLayerId=aa49cc2c-6e4e-4d8d-aa3a-3def89e1837f&mode=build) in Picasso



### How to test

- FIXME: Add the steps describing how to verify your changes

### Screenshots

![ilkgWFM60n](https://user-images.githubusercontent.com/12392666/98810034-d5d42100-241e-11eb-8448-b4296b8e630e.gif)
### Review

- [ ] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/api-principles.md)
- [ ] Make sure you've converted all `js/jsx` file into `ts/tsx` in your PR
- [ ] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that unit tests pass by running `yarn test`
- [ ] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run  whole pipeline
- `@toptal-bot run danger` - Danger checks
- `@toptal-bot run lint` - Run linter
- `@toptal-bot run test` - Run jest
- `@toptal-bot run build` - Check build
- `@toptal-bot run test:visual` or `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>
