### PR TITLE
fix(Link): fix visited state

### DIFF
--- a/packages/picasso/src/Link/styles.ts
+++ b/packages/picasso/src/Link/styles.ts
@@ -12,7 +12,7 @@ PicassoProvider.override(() => ({
 export default ({ typography, palette }: Theme) =>
   createStyles({
     root: {
-      '&:active, &:visited': {
+      '&:focus': {
         outline: `1px dotted ${palette.blue.main}`
       }
     },


### PR DESCRIPTION
[FX-1547]

### Description

Fix the behaviour introduced in https://github.com/toptal/picasso/pull/1893. `:visited` doesn't work in current browsers - you can't add an outline if the link doesn't have outline in normal state (transparent outline doesn't work either)

### How to test

- Open storybook
- Open any Link in a new tab

BTW Peter confirmed that the behaviour is correct now (please see the conversation in the ticket).

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| Insert screenshots or screen recordings | Insert screenshots or screen recordings |

### Review

- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/api-principles.md)
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure that unit tests pass by running `yarn test`
- [x] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use a11y plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/a11y.md).

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run danger` - Danger checks
- `@toptal-bot run lint` - Run linter
- `@toptal-bot run test` - Run jest
- `@toptal-bot run build` - Check build
- `@toptal-bot run test:visual` or `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>


[FX-1547]: https://toptal-core.atlassian.net/browse/FX-1547