### PR TITLE
chore: pass GH_TOKEN because of lerna

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,9 +9,6 @@ ENV GIT_SHA ${GIT_SHA}
 ARG APK_BRANCH=3.10
 ENV APK_BRANCH ${APK_BRANCH}
 
-# Lerna uses GH_TOKEN name https://github.com/lerna/lerna/blob/main/commands/version/README.md#--create-release-type
-ENV GH_TOKEN ${GITHUB_TOKEN}
-
 ENV PATH="${PATH}:/app/node_modules/.bin"
 
 # TODO replace with puppeteer-core

--- a/ci/jobs/picasso-master-release/Jenkinsfile
+++ b/ci/jobs/picasso-master-release/Jenkinsfile
@@ -96,7 +96,8 @@ pipeline {
           // - need to make semantic-release to think
           //   that we are running it inside CI environment
           //
-          // -e GITHUB_TOKEN needed for lerna to authenticated with GitHub
+          // -e GH_TOKEN needed for lerna to authenticated with GitHub
+          // https://github.com/lerna/lerna/blob/main/commands/version/README.md#--create-release-type
           //
           // docker is smart enough to get values of env variables from
           // the host environment
@@ -104,14 +105,14 @@ pipeline {
             docker run --rm \
             -e GIT_COMMITTER_EMAIL \
             -e GIT_COMMITTER_NAME \
-            -e GITHUB_TOKEN \
+            -e GH_TOKEN=${GITHUB_TOKEN} \
             -e NPM_TOKEN \
             -e JENKINS_URL \
             -e GIT_BRANCH \
             -e RELEASE_AND_PUBLISH \
             -e SSH_AUTH_SOCK=/ssh-agent \
-            -v ${PWD}:/artifacts \
             -u 469:469 \
+            -v ${PWD}:/artifacts \
             -v $SSH_AUTH_SOCK:/ssh-agent \
             -v ${PWD}/.git:/app/.git \
             --entrypoint=./bin/release \


### PR DESCRIPTION
[FX-NNNN]

### Description

Pass GH_TOKEN instead of GITHUB_TOKEN for lerna publish

### How to test

- FIXME: Add the steps describing how to verify your changes

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| Insert screenshots or screen recordings | Insert screenshots or screen recordings |

### Review

- [ ] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/api-principles.md)
- [ ] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that tests pass by running `yarn test`
- [ ] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
- [ ] Ensure the changed/created components have not caused accessibility issues. [How to use a11y plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/a11y.md).

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>
