### PR TITLE
chore(Accordion): update tests to use snapshots

### DIFF
--- a/packages/picasso/src/Accordion/__snapshots__/test.tsx.snap
+++ b/packages/picasso/src/Accordion/__snapshots__/test.tsx.snap
@@ -1,0 +1,309 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`controlled version should render collapsed version 1`] = `
+<div>
+  <div
+    class="Picasso-root"
+  >
+    <div
+      class="MuiPaper-root MuiAccordion-root makeStyles-root makeStyles-bordersAll MuiAccordion-rounded MuiPaper-elevation0 MuiPaper-rounded"
+    >
+      <div
+        aria-disabled="false"
+        aria-expanded="false"
+        class="MuiButtonBase-root MuiAccordionSummary-root WithStyles(ForwardRef(AccordionSummary))-root makeStyles-summary"
+        role="button"
+        tabindex="0"
+      >
+        <div
+          class="MuiAccordionSummary-content WithStyles(ForwardRef(AccordionSummary))-content makeStyles-content"
+        >
+          <div>
+            Fryderyk Chopin
+          </div>
+          <div
+            class="makeStyles-expandIconAlignTop"
+          >
+            <button
+              class="MuiButtonBase-root PicassoButton-small PicassoButtonAction-small PicassoButton-secondary PicassoButton-root PicassoButtonAction-root"
+              tabindex="0"
+              type="button"
+            >
+              <span
+                class="Container-centerAlignItems Container-flex Container-inline PicassoButton-content PicassoButtonAction-content"
+              >
+                <svg
+                  class="SvgArrowDownMinor16-root PicassoButton-icon PicassoButtonAction-icon makeStyles-expandIcon"
+                  style="min-width: 16px; min-height: 16px;"
+                  viewBox="0 0 16 16"
+                >
+                  <path
+                    d="M11.997 5.29l.707.707-4 4-.707.707-.707-.707-4-4 .707-.707 4 4 4-4z"
+                  />
+                </svg>
+              </span>
+            </button>
+          </div>
+        </div>
+      </div>
+      <div
+        class="MuiCollapse-container MuiCollapse-hidden"
+        style="min-height: 0px;"
+      >
+        <div
+          class="MuiCollapse-wrapper"
+        >
+          <div
+            class="MuiCollapse-wrapperInner"
+          >
+            <div
+              role="region"
+            >
+              <div
+                class="MuiAccordionDetails-root AccordionDetails-root makeStyles-details"
+              >
+                <div
+                  id="details"
+                >
+                  Fryderyk Chopin was born in Żelazowa Wola, 46 kilometres west of Warsaw, in what was then the Duchy of Warsaw, a Polish state established by Napoleon. The parish baptismal record gives his birthday as 22 February 1810, and cites his given names in the Latin form Fridericus Franciscus (in Polish, he was Fryderyk Franciszek). However, the composer and his family used the birthdate 1 March, which is now generally accepted as the correct date.
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`controlled version should render expanded version 1`] = `
+<div>
+  <div
+    class="Picasso-root"
+  >
+    <div
+      class="MuiPaper-root MuiAccordion-root makeStyles-root makeStyles-bordersAll Mui-expanded MuiAccordion-rounded MuiPaper-elevation0 MuiPaper-rounded"
+    >
+      <div
+        aria-disabled="false"
+        aria-expanded="true"
+        class="MuiButtonBase-root MuiAccordionSummary-root WithStyles(ForwardRef(AccordionSummary))-root makeStyles-summary Mui-expanded"
+        role="button"
+        tabindex="0"
+      >
+        <div
+          class="MuiAccordionSummary-content WithStyles(ForwardRef(AccordionSummary))-content makeStyles-content Mui-expanded"
+        >
+          <div>
+            Fryderyk Chopin
+          </div>
+          <div
+            class="makeStyles-expandIconAlignTop"
+          >
+            <button
+              class="MuiButtonBase-root PicassoButton-small PicassoButtonAction-small PicassoButton-secondary PicassoButton-root PicassoButtonAction-root"
+              tabindex="0"
+              type="button"
+            >
+              <span
+                class="Container-centerAlignItems Container-flex Container-inline PicassoButton-content PicassoButtonAction-content"
+              >
+                <svg
+                  class="SvgArrowDownMinor16-root PicassoButton-icon PicassoButtonAction-icon makeStyles-expandIcon makeStyles-expandIconExpanded"
+                  style="min-width: 16px; min-height: 16px;"
+                  viewBox="0 0 16 16"
+                >
+                  <path
+                    d="M11.997 5.29l.707.707-4 4-.707.707-.707-.707-4-4 .707-.707 4 4 4-4z"
+                  />
+                </svg>
+              </span>
+            </button>
+          </div>
+        </div>
+      </div>
+      <div
+        class="MuiCollapse-container MuiCollapse-entered"
+        style="min-height: 0px;"
+      >
+        <div
+          class="MuiCollapse-wrapper"
+        >
+          <div
+            class="MuiCollapse-wrapperInner"
+          >
+            <div
+              role="region"
+            >
+              <div
+                class="MuiAccordionDetails-root AccordionDetails-root makeStyles-details"
+              >
+                <div
+                  id="details"
+                >
+                  Fryderyk Chopin was born in Żelazowa Wola, 46 kilometres west of Warsaw, in what was then the Duchy of Warsaw, a Polish state established by Napoleon. The parish baptismal record gives his birthday as 22 February 1810, and cites his given names in the Latin form Fridericus Franciscus (in Polish, he was Fryderyk Franciszek). However, the composer and his family used the birthdate 1 March, which is now generally accepted as the correct date.
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`default version for sections should render default version 1`] = `
+<div>
+  <div
+    class="Picasso-root"
+  >
+    <div
+      class="MuiPaper-root MuiAccordion-root makeStyles-root makeStyles-bordersAll MuiAccordion-rounded MuiPaper-elevation0 MuiPaper-rounded"
+    >
+      <div
+        aria-disabled="false"
+        aria-expanded="false"
+        class="MuiButtonBase-root MuiAccordionSummary-root WithStyles(ForwardRef(AccordionSummary))-root makeStyles-summary"
+        role="button"
+        tabindex="0"
+      >
+        <div
+          class="MuiAccordionSummary-content WithStyles(ForwardRef(AccordionSummary))-content makeStyles-content"
+        >
+          <div>
+            Fryderyk Chopin
+          </div>
+          <div
+            class="makeStyles-expandIconAlignTop"
+          >
+            <button
+              class="MuiButtonBase-root PicassoButton-small PicassoButtonAction-small PicassoButton-secondary PicassoButton-root PicassoButtonAction-root"
+              tabindex="0"
+              type="button"
+            >
+              <span
+                class="Container-centerAlignItems Container-flex Container-inline PicassoButton-content PicassoButtonAction-content"
+              >
+                <svg
+                  class="SvgArrowDownMinor16-root PicassoButton-icon PicassoButtonAction-icon makeStyles-expandIcon"
+                  style="min-width: 16px; min-height: 16px;"
+                  viewBox="0 0 16 16"
+                >
+                  <path
+                    d="M11.997 5.29l.707.707-4 4-.707.707-.707-.707-4-4 .707-.707 4 4 4-4z"
+                  />
+                </svg>
+              </span>
+            </button>
+          </div>
+        </div>
+      </div>
+      <div
+        class="MuiCollapse-container MuiCollapse-hidden"
+        style="min-height: 0px;"
+      >
+        <div
+          class="MuiCollapse-wrapper"
+        >
+          <div
+            class="MuiCollapse-wrapperInner"
+          >
+            <div
+              role="region"
+            >
+              <div
+                class="MuiAccordionDetails-root AccordionDetails-root makeStyles-details"
+              >
+                <div
+                  id="details"
+                >
+                  Fryderyk Chopin was born in Żelazowa Wola, 46 kilometres west of Warsaw, in what was then the Duchy of Warsaw, a Polish state established by Napoleon. The parish baptismal record gives his birthday as 22 February 1810, and cites his given names in the Latin form Fridericus Franciscus (in Polish, he was Fryderyk Franciszek). However, the composer and his family used the birthdate 1 March, which is now generally accepted as the correct date.
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`default version for sections should render expanded version after click on summary 1`] = `
+<div>
+  <div
+    class="Picasso-root"
+  >
+    <div
+      class="MuiPaper-root MuiAccordion-root makeStyles-root makeStyles-bordersAll Mui-expanded MuiAccordion-rounded MuiPaper-elevation0 MuiPaper-rounded"
+    >
+      <div
+        aria-disabled="false"
+        aria-expanded="true"
+        class="MuiButtonBase-root MuiAccordionSummary-root WithStyles(ForwardRef(AccordionSummary))-root makeStyles-summary Mui-expanded"
+        role="button"
+        tabindex="0"
+      >
+        <div
+          class="MuiAccordionSummary-content WithStyles(ForwardRef(AccordionSummary))-content makeStyles-content Mui-expanded"
+        >
+          <div>
+            Fryderyk Chopin
+          </div>
+          <div
+            class="makeStyles-expandIconAlignTop"
+          >
+            <button
+              class="MuiButtonBase-root PicassoButton-small PicassoButtonAction-small PicassoButton-secondary PicassoButton-root PicassoButtonAction-root"
+              tabindex="0"
+              type="button"
+            >
+              <span
+                class="Container-centerAlignItems Container-flex Container-inline PicassoButton-content PicassoButtonAction-content"
+              >
+                <svg
+                  class="SvgArrowDownMinor16-root PicassoButton-icon PicassoButtonAction-icon makeStyles-expandIcon makeStyles-expandIconExpanded"
+                  style="min-width: 16px; min-height: 16px;"
+                  viewBox="0 0 16 16"
+                >
+                  <path
+                    d="M11.997 5.29l.707.707-4 4-.707.707-.707-.707-4-4 .707-.707 4 4 4-4z"
+                  />
+                </svg>
+              </span>
+            </button>
+          </div>
+        </div>
+      </div>
+      <div
+        class="MuiCollapse-container"
+        style="min-height: 0px; height: 0px; transition-duration: 0ms;"
+      >
+        <div
+          class="MuiCollapse-wrapper"
+        >
+          <div
+            class="MuiCollapse-wrapperInner"
+          >
+            <div
+              role="region"
+            >
+              <div
+                class="MuiAccordionDetails-root AccordionDetails-root makeStyles-details"
+              >
+                <div
+                  id="details"
+                >
+                  Fryderyk Chopin was born in Żelazowa Wola, 46 kilometres west of Warsaw, in what was then the Duchy of Warsaw, a Polish state established by Napoleon. The parish baptismal record gives his birthday as 22 February 1810, and cites his given names in the Latin form Fridericus Franciscus (in Polish, he was Fryderyk Franciszek). However, the composer and his family used the birthdate 1 March, which is now generally accepted as the correct date.
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/packages/picasso/src/Accordion/test.tsx
+++ b/packages/picasso/src/Accordion/test.tsx
@@ -20,20 +20,17 @@ const Details = () => (
 
 describe('default version for sections', () => {
   test('should render default version', () => {
-    const { queryByText, container } = render(
+    const { container } = render(
       <Accordion content={<Details />}>
         <Summary />
       </Accordion>
     )
 
-    expect(queryByText(summaryHeaderText)).toBeInTheDocument()
-    expect(container.querySelector('.MuiCollapse-container')).toHaveClass(
-      'MuiCollapse-hidden'
-    )
+    expect(container).toMatchSnapshot()
   })
 
   test('should render expanded version after click on summary', () => {
-    const { queryByText, getByText, container } = render(
+    const { getByText, container } = render(
       <Accordion content={<Details />}>
         <Summary />
       </Accordion>
@@ -42,37 +39,28 @@ describe('default version for sections', () => {
 
     fireEvent.click(summary)
 
-    expect(queryByText(summaryHeaderText)).toBeInTheDocument()
-    expect(container.querySelector('.MuiCollapse-container')).not.toHaveClass(
-      'MuiCollapse-hidden'
-    )
+    expect(container).toMatchSnapshot()
   })
 })
 
 describe('controlled version', () => {
   test('should render expanded version', () => {
-    const { container, queryByText } = render(
+    const { container } = render(
       <Accordion content={<Details />} expanded>
         <Summary />
       </Accordion>
     )
 
-    expect(queryByText(summaryHeaderText)).toBeInTheDocument()
-    expect(container.querySelector('.MuiCollapse-container')).not.toHaveClass(
-      'MuiCollapse-hidden'
-    )
+    expect(container).toMatchSnapshot()
   })
 
   test('should render collapsed version', () => {
-    const { container, queryByText } = render(
+    const { container } = render(
       <Accordion content={<Details />} expanded={false}>
         <Summary />
       </Accordion>
     )
 
-    expect(queryByText(summaryHeaderText)).toBeInTheDocument()
-    expect(container.querySelector('.MuiCollapse-container')).toHaveClass(
-      'MuiCollapse-hidden'
-    )
+    expect(container).toMatchSnapshot()
   })
 })


### PR DESCRIPTION
[FX-1092]

### Description

Elements rendered in the accordion are always the same, only their classes change, it makes sense to use snapshot testing

### How to test

- run tests `yarn test Accordion` 

### Review

- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/api-principles.md)
- [x] Ensure that unit tests pass by running `yarn test`
- [x] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run  whole pipeline
- `@toptal-bot run danger` - Danger checks
- `@toptal-bot run lint` - Run linter
- `@toptal-bot run test` - Run jest
- `@toptal-bot run build` - Check build
- `@toptal-bot run test:visual` or `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>


[FX-1092]: https://toptal-core.atlassian.net/browse/FX-1092