### PR TITLE
fix(Modal): calculate margins from base font size

### DIFF
--- a/packages/picasso/src/Modal/styles.ts
+++ b/packages/picasso/src/Modal/styles.ts
@@ -8,7 +8,10 @@ export default ({ screens, sizes }: Theme) =>
   createStyles({
     root: {
       display: 'flex',
-      flexDirection: 'column'
+      flexDirection: 'column',
+      // do not remove, should be covered with test
+      // https://toptal-core.atlassian.net/browse/FX-1543
+      fontSize: '1rem'
     },
     container: {},
     paper: {
@@ -36,7 +39,7 @@ export default ({ screens, sizes }: Theme) =>
     },
     topAlignedDialog: {
       position: 'absolute',
-      top: '0px',
+      top: 0,
       maxHeight: maxHeightForTopAligned
     },
     closeButton: {


### PR DESCRIPTION
[FX-1524]

### Description

Fix modal margins. 

TODO: test

### How to test

- check demo, try to specify different font-size on `#modal-container`

<details>

<summary>code to paste to the example</summary>

```
import React, { useState } from 'react'
import { Modal, Button, Input, Checkbox, Select, Form } from '@toptal/picasso'
import { useModal } from '@toptal/picasso/utils'
import { DatePicker } from '@toptal/picasso-lab'

const STATES = [
  {
    text: 'Alabama',
    value: 'Alabama'
  },
  {
    text: 'Utah',
    value: 'Utah'
  }
]

const ModalDialog = ({
  open,
  onClose
}: {
  open: boolean
  onClose: () => void
}) => {
  const [isLoading, setLoading] = useState(false)
  const [datepickerValue, setDatepickerValue] = useState<Date>()

  return (
    <Modal
      container={() => document.getElementById('modal-container')!}
      onBackdropClick={() => console.log('Clicked backdrop..')}
      onClose={onClose}
      onOpen={() => console.log('onOpen()')}
      open={open}
      transitionDuration={0} // Only for demo purposes, should not be used
    >
      <Modal.Title>Edit address details</Modal.Title>
      <Modal.Content>
        <Form.Field>
          <Input width='full' placeholder='City' value='Alabaster' />
        </Form.Field>
        <Form.Field>
          <Input width='full' placeholder='Street' value='John Fruit' />
        </Form.Field>
        <Form.Field>
          <Select placeholder='State' options={STATES} value='Alabama' />
        </Form.Field>
        <Form.Field>
          <DatePicker
            width='full'
            value={datepickerValue}
            onChange={date => {
              /* eslint-disable-next-line no-console */
              console.log('selected date is: ', date)

              setDatepickerValue(date as Date)
            }}
          />
        </Form.Field>
        <Form.Field>
          <Checkbox label='Use shipping address for billing' />
        </Form.Field>
      </Modal.Content>
      <Modal.Actions>
        <Button disabled={isLoading} variant='secondary' onClick={onClose}>
          Cancel
        </Button>
        <Button
          data-testid='close'
          loading={isLoading}
          onClick={() => {
            setLoading(true)

            setTimeout(() => {
              setLoading(false)
              onClose()
            }, 1000)
          }}
          variant='positive'
        >
          Update
        </Button>
      </Modal.Actions>
    </Modal>
  )
}

const Example = () => {
  const { showModal, hideModal, isOpen } = useModal()

  return (
    <div id='modal-container' style={{fontSize: 10}}>
      <Button data-testid='open' onClick={showModal}>
        Open
      </Button>
      <ModalDialog open={isOpen} onClose={hideModal} />
    </div>
  )
}

export default Example
```

</details>

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| <img width="802" alt="image" src="https://user-images.githubusercontent.com/1291032/102134459-978bb080-3e67-11eb-9a2d-d17748badf3f.png"> |  <img width="749" alt="image" src="https://user-images.githubusercontent.com/1291032/102134495-a5d9cc80-3e67-11eb-8e01-a556ec95889c.png"> |

### Review

- [ ] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/api-principles.md)
- [ ] Make sure you've converted all `*.example.js/jsx` file into `*.example.ts/tsx` in your PR
- [ ] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that unit tests pass by running `yarn test`
- [ ] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run danger` - Danger checks
- `@toptal-bot run lint` - Run linter
- `@toptal-bot run test` - Run jest
- `@toptal-bot run build` - Check build
- `@toptal-bot run test:visual` or `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>


[FX-1524]: https://toptal-core.atlassian.net/browse/FX-1524