### PR TITLE
fix: use document.activeElement for focus check

### DIFF
--- a/packages/picasso-lab/src/DatePicker/DatePicker.tsx
+++ b/packages/picasso-lab/src/DatePicker/DatePicker.tsx
@@ -171,7 +171,7 @@ export const DatePicker = (props: Props) => {
 
   const handleBlur = (event: React.FocusEvent<HTMLDivElement>) => {
     const isFocusedInsideDatePicker = isInsideDatePicker(
-      event.relatedTarget as Node
+      (event.relatedTarget || document.activeElement) as Node
     )
 
     if (isFocusedInsideDatePicker) {


### PR DESCRIPTION
[PRL-⚡️]

### Description

In Internet Explorer 11 in case of onBlur action `event.relatedTarget`
is always null. In order to support IE11 we can check for
`document.activeElement`. In this way we can support modern browsers and
IE 11 at the same time.

### How to test

- Open DatePicker in IE11 with single and range mode

### Screenshots

![screencast 2020-12-04 13-52-52](https://user-images.githubusercontent.com/160962/101168443-c0c46980-363b-11eb-9b79-a1d13459d0b4.gif)


### Review

- [ ] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/api-principles.md)
- [ ] Make sure you've converted all `*.example.js/jsx` file into `*.example.ts/tsx` in your PR
- [ ] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that unit tests pass by running `yarn test`
- [ ] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run  whole pipeline
- `@toptal-bot run danger` - Danger checks
- `@toptal-bot run lint` - Run linter
- `@toptal-bot run test` - Run jest
- `@toptal-bot run build` - Check build
- `@toptal-bot run test:visual` or `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>
