### PR TITLE
fix: alignment of menu icon on mobile

### DIFF
--- a/packages/picasso/src/Sidebar/styles.ts
+++ b/packages/picasso/src/Sidebar/styles.ts
@@ -16,7 +16,7 @@ export default ({ palette, screens, zIndex }: Theme) =>
     },
     responsiveWrapper: {
       position: 'fixed',
-      top: '0.375em',
+      top: '0.75em',
       left: '0.375em',
       zIndex: zIndex.appBar
     },


### PR DESCRIPTION
### Description

Fix vertical alignment for the Menu icon in TopBar for the mobile screens