### PR TITLE
chore: add typecheck in ci

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -58,6 +58,9 @@ jobs:
       - name: Danger
         run: yarn davinci ci danger --conventionalCommits
 
+      - name: Typecheck
+        run: yarn tsc --noEmit
+
       - name: Lint
         run: yarn lint
 

--- a/bin/run-in-docker
+++ b/bin/run-in-docker
@@ -47,7 +47,7 @@ else
   fi
 fi
 
-DOCKER_CMD="docker run -t -i --rm --name $REPO_NAME \
+DOCKER_CMD="docker run -it --rm --name $REPO_NAME \
  -v ${PWD}/packages:/app/packages \
  -v ${PWD}/puppeteer:/app/puppeteer \
  -v ${PWD}/.storybook:/app/.storybook \

--- a/packages/picasso-lab/src/TypographyOverflow/test.tsx
+++ b/packages/picasso-lab/src/TypographyOverflow/test.tsx
@@ -1,20 +1,17 @@
 import React from 'react'
 import { render } from '@toptal/picasso/test-utils'
-import useEllipsis from '@toptal/picasso-lab/Ellipsis/use-ellipsis'
 
 import TypographyOverflow from '.'
 
-jest.mock('@toptal/picasso-lab/Ellipsis/use-ellipsis')
+jest.mock('@toptal/picasso-lab/Ellipsis/use-ellipsis', () => {
+  return jest.fn(() => ({
+    ref: null,
+    isEllipsis: true
+  }))
+})
 
 describe('TypographyOverflow', () => {
   describe('tooltip render when overflow happened', () => {
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
-    useEllipsis.mockImplementation(() => ({
-      ref: null,
-      isEllipsis: true
-    }))
-
     it('renders tooltip by default', () => {
       const { queryByTestId } = render(
         <TypographyOverflow>Just Typography</TypographyOverflow>


### PR DESCRIPTION
[FX-1546]

### Description

Covered type errors in:

- stories
- tests
- code

### How to test

- add some typescript error and run `./bin/test-ci`

### Screenshots

<img width="1526" alt="image" src="https://user-images.githubusercontent.com/1291032/106517537-b0b8f100-64e9-11eb-950d-fb783f9ae692.png">

### Review

- [ ] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/api-principles.md)
- [ ] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that unit tests pass by running `yarn test`
- [ ] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run danger` - Danger checks
- `@toptal-bot run lint` - Run linter
- `@toptal-bot run test` - Run jest
- `@toptal-bot run build` - Check build
- `@toptal-bot run test:visual` or `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>


[FX-1546]: https://toptal-core.atlassian.net/browse/FX-1546