### PR TITLE
chore: [FX-1447] Select background

### DIFF
--- a/packages/picasso/src/InputBase/styles.ts
+++ b/packages/picasso/src/InputBase/styles.ts
@@ -4,7 +4,8 @@ import { PicassoProvider } from '@toptal/picasso-shared'
 PicassoProvider.override(({ typography, palette }: Theme) => ({
   MuiInputBase: {
     root: {
-      fontSize: 'unset'
+      fontSize: 'unset',
+      backgroundColor: palette.common.white
     },
     input: {
       fontSize: typography.inputSize,

--- a/packages/picasso/src/Select/styles.ts
+++ b/packages/picasso/src/Select/styles.ts
@@ -24,7 +24,6 @@ export default ({ palette }: Theme) =>
     rootAuto: {},
     select: {
       width: '100%',
-      zIndex: 1,
       padding: '0.625rem',
 
       '&:focus': {
@@ -36,8 +35,7 @@ export default ({ palette }: Theme) =>
       outline: 0
     },
     input: {
-      zIndex: 1,
-      paddingRight: 'calc(0.625rem + 1rem)'
+      paddingRight: '1.625rem'
     },
     readOnlyInput: {
       cursor: 'pointer'


### PR DESCRIPTION
[FX-1447]

### Description

Fix background for Select, it must use white color and not inherit it from parent.

I checked staff-portal's example of modal + select inside it and removal of z-index like in this PR changes nothing.

### How to test

- check demo

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| <img width="666" alt="image" src="https://user-images.githubusercontent.com/1291032/99771249-d99c2d80-2b19-11eb-817b-5f181f8a2aef.png"> | <img width="1210" alt="image" src="https://user-images.githubusercontent.com/1291032/99771175-ba050500-2b19-11eb-94d8-dfdcd779c030.png"> |

### Review

- [ ] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/api-principles.md)
- [ ] Make sure you've converted all `js/jsx` file into `ts/tsx` in your PR
- [ ] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that unit tests pass by running `yarn test`
- [ ] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run  whole pipeline
- `@toptal-bot run danger` - Danger checks
- `@toptal-bot run lint` - Run linter
- `@toptal-bot run test` - Run jest
- `@toptal-bot run build` - Check build
- `@toptal-bot run test:visual` or `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>


[FX-1447]: https://toptal-core.atlassian.net/browse/FX-1447