### PR TITLE
fix(TreeView): fix tree view node selection

### DIFF
--- a/packages/picasso/src/TreeView/useNodes.ts
+++ b/packages/picasso/src/TreeView/useNodes.ts
@@ -63,10 +63,10 @@ export const useNodes = (
   rootNode: HierarchyPointNode<TreeNodeInterface>
 ): DynamicPointNode[] => {
   const [initialized, setInitializedState] = useState<boolean>(false)
-  const initialNodes = useRef<DynamicPointNode[] | null>(null)
+  const initialNodes = useRef<DynamicPointNode[] | undefined>()
 
-  // we only need to prepare initial nodes once on a first render
-  if (initialNodes.current === null) {
+  // we only need to prepare initial nodes once, on a first render
+  if (!initialNodes.current) {
     initialNodes.current = getDynamicNodes(rootNode.descendants())
   }
 

--- a/packages/picasso/src/TreeView/useNodes.ts
+++ b/packages/picasso/src/TreeView/useNodes.ts
@@ -63,11 +63,12 @@ export const useNodes = (
   rootNode: HierarchyPointNode<TreeNodeInterface>
 ): DynamicPointNode[] => {
   const [initialized, setInitializedState] = useState<boolean>(false)
-  const initialNodes = useMemo(() => {
-    return getDynamicNodes(rootNode.descendants())
-    // we don't want to lose the initial nodes data (e.g. assigned x and y coordinates) even if the rootNode object has changed
+  const initialNodes = useMemo(
+    () => getDynamicNodes(rootNode.descendants()),
+    // we don't want to lose the initial nodes refs even if the rootNode object has changed
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
+    []
+  )
   const dynamicNodes = useMemo(() => {
     const latestNodes = rootNode.descendants()
 

--- a/packages/picasso/src/TreeView/useNodes.ts
+++ b/packages/picasso/src/TreeView/useNodes.ts
@@ -65,7 +65,9 @@ export const useNodes = (
   const [initialized, setInitializedState] = useState<boolean>(false)
   const initialNodes = useMemo(() => {
     return getDynamicNodes(rootNode.descendants())
-  }, [rootNode])
+    // we don't want to lose the initial nodes data (e.g. assigned x and y coordinates) even if the rootNode object has changed
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
   const dynamicNodes = useMemo(() => {
     const latestNodes = rootNode.descendants()
 


### PR DESCRIPTION
[SP-1467]

### Description

Tree view layout got broken some time ago. It can be reproduced in a story book example. The issue was introduced in this PR:
https://github.com/toptal/picasso/pull/1991/files#diff-bba08a19095e57ef714e10873c5ac21c44a8682a8590920d0f89fa64520a33e0R68

It wipes out the refs to DOM nodes whenever the `rootNode` reference changes. This makes coordinates broken. This PR restores the initial behavior.

### How to test

- Go to TreeView storybook
- Try clicking "Reset selection" in "With selected node" example
- Tree should not get broken

### Screenshots

**Before**

https://user-images.githubusercontent.com/763624/121415371-571d7300-c970-11eb-9788-c6a8829c7ca6.mov

**After**

https://user-images.githubusercontent.com/763624/121415517-7e744000-c970-11eb-9ec0-7427f58531ab.mov

### Review

- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/api-principles.md)
- [ ] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that tests pass by running `yarn test`
- [ ] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
- [ ] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>


[SP-1467]: https://toptal-core.atlassian.net/browse/SP-1467