### PR TITLE
fix(outlinedinput): make disabled input text readable on Safari 14

### DIFF
--- a/packages/picasso/src/OutlinedInput/styles.ts
+++ b/packages/picasso/src/OutlinedInput/styles.ts
@@ -55,9 +55,8 @@ PicassoProvider.override(
         '&$disabled': {
           // On Safari the text gets a bit lighter as if it had some transparency applied to it
           // We need this webkit-specific property to achieve the exact font color
-          '-webkit-text-fill-color': 'currentColor',
+          '-webkit-text-fill-color': palette.grey.main,
           '&::placeholder': {
-            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             color: palette.grey.main,
             opacity: 1
           }


### PR DESCRIPTION
[TEA-2127]

### Description

The previous approach worked nicely on Safari 13, but a slightly different fix is needed for Safari
14. Instead of relying on currentColor we set the fill color explicitly.

### How to test

- Visit the demo page on Safari 13 and 14 and see it working in both cases.

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| ![Screenshot 2021-03-05 at 14 34 13](https://user-images.githubusercontent.com/2437969/110122467-f5bd9500-7dbf-11eb-89f3-157c527f32bd.jpeg) | ![Screenshot 2021-03-05 at 14 35 02](https://user-images.githubusercontent.com/2437969/110122540-0c63ec00-7dc0-11eb-88ad-059c4dd1cfd6.png) |

### Review

- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/api-principles.md)
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure that tests pass by running `yarn test`
- [x] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use a11y plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/a11y.md).

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>


[TEA-2127]: https://toptal-core.atlassian.net/browse/TEA-2127