### PR TITLE
fix(TypographyOverflow): add Jest support for ResizeObserver

### DIFF
--- a/packages/picasso-lab/src/Ellipsis/use-ellipsis.ts
+++ b/packages/picasso-lab/src/Ellipsis/use-ellipsis.ts
@@ -28,15 +28,16 @@ const useEllipsis = () => {
 
   React.useEffect(() => {
     // @ts-ignore
-    const resizeObserver = new window.ResizeObserver(measure)
+    const ResizeObserver = window.ResizeObserver
+    const resizeObserver = ResizeObserver ? new ResizeObserver(measure) : null
     const container = ref.current?.parentNode
 
-    resizeObserver.observe(container)
+    resizeObserver?.observe(container)
 
     window.addEventListener('resize', measure)
 
     return () => {
-      resizeObserver.unobserve(container)
+      resizeObserver?.unobserve(container)
 
       window.removeEventListener('resize', measure)
     }


### PR DESCRIPTION
[FX-1601]

### Review

- [ ] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/api-principles.md)
- [ ] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that unit tests pass by running `yarn test`
- [ ] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run danger` - Danger checks
- `@toptal-bot run lint` - Run linter
- `@toptal-bot run test` - Run jest
- `@toptal-bot run build` - Check build
- `@toptal-bot run test:visual` or `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>


[FX-1601]: https://toptal-core.atlassian.net/browse/FX-1601