### PR TITLE
chore: make alpha and main releases more consistent

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,9 @@ ENV PATH="${PATH}:/app/node_modules/.bin" \
   # Replace when puppetter is replaced with puppeteer-core
   PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true \
   # Installs Chromium (77) package.
-  CHROME_BIN=/usr/bin/chromium-browser
+  CHROME_BIN=/usr/bin/chromium-browser \
+  # We don't pass real value here, workaround to bypass npm check on from .npmrc
+  NPM_TOKEN=''
 
 RUN printf "http://nl.alpinelinux.org/alpine/v$APK_BRANCH/%s\n" community main > /etc/apk/repositories && \
   apk add --no-cache \
@@ -50,3 +52,6 @@ RUN yarn install --frozen-lockfile
 
 # COPY sources to workdir
 COPY --chown=node:node . /app
+
+# Need this file for publishing packages to npm
+RUN printf '//registry.npmjs.org/:_authToken=${NPM_TOKEN}\nalways-auth=true\n' > .npmrc

--- a/bin/release
+++ b/bin/release
@@ -1,19 +1,9 @@
 #!/usr/bin/env sh
-CWD="$(dirname "$0")"
-cd "$CWD/../"
-BASE_PATH=$(pwd)
-
-NODE_MODULES="$BASE_PATH/node_modules/"
 
 # add github to known_hosts
 mkdir ~/.ssh
 chmod 700 ~/.ssh
 ssh-keyscan -t ssh-rsa github.com >> ~/.ssh/known_hosts
-
-# Needs to be updated for publishing package to npm
-echo '//registry.npmjs.org/:_authToken=${NPM_TOKEN} \
-always-auth=true ' > .npmrc
-git update-index --assume-unchanged .npmrc
 
 # Build all packages
 npx lerna run build:package
@@ -24,13 +14,13 @@ git config user.name "$GIT_COMMITTER_NAME"
 # Publish packages
 if [[ $RELEASE_AND_PUBLISH == "release" ]]; then
   echo "=== WARNING RUNNING LIVE RELEASE FOR PACKAGES ==="
-  $NODE_MODULES/.bin/lerna publish --contents dist-package
+  npx lerna publish --contents dist-package
 elif [[ $RELEASE_AND_PUBLISH == "force-release-all" ]]; then
   echo "=== WARNING RUNNING LIVE FORCE RELEASE FOR ALL PACKAGES ==="
-  $NODE_MODULES/.bin/lerna publish --contents dist-package --force-publish
+  npx lerna publish --contents dist-package --force-publish
 else
   echo "=== RUNNING TEST RELEASE FOR PACKAGES. NOTHING WILL BE PUBLISHED ==="
-  $NODE_MODULES/.bin/lerna changed
+  npx lerna changed
 fi
 
 # Send data about published packages to jenkins


### PR DESCRIPTION
No ticket

### Description

Both release and alpha release commands need `.npmrc` in the Dockerfile. 
`release` created it by it's own
`alpha` relied on one from Dockerfile

Let's make it consistent so both release and alpha release will rely on file presence based Dockerfile without additional manipulations

### How to test

- FIXME: Add the steps describing how to verify your changes

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| Insert screenshots or screen recordings | Insert screenshots or screen recordings |

### Review

- [ ] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/api-principles.md)
- [ ] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that tests pass by running `yarn test`
- [ ] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
- [ ] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>
