### PR TITLE
fix: reappearing tooltip after moving mouse within boundaries of triggered button

### DIFF
--- a/cypress/component/Tooltip.spec.tsx
+++ b/cypress/component/Tooltip.spec.tsx
@@ -284,7 +284,7 @@ describe('Tooltip', () => {
     cy.get('[data-testid="tooltip-content"').should('be.visible')
 
     cy.get('[data-testid="tooltip-trigger"').click()
-    cy.get('[data-testid="tooltip-content"').should('not.exist')
+    cy.get('[data-testid="tooltip-content"').should('not.be.visible')
   })
 
   it('renders on hover, hides on click, and does not render again until the mouse leave trigger element boundaries', () => {
@@ -301,7 +301,7 @@ describe('Tooltip', () => {
       position: 'bottomRight'
     })
 
-    cy.get('[data-testid="tooltip-content"').should('not.exist')
+    cy.get('[data-testid="tooltip-content"').should('not.be.visible')
   })
 
   it('renders interactive content', () => {

--- a/cypress/component/Tooltip.spec.tsx
+++ b/cypress/component/Tooltip.spec.tsx
@@ -17,6 +17,20 @@ import { TestingPicasso } from '@toptal/picasso/test-utils'
 
 const TOOLTIP_LONG_TEXT = 'Content '.repeat(10)
 
+const BasicTooltipExample = () => {
+  const tooltipContent = <span data-testid='tooltip-content'>Content</span>
+
+  return (
+    <TestingPicasso>
+      <Tooltip content={tooltipContent}>
+        <Button data-testid='tooltip-trigger'>
+          <span style={{ padding: '20px' }}>Button</span>
+        </Button>
+      </Tooltip>
+    </TestingPicasso>
+  )
+}
+
 const SnapshotTooltipExample = (props?: Partial<TooltipProps>) => (
   <TestingPicasso>
     <Tooltip content='Content' open {...props}>
@@ -259,6 +273,35 @@ describe('Tooltip', () => {
   it('renders inside and outside of a modal', () => {
     mount(<ModalTooltipExample />)
     cy.get('body').happoScreenshot()
+  })
+
+  it('renders on hover, and hides on click', () => {
+    mount(<BasicTooltipExample />)
+
+    cy.get('[data-testid="tooltip-content"').should('not.exist')
+    cy.get('[data-testid="tooltip-trigger"').realHover()
+
+    cy.get('[data-testid="tooltip-content"').should('be.visible')
+
+    cy.get('[data-testid="tooltip-trigger"').click()
+    cy.get('[data-testid="tooltip-content"').should('not.exist')
+  })
+
+  it('renders on hover, hides on click, and does not render again until the mouse leave trigger element boundaries', () => {
+    mount(<BasicTooltipExample />)
+
+    cy.get('[data-testid="tooltip-content"').should('not.exist')
+    cy.get('[data-testid="tooltip-trigger"').realHover()
+
+    cy.get('[data-testid="tooltip-content"').should('be.visible')
+
+    cy.get('[data-testid="tooltip-trigger"').click()
+    cy.get('[data-testid="tooltip-trigger"').realHover({ position: 'topLeft' })
+    cy.get('[data-testid="tooltip-trigger"').realHover({
+      position: 'bottomRight'
+    })
+
+    cy.get('[data-testid="tooltip-content"').should('not.exist')
   })
 
   it('renders interactive content', () => {

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -1,3 +1,4 @@
 require('@cypress/react/support')
 require('cypress-plugin-tab')
 require('happo-cypress')
+require('cypress-real-events/support')

--- a/cypress/tsconfig.json
+++ b/cypress/tsconfig.json
@@ -5,7 +5,8 @@
     "types": [
       "cypress",
       "cypress-plugin-tab/src",
-      "@types/happo-cypress"
+      "@types/happo-cypress",
+      "cypress-real-events"
     ]
   },
   "include": [

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "cross-env": "^7.0.3",
     "cypress": "^6.6.0",
     "cypress-plugin-tab": "^1.0.5",
+    "cypress-real-events": "^1.4.0",
     "cz-conventional-changelog": "3.2.0",
     "date-fns": "^2.9.0",
     "debounce": "^1.2.0",

--- a/packages/picasso/src/Tooltip/Tooltip.tsx
+++ b/packages/picasso/src/Tooltip/Tooltip.tsx
@@ -39,6 +39,7 @@ interface UseTooltipHandlersOptions {
 
 type ChildrenProps = {
   onClick?: (event: ChangeEvent<{}>) => void
+  onMouseLeave?: () => void
 }
 
 interface UseTooltipStateOptions {
@@ -80,7 +81,8 @@ const useTooltipHandlers = ({
   children
 }: UseTooltipHandlersOptions) => {
   const isTouchDevice = !isPointerDevice()
-
+  // After closing with click the tooltip should not be opened againg until the mouse leave event
+  const [ignoreOpening, setIgnoreOpening] = useState(false)
   const { isOpen, isControlled, openTooltip, closeTooltip } = useTooltipState({
     externalOpen
   })
@@ -93,10 +95,17 @@ const useTooltipHandlers = ({
       children
     }
   }
-
   const handleClose = (event: ChangeEvent<{}>) => {
     onClose?.(event)
     closeTooltip()
+  }
+  const handleOpen = (event: ChangeEvent<{}>) => {
+    if (ignoreOpening) {
+      return
+    }
+
+    onOpen?.(event)
+    openTooltip()
   }
   const handleClick = (event: ChangeEvent<{}>) => {
     if (disableListeners) {
@@ -105,14 +114,14 @@ const useTooltipHandlers = ({
 
     children.props.onClick?.(event)
     if (isOpen) {
+      setIgnoreOpening(true)
       handleClose(event)
     } else if (isTouchDevice) {
       handleOpen(event)
     }
   }
-  const handleOpen = (event: ChangeEvent<{}>) => {
-    onOpen?.(event)
-    openTooltip()
+  const handleMouseLeave = () => {
+    setIgnoreOpening(false)
   }
 
   return {
@@ -120,7 +129,8 @@ const useTooltipHandlers = ({
     handleOpen,
     handleClose,
     children: cloneElement(children, {
-      onClick: handleClick
+      onClick: handleClick,
+      onMouseLeave: handleMouseLeave
     })
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -9028,6 +9028,11 @@ cypress-plugin-tab@^1.0.5:
   dependencies:
     ally.js "^1.4.1"
 
+cypress-real-events@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/cypress-real-events/-/cypress-real-events-1.4.0.tgz#39575031a4020581e0bbf105d7a306ee57d94f48"
+  integrity sha512-1s4BQN1D++vFSuaad0qKsWcoApM5tQqPBFyDJEa6JeCZIsAdgMdGLuKi5QNIdl5KTJix0jxglzFJAThyz3borQ==
+
 cypress@^6.4.0, cypress@^6.6.0, cypress@^6.9.1:
   version "6.9.1"
   resolved "https://registry.yarnpkg.com/cypress/-/cypress-6.9.1.tgz#ce1106bfdc47f8d76381dba63f943447883f864c"


### PR DESCRIPTION
[SPT-1531](https://toptal-core.atlassian.net/browse/SPT-1531)

### Description
To prevent reappearing tooltip while moving mouse pointer within boundaries of triggered button, `onMouseLeave` has to be added.

### Note regaring "cypress-real-events" usage
There is no way to have "real hover" with cypress, please see cypress [docs](https://docs.cypress.io/api/commands/hover#See-also).

### How to test
- Tooltip -> Trigger section -> "hover" version
- Click on button to hide tooltip
- Try to move mouse over the button
- Tooltip shouldn't reapper again

### Screenshots
| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| <img src="https://user-images.githubusercontent.com/4816942/117996278-36abca00-b36c-11eb-8a66-d4ee278b6cc6.gif" width="600" /> | <img src="https://user-images.githubusercontent.com/4816942/117996748-9d30e800-b36c-11eb-850d-376c5809d1f7.gif" width="600" /> |

### Review

- [ ] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/api-principles.md)
- [ ] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that tests pass by running `yarn test`
- [ ] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
- [ ] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>
