### PR TITLE
feat(tooltip): show tooltip on both label and control

### DIFF
--- a/cypress/component/Tooltip.spec.tsx
+++ b/cypress/component/Tooltip.spec.tsx
@@ -3,12 +3,14 @@ import { mount } from '@cypress/react'
 import {
   Autocomplete,
   Button,
+  Checkbox,
   Container,
   Dropdown,
   Grid,
   Link,
   Menu,
   Modal,
+  Radio,
   Tooltip,
   TooltipProps,
   Typography
@@ -165,6 +167,30 @@ const LinkTooltipExample = () => {
   )
 }
 
+const CheckboxTooltipExample = () => {
+  const tooltipContent = <span data-testid='tooltip-content'>Content</span>
+
+  return (
+    <TestingPicasso>
+      <Tooltip content={tooltipContent} interactive>
+        <Checkbox label='Checkbox' data-testid='tooltip-trigger' />
+      </Tooltip>
+    </TestingPicasso>
+  )
+}
+
+const RadioTooltipExample = () => {
+  const tooltipContent = <span data-testid='tooltip-content'>Content</span>
+
+  return (
+    <TestingPicasso>
+      <Tooltip content={tooltipContent} interactive>
+        <Radio label='Radio' data-testid='trigger' />
+      </Tooltip>
+    </TestingPicasso>
+  )
+}
+
 const AutocompleteTooltipExample = () => {
   const [value, setValue] = useState('')
 
@@ -284,6 +310,30 @@ describe('Tooltip', () => {
     cy.get('[data-testid="tooltip-content"').should('be.visible')
 
     cy.get('[data-testid="tooltip-trigger"').click()
+    cy.get('[data-testid="tooltip-content"').should('not.be.visible')
+  })
+
+  it('renders on hover, and hides on click for Checkbox', () => {
+    mount(<CheckboxTooltipExample />)
+
+    cy.get('[data-testid="tooltip-content"').should('not.exist')
+    cy.get('[data-testid="tooltip-trigger"').realHover()
+
+    cy.get('[data-testid="tooltip-content"').should('be.visible')
+    cy.get('body').happoScreenshot()
+    cy.get('[data-testid="tooltip-trigger"').click()
+    cy.get('[data-testid="tooltip-content"').should('not.be.visible')
+  })
+
+  it('renders on hover, and hides on click for Radio', () => {
+    mount(<RadioTooltipExample />)
+
+    cy.get('[data-testid="tooltip-content"').should('not.exist')
+    cy.get('[data-testid="trigger"').realHover()
+
+    cy.get('[data-testid="tooltip-content"').should('be.visible')
+    cy.get('body').happoScreenshot()
+    cy.get('[data-testid="trigger"').click()
     cy.get('[data-testid="tooltip-content"').should('not.be.visible')
   })
 

--- a/packages/picasso/src/Checkbox/Checkbox.tsx
+++ b/packages/picasso/src/Checkbox/Checkbox.tsx
@@ -7,7 +7,7 @@ import {
   TextLabelProps
 } from '@toptal/picasso-shared'
 import cx from 'classnames'
-import React, { forwardRef, ReactNode } from 'react'
+import React, { ComponentProps, forwardRef, ReactNode } from 'react'
 
 import { RequiredDecoration } from '../FormLabel'
 import CheckboxGroup from '../CheckboxGroup'
@@ -46,76 +46,88 @@ export interface Props
   value?: string
 }
 
