### PR TITLE
fix(Input): fix autocomplete edges non-clickable

### DIFF
--- a/packages/picasso/src/Input/Input.tsx
+++ b/packages/picasso/src/Input/Input.tsx
@@ -275,6 +275,7 @@ export const Input = forwardRef<HTMLInputElement, Props>(function Input(
     rowsMax,
     type,
     onChange,
+    onClick,
     startAdornment,
     endAdornment,
     limit,
@@ -320,6 +321,7 @@ export const Input = forwardRef<HTMLInputElement, Props>(function Input(
       type={type}
       width={width}
       size={size}
+      onClick={onClick}
       // html attributes
       inputProps={{
         ...rest,

--- a/packages/picasso/src/Input/test.tsx
+++ b/packages/picasso/src/Input/test.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { render } from '@toptal/picasso/test-utils'
+import { render, fireEvent } from '@toptal/picasso/test-utils'
 
 import Input from './Input'
 import Search16 from '../Icon/Search16'
@@ -76,5 +76,18 @@ describe('Input', () => {
     )
 
     expect(container).toMatchSnapshot()
+  })
+
+  it('handles clicks', () => {
+    const handleClick = jest.fn()
+    const { container } = render(<Input onClick={handleClick} />)
+
+    const input = container.querySelector('input')!
+    const inputWrapper = input.parentElement!
+
+    fireEvent.click(input)
+    expect(handleClick).toHaveBeenCalledTimes(1)
+    fireEvent.click(inputWrapper)
+    expect(handleClick).toHaveBeenCalledTimes(2)
   })
 })


### PR DESCRIPTION
[FX-1609](https://toptal-core.atlassian.net/browse/FX-1609)

### Description

If you click on the borders of the Autocomplete input, options do not appear. If you click on the center of the input, the options are there.

### How to test

1. Go to temploy.
2. Hover and click on the edge of the input in the Default example.
3. Be sure that the list of items appeared.

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| Insert screenshots or screen recordings | Insert screenshots or screen recordings |

### Review

- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/api-principles.md)
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure that unit tests pass by running `yarn test`
- [x] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run danger` - Danger checks
- `@toptal-bot run lint` - Run linter
- `@toptal-bot run test` - Run jest
- `@toptal-bot run build` - Check build
- `@toptal-bot run test:visual` or `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>
