### PR TITLE
fix(SidebarItem): fix selected styles

### DIFF
--- a/packages/picasso/src/SidebarItem/SidebarItem.tsx
+++ b/packages/picasso/src/SidebarItem/SidebarItem.tsx
@@ -3,7 +3,8 @@ import React, {
   ReactElement,
   ElementType,
   ChangeEvent,
-  memo
+  memo,
+  useContext
 } from 'react'
 import { Theme, makeStyles } from '@material-ui/core/styles'
 import cx from 'classnames'
@@ -21,7 +22,8 @@ import Accordion from '../Accordion'
 import MenuItem, { MenuItemAttributes } from '../MenuItem'
 import { ArrowDownMinor16 } from '../Icon'
 import styles from './styles'
-import { VariantType } from '../Sidebar/types'
+import { SidebarContextProps, VariantType } from '../Sidebar/types'
+import { SidebarContext } from '../Sidebar'
 
 export interface Props extends BaseProps, TextLabelProps, MenuItemAttributes {
   /** Pass icon to be used as part of item */
@@ -61,13 +63,14 @@ export const SidebarItem: OverridableComponent<Props> = memo(
       style,
       onClick,
       as,
-      variant,
       isExpanded,
       expand,
       index,
       titleCase: propsTitleCase,
       ...rest
     } = props
+    const context = useContext<SidebarContextProps>(SidebarContext)
+    const variant = props.variant || context.variant
     const classes = useStyles()
 
     const hasIcon = Boolean(icon)

--- a/packages/picasso/src/SidebarItem/__snapshots__/test.tsx.snap
+++ b/packages/picasso/src/SidebarItem/__snapshots__/test.tsx.snap
@@ -1,5 +1,131 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`SidebarItem apply selected styles when subMenu has a wrapper component 1`] = `
+<div>
+  <div
+    class="Picasso-root"
+  >
+    <div
+      class="MuiPaper-root MuiAccordion-root PicassoAccordion-root PicassoAccordion-bordersNone MuiAccordion-rounded MuiPaper-elevation0 MuiPaper-rounded"
+    >
+      <div
+        aria-disabled="false"
+        aria-expanded="false"
+        class="MuiButtonBase-root MuiAccordionSummary-root WithStyles(ForwardRef(AccordionSummary))-root PicassoAccordion-summary PicassoSidebarItem-collapsibleWrapper"
+        role="button"
+        tabindex="0"
+      >
+        <div
+          class="MuiAccordionSummary-content WithStyles(ForwardRef(AccordionSummary))-content PicassoAccordion-content PicassoSidebarItem-content"
+        >
+          <li
+            aria-disabled="false"
+            class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root PicassoMenuItem-root PicassoMenuItem-light PicassoSidebarItem-root PicassoSidebarItem-noWrap PicassoSidebarItem-roundedBorder PicassoSidebarItem-collapsible PicassoMenuItem-nonSelectable MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+            role="menuitem"
+            tabindex="-1"
+          >
+            <div
+              class="PicassoContainer-flex PicassoContainer-column PicassoMenuItem-content"
+            >
+              <div
+                class="PicassoContainer-centerAlignItems PicassoContainer-flex"
+              >
+                <div
+                  class="PicassoContainer-centerAlignItems PicassoContainer-flex PicassoContainer-inline PicassoSidebarItem-noWrap"
+                >
+                  <svg
+                    class="PicassoSvgCandidates16-root"
+                    style="min-width: 16px; min-height: 16px;"
+                    viewBox="0 0 16 16"
+                  >
+                    <path
+                      d="M16 11H7v4l-7-4V1h16v10zm-1-9H1v8.42l5 2.857V10h9V2z"
+                    />
+                  </svg>
+                  <div
+                    class="PicassoContainer-centerAlignItems PicassoContainer-flex PicassoSidebarItem-label PicassoSidebarItem-noWrap PicassoSidebarItem-withIcon"
+                  >
+                    <p
+                      class="MuiTypography-root PicassoTypography-bodyMedium PicassoTypography-inherit MuiTypography-body1 MuiTypography-noWrap"
+                    >
+                      Test item
+                    </p>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </li>
+          <svg
+            class="PicassoSvgArrowDownMinor16-root PicassoSidebarItem-expandIcon PicassoAccordion-expandIcon"
+            style="min-width: 16px; min-height: 16px;"
+            viewBox="0 0 16 16"
+          >
+            <path
+              d="M11.997 5.29l.707.707-4 4-.707.707-.707-.707-4-4 .707-.707 4 4 4-4z"
+            />
+          </svg>
+        </div>
+      </div>
+      <div
+        class="MuiCollapse-container MuiCollapse-hidden"
+        style="min-height: 0px;"
+      >
+        <div
+          class="MuiCollapse-wrapper"
+        >
+          <div
+            class="MuiCollapse-wrapperInner"
+          >
+            <div
+              role="region"
+            >
+              <div
+                class="MuiAccordionDetails-root PicassoAccordionDetails-root PicassoAccordion-details PicassoSidebarItem-nestedMenuWithIcon"
+              >
+                <ul
+                  class="MuiList-root Menu-root PicassoSidebarMenu-root"
+                  role="menu"
+                  tabindex="-1"
+                >
+                  <li
+                    aria-disabled="false"
+                    class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root PicassoMenuItem-root PicassoMenuItem-light PicassoSidebarItem-root PicassoSidebarItem-noWrap PicassoSidebarItem-roundedBorder PicassoSidebarItem-selected PicassoMenuItem-nonSelectable Mui-selected PicassoMenuItem-selected MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button Mui-selected"
+                    role="menuitem"
+                    tabindex="0"
+                  >
+                    <div
+                      class="PicassoContainer-flex PicassoContainer-column PicassoMenuItem-content"
+                    >
+                      <div
+                        class="PicassoContainer-centerAlignItems PicassoContainer-flex"
+                      >
+                        <div
+                          class="PicassoContainer-centerAlignItems PicassoContainer-flex PicassoContainer-inline PicassoSidebarItem-noWrap"
+                        >
+                          <div
+                            class="PicassoContainer-centerAlignItems PicassoContainer-flex PicassoSidebarItem-label PicassoSidebarItem-noWrap"
+                          >
+                            <p
+                              class="MuiTypography-root PicassoTypography-bodyMedium PicassoTypography-inherit MuiTypography-body1 MuiTypography-noWrap"
+                            >
+                              Menu item
+                            </p>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`SidebarItem collapsible menu is expanded when one of the children is selected 1`] = `
 <div>
   <div

