### PR TITLE
feat(Forms): add Picasso forms Autocomplete

### DIFF
--- a/packages/picasso-forms/src/Autocomplete/Autocomplete.tsx
+++ b/packages/picasso-forms/src/Autocomplete/Autocomplete.tsx
@@ -1,0 +1,23 @@
+import React from 'react'
+import {
+  Autocomplete as PicassoAutocomplete,
+  AutocompleteProps
+} from '@toptal/picasso'
+
+import FieldWrapper, { FieldProps } from '../FieldWrapper'
+
+export type Props = AutocompleteProps & FieldProps<AutocompleteProps['value']>
+
+export const Autocomplete = (props: Props) => (
+  // eslint-disable-next-line react/jsx-props-no-spreading
+  <FieldWrapper<AutocompleteProps> {...props}>
+    {(inputProps: AutocompleteProps) => {
+      // eslint-disable-next-line react/jsx-props-no-spreading
+      return <PicassoAutocomplete {...inputProps} />
+    }}
+  </FieldWrapper>
+)
+
+Autocomplete.displayName = 'Autocomplete'
+
+export default Autocomplete

--- a/packages/picasso-forms/src/Autocomplete/index.ts
+++ b/packages/picasso-forms/src/Autocomplete/index.ts
@@ -1,0 +1,1 @@
+export { default } from './Autocomplete'

--- a/packages/picasso-forms/src/Form/Form.tsx
+++ b/packages/picasso-forms/src/Form/Form.tsx
@@ -7,6 +7,7 @@ import { FormApi, ValidationErrors, getIn, setIn } from 'final-form'
 import { Form as PicassoForm } from '@toptal/picasso'
 import { useNotifications } from '@toptal/picasso/utils'
 
+import Autocomplete from '../Autocomplete'
 import Input from '../Input'
 import Select from '../Select'
 import Radio from '../Radio'
