### PR TITLE
fix(AppUpdateNotification): [ER-12060] Fix non-intractable action buttons

### DIFF
--- a/cypress/component/ApplicationUpdateNotification.spec.tsx
+++ b/cypress/component/ApplicationUpdateNotification.spec.tsx
@@ -12,7 +12,17 @@ const ApplicationUpdateNotificationExample = () => {
       data-testid='trigger'
       variant='secondary'
       onClick={() =>
-        showCustom(<ApplicationUpdateNotification />, { persist: true })
+        showCustom(
+          <ApplicationUpdateNotification
+            data-testid='application-update-notification'
+            testIds={{
+              updateLaterButton: 'update-later-button'
+            }}
+          />,
+          {
+            persist: true
+          }
+        )
       }
     >
       Show App Update Notification
@@ -30,5 +40,24 @@ describe('ApplicationUpdateNotification', () => {
 
     cy.get('[data-testid="trigger"').click()
     cy.get('body').happoScreenshot()
+  })
+
+  it('renders notification when click on trigger and close when click on notification button', () => {
+    mount(
+      <TestingPicasso>
+        <ApplicationUpdateNotificationExample />
+      </TestingPicasso>
+    )
+
+    cy.get('[data-testid="trigger"').click()
+    cy.get('[data-testid="application-update-notification"').should(
+      'be.visible'
+    )
+
+    cy.get('[data-testid="update-later-button"').click()
+
+    cy.get('[data-testid="application-update-notification"').should(
+      'not.be.visible'
+    )
   })
 })

--- a/packages/picasso/package.json
+++ b/packages/picasso/package.json
@@ -32,7 +32,7 @@
     "classnames": "^2.2.6",
     "d3": "^6.6.2",
     "detect-browser": "^5.2.0",
-    "notistack": "^1.0.5",
+    "notistack": "1.0.5",
     "react-content-loader": "^5.1.0",
     "react-helmet": "^6.1.0",
     "react-input-mask": "^3.0.0-alpha.2",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "classnames": "^2.2.6",
     "color": "^3.1.1",
-    "notistack": "^1.0.5"
+    "notistack": "1.0.5"
   },
   "devDependencies": {
     "@types/classnames": "^2.2.10",

--- a/yarn.lock
+++ b/yarn.lock
@@ -16876,7 +16876,7 @@ normalize-url@^5.0.0:
   resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-5.3.0.tgz#8959b3cdaa295b61592c1f245dded34b117618dd"
   integrity sha512-9/nOVLYYe/dO/eJeQUNaGUF4m4Z5E7cb9oNTKabH+bNf19mqj60txTcveQxL0GlcWLXCxkOu2/LwL8oW0idIDA==
 
-notistack@^1.0.5:
+notistack@1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/notistack/-/notistack-1.0.5.tgz#239d5888105c89a9a7f26d75a07d279446dc1624"
   integrity sha512-xCMG0OhzEdczmDs2lDABEiphKQMZUavdOIRAJhfIcyJkCA4UqBDANL3YCLt+mz8VbAPCeKTn76kbCmYQIqksnA==


### PR DESCRIPTION
[ER-12060]

### Description

Because of this change https://github.com/iamhosseindhv/notistack/blob/066cb52f2c8cbdd57e1ba9c4f7937d0d603f5e50/src/SnackbarContainer.tsx#L25 in Notistack (which is released in `1.0.7` version) our Notifications got non-interactable (we can't click on action buttons which are on the Notification). It affected mostly `ApplicationUpdateNotificaton`.

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>


[ER-12060]: https://toptal-core.atlassian.net/browse/ER-12060