### PR TITLE
fix(select): fix background color

### DIFF
--- a/cypress/component/Select.spec.tsx
+++ b/cypress/component/Select.spec.tsx
@@ -2,6 +2,7 @@ import React, { useState, ChangeEvent } from 'react'
 import { mount } from '@cypress/react'
 import { Select, Form, Container, NumberInput } from '@toptal/picasso'
 import { TestingPicasso } from '@toptal/picasso/test-utils'
+import { palette } from '@toptal/picasso/utils'
 
 const SelectSearchBehaviourExample = () => {
   const [value, setValue] = useState<string>()
@@ -16,7 +17,9 @@ const SelectSearchBehaviourExample = () => {
     setValue(event.target.value)
   }
 
-  const handleTresholdChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+  const handleThresholdChange = (
+    event: React.ChangeEvent<HTMLInputElement>
+  ) => {
     setTreshold(parseInt(event.target.value, 10))
   }
 
@@ -42,7 +45,7 @@ const SelectSearchBehaviourExample = () => {
             <Form.Label>Search threshold</Form.Label>
             <NumberInput
               value={threshold}
-              onChange={handleTresholdChange}
+              onChange={handleThresholdChange}
               data-testid='input-threshold'
             />
           </Form.Field>
@@ -82,6 +85,35 @@ const SelectNativeExample = () => {
     </TestingPicasso>
   )
 }
+
+const SelectOverviewExample = () => (
+  <TestingPicasso>
+    <Container flex>
+      <Form.Field>
+        <Form.Label>Select</Form.Label>
+        <Select options={OPTIONS} placeholder='Choose an option...' />
+      </Form.Field>
+      <Form.Field>
+        <Form.Label>Native elect</Form.Label>
+        <Select options={OPTIONS} placeholder='Choose an option...' native />
+      </Form.Field>
+      <Form.Field>
+        <Form.Label>Select with error</Form.Label>
+        <Select options={OPTIONS} placeholder='Choose an option...' error />
+      </Form.Field>
+      <Form.Field>
+        <Form.Label>Native elect with error</Form.Label>
+        <Select
+          options={OPTIONS}
+          placeholder='Choose an option...'
+          native
+          error
+        />
+      </Form.Field>
+    </Container>
+  </TestingPicasso>
+)
+
 const OPTIONS = [
   { value: '1', text: 'Option 1' },
   { value: '2', text: 'Option 2' },
@@ -95,9 +127,7 @@ const openSelectWithTab = () => {
 }
 
 const setThresholdToHideSelectSearch = () => {
-  cy.get('[data-testid=input-threshold]')
-    .type('{backspace}')
-    .type('6')
+  cy.get('[data-testid=input-threshold]').type('{backspace}').type('6')
 }
 
 const getNativeSelect = () => cy.get('select')
@@ -117,8 +147,6 @@ describe('Select', () => {
 
     cy.get('[data-testid=select]').type(' ')
     cy.get('[role=menu]').should('be.visible')
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    // @ts-ignore
     cy.get('[role=menu]').happoScreenshot()
   })
 
@@ -130,5 +158,15 @@ describe('Select', () => {
     cy.get('option[role=option][value=1]')
       .should('have.attr', 'aria-selected')
       .and('match', /true/)
+  })
+
+  it('renders as non-transparent on a colorful background', () => {
+    mount(
+      <div style={{ background: palette.yellow.main }}>
+        <SelectOverviewExample />
+      </div>
+    )
+
+    cy.get('body').happoScreenshot()
   })
 })

--- a/packages/picasso/src/NativeSelect/styles.ts
+++ b/packages/picasso/src/NativeSelect/styles.ts
@@ -34,7 +34,8 @@ export default ({ palette }: Theme) =>
       }
     },
     nativeInput: {
-      padding: 0
+      padding: 0,
+      backgroundColor: palette.common.white
     },
     placeholder: {
       color: palette.grey.main2

--- a/packages/picasso/src/NonNativeSelect/styles.ts
+++ b/packages/picasso/src/NonNativeSelect/styles.ts
@@ -38,6 +38,7 @@ export default ({ palette }: Theme) =>
       outline: 0
     },
     outlinedInput: {
+      backgroundColor: palette.common.white,
       paddingRight: '1.625rem'
     },
     searchOutlinedInput: {


### PR DESCRIPTION
[FX-1814]

See #1994 for v5 fix

### Description

When Select component is rendered in error state on colored background, it inherits the color of the
background. It should stay white instead.

### How to test

- Go to the demo page
- Modify the code to have both error and background
```jsx
<div style={{background: 'red'}}>
  <Select
    onChange={handleChange}
    options={OPTIONS}
    value={value}
    placeholder='Choose an option...'
    width='auto'
    error
  />
</div>
```

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| ![Screenshot 2021-03-18 at 08 41 27](https://user-images.githubusercontent.com/2437969/111589967-d4987380-87c5-11eb-8be0-e294f44e5de9.png) | ![Screenshot 2021-03-18 at 08 41 13](https://user-images.githubusercontent.com/2437969/111589994-db26eb00-87c5-11eb-9a2b-86dbb59f7b36.png) |

### Review

- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/api-principles.md)
- n/a Annotate all `props` in component with documentation
- n/a Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that tests pass by running `yarn test`
- [ ] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
- [ ] Ensure the changed/created components have not caused accessibility issues. [How to use a11y plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/a11y.md).

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>


[FX-1814]: https://toptal-core.atlassian.net/browse/FX-1814