### PR TITLE
chore: fix pr specs not failing when image not built

### DIFF
--- a/ci/jobs/picasso-pr-specs/Jenkinsfile
+++ b/ci/jobs/picasso-pr-specs/Jenkinsfile
@@ -2,7 +2,6 @@
 
 ghHelper = new helpers.GithubNotifyHelper()
 helper = new helpers.Helpers()
-buildImageResult = []
 repoName = 'picasso'
 buildImageJobName = "${repoName}-build-image"
 def FAILURE_REASON
@@ -50,9 +49,9 @@ pipeline {
     stage('Build image') {
       steps {
         script {
-          buildImageResult[0] = buildWithParameters(
+          buildWithParameters(
             jobName: buildImageJobName,
-            propagate: false,
+            propagate: true,
             wait: true,
             parameters: [
               BRANCH: ghprbSourceBranch,


### PR DESCRIPTION
### Description

Fix specs on CI not failing when a build-image job failed by timeout (ex. https://jenkins-build.toptal.net/job/picasso-pr-specs/6637/console)