### PR TITLE
fix(OverviewBlock): fix typecheck in test

### DIFF
--- a/packages/picasso-lab/src/OverviewBlock/test.tsx
+++ b/packages/picasso-lab/src/OverviewBlock/test.tsx
@@ -1,15 +1,14 @@
-import React from 'react'
+import React, { ComponentProps } from 'react'
 import { render, PicassoConfig } from '@toptal/picasso/test-utils'
-import { OmitInternalProps } from '@toptal/picasso-shared'
 import * as titleCaseModule from 'ap-style-title-case'
 import { Link, MemoryRouter as Router } from 'react-router-dom'
 
-import OverviewBlock, { Props } from './OverviewBlock'
+import OverviewBlock from './OverviewBlock'
 
 jest.mock('ap-style-title-case')
 
 const renderOverviewBlock = (
-  props: OmitInternalProps<Props, 'children'>,
+  props: ComponentProps<typeof OverviewBlock>,
   picassoConfig?: PicassoConfig
 ) => {
   return render(


### PR DESCRIPTION
[SPB-1462]

### Description
+ Fix original type declaration inside of tests

### Review

- [ ] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/api-principles.md)
- [ ] Make sure you've converted all `*.example.js/jsx` file into `*.example.ts/tsx` in your PR
- [ ] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that unit tests pass by running `yarn test`
- [ ] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run  whole pipeline
- `@toptal-bot run danger` - Danger checks
- `@toptal-bot run lint` - Run linter
- `@toptal-bot run test` - Run jest
- `@toptal-bot run build` - Check build
- `@toptal-bot run test:visual` or `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>


[SPB-1462]: https://toptal-core.atlassian.net/browse/SPB-1462