### PR TITLE
chore: add data-testid for button to close modal

### DIFF
--- a/packages/picasso/src/Modal/Modal.tsx
+++ b/packages/picasso/src/Modal/Modal.tsx
@@ -50,6 +50,9 @@ export interface Props extends StandardProps, HTMLAttributes<HTMLDivElement> {
   align?: Alignment
   transitionDuration?: number
   paperProps?: PaperProps
+  testIds?: {
+    closeButton?: string
+  }
 }
 
 export interface StaticProps {
@@ -112,7 +115,10 @@ const generateKey = (() => {
 })()
 
 // eslint-disable-next-line react/display-name
-export const Modal = forwardRef<HTMLElement, Props>(function Modal(props, ref) {
+export const Modal = forwardRef<HTMLElement, Props>(function Modal (
+  props,
+  ref
+) {
   const {
     children,
     open,
@@ -127,6 +133,7 @@ export const Modal = forwardRef<HTMLElement, Props>(function Modal(props, ref) {
     transitionDuration = 300,
     paperProps,
     align = 'centered',
+    testIds,
     ...rest
   } = props
   const classes = useStyles(props)
@@ -227,6 +234,7 @@ export const Modal = forwardRef<HTMLElement, Props>(function Modal(props, ref) {
           variant='flat'
           className={classes.closeButton}
           onClick={onClose}
+          data-testid={testIds?.closeButton}
         >
           <CloseMinor16 />
         </Button.Circular>

--- a/packages/picasso/src/Modal/__snapshots__/test.tsx.snap
+++ b/packages/picasso/src/Modal/__snapshots__/test.tsx.snap
@@ -82,6 +82,27 @@ exports[`Modal renders 1`] = `
             </span>
           </button>
         </div>
+        <button
+          class="MuiButtonBase-root PicassoButton-small PicassoButton-primary PicassoButton-root PicassoButtonCircular-flat PicassoButtonCircular-root PicassoModal-closeButton"
+          data-component-type="button"
+          data-testid="close-modal"
+          tabindex="0"
+          type="button"
+        >
+          <span
+            class="PicassoContainer-centerAlignItems PicassoContainer-flex PicassoContainer-inline PicassoButton-content"
+          >
+            <svg
+              class="PicassoSvgCloseMinor16-root"
+              style="min-width: 16px; min-height: 16px;"
+              viewBox="0 0 16 16"
+            >
+              <path
+                d="M8.707 8l3.5 3.5-.707.707-3.5-3.5-3.5 3.5-.707-.707 3.5-3.5-3.5-3.5.707-.707 3.5 3.5 3.5-3.5.707.707-3.5 3.5z"
+              />
+            </svg>
+          </span>
+        </button>
       </div>
     </div>
     <div

--- a/packages/picasso/src/Modal/test.tsx
+++ b/packages/picasso/src/Modal/test.tsx
@@ -13,8 +13,12 @@ import { Props as ModalActionsProps } from '../ModalActions/ModalActions'
 import { Props as ModalTitleProps } from '../ModalTitle/ModalTitle'
 import { Props as ModalContentProps } from '../ModalContent/ModalContent'
 
+const testIds = {
+  closeButton: 'close-modal'
+}
+
 const TestModal = ({ children, open }: OmitInternalProps<ModalProps>) => (
-  <Modal open={open} container={modalRoot}>
+  <Modal open={open} container={modalRoot} onClose={() => {}} testIds={testIds}>
     {children}
   </Modal>
 )


### PR DESCRIPTION
[FX-NNNN]

### Description

https://github.com/toptal/platform/pull/47429 would benefit from having a readable locator to close modal windows.

### How to test

~~Ensure there is `data-testid="close-modal"` on the button to close modal in https://picasso.toptal.net/add-testid-for-close-modal/?path=/story/overlays-modal--modal.~~

Add test IDs to modal in Storybook:

```diff
diff --git a/packages/picasso/src/Modal/story/Default.example.tsx b/packages/picasso/src/Modal/story/Default.example.tsx
index c62a5cdb..56eca8ec 100644
--- a/packages/picasso/src/Modal/story/Default.example.tsx
+++ b/packages/picasso/src/Modal/story/Default.example.tsx
@@ -14,6 +14,10 @@ const STATES = [
   }
 ]
 
+const testIds = {
+  closeButton: 'close-modal'
+}
+
 const ModalDialog = ({
   open,
   onClose
@@ -25,7 +29,7 @@ const ModalDialog = ({
   const [date, setDate] = useState<Date>()
 
   return (
-    <Modal onClose={onClose} open={open}>
+    <Modal onClose={onClose} open={open} testIds={testIds}>
       <Modal.Title>Edit address details</Modal.Title>
       <Modal.Content>
         <Form.Field>
```

Run storybook:

```
yarn start
```

Verify modal close button has test ID at http://localhost:9001/?path=/story/overlays-modal--modal. Just click "Open" on the very first example with "Default" modal and check `data-testid` on the close button. You should see something like this:

```html
<button class="zshs7m-MuiButtonBase-root zshs7m-PicassoButton-small-54 zshs7m-PicassoButton-primary-57 zshs7m-PicassoButton-root-51 zshs7m-PicassoButtonCircular-flat-257 zshs7m-PicassoButtonCircular-root-255 zshs7m-PicassoModal-closeButton-80" tabindex="0" type="button" data-testid="close-modal" data-component-type="button"><span class="zshs7m-PicassoContainer-centerAlignItems-42 zshs7m-PicassoContainer-flex-6 zshs7m-PicassoContainer-inline-8 zshs7m-PicassoButton-content-52"><svg viewBox="0 0 16 16" class="zshs7m-PicassoSvgCloseMinor16-root-264" style="min-width: 16px; min-height: 16px;"><path d="M8.707 8l3.5 3.5-.707.707-3.5-3.5-3.5 3.5-.707-.707 3.5-3.5-3.5-3.5.707-.707 3.5 3.5 3.5-3.5.707.707-3.5 3.5z"></path></svg></span></button>
```


### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| Insert screenshots or screen recordings | Insert screenshots or screen recordings |

### Review

~~- [ ] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/api-principles.md)~~
~~- [ ] Annotate all `props` in component with documentation~~
~~- [ ] Create `examples` for component~~
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure that tests pass by running `yarn test`
- [x] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
~~- [ ] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).~~

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>
