### PR TITLE
feat(picasso-codemod): add accordion borders codemod

### DIFF
--- a/packages/picasso-codemod/README.md
+++ b/packages/picasso-codemod/README.md
@@ -70,3 +70,29 @@ npx jscodeshift -t node_modules/@toptal/picasso-codemod/v5.0.0/label-tag src/**/
 ```
 
 </details>
+
+#### `accordion-borders`
+
+Updates the Accordion prop `bordered?: boolean` to `borders: 'all' | 'none'`.
+
+The diff should look like this:
+
+```diff
+-<Accordion content='Accordion content' bordered>Summary</Accordion>
+-<Accordion content='Accordion content' bordered={true}>Summary</Accordion>
+-<Accordion content='Accordion content' bordered={false}>Summary</Accordion>
+-<Accordion content='Accordion content'>Summary</Accordion>
++<Accordion content='Accordion content' borders='all'>Summary</Accordion>
++<Accordion content='Accordion content' borders='all'>Summary</Accordion>
++<Accordion content='Accordion content' borders='none'>Summary</Accordion>
++<Accordion content='Accordion content'>Summary</Accordion>
+```
+
+<details>
+<summary>Command</summary>
+
+```sh
+npx jscodeshift --parser=tsx -t node_modules/@toptal/picasso-codemod/v5.0.0/accordion-borders src/**/*.tsx
+```
+
+</details>

--- a/packages/picasso-codemod/src/v5.0.0/accordion-borders/__testfixtures__/basic.input.tsx
+++ b/packages/picasso-codemod/src/v5.0.0/accordion-borders/__testfixtures__/basic.input.tsx
@@ -1,0 +1,19 @@
+// @ts-nocheck
+import React from 'react'
+import { Accordion } from '@toptal/picasso'
+
+export default () => (
+  <>
+    <Accordion content='Accordion content' bordered>
+      Summary
+    </Accordion>
+    {/* eslint-disable-next-line react/jsx-boolean-value */}
+    <Accordion content='Accordion content' bordered={true}>
+      Summary
+    </Accordion>
+    <Accordion content='Accordion content' bordered={false}>
+      Summary
+    </Accordion>
+    <Accordion content='Accordion content'>Summary</Accordion>
+  </>
+)

--- a/packages/picasso-codemod/src/v5.0.0/accordion-borders/__testfixtures__/basic.output.tsx
+++ b/packages/picasso-codemod/src/v5.0.0/accordion-borders/__testfixtures__/basic.output.tsx
@@ -1,0 +1,19 @@
+// @ts-nocheck
+import React from 'react'
+import { Accordion } from '@toptal/picasso'
+
+export default () => (
+  <>
+    <Accordion content='Accordion content' borders='all'>
+      Summary
+    </Accordion>
+    {/* eslint-disable-next-line react/jsx-boolean-value */}
+    <Accordion content='Accordion content' borders='all'>
+      Summary
+    </Accordion>
+    <Accordion content='Accordion content' borders='none'>
+      Summary
+    </Accordion>
+    <Accordion content='Accordion content'>Summary</Accordion>
+  </>
+)

--- a/packages/picasso-codemod/src/v5.0.0/accordion-borders/__tests__/test.ts
+++ b/packages/picasso-codemod/src/v5.0.0/accordion-borders/__tests__/test.ts
@@ -1,0 +1,3 @@
+import { defineTest } from 'jscodeshift/src/testUtils'
+
+defineTest(__dirname, 'accordion-borders', {}, 'basic', { parser: 'tsx' })

--- a/packages/picasso-codemod/src/v5.0.0/accordion-borders/accordion-borders.ts
+++ b/packages/picasso-codemod/src/v5.0.0/accordion-borders/accordion-borders.ts
@@ -1,0 +1,43 @@
+import { JSXAttribute, Transform } from 'jscodeshift'
+
+const getNewValue = (attribute: JSXAttribute) => {
+  if (!attribute?.value) {
+    return 'all'
+  }
+
+  return 'expression' in attribute.value &&
+    'value' in attribute.value.expression &&
+    attribute.value.expression.value
+    ? 'all'
+    : 'none'
+}
+
+const transform: Transform = (file, api) => {
+  const j = api.jscodeshift
+
+  return (
+    j(file.source)
+      .findJSXElements('Accordion')
+      // eslint-disable-next-line complexity
+      .forEach(path => {
+        path.node.openingElement.attributes = path.node.openingElement.attributes.map(
+          attribute => {
+            if (
+              attribute.type === 'JSXAttribute' &&
+              attribute.name.name === 'bordered'
+            ) {
+              return j.jsxAttribute(
+                j.jsxIdentifier('borders'),
+                j.literal(getNewValue(attribute))
+              )
+            }
+
+            return attribute
+          }
+        )
+      })
+      .toSource({ quote: 'single' })
+  )
+}
+
+export default transform

--- a/packages/picasso-codemod/src/v5.0.0/accordion-borders/index.ts
+++ b/packages/picasso-codemod/src/v5.0.0/accordion-borders/index.ts
@@ -1,0 +1,1 @@
+export { default } from './accordion-borders'


### PR DESCRIPTION
[FX-1491](https://toptal-core.atlassian.net/browse/FX-1491)

### Description

Updates the Accordion prop `bordered?: boolean` to `borders: 'all' | 'none'`.

The diff should look like this:

```diff
-<Accordion content='Accordion content' bordered>Summary</Accordion>
-<Accordion content='Accordion content' bordered={true}>Summary</Accordion>
-<Accordion content='Accordion content' bordered={false}>Summary</Accordion>
-<Accordion content='Accordion content'>Summary</Accordion>
+<Accordion content='Accordion content' borders='all'>Summary</Accordion>
+<Accordion content='Accordion content' borders='all'>Summary</Accordion>
+<Accordion content='Accordion content' borders='none'>Summary</Accordion>
+<Accordion content='Accordion content'>Summary</Accordion>
```

### How to test

- FIXME: Add the steps describing how to verify your changes

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| Insert screenshots or screen recordings | Insert screenshots or screen recordings |

### Review

- [ ] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/api-principles.md)
- [ ] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that unit tests pass by running `yarn test`
- [ ] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run danger` - Danger checks
- `@toptal-bot run lint` - Run linter
- `@toptal-bot run test` - Run jest
- `@toptal-bot run build` - Check build
- `@toptal-bot run test:visual` or `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>
