### PR TITLE
fix(TableExpandableRow): don't force height on expandable content

### DIFF
--- a/packages/picasso/src/TableExpandableRow/TableExpandableRow.tsx
+++ b/packages/picasso/src/TableExpandableRow/TableExpandableRow.tsx
@@ -79,7 +79,10 @@ export const TableExpandableRow = forwardRef<HTMLTableRowElement, Props>(
             })}
             style={style}
           >
-            <TableCell className={classes.noPadding} colSpan={MAX_COL_SPAN}>
+            <TableCell
+              className={cx(classes.noHeight, classes.noPadding)}
+              colSpan={MAX_COL_SPAN}
+            >
               <MUICollapse appear={shouldTransition} in>
                 {content}
               </MUICollapse>

--- a/packages/picasso/src/TableExpandableRow/styles.ts
+++ b/packages/picasso/src/TableExpandableRow/styles.ts
@@ -6,6 +6,9 @@ export default ({ palette }: Theme) =>
     stripeEven: {
       background: alpha(palette.grey.lighter2!, 0.32)
     },
+    noHeight: {
+      height: 'auto'
+    },
     noPadding: {
       padding: 0,
       '&:last-child': {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4307,12 +4307,7 @@
   dependencies:
     "@types/color-convert" "*"
 
-"@types/d3-array@*":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@types/d3-array/-/d3-array-2.0.0.tgz#a0d63a296a2d8435a9ec59393dcac746c6174a96"
-  integrity sha512-rGqfPVowNDTszSFvwoZIXvrPG7s/qKzm9piCRIH6xwTTRu7pPZ3ootULFnPkTt74B6i5lN0FpLQL24qGOw1uZA==
-
-"@types/d3-array@2.7.0":
+"@types/d3-array@*", "@types/d3-array@2.7.0":
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/@types/d3-array/-/d3-array-2.7.0.tgz#031400c606734e8420d4e874e4860dc3cd284c81"
   integrity sha512-RGZkT8r6+dS5vcImIJbna3HdRbDABiAxaIFoy07SQTK3hyzSgUgM+LbWcGuGEkCvtJ1RJK2KwrEtFC6ibD51uA==
@@ -8108,12 +8103,7 @@ d3-array@1, d3-array@^1.1.1, d3-array@^1.2.0:
   resolved "https://registry.yarnpkg.com/d3-array/-/d3-array-1.2.4.tgz#635ce4d5eea759f6f605863dbcfc30edc737f71f"
   integrity sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw==
 
-"d3-array@1.2.0 - 2":
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/d3-array/-/d3-array-2.4.0.tgz#87f8b9ad11088769c82b5ea846bcb1cc9393f242"
-  integrity sha512-KQ41bAF2BMakf/HdKT865ALd4cgND6VcIztVQZUTt0+BH3RWy6ZYnHghVXf6NFjt2ritLr8H1T8LreAAlfiNcw==
-
-d3-array@2.8.0:
+"d3-array@1.2.0 - 2", d3-array@2.8.0:
   version "2.8.0"
   resolved "https://registry.yarnpkg.com/d3-array/-/d3-array-2.8.0.tgz#f76e10ad47f1f4f75f33db5fc322eb9ffde5ef23"
   integrity sha512-6V272gsOeg7+9pTW1jSYOR1QE37g95I3my1hBmY+vOUNHRrk9yt4OTz/gK7PMkVAVDrYYq4mq3grTiZ8iJdNIw==


### PR DESCRIPTION
[SPT-1114]

### Description

We don't want expandable content to have any predefined styles. Right now there is a minimum height which makes it hard to follow the designs in some places.

### How to test

- Make sure there is no minimum `2.5rem` height applied to expandable row table cell.

### Review

- [ ] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/api-principles.md)
- [ ] Make sure you've converted all `js/jsx` file into `ts/tsx` in your PR
- [ ] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that unit tests pass by running `yarn test`
- [ ] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run  whole pipeline
- `@toptal-bot run danger` - Danger checks
- `@toptal-bot run lint` - Run linter
- `@toptal-bot run test` - Run jest
- `@toptal-bot run build` - Check build
- `@toptal-bot run test:visual` or `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>


[SPT-1114]: https://toptal-core.atlassian.net/browse/SPT-1114