### PR TITLE
chore: bump major version for 4 packages

### DIFF
--- a/packages/picasso-charts/package.json
+++ b/packages/picasso-charts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@toptal/picasso-charts",
-  "version": "1.2.1",
+  "version": "2.0.0",
   "description": "Charts components of Picasso",
   "author": "Toptal",
   "license": "ISC",

--- a/packages/picasso-forms/package.json
+++ b/packages/picasso-forms/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@toptal/picasso-forms",
-  "version": "1.3.1",
+  "version": "2.0.0",
   "description": "Picasso form components",
   "author": "Toptal",
   "homepage": "https://github.com/toptal/picasso/tree/master/packages/picasso-forms#readme",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@toptal/picasso-shared",
-  "version": "2.1.4",
+  "version": "3.0.0",
   "description": "Shared types, utils for Picasso internal usage",
   "author": "Toptal",
   "homepage": "https://github.com/toptal/picasso/tree/master/packages/picasso-shared#readme",

--- a/packages/topkit-analytics-charts/package.json
+++ b/packages/topkit-analytics-charts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@topkit/analytics-charts",
-  "version": "0.6.1",
+  "version": "1.0.0",
   "description": "Charts utilities",
   "author": "Toptal",
   "license": "ISC",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4615,6 +4615,15 @@
     eslint-plugin-sort-keys-fix "^1.1.0"
     requireindex "^1.2.0"
 
+"@toptal/picasso-shared@^2.1.4":
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/@toptal/picasso-shared/-/picasso-shared-2.1.4.tgz#1c2a3291936f5d5a1fe52d2475c481636dfbbd93"
+  integrity sha512-9Ucaba8hzoJkBM9ZnIpt6pWiIZnQYOerT2vB5uvr7EsMJyshAutcMZ0MBnh0XrwsaQKoXDTLd4I86xxzKl5MBA==
+  dependencies:
+    classnames "^2.2.6"
+    color "^3.1.1"
+    notistack "^1.0.5"
+
 "@types/anymatch@*":
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/@types/anymatch/-/anymatch-1.3.1.tgz#336badc1beecb9dacc38bea2cf32adf627a8421a"


### PR DESCRIPTION
[FX-1759]

`picasso-charts`, `picasso-forms`, `shared`, `topkit-analytics-charts`

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>


[FX-1759]: https://toptal-core.atlassian.net/browse/FX-1759