### PR TITLE
test(Accordion): add happo visual test

### DIFF
--- a/cypress/component/Accordion.spec.tsx
+++ b/cypress/component/Accordion.spec.tsx
@@ -1,8 +1,26 @@
-/* eslint-disable no-inline-styles/no-inline-styles */
 import React, { useState } from 'react'
-import { Accordion, Typography, Button, Container, Page } from '@toptal/picasso'
+import {
+  Accordion,
+  AccordionProps,
+  Typography,
+  Button,
+  Container,
+  Check16
+} from '@toptal/picasso'
 import { mount } from '@cypress/react'
 import { TestingPicasso } from '@toptal/picasso/test-utils'
+
+const TestAccordion = (props: Partial<AccordionProps>) => (
+  <Accordion
+    data-testid='accordion'
+    content='Aliqua ut aliquip dolor velit.'
+    {...props}
+  >
+    <Accordion.Summary>
+      Est amet duis deserunt proident Lorem.
+    </Accordion.Summary>
+  </Accordion>
+)
 
 const Summary = ({
   onClick,
@@ -56,12 +74,13 @@ const AccordionCustomSummary = () => {
 
   return (
     <TestingPicasso>
-      <Page>
-        <Page.Article>
-          <Summary onClick={handleClick} expanded={expanded} />
-          <Accordion content={<Content />} expanded={expanded} borders='none' />
-        </Page.Article>
-      </Page>
+      <Summary onClick={handleClick} expanded={expanded} />
+      <Accordion
+        data-testid='accordion-custom-summary'
+        content={<Content />}
+        expanded={expanded}
+        borders='none'
+      />
     </TestingPicasso>
   )
 }
@@ -71,22 +90,51 @@ const getAccordionContent = () => cy.get('[data-testid=content]')
 const clickStartInterviewOnboarding = () =>
   cy.get('[data-testid="start-onboarding"]').click()
 
+describe('Accordion', () => {
+  it('renders', () => {
+    mount(
+      <TestingPicasso>
+        <TestAccordion borders='none' />
+        <TestAccordion borders='middle' />
+        <TestAccordion borders='all' />
+        <TestAccordion defaultExpanded />
+        <TestAccordion expanded />
+        <TestAccordion expanded={false} />
+        <TestAccordion disabled />
+        <TestAccordion expandIcon={<Check16 />} />
+      </TestingPicasso>
+    )
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    cy.get('body').happoScreenshot()
+  })
+})
 describe('Accordion with custom summary', () => {
   it('closes and opens', () => {
     mount(<AccordionCustomSummary />)
     toggleAccordion()
     getAccordionContent().should('not.be.visible')
-    // TODO: Add visual regression test
+
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    cy.get('[data-testid=accordion-custom-summary]').happoScreenshot()
+
     toggleAccordion()
     getAccordionContent().should('be.visible')
-    // TODO: Add visual regression test
+
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    cy.get('[data-testid=accordion-custom-summary]').happoScreenshot()
   })
 
   it('interacts with accordion content', () => {
     mount(<AccordionCustomSummary />)
 
     clickStartInterviewOnboarding()
-    // TODO: Add visual regression test
+
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    cy.get('[data-testid=accordion-custom-summary]').happoScreenshot()
 
     cy.on('window:alert', text => {
       expect(text).equal('Onboarding started')

--- a/packages/picasso/src/Accordion/story/index.jsx
+++ b/packages/picasso/src/Accordion/story/index.jsx
@@ -31,22 +31,22 @@ page
     title: 'Default',
     description:
       'Accordion is uncontrolled until the `expanded` prop is specified.'
-  })
+  }) // picasso-skip-visuals
   .addExample('Accordion/story/Disabled.example.tsx', {
     title: 'Disabled',
     description:
       'Accordion ignores pointer events when the `disabled` prop is truthy.'
-  })
+  }) // picasso-skip-visuals
   .addExample('Accordion/story/BorderedGroups.example.tsx', {
     title: 'Borders and Groups',
     description: 'Accordions have configurable borders and can be grouped'
-  })
+  }) // picasso-skip-visuals
   .addExample('Accordion/story/Controlled.example.tsx', {
     title: 'Controlled',
     description: 'Accordion can be controlled via the `expanded` prop.'
-  })
+  }) // picasso-skip-visuals
   .addExample('Accordion/story/CustomSummary.example.tsx', {
     title: 'Custom Summary',
     description:
       "Accordion's summary is customizable. It either can be passed as `children` or be an external custom component."
-  })
+  }) // picasso-skip-visuals


### PR DESCRIPTION
[FX-NNNN]

### Description

- added visual regression tests to all component props
- added visual assertions in integration tests
- disabled storyshot Accordion visuals

### How to test

- run `yarn test:cypress`

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| Insert screenshots or screen recordings | Insert screenshots or screen recordings |

### Review

- [ ] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/api-principles.md)
- [ ] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that tests pass by running `yarn test`
- [ ] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
- [ ] Ensure the changed/created components have not caused accessibility issues. [How to use a11y plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/a11y.md).

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>
