### PR TITLE
fix(autocomplete): [CRT-2775] fix focus on input reset

### DIFF
--- a/packages/picasso/src/Autocomplete/test.tsx
+++ b/packages/picasso/src/Autocomplete/test.tsx
@@ -366,4 +366,27 @@ describe('Autocomplete', () => {
       expect(input.getAttribute('autocomplete')).toBe('country-name')
     })
   })
+
+  describe('reset behavior', () => {
+    it('when reset button clicked', () => {
+      const {
+        getByRole,
+        getByText,
+        getByPlaceholderText,
+        queryByText
+      } = renderAutocomplete({
+        options: testOptions,
+        placeholder,
+        value: ''
+      })
+
+      const input = getByPlaceholderText(placeholder) as HTMLInputElement
+
+      fireEvent.click(input)
+      fireEvent.click(getByText('Slovakia'))
+      fireEvent.click(getByRole('reset'))
+
+      expect(queryByText('Slovakia')).not.toBeInTheDocument()
+    })
+  })
 })

--- a/packages/picasso/src/Autocomplete/useAutocomplete.ts
+++ b/packages/picasso/src/Autocomplete/useAutocomplete.ts
@@ -272,7 +272,10 @@ const useAutocomplete = ({
 
     onBlur: handleBlur,
     enableReset,
-    onResetClick: () => {
+    onResetClick: (
+      event: MouseEvent<HTMLButtonElement & HTMLAnchorElement>
+    ) => {
+      event.stopPropagation()
       handleChange(getDisplayValue(null))
     }
   })

--- a/packages/picasso/src/Input/Input.tsx
+++ b/packages/picasso/src/Input/Input.tsx
@@ -4,6 +4,7 @@ import React, {
   ReactElement,
   ChangeEvent,
   InputHTMLAttributes,
+  MouseEvent,
   forwardRef
 } from 'react'
 import cx from 'classnames'
@@ -77,7 +78,9 @@ export interface Props
   /** Whether to render reset icon when there is a value in the input */
   enableReset?: boolean
   /** Callback invoked when reset button was clicked */
-  onResetClick?: () => void
+  onResetClick?: (
+    event: MouseEvent<HTMLButtonElement & HTMLAnchorElement>
+  ) => void
   /** Ref of the input outline */
   outlineRef?: React.Ref<HTMLElement>
 }

--- a/packages/picasso/src/OutlinedInput/OutlinedInput.tsx
+++ b/packages/picasso/src/OutlinedInput/OutlinedInput.tsx
@@ -3,6 +3,7 @@ import React, {
   ReactType,
   ReactNode,
   InputHTMLAttributes,
+  MouseEvent,
   forwardRef
 } from 'react'
 import cx from 'classnames'
@@ -63,7 +64,9 @@ export interface Props
   /** Whether to render reset icon when there is a value in the input */
   enableReset?: boolean
   /** Callback invoked when reset button was clicked */
-  onResetClick?: () => void
+  onResetClick?: (
+    event: MouseEvent<HTMLButtonElement & HTMLAnchorElement>
+  ) => void
   /** Ref of the input element */
   inputRef?: React.Ref<HTMLInputElement>
 }
@@ -79,7 +82,7 @@ const ResetButton = ({
 }: {
   classes: Classes
   hasValue: boolean
-  onClick: () => void
+  onClick: (event: MouseEvent<HTMLButtonElement & HTMLAnchorElement>) => void
 }) => (
   <InputAdornment
     position='end'


### PR DESCRIPTION
[CRT-2775]

### Description

Autocomplete component lose focus when you reset it content by reset button click, and as a result dropdown can't be closed

### How to test

1. Open Autocomplete Demo Page https://picasso.toptal.net/crt-2775-fix-focus-on-input-reset/?path=/story/forms-autocomplete--autocomplete
2. Scroll to the Default section 
3. Select Slovakia
4. Reset content by clicking a cross icon
5. Ensure that the dropdown is closed

You can use master to see how it was before changes https://picasso.toptal.net/?path=/story/forms-autocomplete--autocomplete

### Screenshots (after reset button pressed)

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| <img width="447" alt="Screenshot 2021-03-01 at 14 02 10" src="https://user-images.githubusercontent.com/768328/109488583-cf81b780-7a96-11eb-9b2a-77dd32195371.png">| <img width="430" alt="Screenshot 2021-03-01 at 14 04 22" src="https://user-images.githubusercontent.com/768328/109488818-1bccf780-7a97-11eb-8c27-d33ef18897c4.png">|

### Review

- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/api-principles.md)
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure that tests pass by running `yarn test`
- [x] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use a11y plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/a11y.md).

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>


[CRT-2775]: https://toptal-core.atlassian.net/browse/CRT-2775