### PR TITLE
chore: add ci as codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,3 +8,7 @@
 
 # These owners will be the default owners for everything in the repo.
 * @toptal/frontend-experience-eng
+
+# CI Infrastructure team
+ci/jobs/ @toptal/ci-infrastructure-eng @toptal/frontend-experience-eng
+.github/workflows/ @toptal/ci-infrastructure-eng @toptal/frontend-experience-eng


### PR DESCRIPTION
[CI-480](https://toptal-core.atlassian.net/browse/CI-480)

 ### Description

Adding CI team as code owners for all CI-related files - both Jenkins and GitHub Actions related.


 ### Review

- [ ] Get one 👍 

 ### Pre-merge checklist

- [x] The PR relates to a single subject with a clear title and description in grammatically correct, complete sentences.
- [x] Verify that the feature branch is up-to-date with `master` (if not - rebase it).
- [x] Double-check the quality of [commit messages](https://toptal-core.atlassian.net/wiki/spaces/ENG/pages/210665897/Message+Quality).
- [x] Squash related commits together.