--- a/packages/picasso/src/SidebarItem/styles.ts
+++ b/packages/picasso/src/SidebarItem/styles.ts
@@ -25,20 +25,20 @@ export default ({ palette, sizes }: Theme) =>
 
       '&:hover': {
         color: palette.blue.main,
-        '&$selected': {
+        '&$selected, $selected': {
           color: palette.blue.main,
           backgroundColor: palette.grey.light
         }
       },
-
-      '&$selected': {
+      // to cover cases when Sidebar.Item or Sidebar.Menu has a wrapper component
+      '&$selected, $selected': {
         color: palette.blue.main,
         backgroundColor: palette.grey.light
       },
 
       '&:focus': {
         color: palette.blue.main,
-        '&$selected': {
+        '&$selected, $selected': {
           color: palette.blue.main,
           backgroundColor: palette.grey.light
         }
@@ -47,19 +47,19 @@ export default ({ palette, sizes }: Theme) =>
     dark: {
       '&:hover': {
         color: palette.common.white,
-        '&$selected': {
+        '&$selected, $selected': {
           color: palette.common.white,
           backgroundColor: palette.grey.dark
         }
       },
-      '&$selected': {
+      '&$selected, $selected': {
         color: palette.common.white,
         backgroundColor: palette.grey.dark
       },
 
       '&:focus': {
         color: palette.common.white,
-        '&$selected': {
+        '&$selected, $selected': {
           color: palette.common.white,
           backgroundColor: palette.grey.dark
         }

--- a/packages/picasso/src/SidebarItem/test.tsx
+++ b/packages/picasso/src/SidebarItem/test.tsx
@@ -99,6 +99,27 @@ describe('SidebarItem', () => {
     expect(container).toMatchSnapshot()
   })
 
+  it('apply selected styles when subMenu has a wrapper component', () => {
+    const SubMenu = () => (
+      <Sidebar.Menu>
+        <Sidebar.Item selected>Menu item</Sidebar.Item>
+      </Sidebar.Menu>
+    )
+
+    const { container } = render(
+      <TestSidebarItem
+        icon={<Candidates16 />}
+        menu={<SubMenu />}
+        collapsible
+        isExpanded
+      >
+        Test item
+      </TestSidebarItem>
+    )
+
+    expect(container).toMatchSnapshot()
+  })
+
   it("don't use accordion for non-collapsible with menu", () => {
     const menu = (
       <Sidebar.Menu>


### PR DESCRIPTION
[FX-1704](https://toptal-core.atlassian.net/browse/FX-1704)

### Problem
Expanding by default doesn't work for the `Sidebar` component in case `Sidebar.Menu` or `Sidebar.Item` is in different components. Also, styles for selected items is broken

### Description

It is a partial fix of this bug. The full fix will be later. Because this [PR](https://github.com/toptal/staff-portal/pull/2307) is blocked by this bug. With this fix of the styles in Picasso, I can unblock my PR and handle expanding by default in my project.

### How to test

- Open storybook on the [temploy](https://picasso.toptal.net/SPC-932-fix-styles-sidebar-expanding-by-default/?path=/story/components-sidebar--sidebar).
- Go to the `Sidebar` section component
- Scroll down to the `Icons` section and press `Edit code`
- Add at the bottom, before `const Example = () => (`
```
const SubMenu = () => (
  <>
    <Sidebar.Item selected>Share Online</Sidebar.Item>
    <Sidebar.Item>Referred Users</Sidebar.Item>
    <Sidebar.Item>Commissions</Sidebar.Item>
    <Sidebar.Item>Payment Options</Sidebar.Item>
    <Sidebar.Item>Expected Commissions</Sidebar.Item>
  </>
)

const sidebarWithSeparateSubMenu = (
  <Sidebar>
    <Sidebar.Menu>
      <Sidebar.Item icon={<Overview16 />}>Overview</Sidebar.Item>
      <Sidebar.Item
        collapsible
        icon={<Referrals16 />}
        menu={
          <Sidebar.Menu>
            <SubMenu />
          </Sidebar.Menu>
        }
      >
        Referrals
      </Sidebar.Item>
    </Sidebar.Menu>
  </Sidebar>
)
```
- Then change `sidebarWithoutIcons` at line `88` to `sidebarWithSeparateSubMenu` and compare hover effect, focus state, and other styles on two menus: where there is a submenu as a separate component and where everything is in one component. They should be the same

P.S. Example with `sidebarWithSeparateSubMenu` will not be expanded by default, it is expected result. It will be fixed in a separate PR

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| <img width="246" alt="Screenshot 2021-02-08 at 11 16 43" src="https://user-images.githubusercontent.com/16545305/107199688-65c63e80-69ff-11eb-9161-7ab32360cd46.png"> | <img width="244" alt="Screenshot 2021-02-08 at 11 16 52" src="https://user-images.githubusercontent.com/16545305/107199718-6eb71000-69ff-11eb-847e-f1b21c0c5c42.png"> |


### Review

- [ ] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/api-principles.md)
- [ ] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that unit tests pass by running `yarn test`
- [ ] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
- [ ] Ensure the changed/created components have not caused accessibility issues. [How to use a11y plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/a11y.md).

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run danger` - Danger checks
- `@toptal-bot run lint` - Run linter
- `@toptal-bot run test` - Run jest
- `@toptal-bot run build` - Check build
- `@toptal-bot run test:visual` or `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>
