### PR TITLE
fix(Select): close menu on second click

### DIFF
--- a/packages/picasso/src/NonNativeSelect/test.tsx
+++ b/packages/picasso/src/NonNativeSelect/test.tsx
@@ -285,7 +285,7 @@ describe('NonNativeSelect', () => {
     expect(queryByRole('menu')).not.toBeInTheDocument()
   })
 
-  it('closes menu when open and select is clicked', () => {
+  it('closes opened menu after a click on select', () => {
     const placeholder = 'Choose an option...'
     const { getByPlaceholderText, queryByRole } = renderSelect({
       options: OPTIONS,

--- a/packages/picasso/src/NonNativeSelect/test.tsx
+++ b/packages/picasso/src/NonNativeSelect/test.tsx
@@ -1,5 +1,4 @@
 /* eslint-disable max-lines */
-
 import React from 'react'
 import { render, fireEvent, PicassoConfig } from '@toptal/picasso/test-utils'
 import { OmitInternalProps } from '@toptal/picasso-shared'
@@ -283,6 +282,21 @@ describe('NonNativeSelect', () => {
     expect(queryByRole('menu')).toBeInTheDocument()
 
     fireEvent.click(getByText(OPTIONS[0].text))
+    expect(queryByRole('menu')).not.toBeInTheDocument()
+  })
+
+  it('closes menu when open and select is clicked', () => {
+    const placeholder = 'Choose an option...'
+    const { getByPlaceholderText, queryByRole } = renderSelect({
+      options: OPTIONS,
+      placeholder
+    })
+
+    const selectInput = getByPlaceholderText(placeholder)
+
+    fireEvent.click(selectInput)
+    expect(queryByRole('menu')).toBeInTheDocument()
+    fireEvent.click(selectInput)
     expect(queryByRole('menu')).not.toBeInTheDocument()
   })
 

--- a/packages/picasso/src/Select/hooks/use-select-props/use-blur-handler/index.ts
+++ b/packages/picasso/src/Select/hooks/use-select-props/use-blur-handler/index.ts
@@ -1,0 +1,1 @@
+export { default } from './use-blur-handler'

--- a/packages/picasso/src/Select/hooks/use-select-props/use-blur-handler/test.ts
+++ b/packages/picasso/src/Select/hooks/use-select-props/use-blur-handler/test.ts
@@ -1,7 +1,7 @@
 import { renderHook } from '@testing-library/react-hooks'
 
 import { getUseSelectPropsMock } from '../mocks'
-import useSelectBlurHandler from './use-select-blur-handler'
+import useBlurHandler from './use-blur-handler'
 import isRelatedTargetInsidePopper from '../../../utils/is-related-target-inside-popper'
 
 const mockedIsRelatedTargetInsidePopper = isRelatedTargetInsidePopper as jest.MockedFunction<
@@ -10,7 +10,7 @@ const mockedIsRelatedTargetInsidePopper = isRelatedTargetInsidePopper as jest.Mo
 
 jest.mock('../../../utils/is-related-target-inside-popper', () => jest.fn())
 
-describe('useSelectBlurHandler', () => {
+describe('useBlurHandler', () => {
   beforeEach(() => {
     mockedIsRelatedTargetInsidePopper.mockClear()
   })
@@ -22,7 +22,7 @@ describe('useSelectBlurHandler', () => {
     props.selectProps.onBlur = jest.fn()
     mockedIsRelatedTargetInsidePopper.mockReturnValue(false)
 
-    const { result } = renderHook(() => useSelectBlurHandler(props))
+    const { result } = renderHook(() => useBlurHandler(props))
     const event = new FocusEvent('focus') as any
 
     result.current(event)
@@ -41,7 +41,7 @@ describe('useSelectBlurHandler', () => {
     props.selectProps.onBlur = jest.fn()
     mockedIsRelatedTargetInsidePopper.mockReturnValue(true)
 
-    const { result } = renderHook(() => useSelectBlurHandler(props))
+    const { result } = renderHook(() => useBlurHandler(props))
     const event = new FocusEvent('focus') as any
 
     result.current(event)

--- a/packages/picasso/src/Select/hooks/use-select-props/use-blur-handler/use-blur-handler.ts
+++ b/packages/picasso/src/Select/hooks/use-select-props/use-blur-handler/use-blur-handler.ts
@@ -3,7 +3,7 @@ import { useCallback } from 'react'
 import { ValueType, UseSelectProps } from '../../../types'
 import { isRelatedTargetInsidePopper, EMPTY_INPUT_VALUE } from '../../../utils'
 
-const useSelectBlurHandler = <T extends ValueType, M extends boolean = false>({
+const useBlurHandler = <T extends ValueType, M extends boolean = false>({
   popperRef,
   selectState: { close, setFilterOptionsValue },
   selectProps: { onBlur }
@@ -21,4 +21,4 @@ const useSelectBlurHandler = <T extends ValueType, M extends boolean = false>({
     [close, onBlur, setFilterOptionsValue, popperRef]
   )
 
-export default useSelectBlurHandler
+export default useBlurHandler

--- a/packages/picasso/src/Select/hooks/use-select-props/use-click-handler/test.ts
+++ b/packages/picasso/src/Select/hooks/use-select-props/use-click-handler/test.ts
@@ -15,10 +15,23 @@ describe('useClickHandler', () => {
     expect(props.selectState.open).toHaveBeenCalledTimes(1)
   })
 
-  it("does nothing when can't be open", () => {
+  it('closes when open', () => {
     const props = getUseSelectPropsMock()
 
     props.selectState.canOpen = false
+    props.selectState.isOpen = true
+    const { result } = renderHook(() => useClickHandler(props))
+
+    result.current()
+
+    expect(props.selectState.close).toHaveBeenCalledTimes(1)
+  })
+
+  it("does nothing when can't be open and not open", () => {
+    const props = getUseSelectPropsMock()
+
+    props.selectState.canOpen = false
+    props.selectState.isOpen = false
     const { result } = renderHook(() => useClickHandler(props))
 
     result.current()

--- a/packages/picasso/src/Select/hooks/use-select-props/use-click-handler/use-click-handler.ts
+++ b/packages/picasso/src/Select/hooks/use-select-props/use-click-handler/use-click-handler.ts
@@ -4,13 +4,15 @@ import { ValueType, UseSelectProps } from '../../../types'
 import { EMPTY_INPUT_VALUE } from '../../../utils'
 
 const useClickHandler = <T extends ValueType, M extends boolean = false>({
-  selectState: { canOpen, open, setFilterOptionsValue }
+  selectState: { isOpen, canOpen, open, close, setFilterOptionsValue }
 }: UseSelectProps<T, M>) =>
   useCallback(() => {
     if (canOpen) {
       setFilterOptionsValue(EMPTY_INPUT_VALUE)
       open()
+    } else if (isOpen) {
+      close()
     }
-  }, [canOpen, open, setFilterOptionsValue])
+  }, [isOpen, canOpen, open, close, setFilterOptionsValue])
 
 export default useClickHandler

--- a/packages/picasso/src/Select/hooks/use-select-props/use-select-blur-handler/index.ts
+++ b/packages/picasso/src/Select/hooks/use-select-props/use-select-blur-handler/index.ts
@@ -1,1 +1,0 @@
-export { default } from './use-select-blur-handler'

--- a/packages/picasso/src/Select/hooks/use-select-props/use-select-props.ts
+++ b/packages/picasso/src/Select/hooks/use-select-props/use-select-props.ts
@@ -7,7 +7,7 @@ import {
 } from '../../types'
 import useFocusHandler from './use-focus-handler'
 import useClickHandler from './use-click-handler'
-import useSelectBlurHandler from './use-select-blur-handler'
+import useBlurHandler from './use-blur-handler'
 import useSelectHandler from './use-select-handler'
 import useSearchBlurHandler from './use-search-blur-handler'
 import useEscapeKeyDownHandler from './use-escape-keydown-handler'
@@ -26,7 +26,7 @@ const useSelectProps = <T extends ValueType, M extends boolean = false>(
 ): UseSelectOutput => {
   const handleFocus = useFocusHandler(props)
   const handleClick = useClickHandler(props)
-  const handleSelectBlur = useSelectBlurHandler(props)
+  const handleBlur = useBlurHandler(props)
   const handleSelect = useSelectHandler(props)
   const handleSearchBlur = useSearchBlurHandler(props)
   const handleEscapeKeyDown = useEscapeKeyDownHandler(props)
@@ -67,7 +67,7 @@ const useSelectProps = <T extends ValueType, M extends boolean = false>(
   const getRootProps = () => ({
     onFocus: handleFocus,
     onClick: handleClick,
-    onBlur: handleSelectBlur
+    onBlur: handleBlur
   })
 
   const getInputProps = () => ({

--- a/packages/picasso/src/SelectCaret/styles.ts
+++ b/packages/picasso/src/SelectCaret/styles.ts
@@ -11,8 +11,7 @@ export default ({ palette }: Theme) =>
       right: '0.3125rem',
       color: palette.grey.dark,
       fontSize: '1rem',
-      cursor: 'inherit',
-      pointerEvents: 'none'
+      cursor: 'inherit'
     },
     caretDisabled: {
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion

--- a/packages/picasso/src/SelectCaret/styles.ts
+++ b/packages/picasso/src/SelectCaret/styles.ts
@@ -11,7 +11,8 @@ export default ({ palette }: Theme) =>
       right: '0.3125rem',
       color: palette.grey.dark,
       fontSize: '1rem',
-      cursor: 'inherit'
+      cursor: 'inherit',
+      pointerEvents: 'none'
     },
     caretDisabled: {
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion


### PR DESCRIPTION
[FX-965](https://toptal-core.atlassian.net/browse/FX-965)

### Description

Fixed the bug when you click on open Select and it doesn't close.

### How to test

#### Default

1. Go to `Select` chapter.
2. Click on select in the default example.
3. Click on select again.
4. Be sure that the menu is closed.

#### Multiple

1. Go to `Select` chapter.
2. Click on select in the multiple example.
3. Choose an option.
4. Click on select again.
5. Be sure that the menu is closed.

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| Insert screenshots or screen recordings | Insert screenshots or screen recordings |

### Review

- [ ] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/api-principles.md)
- [ ] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that tests pass by running `yarn test`
- [ ] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
- [ ] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>
