### PR TITLE
chore: add color utils docs section

### DIFF
--- a/packages/picasso/src/utils/Utils/story/Browser.example.tsx
+++ b/packages/picasso/src/utils/Utils/story/Browser.example.tsx
@@ -1,29 +1,27 @@
 import { Table } from '@toptal/picasso'
 import React from 'react'
 
-const Example = () => {
-  const data = {
-    isPointerDevice: `Checks if the primary input mechanism includes an accurate pointing device`
-  }
-
-  return (
-    <Table>
-      <Table.Head>
-        <Table.Row>
-          <Table.Cell>Name</Table.Cell>
-          <Table.Cell>Description</Table.Cell>
-        </Table.Row>
-      </Table.Head>
-      <Table.Body>
-        {Object.entries(data).map(([name, description], index) => (
-          <Table.Row key={index}>
-            <Table.Cell>{name}</Table.Cell>
-            <Table.Cell>{description}</Table.Cell>
-          </Table.Row>
-        ))}
-      </Table.Body>
-    </Table>
-  )
+const data = {
+  isPointerDevice: `Checks if the primary input mechanism includes an accurate pointing device`
 }
+
+const Example = () => (
+  <Table>
+    <Table.Head>
+      <Table.Row>
+        <Table.Cell>Name</Table.Cell>
+        <Table.Cell>Description</Table.Cell>
+      </Table.Row>
+    </Table.Head>
+    <Table.Body>
+      {Object.entries(data).map(([name, description]) => (
+        <Table.Row key={name}>
+          <Table.Cell>{name}</Table.Cell>
+          <Table.Cell>{description}</Table.Cell>
+        </Table.Row>
+      ))}
+    </Table.Body>
+  </Table>
+)
 
 export default Example

--- a/packages/picasso/src/utils/Utils/story/Colors.example.tsx
+++ b/packages/picasso/src/utils/Utils/story/Colors.example.tsx
@@ -1,0 +1,31 @@
+import { Table } from '@toptal/picasso'
+import React from 'react'
+
+const Example = () => {
+  const data = {
+    'colorUtils.alpha': `Sets the alpha channel for the color and returns the hex color format`,
+    'colorUtils.lighten': `Sets the lightness of the color and returns the hex color format`,
+    'colorUtils.darken': `Sets the darkness of the color and returns the hex color format`
+  }
+
+  return (
+    <Table>
+      <Table.Head>
+        <Table.Row>
+          <Table.Cell>Name</Table.Cell>
+          <Table.Cell>Description</Table.Cell>
+        </Table.Row>
+      </Table.Head>
+      <Table.Body>
+        {Object.entries(data).map(([name, description], index) => (
+          <Table.Row key={index}>
+            <Table.Cell>{name}</Table.Cell>
+            <Table.Cell>{description}</Table.Cell>
+          </Table.Row>
+        ))}
+      </Table.Body>
+    </Table>
+  )
+}
+
+export default Example

--- a/packages/picasso/src/utils/Utils/story/Colors.example.tsx
+++ b/packages/picasso/src/utils/Utils/story/Colors.example.tsx
@@ -1,31 +1,29 @@
 import { Table } from '@toptal/picasso'
 import React from 'react'
 
-const Example = () => {
-  const data = {
-    'colorUtils.alpha': `Sets the alpha channel for the color and returns the hex color format`,
-    'colorUtils.lighten': `Sets the lightness of the color and returns the hex color format`,
-    'colorUtils.darken': `Sets the darkness of the color and returns the hex color format`
-  }
-
-  return (
-    <Table>
-      <Table.Head>
-        <Table.Row>
-          <Table.Cell>Name</Table.Cell>
-          <Table.Cell>Description</Table.Cell>
-        </Table.Row>
-      </Table.Head>
-      <Table.Body>
-        {Object.entries(data).map(([name, description], index) => (
-          <Table.Row key={index}>
-            <Table.Cell>{name}</Table.Cell>
-            <Table.Cell>{description}</Table.Cell>
-          </Table.Row>
-        ))}
-      </Table.Body>
-    </Table>
-  )
+const data = {
+  'colorUtils.alpha': `Sets the alpha channel for the color and returns the hex color format`,
+  'colorUtils.lighten': `Sets the lightness of the color and returns the hex color format`,
+  'colorUtils.darken': `Sets the darkness of the color and returns the hex color format`
 }
+
+const Example = () => (
+  <Table>
+    <Table.Head>
+      <Table.Row>
+        <Table.Cell>Name</Table.Cell>
+        <Table.Cell>Description</Table.Cell>
+      </Table.Row>
+    </Table.Head>
+    <Table.Body>
+      {Object.entries(data).map(([name, description]) => (
+        <Table.Row key={name}>
+          <Table.Cell>{name}</Table.Cell>
+          <Table.Cell>{description}</Table.Cell>
+        </Table.Row>
+      ))}
+    </Table.Body>
+  </Table>
+)
 
 export default Example

--- a/packages/picasso/src/utils/Utils/story/Generic.example.tsx
+++ b/packages/picasso/src/utils/Utils/story/Generic.example.tsx
@@ -1,32 +1,30 @@
 import { Table } from '@toptal/picasso'
 import React from 'react'
 
-const Example = () => {
-  const data = {
-    noop: `A function that does nothing, a replacement for () => {}`,
-    isBoolean: `Checks if the provided value is a boolean`,
-    isNumber: `Checks if the provided value is a number`,
-    isString: `Checks if the provided value is a string`
-  }
-
-  return (
-    <Table>
-      <Table.Head>
-        <Table.Row>
-          <Table.Cell>Name</Table.Cell>
-          <Table.Cell>Description</Table.Cell>
-        </Table.Row>
-      </Table.Head>
-      <Table.Body>
-        {Object.entries(data).map(([name, description], index) => (
-          <Table.Row key={index}>
-            <Table.Cell>{name}</Table.Cell>
-            <Table.Cell>{description}</Table.Cell>
-          </Table.Row>
-        ))}
-      </Table.Body>
-    </Table>
-  )
+const data = {
+  noop: `A function that does nothing, a replacement for () => {}`,
+  isBoolean: `Checks if the provided value is a boolean`,
+  isNumber: `Checks if the provided value is a number`,
+  isString: `Checks if the provided value is a string`
 }
+
+const Example = () => (
+  <Table>
+    <Table.Head>
+      <Table.Row>
+        <Table.Cell>Name</Table.Cell>
+        <Table.Cell>Description</Table.Cell>
+      </Table.Row>
+    </Table.Head>
+    <Table.Body>
+      {Object.entries(data).map(([name, description]) => (
+        <Table.Row key={name}>
+          <Table.Cell>{name}</Table.Cell>
+          <Table.Cell>{description}</Table.Cell>
+        </Table.Row>
+      ))}
+    </Table.Body>
+  </Table>
+)
 
 export default Example

--- a/packages/picasso/src/utils/Utils/story/React.example.tsx
+++ b/packages/picasso/src/utils/Utils/story/React.example.tsx
@@ -1,34 +1,32 @@
 import { Table } from '@toptal/picasso'
 import React from 'react'
 
-const Example = () => {
-  const data = {
-    forwardRef: `Wrapper around React.forwardRef that preserves genericity of the passed component`,
-    useSafeState: `Wrapper around React.useState that ignores state updates when the component is unmounted`,
-    useCombinedRefs: `Combines multiple refs into one`,
-    useWidthOf: `Calculates width of an element`,
-    disableUnsupportedProps: `Removes props that are not supported for passed props values`,
-    ClickAwayListener: `Listen for click events that occur somewhere in the document, outside of the element itself`
-  }
-
-  return (
-    <Table>
-      <Table.Head>
-        <Table.Row>
-          <Table.Cell>Name</Table.Cell>
-          <Table.Cell>Description</Table.Cell>
-        </Table.Row>
-      </Table.Head>
-      <Table.Body>
-        {Object.entries(data).map(([name, description], index) => (
-          <Table.Row key={index}>
-            <Table.Cell>{name}</Table.Cell>
-            <Table.Cell>{description}</Table.Cell>
-          </Table.Row>
-        ))}
-      </Table.Body>
-    </Table>
-  )
+const data = {
+  forwardRef: `Wrapper around React.forwardRef that preserves genericity of the passed component`,
+  useSafeState: `Wrapper around React.useState that ignores state updates when the component is unmounted`,
+  useCombinedRefs: `Combines multiple refs into one`,
+  useWidthOf: `Calculates width of an element`,
+  disableUnsupportedProps: `Removes props that are not supported for passed props values`,
+  ClickAwayListener: `Listen for click events that occur somewhere in the document, outside of the element itself`
 }
+
+const Example = () => (
+  <Table>
+    <Table.Head>
+      <Table.Row>
+        <Table.Cell>Name</Table.Cell>
+        <Table.Cell>Description</Table.Cell>
+      </Table.Row>
+    </Table.Head>
+    <Table.Body>
+      {Object.entries(data).map(([name, description]) => (
+        <Table.Row key={name}>
+          <Table.Cell>{name}</Table.Cell>
+          <Table.Cell>{description}</Table.Cell>
+        </Table.Row>
+      ))}
+    </Table.Body>
+  </Table>
+)
 
 export default Example

--- a/packages/picasso/src/utils/Utils/story/Strings.example.tsx
+++ b/packages/picasso/src/utils/Utils/story/Strings.example.tsx
@@ -1,35 +1,33 @@
 import { Table } from '@toptal/picasso'
 import React from 'react'
 
-const Example = () => {
-  const data = {
-    capitalize: `e.g. capitalize('a test string') === 'A test string'`,
-    toTitleCase: `e.g. toTitleCase('a test string') === 'A Test String'`,
-    kebabToCamelCase: `e.g. kebabToCamelCase('a-test-string') === 'aTestString'`,
-    getNameInitials: `e.g. getNameInitials('John Doe') === 'JD'`,
-    isSubstring: `e.g. isSubstring('test', 'a test string') === true`,
-    generateRandomString: `e.g. 'qw8vd8'`,
-    generateRandomStringOrGetEmptyInTest: ``
-  }
-
-  return (
-    <Table>
-      <Table.Head>
-        <Table.Row>
-          <Table.Cell>Name</Table.Cell>
-          <Table.Cell>Description</Table.Cell>
-        </Table.Row>
-      </Table.Head>
-      <Table.Body>
-        {Object.entries(data).map(([name, description], index) => (
-          <Table.Row key={index}>
-            <Table.Cell>{name}</Table.Cell>
-            <Table.Cell>{description}</Table.Cell>
-          </Table.Row>
-        ))}
-      </Table.Body>
-    </Table>
-  )
+const data = {
+  capitalize: `e.g. capitalize('a test string') === 'A test string'`,
+  toTitleCase: `e.g. toTitleCase('a test string') === 'A Test String'`,
+  kebabToCamelCase: `e.g. kebabToCamelCase('a-test-string') === 'aTestString'`,
+  getNameInitials: `e.g. getNameInitials('John Doe') === 'JD'`,
+  isSubstring: `e.g. isSubstring('test', 'a test string') === true`,
+  generateRandomString: `e.g. 'qw8vd8'`,
+  generateRandomStringOrGetEmptyInTest: ``
 }
+
+const Example = () => (
+  <Table>
+    <Table.Head>
+      <Table.Row>
+        <Table.Cell>Name</Table.Cell>
+        <Table.Cell>Description</Table.Cell>
+      </Table.Row>
+    </Table.Head>
+    <Table.Body>
+      {Object.entries(data).map(([name, description]) => (
+        <Table.Row key={name}>
+          <Table.Cell>{name}</Table.Cell>
+          <Table.Cell>{description}</Table.Cell>
+        </Table.Row>
+      ))}
+    </Table.Body>
+  </Table>
+)
 
 export default Example

--- a/packages/picasso/src/utils/Utils/story/index.jsx
+++ b/packages/picasso/src/utils/Utils/story/index.jsx
@@ -20,3 +20,7 @@ page
     title: 'React',
     showEditCode: false
   }) // picasso-skip-visuals
+  .addExample('utils/Utils/story/Colors.example.tsx', {
+    title: 'Colors',
+    showEditCode: false
+  }) // picasso-skip-visuals


### PR DESCRIPTION
[FX-1906](https://toptal-core.atlassian.net/browse/FX-1906)

### Description

Add a section for Color utils.

<img width="1248" alt="Screenshot 2021-05-13 at 11 48 44" src="https://user-images.githubusercontent.com/2836281/118102225-33065a80-b3e1-11eb-8c17-713f5be04b19.png">


<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>
