### PR TITLE
test(BarChart): fix cypress tests

### DIFF
--- a/cypress/integration/BarChart.spec.ts
+++ b/cypress/integration/BarChart.spec.ts
@@ -2,10 +2,7 @@
 // @ts-ignore
 const getBar = name => cy.get(`path[name="${name}"]`).first()
 // @ts-ignore
-const hoverOverBar = name =>
-  getBar(name)
-    .first()
-    .trigger('mouseover')
+const hoverOverBar = name => getBar(name).trigger('mousemove')
 // @ts-ignore
 const assertTooltipContent = text => {
   cy.get('.recharts-default-tooltip')


### PR DESCRIPTION
[FX-NNNN]

### Description

It seems that after `recharts` update, `mouseover` in Cypress stopped triggering the tooltip to show. Fixed by changing it to `mousemove`.

### How to test

1. `yarn cypress:start`.
2. Wait until Cypress is open.
3. Click `BarChart.spec.ts`.

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| Insert screenshots or screen recordings | Insert screenshots or screen recordings |

### Review

- [ ] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/api-principles.md)
- [ ] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that unit tests pass by running `yarn test`
- [ ] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
- [ ] Ensure the changed/created components have not caused accessibility issues. [How to use a11y plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/a11y.md).

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run danger` - Danger checks
- `@toptal-bot run lint` - Run linter
- `@toptal-bot run test` - Run jest
- `@toptal-bot run build` - Check build
- `@toptal-bot run test:visual` or `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>
