### PR TITLE
ci: remove merge before build in pr specs Jenkins job

### DIFF
--- a/ci/jobs/picasso-pr-specs/Jenkinsfile
+++ b/ci/jobs/picasso-pr-specs/Jenkinsfile
@@ -37,8 +37,7 @@ pipeline {
                   advancedCheckoutBehaviour: [timeout: 120],
                   advancedCloneBehaviour   : [depth: 0, noTags: true, reference: '', shallow: false, timeout: 340],
                   cleanBeforeCheckout      : false,
-                  calculateChangelog       : [compareRemote: 'origin', compareTarget: "${ghprbTargetBranch}"],
-                  mergeBeforeBuild         : [mergeRemote: 'origin', mergeTarget: "${ghprbTargetBranch}", mergeStrategy: 'DEFAULT', fastForwardMode: 'FF']
+                  calculateChangelog       : [compareRemote: 'origin', compareTarget: "${ghprbTargetBranch}"]
           ]
         )
 


### PR DESCRIPTION
[FX-1806](https://toptal-core.atlassian.net/browse/FX-1806)

### Description

#### Problem
`picasso-pr-specs` fails if there are any merge conflicts. It limits us from deploying temploys for the branches with conflicts. 

#### Solution
As GH already does this job (prohibits merging with conflicts) we can get rid of it in Jenkins.

### How to test

- FIXME: Add the steps describing how to verify your changes

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| Insert screenshots or screen recordings | Insert screenshots or screen recordings |

### Review

- [ ] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/api-principles.md)
- [ ] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that tests pass by running `yarn test`
- [ ] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
- [ ] Ensure the changed/created components have not caused accessibility issues. [How to use a11y plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/a11y.md).

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>
