### PR TITLE
chore(pause16): add data-testid

### DIFF
--- a/packages/picasso/src/Icon/Pause16.tsx
+++ b/packages/picasso/src/Icon/Pause16.tsx
@@ -40,6 +40,7 @@ const SvgPause16 = forwardRef(function SvgPause16(
       className={cx(...classNames)}
       style={svgStyle}
       ref={ref}
+      data-testid='icon-pause16'
     >
       <path d='M8 0a8 8 0 110 16A8 8 0 018 0zm0 1a7 7 0 100 14A7 7 0 008 1zM7 5v6H6V5h1zm3 0v6H9V5h1z' />
     </svg>


### PR DESCRIPTION
[SP-1208](https://toptal-core.atlassian.net/browse/SP-1208)

### Description

For migration of cucumber scenarios I need to check presence of the pause icon in Tasks table. At the moment I do not have any reliable selector to use, so I believe adding data-testid to icon itself is the best option at the moment.

### Review

- [ ] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/api-principles.md)
- [ ] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that tests pass by running `yarn test`
- [ ] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
- [ ] Ensure the changed/created components have not caused accessibility issues. [How to use a11y plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/a11y.md).

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>
