### PR TITLE
fix(TagSelector): add definition of popperContainer prop

### DIFF
--- a/packages/picasso/src/TagSelector/TagSelector.tsx
+++ b/packages/picasso/src/TagSelector/TagSelector.tsx
@@ -78,6 +78,8 @@ export interface Props
     onDelete: () => void
     disabled?: boolean
   }) => ReactNode
+  /** DOM element that wraps the Popper */
+  popperContainer?: HTMLElement
 }
 
 export interface StaticProps {
@@ -85,7 +87,7 @@ export interface StaticProps {
 }
 
 export const TagSelector = forwardRef<HTMLInputElement, Props>(
-  function TagSelector(props, ref) {
+  function TagSelector (props, ref) {
     const {
       disabled,
       enableAutofill,

--- a/packages/picasso/src/TagSelector/TagSelector.tsx
+++ b/packages/picasso/src/TagSelector/TagSelector.tsx
@@ -109,6 +109,7 @@ export const TagSelector = forwardRef<HTMLInputElement, Props>(
       showOtherOption,
       value: values = [],
       width,
+      popperContainer,
       ...rest
     } = props
 
@@ -213,6 +214,7 @@ export const TagSelector = forwardRef<HTMLInputElement, Props>(
         renderOption={renderOption}
         enableReset={false}
         getKey={getKey}
+        popperContainer={popperContainer}
       />
     )
   }


### PR DESCRIPTION
### Description

To avoid TS error we need to add a definition of `popperContainer` to `TagSelector` interface


### Review

- [ ] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/api-principles.md)
- [ ] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that tests pass by running `yarn test`
- [ ] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
- [ ] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>
