### PR TITLE
fix(picasso-forms): scroll to any field with error

### DIFF
--- a/packages/picasso-forms/src/Form/__snapshots__/test.tsx.snap
+++ b/packages/picasso-forms/src/Form/__snapshots__/test.tsx.snap
@@ -8,6 +8,7 @@ exports[`FormInput default render 1`] = `
     <form>
       <div
         class="FormField-root"
+        data-field-has-error="false"
       >
         <div
           class="MuiInputBase-root MuiOutlinedInput-root OutlinedInput-root PicassoInput-root OutlinedInput-rootAuto OutlinedInput-rootMedium MuiInputBase-adornedStart MuiOutlinedInput-adornedStart MuiInputBase-adornedEnd MuiOutlinedInput-adornedEnd"

--- a/packages/picasso-forms/src/Radio/__snapshots__/test.tsx.snap
+++ b/packages/picasso-forms/src/Radio/__snapshots__/test.tsx.snap
@@ -8,6 +8,7 @@ exports[`FormRadio default render 1`] = `
     <form>
       <div
         class="FormField-root"
+        data-field-has-error="false"
       >
         <label
           class="FormLabel-root"

--- a/packages/picasso-forms/src/utils/scroll-to-error-decorator.ts
+++ b/packages/picasso-forms/src/utils/scroll-to-error-decorator.ts
@@ -1,29 +1,22 @@
-import { FormApi, getIn } from 'final-form'
+import { FormApi } from 'final-form'
 
-import flatMap from './flat-map'
+const UNHIDDEN_INPUT_SELECTOR = 'input:not([type=hidden])'
 
-const formInputs = (form: HTMLFormElement) =>
-  Array.from(form.elements).filter(
-    element =>
-      element instanceof HTMLElement && typeof element.focus === 'function'
-  ) as HTMLInputElement[]
+const findFirstFieldWithError = (): HTMLElement | null => {
+  if (typeof document === 'undefined') return null
 
-const getInputs = (): HTMLInputElement[] => {
-  if (typeof document === 'undefined') return []
-
-  return flatMap(Array.from(document.forms), formInputs)
+  return document.querySelector<HTMLElement>('[data-field-has-error="true"]')
 }
 
-const findInputWithError = (inputs: HTMLInputElement[], errors: {}) =>
-  inputs.find(input => input.name && getIn(errors, input.name))
+const scrollToError = () => {
+  const field = findFirstFieldWithError()
 
-const scrollToError = (errors: object) => {
-  const firstInput = findInputWithError(getInputs(), errors)
+  if (!field) return
 
-  if (!firstInput) return
-
-  firstInput.focus({ preventScroll: true })
-  firstInput.scrollIntoView({ block: 'center', behavior: 'smooth' })
+  field.scrollIntoView({ block: 'center', behavior: 'smooth' })
+  field
+    .querySelector<HTMLInputElement>(UNHIDDEN_INPUT_SELECTOR)
+    ?.focus({ preventScroll: true })
 }
 
 export default () => <T>(form: FormApi<T>) => {
@@ -40,10 +33,8 @@ export default () => <T>(form: FormApi<T>) => {
   const scrollOnErrors = () => {
     const { errors = {}, submitErrors = {} } = state
 
-    if (Object.keys(errors).length) {
-      scrollToError(errors)
-    } else if (Object.keys(submitErrors).length) {
-      scrollToError(submitErrors)
+    if (Object.keys(errors).length || Object.keys(submitErrors).length) {
+      scrollToError()
     }
   }
 

--- a/packages/picasso/src/FormError/__snapshots__/test.tsx.snap
+++ b/packages/picasso/src/FormError/__snapshots__/test.tsx.snap
@@ -8,6 +8,7 @@ exports[`FormError default render 1`] = `
     <form>
       <div
         class="FormField-root"
+        data-field-has-error="false"
       >
         <label
           class="FormLabel-root"

--- a/packages/picasso/src/FormField/FormField.tsx
+++ b/packages/picasso/src/FormField/FormField.tsx
@@ -27,6 +27,7 @@ export const FormField = forwardRef<HTMLDivElement, Props>(function FormField(
       ref={ref}
       className={cx(classes.root, className)}
       style={style}
+      data-field-has-error={Boolean(error)}
     >
       {children}
       {error && <FormError className={classes.error}>{error}</FormError>}

--- a/packages/picasso/src/FormField/__snapshots__/test.tsx.snap
+++ b/packages/picasso/src/FormField/__snapshots__/test.tsx.snap
@@ -4,6 +4,7 @@ exports[`FormField default render 1`] = `
 <div>
   <div
     class="FormField-root"
+    data-field-has-error="false"
   >
     <input />
   </div>

--- a/packages/picasso/src/FormLabel/__snapshots__/test.tsx.snap
+++ b/packages/picasso/src/FormLabel/__snapshots__/test.tsx.snap
@@ -8,6 +8,7 @@ exports[`FormLabel default render 1`] = `
     <form>
       <div
         class="FormField-root"
+        data-field-has-error="false"
       >
         <label
           class="FormLabel-root"
@@ -56,6 +57,7 @@ exports[`FormLabel disabled 1`] = `
     <form>
       <div
         class="FormField-root"
+        data-field-has-error="false"
       >
         <label
           class="FormLabel-root FormLabel-disabled"
@@ -104,6 +106,7 @@ exports[`FormLabel required 1`] = `
     <form>
       <div
         class="FormField-root"
+        data-field-has-error="false"
       >
         <label
           class="FormLabel-root"
@@ -157,6 +160,7 @@ exports[`FormLabel required and disabled 1`] = `
     <form>
       <div
         class="FormField-root"
+        data-field-has-error="false"
       >
         <label
           class="FormLabel-root FormLabel-disabled"


### PR DESCRIPTION
[N/A]

### Description

Currently scroll to error on form submission is not working quite right with complex fields such as selects as it finds hidden inputs and attempts to scroll to them. To mitigate that and make the scroll to error logic as resilient as possible one solution is to make it scroll to `FormField`s themselves and not rely on inputs thus maximizing control over the behavior. This PR does exactly that.

### How to test

- Create a form with erred Form.Select
- Attempt submission
- _Expected:_ Form should scroll to the erred field
- _Expected:_ Select should show dropdown

### Review

- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/api-principles.md)
- ~Make sure you've converted all `*.example.js/jsx` file into `*.example.ts/tsx` in your PR~
- ~Annotate all `props` in component with documentation~
- ~Create `examples` for component~
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure that unit tests pass by running `yarn test`
- [x] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run  whole pipeline
- `@toptal-bot run danger` - Danger checks
- `@toptal-bot run lint` - Run linter
- `@toptal-bot run test` - Run jest
- `@toptal-bot run build` - Check build
- `@toptal-bot run test:visual` or `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>
