### PR TITLE
chore: fix link to accessibility doc in the PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -22,7 +22,7 @@ Describe the changes and motivations for the pull request.
 - [ ] Ensure that deployed demo has expected results and good examples
 - [ ] Ensure that tests pass by running `yarn test`
 - [ ] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
-- [ ] Ensure the changed/created components have not caused accessibility issues. [How to use a11y plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/a11y.md).
+- [ ] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
 
 <details>
 <summary>PR commands</summary>


### PR DESCRIPTION
### Description

The files was name with a full version while the link in the template lead to abbrieviation.

### How to test

- See that the link is correct

### Review

- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/api-principles.md)
- n/a Annotate all `props` in component with documentation
- n/a Create `examples` for component
- n/a Ensure that deployed demo has expected results and good examples
- n/a Ensure that tests pass by running `yarn test`
- n/a Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
- n/a Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md)


<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>
