### PR TITLE
feat: setup LTS release job

### DIFF
--- a/ci/jobs/picasso-lts-release/Jenkinsfile
+++ b/ci/jobs/picasso-lts-release/Jenkinsfile
@@ -3,11 +3,9 @@
 helper = new helpers.Helpers()
 ghHelper = new helpers.GithubNotifyHelper()
 
-downStreamBuilds = []
 repoName = 'picasso'
 buildImageJobName = "${repoName}-build-image"
-imageCommitId = ''
-def VERSION
+imageCommitId = gitCommit()
 
 pipeline {
   agent { label 'docker' }
@@ -59,11 +57,10 @@ pipeline {
 
     stage('Build image') {
       steps {
-        script {
-          imageCommitId = gitCommit()
-          downStreamBuilds[0] = buildWithParameters(
+        script {         
+          buildWithParameters(
             jobName: buildImageJobName,
-            propagate: false,
+            propagate: true,
             wait: true,
             parameters: [
               BRANCH: gitBranch(),
@@ -82,21 +79,6 @@ pipeline {
         }
 
         sshagent(credentials: ['toptal-build-ssh-key']) {
-          // $SSH_AUTH_SOCK - is the ssh key passed from "picasso-ssh-deploy-key" credentials
-          //
-          // -u 469:469 \
-          // - all those need to be passed to reuse jenkins user from Jenkins
-          //   and it's .ssh folder, keys and passwords
-          //
-          // -v ${PWD}:/artifacts - needs to pass .versions file
-          //
-          // -e JENKINS_URL=${JENKINS_URL} \
-          // -e GIT_BRANCH=${GIT_BRANCH} \
-          // - need to make semantic-release to think
-          //   that we are running it inside CI environment
-          //
-          // -e GH_TOKEN needed for lerna to authenticated with GitHub
-          //
           sh """
             docker run \
             --rm \
@@ -122,15 +104,6 @@ pipeline {
         }
       } //steps
     } //stage
-
-    stage('Build results') {
-      steps {
-        script {
-          helper.printBuildsResults(downStreamBuilds)
-          helper.setBuildStatus(downStreamBuilds)
-        }
-      }
-    }
   }//stages
 
   post {

--- a/docs/bug-fixes-in-lts.md
+++ b/docs/bug-fixes-in-lts.md
@@ -6,4 +6,7 @@ Current LTS version of Picasso is in `v5` branch.
 
 - branch out of `master` and fix the bug. Create PR to `master`;
 - branch out of `v5` and `cherry-pick` the commit done here :point_up:. Create PR to `v5`;
-- get approvals for the both PRs and merge them in respective branches.
+- get approvals for the both PRs and merge them in respective branches;
+- right after you merge your PR to `v5` a new LTS version will be released.
+
+_Important:_ It's not allowed to commit breaking changes into LTS branch


### PR DESCRIPTION
[FX-1759]

### Description

Setup the release of LTS versions. Please, find the Jenkins job [here](https://jenkins-build.toptal.net/job/picasso-lts-release/).


### Review

- [ ] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/api-principles.md)
- [ ] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that tests pass by running `yarn test`
- [ ] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
- [ ] Ensure the changed/created components have not caused accessibility issues. [How to use a11y plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/a11y.md).

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>

[FX-1759]: https://toptal-core.atlassian.net/browse/FX-1759