### PR TITLE
fix(ScrollMenu): fix scroll menu error when no item selected

### DIFF
--- a/packages/picasso/src/ScrollMenu/ScrollMenu.tsx
+++ b/packages/picasso/src/ScrollMenu/ScrollMenu.tsx
@@ -21,16 +21,25 @@ const useStyles = makeStyles<Theme>(styles, {
   name: 'PicassoScrollMenu'
 })
 
+const getMenuSelectedNode = (
+  menuRef: RefObject<HTMLDivElement>,
+  selectedIndex?: number | null
+) =>
+  typeof selectedIndex === 'number'
+    ? menuRef.current?.children[selectedIndex]
+    : undefined
+
 export const scrollToSelection = (
   menuRef: RefObject<HTMLDivElement>,
   selectedIndex?: number | null
 ) => {
-  if (!menuRef.current || selectedIndex == null) {
+  const menuNode = menuRef.current
+  const selectedNode = getMenuSelectedNode(menuRef, selectedIndex)
+
+  if (!menuNode || !selectedNode) {
     return
   }
 
-  const menuNode = menuRef.current
-  const selectedNode = menuRef.current.children[selectedIndex]
   const menuRect = menuNode.getBoundingClientRect()
   const selectedRect = selectedNode.getBoundingClientRect()
 

--- a/packages/picasso/src/ScrollMenu/test.tsx
+++ b/packages/picasso/src/ScrollMenu/test.tsx
@@ -28,8 +28,12 @@ const createElement = (opts: Partial<DOMRect>) => {
   return element
 }
 
+const createEmptyMenu = () => {
+  return createElement({ top: 20, bottom: 100 })
+}
+
 const createMenu = () => {
-  const menu = createElement({ top: 20, bottom: 100 })
+  const menu = createEmptyMenu()
 
   menu.append(createElement({ top: 10, bottom: 30 }))
   menu.append(createElement({ top: 40, bottom: 60 }))
@@ -43,11 +47,20 @@ const createRef = (current: HTMLDivElement) => {
 }
 
 describe('scrollToSelection', () => {
-  it('should not scroll when there is no selected item', () => {
+  it('should not scroll when there is no selected index', () => {
     const menu = createMenu()
     const menuRef = createRef(menu)
 
     scrollToSelection(menuRef, undefined)
+
+    expect(menu.scrollTop).toBe(0)
+  })
+
+  it('should not scroll when there is no select item', () => {
+    const menu = createEmptyMenu()
+    const menuRef = createRef(menu)
+
+    scrollToSelection(menuRef, 1)
 
     expect(menu.scrollTop).toBe(0)
   })


### PR DESCRIPTION
[FX-1738](https://toptal-core.atlassian.net/browse/FX-1738)

### Description

This bug happens quite randomly. @inemiro was the first who found it. Here is the scenario which raises the error for him:

1. Open `Select` default example.
2. Click on `Select`.
3. Choose some option
4. Click on `Select` again.
3. Scroll a bit.
4. Press `Tab` to focus on the search input.
5. Input some text.
6. Press `CMD+A`.
7. Input some text.
10. See an error: `TypeError: Cannot read property 'getBoundingClientRect' of undefined.`

### How to test

I have no idea because I can't reproduce it. 😅

### Video

https://drive.google.com/file/d/1XeMWF5NZX4F74gXsCoBbsTvF2jwa2Qs-/view

### Review

- [ ] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/api-principles.md)
- [ ] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that unit tests pass by running `yarn test`
- [ ] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
- [ ] Ensure the changed/created components have not caused accessibility issues. [How to use a11y plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/a11y.md).

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run danger` - Danger checks
- `@toptal-bot run lint` - Run linter
- `@toptal-bot run test` - Run jest
- `@toptal-bot run build` - Check build
- `@toptal-bot run test:visual` or `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>
