### PR TITLE
chore: restructure code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,4 +7,4 @@
 # Each line is a file pattern followed by one or more owners.
 
 # These owners will be the default owners for everything in the repo.
-* @toptal/fx-codeowners 
+* @toptal/frontend-experience-eng

--- a/.github/workflows/request-review-on-pr.yml
+++ b/.github/workflows/request-review-on-pr.yml
@@ -1,0 +1,19 @@
+name: Request review on PRs
+
+on:
+  pull_request:
+    types:
+      - opened
+
+jobs:
+  request:
+    name: Request reviews on opened PRs
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Create PR review request
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr edit ${{ github.event.pull_request.html_url }} \
+              --add-reviewer @toptal/fx-codeowners


### PR DESCRIPTION
This is to have FX team members automatically assigned to the tickets.
`@toptal/fx-codeowners` reduced to non FX engineers
![image](https://user-images.githubusercontent.com/14070311/117023831-20fe2b00-ad02-11eb-8b19-d6362546a385.png)

FX team as an owner of this repo has now the following seting of assignment:

![image](https://user-images.githubusercontent.com/14070311/117024134-6589c680-ad02-11eb-8d52-8120103483ab.png)

I expect all this setting to request whole `FX & Codeowners` + 2 random reviewers from FX.

### Review

- [ ] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/api-principles.md)
- [ ] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that tests pass by running `yarn test`
- [ ] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
- [ ] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>
