### PR TITLE
feat: add table.cell rowspan property

### DIFF
--- a/cypress/component/TableCell.spec.tsx
+++ b/cypress/component/TableCell.spec.tsx
@@ -1,0 +1,27 @@
+import React from 'react'
+import { Table } from '@toptal/picasso'
+import { mount } from '@cypress/react'
+import { TestingPicasso } from '@toptal/picasso/test-utils'
+
+describe('TableCell', () => {
+  it('row spans', () => {
+    mount(
+      <TestingPicasso>
+        <Table>
+          <Table.Body>
+            <Table.Row>
+              <Table.Cell rowSpan={2}>Cell test</Table.Cell>
+              <Table.Cell>Cell test</Table.Cell>
+            </Table.Row>
+            <Table.Row>
+              <Table.Cell>Cell test</Table.Cell>
+            </Table.Row>
+          </Table.Body>
+        </Table>
+      </TestingPicasso>
+    )
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    // @ts-ignore
+    cy.get('body').happoScreenshot()
+  })
+})

--- a/packages/picasso/src/TableCell/TableCell.tsx
+++ b/packages/picasso/src/TableCell/TableCell.tsx
@@ -18,6 +18,8 @@ export interface Props
   align?: AlignType
   /** Indicates for how many columns the cell extends */
   colSpan?: number
+  /** Indicates for how many rows the cell extends */
+  rowSpan?: number
 }
 
 const useStyles = makeStyles<Theme>(styles, { name: 'PicassoTableCell' })
@@ -30,6 +32,7 @@ export const TableCell = forwardRef<HTMLTableCellElement, Props>(
       style,
       children,
       colSpan,
+      rowSpan,
       titleCase: propsTitleCase,
       ...rest
     } = props
@@ -48,6 +51,7 @@ export const TableCell = forwardRef<HTMLTableCellElement, Props>(
         className={className}
         style={style}
         colSpan={colSpan}
+        rowSpan={rowSpan}
       >
         {tableSection === TableSection.HEAD && titleCase
           ? toTitleCase(children)

--- a/packages/picasso/src/TableCell/test.tsx
+++ b/packages/picasso/src/TableCell/test.tsx
@@ -32,4 +32,20 @@ describe('TableCell', () => {
 
     expect(container).toMatchSnapshot()
   })
+
+  it('sets rowSpan', () => {
+    const { getByTestId } = render(
+      <Table>
+        <Table.Head>
+          <Table.Row>
+            <Table.Cell data-testid='cell' rowSpan={10}>
+              Cell test
+            </Table.Cell>
+          </Table.Row>
+        </Table.Head>
+      </Table>
+    )
+
+    expect(getByTestId('cell')).toHaveAttribute('rowspan', '10')
+  })
 })


### PR DESCRIPTION
[FX-1779]

### Description

Table.Cell doesn't support rowSpan property which is supported by MaterialUI.

### How to test

- FIXME: Add the steps describing how to verify your changes

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| Insert screenshots or screen recordings | Insert screenshots or screen recordings |

### Review

- [ ] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/api-principles.md)
- [ ] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that tests pass by running `yarn test`
- [ ] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
- [ ] Ensure the changed/created components have not caused accessibility issues. [How to use a11y plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/a11y.md).

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>


[FX-1779]: https://toptal-core.atlassian.net/browse/FX-1779