### PR TITLE
docs(Container): change 'em' to 'rem' in the props description

### DIFF
--- a/packages/picasso/src/Container/Container.tsx
+++ b/packages/picasso/src/Container/Container.tsx
@@ -27,15 +27,15 @@ export interface Props
     HTMLAttributes<HTMLDivElement | HTMLSpanElement> {
   /** Content of Container */
   children: ReactNode
-  /** margin-top for the container transformed to `em` */
+  /** margin-top for the container transformed to `rem` */
   top?: SpacingType
-  /** margin-bottom for the container transformed to `em` */
+  /** margin-bottom for the container transformed to `rem` */
   bottom?: SpacingType
-  /** margin-left for the container transformed to `em` */
+  /** margin-left for the container transformed to `rem` */
   left?: SpacingType
-  /** margin-right for the container transformed to `em` */
+  /** margin-right for the container transformed to `rem` */
   right?: SpacingType
-  /** padding for the container transformed to `em` */
+  /** padding for the container transformed to `rem` */
   padded?: SpacingType
   /** Whether container should act as inline element `display: inline-block` */
   inline?: boolean

--- a/packages/picasso/src/Container/story/index.jsx
+++ b/packages/picasso/src/Container/story/index.jsx
@@ -20,13 +20,13 @@ page
     title: 'Spacing',
     description: 'Creating inner and outer space for component',
     extra: `
-Spacing is based on size enum that gets transformed into **em** unit in following manner: 
-- xsmall = 0.5em,
-- small = 1em,
-- medium = 1.5em,
-- large = 2em
-- xlarge = 2.5em
+Spacing is based on size enum that gets transformed into **rem** unit in following manner: 
+- xsmall = 0.5rem,
+- small = 1rem,
+- medium = 1.5rem,
+- large = 2rem
+- xlarge = 2.5rem
 
-For other custom  cases use **number** in em units or **className** to define spacings.
+For other custom  cases use **number** in rem units or **className** to define spacings.
 `
   })


### PR DESCRIPTION
[FX-NNNN]

### Description

Previously it was a typo in the description of the props of the `Container` component. There was `em` instead of `rem`. But actually, all styles are set using `rem`.

### How to test

- See the description of the props of the `Container` component

### Review

- [ ] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/api-principles.md)
- [ ] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that unit tests pass by running `yarn test`
- [ ] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run danger` - Danger checks
- `@toptal-bot run lint` - Run linter
- `@toptal-bot run test` - Run jest
- `@toptal-bot run build` - Check build
- `@toptal-bot run test:visual` or `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>
