### PR TITLE
chore: add data-testid for button to close modal

### DIFF
--- a/packages/picasso/src/Modal/Modal.tsx
+++ b/packages/picasso/src/Modal/Modal.tsx
@@ -50,6 +50,9 @@ export interface Props extends StandardProps, HTMLAttributes<HTMLDivElement> {
   align?: Alignment
   transitionDuration?: number
   paperProps?: PaperProps
+  testIds?: {
+    closeButton?: string
+  }
 }
 
 export interface StaticProps {
@@ -127,6 +130,7 @@ export const Modal = forwardRef<HTMLElement, Props>(function Modal(props, ref) {
     transitionDuration,
     paperProps,
     align,
+    testIds,
     ...rest
   } = props
   const classes = useStyles(props)
@@ -226,6 +230,7 @@ export const Modal = forwardRef<HTMLElement, Props>(function Modal(props, ref) {
           variant='flat'
           className={classes.closeButton}
           onClick={onClose}
+          data-testid={testIds?.closeButton}
         >
           <CloseMinor16 />
         </Button.Circular>

--- a/packages/picasso/src/Modal/__snapshots__/test.tsx.snap
+++ b/packages/picasso/src/Modal/__snapshots__/test.tsx.snap
@@ -82,6 +82,27 @@ exports[`Modal renders 1`] = `
             </span>
           </button>
         </div>
+        <button
+          class="MuiButtonBase-root PicassoButton-small PicassoButton-primary PicassoButton-root PicassoButtonCircular-flat PicassoButtonCircular-root PicassoModal-closeButton"
+          data-component-type="button"
+          data-testid="close-modal"
+          tabindex="0"
+          type="button"
+        >
+          <span
+            class="PicassoContainer-centerAlignItems PicassoContainer-flex PicassoContainer-inline PicassoButton-content"
+          >
+            <svg
+              class="PicassoSvgCloseMinor16-root"
+              style="min-width: 16px; min-height: 16px;"
+              viewBox="0 0 16 16"
+            >
+              <path
+                d="M8.707 8l3.5 3.5-.707.707-3.5-3.5-3.5 3.5-.707-.707 3.5-3.5-3.5-3.5.707-.707 3.5 3.5 3.5-3.5.707.707-3.5 3.5z"
+              />
+            </svg>
+          </span>
+        </button>
       </div>
     </div>
     <div

--- a/packages/picasso/src/Modal/test.tsx
+++ b/packages/picasso/src/Modal/test.tsx
@@ -13,8 +13,12 @@ import { Props as ModalActionsProps } from '../ModalActions/ModalActions'
 import { Props as ModalTitleProps } from '../ModalTitle/ModalTitle'
 import { Props as ModalContentProps } from '../ModalContent/ModalContent'
 
+const testIds = {
+  closeButton: 'close-modal'
+}
+
 const TestModal = ({ children, open }: OmitInternalProps<ModalProps>) => (
-  <Modal open={open} container={modalRoot}>
+  <Modal open={open} container={modalRoot} onClose={() => {}} testIds={testIds}>
     {children}
   </Modal>
 )


### PR DESCRIPTION
[FX-NNNN]

### Description

Backport of #2031 to Picasso v5 which is used in Staff Portal.

### How to test

See original PR for testing instructions.

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| Insert screenshots or screen recordings | Insert screenshots or screen recordings |

### Review

- [ ] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/api-principles.md)
- [ ] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that tests pass by running `yarn test`
- [ ] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
- [ ] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>
