### PR TITLE
fix(Drawer): fix incorrect z-index of the Drawer

### DIFF
--- a/packages/picasso-lab/src/Drawer/Drawer.tsx
+++ b/packages/picasso-lab/src/Drawer/Drawer.tsx
@@ -1,5 +1,5 @@
 import MUIDrawer from '@material-ui/core/Drawer'
-import { makeStyles, Theme } from '@material-ui/core/styles'
+import { makeStyles, Theme, useTheme } from '@material-ui/core/styles'
 import cx from 'classnames'
 import { Button, Container } from '@toptal/picasso'
 import { BaseProps, useDrawer, usePicassoRoot } from '@toptal/picasso-shared'
@@ -44,6 +44,7 @@ export const Drawer: FunctionComponent<Props> = props => {
   } = props
   const classes = useStyles()
   const { setHasDrawer } = useDrawer()
+  const theme = useTheme()
   const container = usePicassoRoot()
 
   useLayoutEffect(() => {
@@ -69,6 +70,7 @@ export const Drawer: FunctionComponent<Props> = props => {
       onClose={handleOnClose}
       disablePortal={disablePortal}
       container={container}
+      ModalProps={{ style: { zIndex: theme.zIndex.drawer } }}
     >
       <Container
         flex


### PR DESCRIPTION
### Description

The Drawer's appearance covers the appearance of the `Modal` window, however `zIndex` of the Drawer and `Modal` must be 1200 and 1300 accordingly.

The problem seems to be on the UI-Material side because their Drawer's zIndex also equals 1300 (https://material-ui.com/components/drawers/#api)
I'm going to create a PR to UI Material repo as well.


### Screenshots

before:


https://user-images.githubusercontent.com/76203853/120647367-33938d80-c483-11eb-9999-77da0c298aa7.mp4



after:


https://user-images.githubusercontent.com/76203853/120647368-33938d80-c483-11eb-815e-bc803e8470b0.mp4



### Review

- [ ] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/api-principles.md)
- [ ] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that tests pass by running `yarn test`
- [ ] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
- [ ] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>