@@ -31,6 +32,7 @@ import {
 type AnyObject = Record<string, any>
 
 export type Props<T = AnyObject> = FinalFormProps<T> & {
+  autoComplete?: HTMLFormElement['autocomplete']
   successSubmitMessage?: ReactNode
   failedSubmitMessage?: ReactNode
   scrollOffsetTop?: number
@@ -61,6 +63,7 @@ const getSubmitErrors = (
 export const Form = <T extends any = AnyObject>(props: Props<T>) => {
   const {
     children,
+    autoComplete,
     onSubmit,
     successSubmitMessage,
     failedSubmitMessage,
@@ -110,7 +113,9 @@ export const Form = <T extends any = AnyObject>(props: Props<T>) => {
     <FormContext.Provider value={validationObject}>
       <FinalForm
         render={({ handleSubmit }) => (
-          <PicassoForm onSubmit={handleSubmit}>{children}</PicassoForm>
+          <PicassoForm autoComplete={autoComplete} onSubmit={handleSubmit}>
+            {children}
+          </PicassoForm>
         )}
         onSubmit={handleSubmit}
         decorators={[...decorators, scrollToErrorDecorator]}
@@ -125,6 +130,7 @@ Form.defaultProps = {}
 
 Form.displayName = 'Form'
 
+Form.Autocomplete = Autocomplete
 Form.Input = Input
 Form.Select = Select
 Form.Radio = Radio

--- a/packages/picasso-forms/src/Form/story/Default.example.tsx
+++ b/packages/picasso-forms/src/Form/story/Default.example.tsx
@@ -4,11 +4,27 @@ import { Item } from '@toptal/picasso/Autocomplete'
 import { isSubstring } from '@toptal/picasso/utils'
 import { Form } from '@toptal/picasso-forms'
 
+const countries = [
+  { value: 'Afghanistan', text: 'Afghanistan' },
+  { value: 'Albania', text: 'Albania' },
+  { value: 'Algeria', text: 'Algeria' },
+  { value: 'Belarus', text: 'Belarus' },
+  { value: 'Croatia', text: 'Croatia' },
+  { value: 'Lithuania', text: 'Lithuania' },
+  { value: 'Slovakia', text: 'Slovakia' },
+  { value: 'Spain', text: 'Spain' },
+  { value: 'Ukraine', text: 'Ukraine' }
+]
+
 const skills = [
   { value: 0, text: 'HTML' },
   { value: 1, text: 'CSS' },
   { value: 2, text: 'Javascript' }
 ]
+
+const EMPTY_INPUT_VALUE = ''
+const getAutocompleteDisplayValue = (item: Item | null) =>
+  item?.text || EMPTY_INPUT_VALUE
 
 const filterOptions = (str = '', options: Item[] = []): Item[] | null => {
   if (!str) {
@@ -22,11 +38,21 @@ const filterOptions = (str = '', options: Item[] = []): Item[] | null => {
 }
 
 const DefaultExample = () => {
-  const [skillInputValue, setSkillInputValue] = useState<string>('')
+  const [skillInputValue, setSkillInputValue] = useState<string>(
+    EMPTY_INPUT_VALUE
+  )
   const skillOptions = filterOptions(skillInputValue, skills)
+
+  const [autocompleteValue, setAutocompleteValue] = useState<string>(
+    EMPTY_INPUT_VALUE
+  )
+  const [autocompleteOptions, setAutocompleteOptions] = useState<Item[] | null>(
+    countries
+  )
 
   return (
     <Form
+      autoComplete='off'
       onSubmit={values => console.log(values)}
       initialValues={{ gender: 'female' }}
     >
@@ -83,10 +109,34 @@ const DefaultExample = () => {
         ]}
       />
       <Form.Select
-        name='country'
-        label='Country'
+        name='origin_country'
+        label='Origin country'
         width='auto'
-        options={options}
+        options={countries}
+      />
+      <Form.Autocomplete
+        name='current_country'
+        label='Current country'
+        placeholder='Start typing country...'
+        width='auto'
+        value={autocompleteValue}
+        options={autocompleteOptions}
+        onSelect={(item: Item) => {
+          console.log('onSelect returns item object:', item)
+
+          const itemValue = getAutocompleteDisplayValue(item)
+
+          if (autocompleteValue !== itemValue) {
+            setAutocompleteValue(itemValue)
+          }
+        }}
+        onChange={(newValue: string) => {
+          console.log('onChange returns just item value:', newValue)
+
+          setAutocompleteOptions(filterOptions(newValue, countries))
+          setAutocompleteValue(newValue)
+        }}
+        getDisplayValue={getAutocompleteDisplayValue}
       />
       <Form.FileInput
         required
@@ -106,17 +156,5 @@ const DefaultExample = () => {
     </Form>
   )
 }
-
-const options = [
-  { value: 'Afghanistan', text: 'Afghanistan' },
-  { value: 'Albania', text: 'Albania' },
-  { value: 'Algeria', text: 'Algeria' },
-  { value: 'Belarus', text: 'Belarus' },
-  { value: 'Croatia', text: 'Croatia' },
-  { value: 'Lithuania', text: 'Lithuania' },
-  { value: 'Slovakia', text: 'Slovakia' },
-  { value: 'Spain', text: 'Spain' },
-  { value: 'Ukraine', text: 'Ukraine' }
-]
 
 export default DefaultExample

--- a/packages/picasso-forms/src/Form/story/index.jsx
+++ b/packages/picasso-forms/src/Form/story/index.jsx
@@ -10,6 +10,17 @@ page
     component: Form,
     name: 'Form',
     additionalDocs: {
+      autoComplete: {
+        name: 'autoComplete',
+        type: {
+          name: 'string',
+          enums: ['on', 'off']
+        },
+        description: `HTML Form autocomplete attribute.\n
+          The autocomplete attribute specifies whether a form should have autocomplete 'on' or 'off'.
+          When autocomplete is 'on', the browser automatically complete values based on values that the user has entered before.
+          Tip: It is possible to have autocomplete 'on' for the form, and 'off' for specific input fields, or vice versa.`
+      },
       debug: {
         name: 'debug',
         type: {
@@ -98,7 +109,7 @@ page
         name: 'failedSubmitMessage',
         type: 'ReactNode',
         description:
-          'Message to display in a tooltip when form submittion failed'
+          'Message to display in a tooltip when form submission failed'
       },
       scrollOffsetTop: {
         name: 'scrollOffsetTop',


### PR DESCRIPTION
[SPB-1203]

### Description

`Autocomplete` is not implemented for Picasso Forms. It required for some forms.

### How to test

Open `Default` example `?path=/story/picasso-forms--form` (use temploy),
play with autocomplete attribute `Current country`

### Screenshots

![image](https://user-images.githubusercontent.com/67374194/99269252-31dfe080-2837-11eb-914c-daebe17dc3ed.png)

### Review

- [ ] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/api-principles.md)
- [ ] Make sure you've converted all `js/jsx` file into `ts/tsx` in your PR
- [ ] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that unit tests pass by running `yarn test`
- [ ] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run  whole pipeline
- `@toptal-bot run danger` - Danger checks
- `@toptal-bot run lint` - Run linter
- `@toptal-bot run test` - Run jest
- `@toptal-bot run build` - Check build
- `@toptal-bot run test:visual` or `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>


[SPB-1203]: https://toptal-core.atlassian.net/browse/SPB-1203