### PR TITLE
fix(Slider): overlapping labels on range slider

### DIFF
--- a/packages/picasso/src/Slider/Slider.tsx
+++ b/packages/picasso/src/Slider/Slider.tsx
@@ -3,7 +3,8 @@ import React, {
   ChangeEvent,
   ComponentProps,
   useRef,
-  useState
+  useState,
+  useMemo
 } from 'react'
 import { makeStyles, Theme } from '@material-ui/core/styles'
 import MUISlider, { ValueLabelProps } from '@material-ui/core/Slider'
@@ -62,13 +63,19 @@ type ValueLabelComponentProps = ValueLabelProps & {
   index: number
 }
 
-const DefaultTooltip = (
-  isTooltipAlwaysVisible: boolean,
-  disablePortal?: boolean,
-  compact?: boolean,
+type DefaultTooltipProps = {
+  isTooltipAlwaysVisible: boolean
+  disablePortal?: boolean
+  compact?: boolean
   isTooltipReversed?: boolean
-  // eslint-disable-next-line max-params
-): React.FunctionComponent<ValueLabelComponentProps> => ({
+}
+
+const DefaultTooltip = ({
+  isTooltipAlwaysVisible,
+  disablePortal,
+  compact,
+  isTooltipReversed
+}: DefaultTooltipProps): React.FunctionComponent<ValueLabelComponentProps> => ({
   children,
   open,
   value,
@@ -141,13 +148,23 @@ export const Slider = forwardRef<HTMLElement, Props>(function Slider (
   const isTooltipAlwaysVisible = tooltip === 'on'
   const isThumbHidden =
     hideThumbOnEmpty && (typeof value === 'undefined' || value === null)
-  const ValueLabelComponent = (UserDefinedTooltip ||
-    DefaultTooltip(
-      isTooltipAlwaysVisible,
-      disablePortal,
+  const ValueLabelComponent = useMemo(
+    () =>
+      (UserDefinedTooltip ||
+        DefaultTooltip({
+          isTooltipAlwaysVisible,
+          disablePortal,
+          compact,
+          isTooltipReversed
+        })) as typeof UserDefinedTooltip,
+    [
+      UserDefinedTooltip,
       compact,
+      disablePortal,
+      isTooltipAlwaysVisible,
       isTooltipReversed
-    )) as typeof UserDefinedTooltip
+    ]
+  )
 
   const watchTooltipsPlacement = () => {
     if (sliderRef.current) {
@@ -209,7 +226,7 @@ export const Slider = forwardRef<HTMLElement, Props>(function Slider (
         }}
         ValueLabelComponent={
           // From Workaround for https://github.com/mui-org/material-ui/issues/21889
-          ValueLabelComponent as React.ElementType<ValueLabelProps>
+          (ValueLabelComponent as unknown) as React.ElementType<ValueLabelProps>
         }
         valueLabelFormat={tooltipFormat}
         valueLabelDisplay={tooltip}

--- a/packages/picasso/src/Slider/Slider.tsx
+++ b/packages/picasso/src/Slider/Slider.tsx
@@ -68,13 +68,15 @@ type DefaultTooltipProps = {
   disablePortal?: boolean
   compact?: boolean
   isTooltipReversed?: boolean
+  isRange?: boolean
 }
 
 const DefaultTooltip = ({
   isTooltipAlwaysVisible,
   disablePortal,
   compact,
-  isTooltipReversed
+  isTooltipReversed,
+  isRange
 }: DefaultTooltipProps): React.FunctionComponent<ValueLabelComponentProps> => ({
   children,
   open,
@@ -87,15 +89,15 @@ const DefaultTooltip = ({
   }
 
   const placement = () => {
-    if (!isTooltipAlwaysVisible) {
-      return 'top'
+    if (!isRange) {
+      return 'right'
     }
 
     if (isTooltipReversed) {
-      return index === 0 ? 'left' : 'right'
+      return index === 0 ? 'top-end' : 'top-start'
     }
 
-    return index === 0 ? 'right' : 'left'
+    return 'top'
   }
 
   return (
@@ -112,7 +114,7 @@ const DefaultTooltip = ({
   )
 }
 
-export const Slider = forwardRef<HTMLElement, Props>(function Slider (
+export const Slider = forwardRef<HTMLElement, Props>(function Slider(
   props,
   ref
 ) {
@@ -146,6 +148,7 @@ export const Slider = forwardRef<HTMLElement, Props>(function Slider (
   const [isTooltipReversed, setIsTooltipReversed] = useState(false)
 
   const isTooltipAlwaysVisible = tooltip === 'on'
+  const isRange = Array.isArray(value) && value.length === 2
   const isThumbHidden =
     hideThumbOnEmpty && (typeof value === 'undefined' || value === null)
   const ValueLabelComponent = useMemo(
@@ -155,14 +158,16 @@ export const Slider = forwardRef<HTMLElement, Props>(function Slider (
           isTooltipAlwaysVisible,
           disablePortal,
           compact,
-          isTooltipReversed
+          isTooltipReversed,
+          isRange
         })) as typeof UserDefinedTooltip,
     [
       UserDefinedTooltip,
       compact,
       disablePortal,
       isTooltipAlwaysVisible,
-      isTooltipReversed
+      isTooltipReversed,
+      isRange
     ]
   )
 
@@ -176,16 +181,17 @@ export const Slider = forwardRef<HTMLElement, Props>(function Slider (
       )
 
       if (sliders.length === 2 && tooltips.length === 2) {
-        const minDistance = Array.from(tooltips).reduce((acc, cur) => {
-          return acc + cur.offsetWidth
-        }, 0)
+        const minDistance =
+          Array.from(tooltips).reduce((acc, cur) => {
+            return acc + cur.offsetWidth
+          }, 0) / 2
 
         const distance = sliders[1].offsetLeft - sliders[0].offsetLeft
 
-        if (distance < minDistance) {
-          setIsTooltipReversed(true)
-        } else {
+        if (distance > minDistance || distance === 0) {
           setIsTooltipReversed(false)
+        } else {
+          setIsTooltipReversed(true)
         }
       }
     }
@@ -194,7 +200,7 @@ export const Slider = forwardRef<HTMLElement, Props>(function Slider (
   const handleChange = (event: React.ChangeEvent<{}>, newValue: Value) => {
     onChange?.(event, newValue)
 
-    if (disablePortal && Array.isArray(value) && value.length === 2) {
+    if (isRange && disablePortal) {
       watchTooltipsPlacement()
     }
   }

--- a/packages/picasso/src/Slider/story/Range.example.tsx
+++ b/packages/picasso/src/Slider/story/Range.example.tsx
@@ -32,6 +32,7 @@ const Example = () => {
           tooltip='on'
           tooltipFormat={renderLabel}
           compact
+          disablePortal
         />
       </Container>
     </Container>

--- a/packages/picasso/src/Slider/story/Range.example.tsx
+++ b/packages/picasso/src/Slider/story/Range.example.tsx
@@ -23,7 +23,7 @@ const Example = () => {
       <Typography variant='heading' size='small'>
         Time Zone
       </Typography>
-      <Container top='large'>
+      <Container top='xlarge' right='large' left='large'>
         <Slider
           value={value}
           min={0}

--- a/packages/picasso/src/Slider/styles.ts
+++ b/packages/picasso/src/Slider/styles.ts
@@ -3,6 +3,14 @@ import { PicassoProvider, rem } from '@toptal/picasso-shared'
 
 PicassoProvider.override(() => ({
   MuiSlider: {
+    root: {
+      '& [x-placement*="top-start"]': {
+        left: '-10px !important'
+      },
+      '& [x-placement*="top-end"]': {
+        left: '10px !important'
+      }
+    },
     thumb: {
       '&:hover, &$active, &$focusVisible': {
         boxShadow: 'none'


### PR DESCRIPTION
[SPC-1098]

### Description

The labels for range sliders are overlapping themself when they are close to each other. We need to change tooltip placement when labels intersect. 

### How to test

- Go to the `Slider` story: `/?path=/story/components-slider--slider`
- Test Range Slider. 

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
|![Kapture 2021-06-02 at 15 05 09](https://user-images.githubusercontent.com/11710994/120485047-fa401c80-c3b3-11eb-9a7f-5e208e108a16.gif)|![Kapture 2021-06-02 at 14 59 41](https://user-images.githubusercontent.com/11710994/120484316-3d4dc000-c3b3-11eb-892b-2888ccbf3d08.gif)|

### Review

- [ ] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/api-principles.md)
- [ ] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that tests pass by running `yarn test`
- [ ] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
- [ ] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>


[SPC-1098]: https://toptal-core.atlassian.net/browse/SPC-1098