-export const Checkbox = forwardRef<HTMLButtonElement, Props>(function Checkbox(
-  props,
-  ref
-) {
-  const {
-    label,
-    id,
-    className,
-    style,
-    disabled,
-    requiredDecoration,
-    onChange,
-    value,
-    checked,
-    indeterminate,
-    titleCase,
-    ...rest
-  } = props
+export const Checkbox = forwardRef<HTMLButtonElement | HTMLLabelElement, Props>(
+  function Checkbox (props, ref) {
+    const {
+      label,
+      id,
+      className,
+      style,
+      disabled,
+      requiredDecoration,
+      onChange,
+      value,
+      checked,
+      indeterminate,
+      titleCase,
+      ...rest
+    } = props
 
-  const classes = useStyles()
-  const rootClasses = {
-    root: classes.root,
-    disabled: classes.disabled
-  }
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const { color, ...checkboxAttributes } = rest
+    const classes = useStyles()
+    const rootClasses = {
+      root: classes.root,
+      disabled: classes.disabled
+    }
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { color, ...checkboxAttributes } = rest
 
-  const muiCheckbox = (
-    <Container as='span' flex inline className={classes.checkboxWrapper}>
-      <MUICheckbox
-        {...checkboxAttributes}
-        ref={ref}
-        checked={checked}
-        icon={<div className={classes.uncheckedIcon} />}
-        checkedIcon={<div className={classes.checkedIcon} />}
-        indeterminateIcon={<div className={classes.indeterminateIcon} />}
-        classes={rootClasses}
-        className={cx(className, {
-          [classes.withLabel]: Boolean(label)
-        })}
-        style={style}
+    const muiCheckbox = (
+      <Container as='span' flex inline className={classes.checkboxWrapper}>
+        <MUICheckbox
+          {...checkboxAttributes}
+          ref={
+            label ? undefined : (ref as React.ForwardedRef<HTMLButtonElement>)
+          }
+          checked={checked}
+          icon={<div className={classes.uncheckedIcon} />}
+          checkedIcon={<div className={classes.checkedIcon} />}
+          indeterminateIcon={<div className={classes.indeterminateIcon} />}
+          classes={rootClasses}
+          className={cx(className, {
+            [classes.withLabel]: Boolean(label)
+          })}
+          style={style}
+          disabled={disabled}
+          id={id}
+          indeterminate={indeterminate}
+          onChange={onChange}
+          value={value}
+          focusVisibleClassName={classes.focused}
+        />
+      </Container>
+    )
+
+    if (!label) {
+      return muiCheckbox
+    }
+
+    const externalEventListeners = {
+      onMouseLeave: rest.onMouseLeave,
+      onMouseOver: rest.onMouseOver
+    } as ComponentProps<typeof FormControlLabel>
+
+    return (
+      <FormControlLabel
+        {...externalEventListeners}
+        ref={ref as React.ForwardedRef<HTMLLabelElement>}
+        classes={{
+          ...rootClasses,
+          label: classes.label
+        }}
+        control={muiCheckbox}
+        requiredDecoration={requiredDecoration}
         disabled={disabled}
-        id={id}
-        indeterminate={indeterminate}
-        onChange={onChange}
-        value={value}
-        focusVisibleClassName={classes.focused}
+        label={label}
+        titleCase={titleCase}
+        className='picasso-checkbox'
       />
-    </Container>
-  )
-
-  if (!label) {
-    return muiCheckbox
+    )
   }
-
-  return (
-    <FormControlLabel
-      classes={{
-        ...rootClasses,
-        label: classes.label
-      }}
-      control={muiCheckbox}
-      requiredDecoration={requiredDecoration}
-      disabled={disabled}
-      label={label}
-      titleCase={titleCase}
-      className='picasso-checkbox'
-    />
-  )
-}) as CompoundedComponentWithRef<Props, HTMLButtonElement, StaticProps>
+) as CompoundedComponentWithRef<
+  Props,
+  HTMLButtonElement | HTMLLabelElement,
+  StaticProps
+>
 
 Checkbox.defaultProps = {
   disabled: false,

--- a/packages/picasso/src/FormControlLabel/FormControlLabel.tsx
+++ b/packages/picasso/src/FormControlLabel/FormControlLabel.tsx
@@ -1,8 +1,8 @@
 import React, {
-  FunctionComponent,
   ReactElement,
   ReactNode,
-  LabelHTMLAttributes
+  LabelHTMLAttributes,
+  forwardRef
 } from 'react'
 import { FormControlLabelProps } from '@material-ui/core/FormControlLabel'
 import { makeStyles, Theme } from '@material-ui/core/styles'
@@ -36,48 +36,51 @@ const useStyles = makeStyles<Theme, Props>(styles, {
   name: 'PicassoFormControlLabel'
 })
 
-const FormControlLabel: FunctionComponent<Props> = props => {
-  const {
-    control,
-    label,
-    className,
-    style,
-    disabled,
-    requiredDecoration,
-    titleCase,
-    // Avoid passing external classes inside the rest props
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    classes: externalClasses,
-    ...rest
-  } = props
+const FormControlLabel = forwardRef<HTMLLabelElement, Props>(
+  function FormControlLabel (props, ref) {
+    const {
+      control,
+      label,
+      className,
+      style,
+      disabled,
+      requiredDecoration,
+      titleCase,
+      // Avoid passing external classes inside the rest props
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      classes: externalClasses,
+      ...rest
+    } = props
 
-  const classes = useStyles(props)
+    const classes = useStyles(props)
 
-  return (
-    <label
-      {...rest}
-      className={cx(
-        classes.root,
-        {
-          [classes.disabled]: disabled
-        },
-        className
-      )}
-      style={style}
-    >
-      {React.cloneElement(control, { disabled })}
-      <Form.Label
-        className={classes.label}
-        as='span'
-        requiredDecoration={requiredDecoration}
-        disabled={disabled}
-        titleCase={titleCase}
+    return (
+      <label
+        {...rest}
+        ref={ref}
+        className={cx(
+          classes.root,
+          {
+            [classes.disabled]: disabled
+          },
+          className
+        )}
+        style={style}
       >
-        {label}
-      </Form.Label>
-    </label>
-  )
-}
+        {React.cloneElement(control, { disabled })}
+        <Form.Label
+          className={classes.label}
+          as='span'
+          requiredDecoration={requiredDecoration}
+          disabled={disabled}
+          titleCase={titleCase}
+        >
+          {label}
+        </Form.Label>
+      </label>
+    )
+  }
+)
 
 FormControlLabel.displayName = 'FormControlLabel'
 

--- a/packages/picasso/src/Radio/Radio.tsx
+++ b/packages/picasso/src/Radio/Radio.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, ReactNode } from 'react'
+import React, { ComponentProps, forwardRef, ReactNode } from 'react'
 import MUIRadio from '@material-ui/core/Radio'
 import { makeStyles, Theme } from '@material-ui/core/styles'
 import {
@@ -40,67 +40,76 @@ const useStyles = makeStyles<Theme, Props>(styles, {
 })
 
 // eslint-disable-next-line react/display-name
-export const Radio = forwardRef<HTMLButtonElement, Props>(function Radio(
-  props,
-  ref
-) {
-  const {
-    className,
-    style,
-    label,
-    checked,
-    disabled,
-    value,
-    onChange,
-    titleCase,
-    ...rest
-  } = props
-  const classes = useStyles(props)
+export const Radio = forwardRef<HTMLButtonElement | HTMLLabelElement, Props>(
+  function Radio (props, ref) {
+    const {
+      className,
+      style,
+      label,
+      checked,
+      disabled,
+      value,
+      onChange,
+      titleCase,
+      ...rest
+    } = props
+    const classes = useStyles(props)
+    const rootClasses = {
+      root: classes.root,
+      disabled: classes.disabled
+    }
+    const muiRadio = (
+      <MUIRadio
+        {...rest}
+        ref={label ? undefined : (ref as React.ForwardedRef<HTMLButtonElement>)}
+        checked={checked}
+        disabled={disabled}
+        onChange={onChange}
+        value={value}
+        icon={<div className={classes.uncheckedIcon} />}
+        checkedIcon={<div className={classes.checkedIcon} />}
+        color='default'
+        classes={rootClasses}
+        className={cx(className, {
+          [classes.withLabel]: Boolean(label)
+        })}
+        style={style}
+        focusVisibleClassName={classes.focused}
+        data-testid='trigger'
+      />
+    )
 
-  const rootClasses = {
-    root: classes.root,
-    disabled: classes.disabled
+    if (!label) {
+      return muiRadio
+    }
+
+    const externalEventListeners = {
+      onMouseLeave: rest.onMouseLeave,
+      onMouseOver: rest.onMouseOver
+    } as ComponentProps<typeof FormControlLabel>
+
+    return (
+      <FormControlLabel
+        {...externalEventListeners}
+        ref={ref as React.ForwardedRef<HTMLLabelElement>}
+        control={muiRadio}
+        className={classes.labelWithRightSpacing}
+        classes={{
+          ...rootClasses,
+          label: classes.label
+        }}
+        style={style}
+        label={label}
+        disabled={disabled}
+        titleCase={titleCase}
+      />
+    )
   }
-  const muiRadio = (
-    <MUIRadio
-      {...rest}
-      ref={ref}
-      checked={checked}
-      disabled={disabled}
-      onChange={onChange}
-      value={value}
-      icon={<div className={classes.uncheckedIcon} />}
-      checkedIcon={<div className={classes.checkedIcon} />}
-      color='default'
-      classes={rootClasses}
-      className={cx(className, {
-        [classes.withLabel]: Boolean(label)
-      })}
-      style={style}
-      focusVisibleClassName={classes.focused}
-      data-testid='trigger'
-    />
-  )
-
-  if (!label) {
-    return muiRadio
-  }
-
-  return (
-    <FormControlLabel
-      control={muiRadio}
-      className={classes.labelWithRightSpacing}
-      classes={{
-        ...rootClasses,
-        label: classes.label
-      }}
-      style={style}
-      label={label}
-      disabled={disabled}
-      titleCase={titleCase}
-    />
-  )
-}) as CompoundedComponentWithRef<Props, HTMLButtonElement, StaticProps>
+) as CompoundedComponentWithRef<
+  Props,
+  HTMLButtonElement | HTMLLabelElement,
+  StaticProps
+>
 
 Radio.defaultProps = {
   disabled: false
@@ -112,6 +121,6 @@ Radio.Group = RadioGroup
 
 export default Radio as PicassoComponentWithRef<
   Props,
-  HTMLButtonElement,
+  HTMLButtonElement | HTMLLabelElement,
   StaticProps
 >


### PR DESCRIPTION
[FX-1874](https://toptal-core.atlassian.net/browse/FX-1874)

### Description

The tooltip for the radio and checkbox with the label was positioned incorrectly and was not visible if we hover over the label. It was always centered relatively on radio or checkbox. Now it is either in the center of the button or in the center of the button and label. 
The problems that I solved here:
1. Pass only one `ref` to the child component. In case we have `label` pass `ref` to the `label`, otherwise, pass it to the `button`(`checkbox` or `radio`)
2. Pass listeners (`onMouseLeave`, `onMouseOver`) from `Tooltip` to the `label`
3. Created two examples in `Radio` and `Checkbox` components instead of `Tooltip`, because changes were done in these components 

### How to test

- Go to Radio and Checkbox story
- Scroll down to the `With tooltip` example
- Tooltip should be centered

### Screenshots
<img width="216" alt="Screenshot 2021-06-16 at 17 25 23" src="https://user-images.githubusercontent.com/16545305/122238185-9ac03180-cec8-11eb-9a25-dc992a0ba25f.png">
<img width="209" alt="Screenshot 2021-06-16 at 17 25 16" src="https://user-images.githubusercontent.com/16545305/122238191-9bf15e80-cec8-11eb-96cb-78164932d0ef.png">

### Review

- [ ] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/api-principles.md)
- [ ] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that tests pass by running `yarn test`
- [ ] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
- [ ] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>
