### PR TITLE
chore(Accordion): extract test render function

### DIFF
--- a/packages/picasso/src/Accordion/test.tsx
+++ b/packages/picasso/src/Accordion/test.tsx
@@ -106,7 +106,6 @@ describe('Accordion', () => {
     })
 
     expect(getByTestId('custom-expand-icon')).toBeInTheDocument()
-
     expect(container).toMatchSnapshot()
   })
 


### PR DESCRIPTION
[FX-1518]

### Description

Extrated a test rendering function to match [existing tests](https://github.com/toptal/picasso/blob/master/packages/picasso/src/Autocomplete/test.tsx#L18-L30) and [the new component templates](https://github.com/toptal/picasso/blob/master/_templates/component/new/test.ejs.t#L13-L20).

Having this extraction reduces duplication. Sometimes, rendering a test-case directly is more apt, which is why I [didn't use the abstraction in each test](https://github.com/toptal/picasso/blob/accordion-tests/packages/picasso/src/Accordion/test.tsx#L125-L141).

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run danger` - Danger checks
- `@toptal-bot run lint` - Run linter
- `@toptal-bot run test` - Run jest
- `@toptal-bot run build` - Check build
- `@toptal-bot run test:visual` or `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>


[FX-1518]: https://toptal-core.atlassian.net/browse/FX-1518