### PR TITLE
fix(picasso): pin d3-array version

### DIFF
--- a/packages/picasso/package.json
+++ b/packages/picasso/package.json
@@ -51,7 +51,7 @@
   "resolutions": {
     "js-yaml": "^3.13.1",
     "lodash": "^4.17.12",
-    "d3-array": "^2.12.1",
+    "**/d3-geo/d3-array": "^2.12.1",
     "**/marksy/marked": "^0.6.0",
     "**/npx/npm": "^5.7.1"
   },

--- a/packages/picasso/package.json
+++ b/packages/picasso/package.json
@@ -51,6 +51,7 @@
   "resolutions": {
     "js-yaml": "^3.13.1",
     "lodash": "^4.17.12",
+    "d3-array": "^2.12.1",
     "**/marksy/marked": "^0.6.0",
     "**/npx/npm": "^5.7.1"
   },


### PR DESCRIPTION
### Description

d3-array v3 was published a few days ago and contains ES module syntax. That breaks unit tests, we
would need to be transpiled in tests. Start by pinning the version to the latest that worked in jest
environment.

### How to test

I tested it with davinci
- Comment out projectTeardown so the test project is kept
- Run `yarn test` 
- See it red
- Discard any local changes
- Check out https://github.com/toptal/davinci/tree/integration-test-fix-test
- Modify test project to install `"@toptal/picasso": "9.2.1-alpha-pin-d3-array-dependency-v2.2398",`
- Run `yarn test`
- See it green


### Review

- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/api-principles.md)
- n/a Annotate all `props` in component with documentation
- n/a Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that tests pass by running `yarn test`
- [ ] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
- n/a Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>
