### PR TITLE
fix: v5 update picasso peer dep version resolution

### DIFF
--- a/packages/picasso-charts/package.json
+++ b/packages/picasso-charts/package.json
@@ -21,7 +21,7 @@
     "url": "https://github.com/toptal/picasso/issues"
   },
   "peerDependencies": {
-    "@toptal/picasso": "^4.49.2"
+    "@toptal/picasso": "^4.x"
   },
   "devDependencies": {
     "@types/d3-array": "2.7.0"

--- a/packages/picasso-forms/package.json
+++ b/packages/picasso-forms/package.json
@@ -22,7 +22,7 @@
     "url": "https://github.com/toptal/picasso/issues"
   },
   "peerDependencies": {
-    "@toptal/picasso": "^4.49.2",
+    "@toptal/picasso": "^4.x",
     "@toptal/picasso-lab": "^2.12.10",
     "@toptal/picasso-shared": "^1.11.1",
     "react": "^16.12.0",

--- a/packages/picasso-lab/package.json
+++ b/packages/picasso-lab/package.json
@@ -23,7 +23,7 @@
   },
   "peerDependencies": {
     "@material-ui/core": "^4.11.0",
-    "@toptal/picasso": "^4.49.2",
+    "@toptal/picasso": "^4.x",
     "@toptal/picasso-shared": "^1.11.1",
     "react": "^16.12.0",
     "react-dom": "^16.12.0"


### PR DESCRIPTION
### Description

This is needed for `yarn` to be able to override the version to `v5-alpha` branch by using version `resolutions` in the `package.json`. For Billing and Chronicles inside Staff Portal.

This is the part of the `yarn.lock` file from SP:

<img width="1469" alt="Screenshot 2020-11-17 at 11 00 00" src="https://user-images.githubusercontent.com/2836281/99368700-25ee3000-28c4-11eb-8b16-ad0422e1d67b.png">

Notice how versions are grouped by `yarn`.