### PR TITLE
fix(OverviewBlock): fix usage with Link

### DIFF
--- a/packages/picasso-lab/src/OverviewBlock/OverviewBlock.tsx
+++ b/packages/picasso-lab/src/OverviewBlock/OverviewBlock.tsx
@@ -94,7 +94,7 @@ export const OverviewBlock: OverridableComponent<Props> & StaticProps =
       color[partName] = colorName
     }
 
-    const isClickable = Boolean(onClick)
+    const isClickable = Boolean(onClick) || typeof as !== 'string'
 
     const Component = isClickable && as ? as : 'div'
 

--- a/packages/picasso-lab/src/OverviewBlock/test.tsx
+++ b/packages/picasso-lab/src/OverviewBlock/test.tsx
@@ -94,5 +94,18 @@ describe('OverviewBlock', () => {
 
       expect(getByTestId('OverviewBlock').nodeName).toBe('DIV')
     })
+
+    it('renders the element as `Link`', () => {
+      const { getByTestId } = renderOverviewBlock({
+        as: Link,
+        to: '/',
+        'data-testid': 'OverviewBlock'
+      })
+      const block = getByTestId('OverviewBlock')
+
+      // By the Link component to -> href
+      expect(block).toHaveAttribute('href', '/')
+      expect(block.nodeName).toBe('A')
+    })
   })
 })


### PR DESCRIPTION
[FX-1651]

### Description

Adds `active` prop to make usage with `Link` work. 

The bug was introduced with https://github.com/toptal/picasso/pull/1786. It added conditional logic based on `onClick` handler. When `OverviewBlock` is used with `Link`, there is no `onClick` handler provided, that's why it renders `div` and not the `Link`. To fix this bug without introducing a breaking change, I added `active` prop which can override this behaviour:
- When `active` is true, the component will render a component in `as`, even if there is no `onClick` handler
- When `active` is false, the component will always render `div`
- When `active` is not specified, the component will fallback to the old logic based on `onClick` handler.

Name `active` seems to be used often. I also had in mind `interactive` and `disabled`.

### How to test

- Run `yarn test`
- Open storybook, scroll to routing example of `OverviewBlock` and notice that these blocks can be clicked and routing works.

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
|<img width="576" alt="Screen Shot 2021-01-29 at 6 23 33 pm" src="https://user-images.githubusercontent.com/77451815/106293488-1f364e80-625f-11eb-9dda-fe2b8f2dd60e.png">|<img width="557" alt="Screen Shot 2021-01-29 at 6 23 29 pm" src="https://user-images.githubusercontent.com/77451815/106293504-25c4c600-625f-11eb-9d04-3ad304d57175.png">|

### Review

- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/api-principles.md)
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure that unit tests pass by running `yarn test`
- [x] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run danger` - Danger checks
- `@toptal-bot run lint` - Run linter
- `@toptal-bot run test` - Run jest
- `@toptal-bot run build` - Check build
- `@toptal-bot run test:visual` or `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>


[FX-1651]: https://toptal-core.atlassian.net/browse/FX-1651