### PR TITLE
fix(select): [TEA-2562] Fix indexing for grouped options

### DIFF
--- a/packages/picasso/src/NonNativeSelectOptions/NonNativeSelectOptions.tsx
+++ b/packages/picasso/src/NonNativeSelectOptions/NonNativeSelectOptions.tsx
@@ -22,6 +22,10 @@ const useStyles = makeStyles<Theme>(styles)
 
 // TODO: Replace with a real component as soon as it's implemented
 // https://toptal-core.atlassian.net/browse/FX-1479
+// Note: In the current implementation children are siblings for the group node.
+// If in the new MenuGroup children are inside the group node, that will
+// brake the current implementation of highlightedIndex calculations in this
+// component and selectedIndex in ScrollMenu component.
 interface MenuGroupProps extends BaseProps {
   group: string
   children: ReactNode
@@ -115,6 +119,7 @@ const NonNativeSelectOptions = ({
     let cursor = 0
 
     return Object.keys(optionGroups).map(group => {
+      cursor += 1 // for the group item itself
       const offset = cursor
 
       cursor += optionGroups[group].length

--- a/packages/picasso/src/NonNativeSelectOptions/__snapshots__/test.tsx.snap
+++ b/packages/picasso/src/NonNativeSelectOptions/__snapshots__/test.tsx.snap
@@ -114,3 +114,163 @@ exports[`NonNativeSelectOptions renders no option 1`] = `
   </div>
 </div>
 `;
+
+exports[`NonNativeSelectOptions renders option groups 1`] = `
+<div>
+  <div
+    class="Picasso-root"
+  >
+    <ul
+      class="MuiList-root PicassoMenuList-root PicassoScrollMenu-menu"
+      role="menu"
+      tabindex="-1"
+    >
+      <div
+        class="PicassoScrollMenu-scrollView"
+        tabindex="0"
+      >
+        <li
+          aria-disabled="false"
+          class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root PicassoMenuListItem-root PicassoMenuListItem-light makeStyles-menuGroup PicassoMenuListItem-nonSelectable MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+          role="option"
+          tabindex="-1"
+        >
+          <div
+            class="PicassoContainer-flex PicassoContainer-column PicassoMenuListItem-content"
+          >
+            <div
+              class="PicassoContainer-centerAlignItems PicassoContainer-flex"
+            >
+              <p
+                class="MuiTypography-root PicassoTypography-bodySmall PicassoTypography-semibold PicassoTypography-darkGrey MuiTypography-body1"
+              >
+                Group 1
+              </p>
+            </div>
+          </div>
+        </li>
+        <li
+          aria-disabled="false"
+          aria-selected="false"
+          class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root PicassoMenuListItem-root PicassoMenuListItem-light MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+          role="option"
+          tabindex="-1"
+          value="1"
+        >
+          <div
+            class="PicassoContainer-flex PicassoContainer-column PicassoMenuListItem-content"
+          >
+            <div
+              class="PicassoContainer-centerAlignItems PicassoContainer-flex"
+            >
+              <div
+                class="PicassoContainer-rightxsmallMargin PicassoContainer-flex PicassoContainer-inline PicassoMenuListItem-iconContainer"
+              />
+            </div>
+          </div>
+        </li>
+        <li
+          aria-disabled="false"
+          aria-selected="false"
+          class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root PicassoMenuListItem-root PicassoMenuListItem-light MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+          role="option"
+          tabindex="-1"
+          value="2"
+        >
+          <div
+            class="PicassoContainer-flex PicassoContainer-column PicassoMenuListItem-content"
+          >
+            <div
+              class="PicassoContainer-centerAlignItems PicassoContainer-flex"
+            >
+              <div
+                class="PicassoContainer-rightxsmallMargin PicassoContainer-flex PicassoContainer-inline PicassoMenuListItem-iconContainer"
+              />
+            </div>
+          </div>
+        </li>
+        <li
+          aria-disabled="false"
+          aria-selected="false"
+          class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root PicassoMenuListItem-root PicassoMenuListItem-light MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+          role="option"
+          tabindex="-1"
+          value="3"
+        >
+          <div
+            class="PicassoContainer-flex PicassoContainer-column PicassoMenuListItem-content"
+          >
+            <div
+              class="PicassoContainer-centerAlignItems PicassoContainer-flex"
+            >
+              <div
+                class="PicassoContainer-rightxsmallMargin PicassoContainer-flex PicassoContainer-inline PicassoMenuListItem-iconContainer"
+              />
+            </div>
+          </div>
+        </li>
+        <li
+          aria-disabled="false"
+          class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root PicassoMenuListItem-root PicassoMenuListItem-light makeStyles-menuGroup PicassoMenuListItem-nonSelectable MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+          role="option"
+          tabindex="-1"
+        >
+          <div
+            class="PicassoContainer-flex PicassoContainer-column PicassoMenuListItem-content"
+          >
+            <div
+              class="PicassoContainer-centerAlignItems PicassoContainer-flex"
+            >
+              <p
+                class="MuiTypography-root PicassoTypography-bodySmall PicassoTypography-semibold PicassoTypography-darkGrey MuiTypography-body1"
+              >
+                Group 2
+              </p>
+            </div>
+          </div>
+        </li>
+        <li
+          aria-disabled="false"
+          aria-selected="false"
+          class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root PicassoMenuListItem-root PicassoMenuListItem-light MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+          role="option"
+          tabindex="-1"
+          value="4"
+        >
+          <div
+            class="PicassoContainer-flex PicassoContainer-column PicassoMenuListItem-content"
+          >
+            <div
+              class="PicassoContainer-centerAlignItems PicassoContainer-flex"
+            >
+              <div
+                class="PicassoContainer-rightxsmallMargin PicassoContainer-flex PicassoContainer-inline PicassoMenuListItem-iconContainer"
+              />
+            </div>
+          </div>
+        </li>
+        <li
+          aria-disabled="false"
+          aria-selected="false"
+          class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root PicassoMenuListItem-root PicassoMenuListItem-light MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+          role="option"
+          tabindex="-1"
+          value="5"
+        >
+          <div
+            class="PicassoContainer-flex PicassoContainer-column PicassoMenuListItem-content"
+          >
+            <div
+              class="PicassoContainer-centerAlignItems PicassoContainer-flex"
+            >
+              <div
+                class="PicassoContainer-rightxsmallMargin PicassoContainer-flex PicassoContainer-inline PicassoMenuListItem-iconContainer"
+              />
+            </div>
+          </div>
+        </li>
+      </div>
+    </ul>
+  </div>
+</div>
+`;

--- a/packages/picasso/src/NonNativeSelectOptions/test.tsx
+++ b/packages/picasso/src/NonNativeSelectOptions/test.tsx
@@ -10,6 +10,18 @@ const OPTIONS = [
   { text: 'Three', value: '3' }
 ]
 
+const OPTION_GROUPS = {
+  'Group 1': [
+    { text: 'One', value: '1' },
+    { text: 'Two', value: '2' },
+    { text: 'Three', value: '3' }
+  ],
+  'Group 2': [
+    { text: 'Four', value: '4' },
+    { text: 'Five', value: '5' }
+  ]
+}
+
 const defaultGetItemProps = () => ({
   role: 'option',
   'aria-selected': false,
@@ -50,6 +62,14 @@ const renderNonNativeSelectOptions = ({
 describe('NonNativeSelectOptions', () => {
   it('renders', () => {
     const { container } = renderNonNativeSelectOptions()
+
+    expect(container).toMatchSnapshot()
+  })
+
+  it('renders option groups', () => {
+    const { container } = renderNonNativeSelectOptions({
+      options: OPTION_GROUPS
+    })
 
     expect(container).toMatchSnapshot()
   })

--- a/packages/picasso/src/Select/story/Grouped.example.tsx
+++ b/packages/picasso/src/Select/story/Grouped.example.tsx
@@ -10,6 +10,15 @@ const OPTION_GROUPS = {
     { value: '3', text: 'Option 3' },
     { value: '4', text: 'Option 4' },
     { value: '5', text: 'Option 5' }
+  ],
+  'Group 3': [
+    { value: '6', text: 'Option 6' },
+    { value: '7', text: 'Option 7' }
+  ],
+  'Group 4': [
+    { value: '8', text: 'Option 8' },
+    { value: '9', text: 'Option 9' },
+    { value: '10', text: 'Option 10' }
   ]
 }
 


### PR DESCRIPTION
### [TEA-2562]

### Description

Fix indexing for grouped options that caused jumping while scrolling options.

<details>
<summary>Old behaviour</summary>
<img src="https://user-images.githubusercontent.com/2437969/116355540-48349400-a7fa-11eb-8ed7-ab846c97f507.gif">
</details>

### How to test

- Open `Grouped options` example in storybook
- Open the non-native select and check that scroll works and you can pick any option.

### Review

- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/api-principles.md)
- Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure that tests pass by running `yarn test`
- [x] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>


[TEA-2562]: https://toptal-core.atlassian.net/browse/TEA-2562