### PR TITLE
fix(list): render ListItem as div to avoid nested paragraph warning

### DIFF
--- a/packages/picasso-lab/src/ListItem/ListItem.tsx
+++ b/packages/picasso-lab/src/ListItem/ListItem.tsx
@@ -56,7 +56,9 @@ export const ListItem = (props: Props) => {
         >
           {itemIcon}
         </Container>
-        <Typography size='medium'>{children}</Typography>
+        <Typography as='div' size='medium'>
+          {children}
+        </Typography>
       </Container>
     </li>
   )


### PR DESCRIPTION
### Description

When we render a Typography element inside <List.Item> it leads
to two nested `<p>` and React displays a warning:

`Warning: validateDOMnesting(...): <p> cannot appear as a descendant of <p>`

Treat List.Item as a block element with `<div>` tag so it's easier to
use Typography inside of it.

### How to test

- See List component still working

### Review

- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/api-principles.md)
- n/a Annotate all `props` in component with documentation
- n/a Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure that tests pass by running `yarn test`
- [x] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>
