### PR TITLE
feat(codemod): rename Page.Header to Page.TopBar

### DIFF
--- a/packages/picasso-codemod/README.md
+++ b/packages/picasso-codemod/README.md
@@ -131,3 +131,28 @@ npx jscodeshift -t node_modules/@toptal/picasso-codemod/v5.0.0/subheader-pagehea
 ```
 
 </details>
+
+#### `header-topbar`
+
+Renames occurrences of `Page.Header` to `Page.TopBar`.
+
+```diff
+  import { Page } from '@toptal/picasso'
+
+  const Example = () => (
+-   <Page.Header>
++   <Page.TopBar>
+       Content
+-   </Page.Header>
++   </Page.TopBar>
+  )
+```
+
+<details>
+<summary>Command</summary>
+
+```sh
+npx jscodeshift -t node_modules/@toptal/picasso-codemod/v5.0.0/header-topbar src/**/*.tsx --parser=tsx
+```
+
+</details>

--- a/packages/picasso-codemod/src/v5.0.0/header-topbar/__testfixtures__/basic.input.tsx
+++ b/packages/picasso-codemod/src/v5.0.0/header-topbar/__testfixtures__/basic.input.tsx
@@ -1,0 +1,6 @@
+import React from 'react'
+import { Page } from '@toptal/picasso'
+
+const Example = () => <Page.Header />
+
+export default Example

--- a/packages/picasso-codemod/src/v5.0.0/header-topbar/__testfixtures__/basic.output.tsx
+++ b/packages/picasso-codemod/src/v5.0.0/header-topbar/__testfixtures__/basic.output.tsx
@@ -1,0 +1,6 @@
+import React from 'react'
+import { Page } from '@toptal/picasso'
+
+const Example = () => <Page.TopBar />
+
+export default Example

--- a/packages/picasso-codemod/src/v5.0.0/header-topbar/__tests__/test.ts
+++ b/packages/picasso-codemod/src/v5.0.0/header-topbar/__tests__/test.ts
@@ -1,0 +1,7 @@
+import { defineTest } from 'jscodeshift/src/testUtils'
+
+const testTypes = ['basic']
+
+testTypes.forEach(testType => {
+  defineTest(__dirname, 'header-topbar', {}, testType, { parser: 'tsx' })
+})

--- a/packages/picasso-codemod/src/v5.0.0/header-topbar/header-topbar.ts
+++ b/packages/picasso-codemod/src/v5.0.0/header-topbar/header-topbar.ts
@@ -1,0 +1,21 @@
+import { Transform } from 'jscodeshift'
+
+import { findComponents } from '../../utils'
+
+const transform: Transform = (file, api) => {
+  const j = api.jscodeshift
+
+  const root = j(file.source)
+
+  findComponents('Page.Header', root, j)
+    .find(j.JSXIdentifier, { name: 'Header' })
+    .replaceWith(({ node }) => {
+      node.name = 'TopBar'
+
+      return node
+    })
+
+  return root.toSource()
+}
+
+export default transform

--- a/packages/picasso-codemod/src/v5.0.0/header-topbar/index.ts
+++ b/packages/picasso-codemod/src/v5.0.0/header-topbar/index.ts
@@ -1,0 +1,1 @@
+export { default } from './header-topbar'


### PR DESCRIPTION
[FX-1505]

### Description

Codemod to rename `Page.Head` to `Page.TopBar`

### Review

- [ ] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/api-principles.md)
- [ ] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that unit tests pass by running `yarn test`
- [ ] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run danger` - Danger checks
- `@toptal-bot run lint` - Run linter
- `@toptal-bot run test` - Run jest
- `@toptal-bot run build` - Check build
- `@toptal-bot run test:visual` or `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>

[FX-1505]: https://toptal-core.atlassian.net/browse/FX-1505