### PR TITLE
fix(picasso-forms): validation on submit

### DIFF
--- a/packages/picasso-forms/src/Form/Form.tsx
+++ b/packages/picasso-forms/src/Form/Form.tsx
@@ -43,7 +43,7 @@ const getValidationErrors = (
   formValues: any,
   form: FormApi<any>
 ): SubmissionErrors | void => {
-  let errors: SubmissionErrors = {}
+  let errors: SubmissionErrors
 
   Object.entries(validators).forEach(([key, validator]) => {
     const fieldValue = getIn(formValues, key)
@@ -55,8 +55,8 @@ const getValidationErrors = (
 
     const error = validator(fieldValue, formValues, fieldMetaState)
 
-    if (errors && error) {
-      errors = setIn(errors, key, error)
+    if (error) {
+      errors = setIn(errors || {}, key, error)
     }
   })
 

--- a/packages/picasso-forms/src/Form/Form.tsx
+++ b/packages/picasso-forms/src/Form/Form.tsx
@@ -81,8 +81,6 @@ export const Form = <T extends any = AnyObject>(props: Props<T>) => {
 
   const validationObject = useRef<FormContextProps>(createFormContext())
 
-  console.log('render valobj', validationObject)
-
   const showSuccessNotification = () => {
     if (!successSubmitMessage) {
       return

--- a/packages/picasso-forms/src/Form/Form.tsx
+++ b/packages/picasso-forms/src/Form/Form.tsx
@@ -43,7 +43,7 @@ const getValidationErrors = (
   formValues: any,
   form: FormApi<any>
 ): SubmissionErrors | void => {
-  let errors: SubmissionErrors
+  let errors: SubmissionErrors = {}
 
   Object.entries(validators).forEach(([key, validator]) => {
     const fieldValue = getIn(formValues, key)
@@ -80,6 +80,8 @@ export const Form = <T extends any = AnyObject>(props: Props<T>) => {
   )
 
   const validationObject = useRef<FormContextProps>(createFormContext())
+
+  console.log('render valobj', validationObject)
 
   const showSuccessNotification = () => {
     if (!successSubmitMessage) {

--- a/packages/picasso-forms/src/FormConfig/test.tsx
+++ b/packages/picasso-forms/src/FormConfig/test.tsx
@@ -9,11 +9,7 @@ const TEXT_INPUT_LABEL = 'Test text field'
 const renderForm = (configProps: FormConfigProps) => {
   return render(
     <Form.ConfigProvider value={configProps}>
-      <Form
-        onSubmit={() => {
-          console.log('test')
-        }}
-      >
+      <Form onSubmit={() => {}}>
         <Form.Input label={TEXT_INPUT_LABEL} required name='test' />
         <Form.SubmitButton>Submit</Form.SubmitButton>
       </Form>

--- a/packages/picasso-forms/src/FormConfig/test.tsx
+++ b/packages/picasso-forms/src/FormConfig/test.tsx
@@ -1,0 +1,48 @@
+import React from 'react'
+import { screen, render, fireEvent } from '@toptal/picasso/test-utils'
+
+import Form from '../Form'
+import { FormConfigProps } from './FormConfig'
+
+const TEXT_INPUT_LABEL = 'Test text field'
+
+const renderForm = (configProps: FormConfigProps) => {
+  return render(
+    <Form.ConfigProvider value={configProps}>
+      <Form
+        onSubmit={() => {
+          console.log('test')
+        }}
+      >
+        <Form.Input label={TEXT_INPUT_LABEL} required name='test' />
+        <Form.SubmitButton>Submit</Form.SubmitButton>
+      </Form>
+    </Form.ConfigProvider>
+  )
+}
+
+describe('Form.ConfigProvider', () => {
+  it('validate only on submit', async () => {
+    renderForm({ validateOnSubmit: true })
+
+    fireEvent.blur(screen.getByLabelText(TEXT_INPUT_LABEL))
+
+    expect(
+      screen.queryByText('Please complete this field.')
+    ).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Submit' }))
+
+    expect(
+      await screen.findByText('Please complete this field.')
+    ).toBeInTheDocument()
+  })
+
+  it('validate normally on blur / change', async () => {
+    renderForm({ validateOnSubmit: false })
+
+    fireEvent.blur(screen.getByLabelText(TEXT_INPUT_LABEL))
+
+    expect(screen.getByText('Please complete this field.')).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
[FX-NNNN]

### Description

There was no initial object for `errors` so `setIn` doesn't work.

### How to test

- Go to Form story
- Scroll down to `Validate only on submit` example
- It should work normally

### Screenshots

![image](https://user-images.githubusercontent.com/18625278/122200314-1f10b580-cec5-11eb-84ce-cb34b850b416.png)

### Review

- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/api-principles.md)
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure that tests pass by running `yarn test`
- [ ] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>
