### PR TITLE
fix(dropdown): render popper only when opened

### DIFF
--- a/packages/picasso/src/Dropdown/Dropdown.tsx
+++ b/packages/picasso/src/Dropdown/Dropdown.tsx
@@ -83,7 +83,7 @@ const useStyles = makeStyles<Theme, Props>(styles, {
 })
 
 // eslint-disable-next-line react/display-name
-export const Dropdown = forwardRef<HTMLDivElement, Props>(function Dropdown(
+export const Dropdown = forwardRef<HTMLDivElement, Props>(function Dropdown (
   props,
   ref
 ) {
@@ -224,10 +224,9 @@ export const Dropdown = forwardRef<HTMLDivElement, Props>(function Dropdown(
         {children}
       </div>
 
-      {anchorEl && (
+      {anchorEl && isOpen && (
         <Popper
           className={classes.popper}
-          open={isOpen}
           anchorEl={anchorEl}
           popperOptions={{
             onCreate: focus,
@@ -237,6 +236,7 @@ export const Dropdown = forwardRef<HTMLDivElement, Props>(function Dropdown(
           style={paperMargins}
           disablePortal={disablePortal}
           autoWidth={false}
+          open
           enableCompactMode
           container={popperContainer}
         >


### PR DESCRIPTION
[FX-1890]

### Description

Describe the changes and motivations for the pull request.

### How to test

- `yarn test`

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| Insert screenshots or screen recordings | Insert screenshots or screen recordings |

### Review

- [ ] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/api-principles.md)
- [ ] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that tests pass by running `yarn test`
- [ ] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
- [ ] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>


[FX-1890]: https://toptal-core.atlassian.net/browse/FX-1890