### PR TITLE
fix: [FX-1499] Use correct cursor in form elements

### DIFF
--- a/packages/picasso-lab/src/TimePicker/TimePicker.tsx
+++ b/packages/picasso-lab/src/TimePicker/TimePicker.tsx
@@ -5,6 +5,7 @@ import { Time16 } from '@toptal/picasso/Icon'
 import { Theme, makeStyles } from '@material-ui/core/styles'
 import InputMask from 'react-input-mask'
 import { detect } from 'detect-browser'
+import cx from 'classnames'
 
 import styles from './styles'
 
@@ -41,7 +42,7 @@ export interface Props
 }
 
 export const TimePicker = (props: Props) => {
-  const { onChange, value, width, ...rest } = props
+  const { onChange, value, width, className, ...rest } = props
   const classes = useStyles(props)
   const browser = detect()
   const isSafari = browser?.name === 'safari'
@@ -55,7 +56,7 @@ export const TimePicker = (props: Props) => {
     /[0-9]/
   ]
 
-  const getIcon = () => <Time16 classes={{ root: classes.icon }} />
+  const icon = <Time16 classes={{ root: classes.icon }} />
 
   if (isSafari) {
     return (
@@ -63,8 +64,9 @@ export const TimePicker = (props: Props) => {
         type='text'
         readOnly
         iconPosition='end'
-        icon={getIcon()}
+        icon={icon}
         width={width}
+        className={cx(classes.root, className)}
         inputProps={{
           className: classes.inputBase,
           ...rest
@@ -88,9 +90,10 @@ export const TimePicker = (props: Props) => {
     <Input
       type='time'
       value={value}
+      className={cx(classes.root, className)}
       onChange={onChange}
       iconPosition='end'
-      icon={getIcon()}
+      icon={icon}
       width={width}
       inputProps={{
         className: classes.inputBase,
@@ -100,8 +103,6 @@ export const TimePicker = (props: Props) => {
     />
   )
 }
-
-TimePicker.defaultProps = {}
 
 TimePicker.displayName = 'TimePicker'
 

--- a/packages/picasso-lab/src/TimePicker/__snapshots__/test.tsx.snap
+++ b/packages/picasso-lab/src/TimePicker/__snapshots__/test.tsx.snap
@@ -6,7 +6,7 @@ exports[`TimePicker default render 1`] = `
     class="Picasso-root"
   >
     <div
-      class="MuiInputBase-root MuiOutlinedInput-root OutlinedInput-root PicassoInput-root OutlinedInput-rootAuto OutlinedInput-rootMedium MuiInputBase-adornedStart MuiOutlinedInput-adornedStart MuiInputBase-adornedEnd MuiOutlinedInput-adornedEnd"
+      class="MuiInputBase-root MuiOutlinedInput-root OutlinedInput-root PicassoInput-root OutlinedInput-rootAuto OutlinedInput-rootMedium PicassoTimePicker-root MuiInputBase-adornedStart MuiOutlinedInput-adornedStart MuiInputBase-adornedEnd MuiOutlinedInput-adornedEnd"
     >
       <input
         autocomplete="none"

--- a/packages/picasso-lab/src/TimePicker/styles.ts
+++ b/packages/picasso-lab/src/TimePicker/styles.ts
@@ -2,15 +2,25 @@ import { Theme, createStyles } from '@material-ui/core/styles'
 
 export default ({ palette }: Theme) =>
   createStyles({
+    root: {
+      cursor: 'default'
+    },
     icon: {
       background: palette.common.white,
       position: 'absolute',
       right: '0.625rem',
       pointerEvents: 'none',
-      margin: 0
+      margin: 0,
+      userSelect: 'none'
     },
     inputBase: {
-      marginRight: '-8px' // override default margin for icon position
+      marginRight: '-8px', // override default margin for icon position
+
+      // override styles for native 'clock' icon for type='time'
+      '&::-webkit-calendar-picker-indicator': {
+        outline: 'none',
+        cursor: 'pointer'
+      }
     },
     inputMask: {
       fontSize: '0.8125rem',

--- a/packages/picasso/src/Input/styles.ts
+++ b/packages/picasso/src/Input/styles.ts
@@ -9,7 +9,8 @@ export default ({ palette }: Theme) =>
   createStyles({
     root: {
       fontSize: '1rem',
-      backgroundColor: palette.common.white
+      backgroundColor: palette.common.white,
+      cursor: 'text'
     },
     rootMultiline: {
       height: 'auto'

--- a/packages/picasso/src/NumberInput/styles.ts
+++ b/packages/picasso/src/NumberInput/styles.ts
@@ -3,7 +3,8 @@ import { createStyles, Theme } from '@material-ui/core/styles'
 export default ({ palette, transitions }: Theme) =>
   createStyles({
     root: {
-      paddingRight: 0
+      paddingRight: 0,
+      cursor: 'text'
     },
     input: {
       '&::-webkit-outer-spin-button, &::-webkit-inner-spin-button': {

--- a/packages/picasso/src/TagSelectorInput/styles.ts
+++ b/packages/picasso/src/TagSelectorInput/styles.ts
@@ -14,13 +14,14 @@ export default () =>
       paddingBottom: 0,
       paddingLeft: TAG_SELECTOR_INPUT_GUTTER_SIZE,
       paddingTop: TAG_SELECTOR_INPUT_GUTTER_SIZE,
+      cursor: 'pointer',
 
       '& > input': {
         flexGrow: 1,
-        width: '0',
+        width: 0,
         height: rem('24px'),
         paddingLeft: rem('4px'),
-        paddingRight: '0',
+        paddingRight: 0,
         marginBottom: TAG_SELECTOR_INPUT_GUTTER_SIZE
       }
     },

--- a/packages/shared/src/styles/index.ts
+++ b/packages/shared/src/styles/index.ts
@@ -39,7 +39,7 @@ export const outline = (baseColor: string, width = 3) => ({
   boxShadow: `0 0 0 ${width}px ${alpha(baseColor, 0.48)}`
 })
 
-export const remToNumber = (value: string): number => Number.parseFloat(value)
+export const remToNumber = (value: string) => Number.parseFloat(value)
 
 export { default as withClasses } from './withClasses'
 


### PR DESCRIPTION
[FX-1499]

### Description

Update cursor styles for form elements.

### How to test

- FIXME: Add the steps describing how to verify your changes

### Screenshots

<details>
<summary>Checkbox</summary>

![checkbox](https://user-images.githubusercontent.com/1291032/101814497-4f028900-3b2f-11eb-96b0-b294b52e897c.gif)
</details>

<details>
<summary>Radio</summary>

![radio](https://user-images.githubusercontent.com/1291032/101819555-7ad53d00-3b36-11eb-82ca-ac0cafa4a1f7.gif)

</details>


<details>
<summary> Datepicker </summary>

![datepicker](https://user-images.githubusercontent.com/1291032/101814517-53c73d00-3b2f-11eb-9ce1-1b80617d3505.gif)
</details>

<details>
<summary> Input </summary>

![input](https://user-images.githubusercontent.com/1291032/101814524-55910080-3b2f-11eb-8f19-b82f03c0a0e7.gif)
</details>

<details>
<summary> Switch </summary>

![Kapture 2020-12-10 at 19 08 32](https://user-images.githubusercontent.com/1291032/101814525-55910080-3b2f-11eb-8f75-a9a99ea1a0ec.gif)
</details>

<details>
<summary> NumberInput </summary>

![number_input](https://user-images.githubusercontent.com/1291032/101814528-56299700-3b2f-11eb-86ea-e2ce7713fb38.gif)
</details>

<details>
<summary> TagSelector </summary>

![tagselector](https://user-images.githubusercontent.com/1291032/101814530-56c22d80-3b2f-11eb-837c-d61302beee69.gif)
</details>

<details>
<summary> TImepicker </summary>

![timepicker](https://user-images.githubusercontent.com/1291032/101814533-56c22d80-3b2f-11eb-975a-18b3d22d9369.gif)
</details>


### Review

- [ ] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/api-principles.md)
- [ ] Make sure you've converted all `*.example.js/jsx` file into `*.example.ts/tsx` in your PR
- [ ] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that unit tests pass by running `yarn test`
- [ ] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run danger` - Danger checks
- `@toptal-bot run lint` - Run linter
- `@toptal-bot run test` - Run jest
- `@toptal-bot run build` - Check build
- `@toptal-bot run test:visual` or `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>


[FX-1499]: https://toptal-core.atlassian.net/browse/FX-1499