### PR TITLE
feat(Section): prevent rendering empty header

### DIFF
--- a/packages/picasso-lab/src/Section/Section.tsx
+++ b/packages/picasso-lab/src/Section/Section.tsx
@@ -14,13 +14,19 @@ export interface Props extends BaseProps {
   actions?: ReactNode
   /** Main content of the Section */
   children?: ReactNode
+  testIds?: {
+    header?: string
+    title?: string
+    subtitle?: string
+    actions?: string
+  }
 }
 
 const useStyles = makeStyles(styles, {
   name: 'PicassoSection'
 })
 
-export const Section = forwardRef<HTMLDivElement, Props>(function Section(
+export const Section = forwardRef<HTMLDivElement, Props>(function Section (
   props,
   ref
 ) {
@@ -31,9 +37,46 @@ export const Section = forwardRef<HTMLDivElement, Props>(function Section(
     subtitle,
     actions,
     children,
+    testIds,
     ...rest
   } = props
   const classes = useStyles()
+
+  const hasTitle = typeof title !== 'undefined'
+  const hasSubtitle = typeof subtitle !== 'undefined'
+  const hasActions = typeof actions !== 'undefined'
+  const hasHeader = hasTitle || hasSubtitle || hasActions
+
+  const renderTitle = () =>
+    hasTitle ? (
+      <Typography
+        className={classes.title}
+        data-testid={testIds?.title}
+        variant='heading'
+        size='medium'
+      >
+        {title}
+      </Typography>
+    ) : null
+
+  const renderSubtitle = () =>
+    hasSubtitle ? (
+      <Typography
+        className={classes.subtitle}
+        data-testid={testIds?.subtitle}
+        size='medium'
+        color='dark-grey'
+      >
+        {subtitle}
+      </Typography>
+    ) : null
+
+  const renderActions = () =>
+    hasActions ? (
+      <Container data-testid={testIds?.actions} className={classes.actions}>
+        {actions}
+      </Container>
+    ) : null
 
   return (
     <Container
@@ -42,25 +85,13 @@ export const Section = forwardRef<HTMLDivElement, Props>(function Section(
       style={style}
       {...rest}
     >
-      <Container className={classes.header}>
-        {title && (
-          <Typography className={classes.title} variant='heading' size='medium'>
-            {title}
-          </Typography>
-        )}
-        {subtitle && (
-          <Typography
-            className={classes.subtitle}
-            size='medium'
-            color='dark-grey'
-          >
-            {subtitle}
-          </Typography>
-        )}
-        {actions && (
-          <Container className={classes.actions}>{actions}</Container>
-        )}
-      </Container>
+      {hasHeader && (
+        <Container data-testid={testIds?.header} className={classes.header}>
+          {renderTitle()}
+          {renderSubtitle()}
+          {renderActions()}
+        </Container>
+      )}
       {children}
     </Container>
   )

--- a/packages/picasso-lab/src/Section/Section.tsx
+++ b/packages/picasso-lab/src/Section/Section.tsx
@@ -42,13 +42,8 @@ export const Section = forwardRef<HTMLDivElement, Props>(function Section (
   } = props
   const classes = useStyles()
 
-  const hasTitle = typeof title !== 'undefined'
-  const hasSubtitle = typeof subtitle !== 'undefined'
-  const hasActions = typeof actions !== 'undefined'
-  const hasHeader = hasTitle || hasSubtitle || hasActions
-
   const renderTitle = () =>
-    hasTitle ? (
+    title ? (
       <Typography
         className={classes.title}
         data-testid={testIds?.title}
@@ -60,7 +55,7 @@ export const Section = forwardRef<HTMLDivElement, Props>(function Section (
     ) : null
 
   const renderSubtitle = () =>
-    hasSubtitle ? (
+    subtitle ? (
       <Typography
         className={classes.subtitle}
         data-testid={testIds?.subtitle}
@@ -72,11 +67,13 @@ export const Section = forwardRef<HTMLDivElement, Props>(function Section (
     ) : null
 
   const renderActions = () =>
-    hasActions ? (
+    actions ? (
       <Container data-testid={testIds?.actions} className={classes.actions}>
         {actions}
       </Container>
     ) : null
+
+  const hasHeader = title || subtitle || actions
 
   return (
     <Container

--- a/packages/picasso-lab/src/Section/__snapshots__/test.tsx.snap
+++ b/packages/picasso-lab/src/Section/__snapshots__/test.tsx.snap
@@ -10,24 +10,46 @@ exports[`Section renders with title, subtitle, actions and content 1`] = `
     >
       <div
         class="PicassoSection-header"
+        data-testid="header"
       >
         <h3
           class="MuiTypography-root PicassoTypography-headingMedium PicassoSection-title MuiTypography-h3"
+          data-testid="title"
         >
           Title
         </h3>
         <p
           class="MuiTypography-root PicassoTypography-bodyMedium PicassoTypography-darkGrey PicassoSection-subtitle MuiTypography-body1"
+          data-testid="subtitle"
         >
           Subtitle
         </p>
         <div
           class="PicassoSection-actions"
+          data-testid="actions"
         >
           Actions
         </div>
       </div>
-      Content
+      <div
+        data-testid="content"
+      />
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Section renders without header 1`] = `
+<div>
+  <div
+    class="Picasso-root"
+  >
+    <div
+      class="PicassoSection-root"
+    >
+      <div
+        data-testid="content"
+      />
     </div>
   </div>
 </div>

--- a/packages/picasso-lab/src/Section/test.tsx
+++ b/packages/picasso-lab/src/Section/test.tsx
@@ -1,16 +1,72 @@
 import React from 'react'
 import { render } from '@toptal/picasso/test-utils'
 
-import Section from './Section'
+import Section, { Props } from './Section'
+
+const DEFAULT_HEADER_TEST_ID = 'header'
+const DEFAULT_TITLE_TEST_ID = 'title'
+const DEFAULT_SUBTITLE_TEST_ID = 'subtitle'
+const DEFAULT_ACTIONS_TEST_ID = 'actions'
+
+const DEFAULT_CONTENT_TEST_ID = 'content'
+
+const renderSection = ({
+  testIds = {
+    header: DEFAULT_HEADER_TEST_ID,
+    title: DEFAULT_TITLE_TEST_ID,
+    subtitle: DEFAULT_SUBTITLE_TEST_ID,
+    actions: DEFAULT_ACTIONS_TEST_ID
+  },
+  children = <div data-testid={DEFAULT_CONTENT_TEST_ID} />,
+  ...rest
+}: Partial<Props> = {}) =>
+  render(
+    <Section testIds={testIds} {...rest}>
+      {children}
+    </Section>
+  )
 
 describe('Section', () => {
   it('renders with title, subtitle, actions and content', () => {
-    const { container } = render(
-      <Section title='Title' subtitle='Subtitle' actions='Actions'>
-        Content
-      </Section>
-    )
+    const { container, getByTestId } = renderSection({
+      title: 'Title',
+      subtitle: 'Subtitle',
+      actions: 'Actions'
+    })
+
+    const title = getByTestId(DEFAULT_TITLE_TEST_ID)
+    const subtitle = getByTestId(DEFAULT_SUBTITLE_TEST_ID)
+    const actions = getByTestId(DEFAULT_ACTIONS_TEST_ID)
+
+    expect(title).toBeInTheDocument()
+    expect(title).toHaveTextContent('Title')
+    expect(subtitle).toBeInTheDocument()
+    expect(subtitle).toHaveTextContent('Subtitle')
+    expect(actions).toBeInTheDocument()
+    expect(actions).toHaveTextContent('Actions')
+    expect(getByTestId(DEFAULT_CONTENT_TEST_ID)).toBeInTheDocument()
 
     expect(container).toMatchSnapshot()
+  })
+
+  it('renders without header', () => {
+    const { container, queryByTestId } = renderSection()
+
+    expect(queryByTestId(DEFAULT_HEADER_TEST_ID)).not.toBeInTheDocument()
+    expect(queryByTestId(DEFAULT_TITLE_TEST_ID)).not.toBeInTheDocument()
+    expect(queryByTestId(DEFAULT_SUBTITLE_TEST_ID)).not.toBeInTheDocument()
+    expect(queryByTestId(DEFAULT_ACTIONS_TEST_ID)).not.toBeInTheDocument()
+    expect(queryByTestId(DEFAULT_CONTENT_TEST_ID)).toBeInTheDocument()
+
+    expect(container).toMatchSnapshot()
+  })
+
+  it('renders with only title', () => {
+    const { queryByTestId } = renderSection({ title: 'Title' })
+
+    expect(queryByTestId(DEFAULT_HEADER_TEST_ID)).toBeInTheDocument()
+    expect(queryByTestId(DEFAULT_TITLE_TEST_ID)).toBeInTheDocument()
+    expect(queryByTestId(DEFAULT_SUBTITLE_TEST_ID)).not.toBeInTheDocument()
+    expect(queryByTestId(DEFAULT_ACTIONS_TEST_ID)).not.toBeInTheDocument()
   })
 })


### PR DESCRIPTION
[FX-1849]

### Description

If `Section` does not receive any of the following: `title`, `subtitle`, `actions`, it'll render an empty header div. This PR fixes it.

### How to test

- FIXME: Add the steps describing how to verify your changes

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| Insert screenshots or screen recordings | Insert screenshots or screen recordings |

### Review

- [ ] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/api-principles.md)
- [ ] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that tests pass by running `yarn test`
- [ ] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
- [ ] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>


[FX-1849]: https://toptal-core.atlassian.net/browse/FX-1849