### PR TITLE
fix(Modal): fix width and height of top aligned modal on small screens

### DIFF
--- a/packages/picasso/src/Modal/styles.ts
+++ b/packages/picasso/src/Modal/styles.ts
@@ -4,6 +4,7 @@ const maxHeight = 'calc(100% - 6rem)'
 const maxWidth = 'calc(100% - 6rem)'
 const maxHeightForTopAligned = 'calc(100% - 4rem)'
 const maxHeightForSmall = 'calc(100% - 2rem)'
+const maxWidthForSmall = 'calc(100% - 2rem)'
 
 export default ({ screens, sizes }: Theme) =>
   createStyles({
@@ -23,8 +24,8 @@ export default ({ screens, sizes }: Theme) =>
       margin: '2rem',
 
       [screens('small')]: {
-        maxWidth: 'none',
         maxHeight: maxHeightForSmall,
+        maxWidth: maxWidthForSmall,
         margin: '1rem'
       }
     },
@@ -44,7 +45,11 @@ export default ({ screens, sizes }: Theme) =>
     topAlignedDialog: {
       position: 'absolute',
       top: 0,
-      maxHeight: maxHeightForTopAligned
+      maxHeight: maxHeightForTopAligned,
+
+      [screens('small')]: {
+        maxHeight: maxHeightForSmall
+      }
     },
     closeButton: {
       position: 'absolute',


### PR DESCRIPTION
[FX-1833]

### Description

When the modal is top-aligned it is wider than the window on small screens. Also, the max height of the modal is set to 2rem vertical margin instead of 1rem margin that should be on small screens.

### How to test

- Go to  the ["Max Height" section](https://picasso.toptal.net/fx-1833-fix-top-aligned-modal/?path=/story/overlays-modal--modal#max-height) of the Modals page
- Edit the code as follows:

    ```diff
    - 14    <Modal onClose={onClose} open={open}>
    + 14    <Modal align='top' onClose={onClose} open={open}>
    ```
- Change emulated screen size to small mobile
- Click the "Open" button in the "Max Height" section. The modal should fit the screen with 1rem margins.
- Click the "Open Top Aligned Modal" button at the bottom of the Modals page. The modal should fit the screen with 1rem margins.

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| ![FireShot Capture 448 - Picasso - Modal - picasso toptal net](https://user-images.githubusercontent.com/3861498/118240405-a670a080-b4a3-11eb-9e09-bf2e50db3855.png) | ![FireShot Capture 445 - Picasso - Modal - localhost](https://user-images.githubusercontent.com/3861498/118240460-b6888000-b4a3-11eb-9730-f9e687c6eb31.png) |

### Review

- [ ] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/api-principles.md)
- [ ] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that tests pass by running `yarn test`
- [ ] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
- [ ] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>


[FX-1833]: https://toptal-core.atlassian.net/browse/FX-1833