### PR TITLE
fix(TypographyOverflow): improve performance

### DIFF
--- a/packages/picasso-lab/src/TypographyOverflow/TypographyOverflow.tsx
+++ b/packages/picasso-lab/src/TypographyOverflow/TypographyOverflow.tsx
@@ -1,5 +1,5 @@
 import cx from 'classnames'
-import React, { ReactNode, useCallback, useMemo, useState } from 'react'
+import React, { ReactNode, useCallback, useState } from 'react'
 import { makeStyles, Theme } from '@material-ui/core/styles'
 import { Tooltip, Typography, TypographyProps } from '@toptal/picasso'
 import { isOverflown } from '@toptal/picasso/utils'
@@ -54,10 +54,9 @@ export const TypographyOverflow = (props: Props) => {
   // It was causing a major UI freezes and unnecessary style recalculations,
   // that's why we decided to go with inline styles:
   // https://github.com/toptal/picasso/pull/2110
-  const extendedStyle = useMemo(
-    () => (isMultiline ? { ...style, WebkitLineClamp: lines } : style),
-    [style, isMultiline, lines]
-  )
+  const extendedStyle = isMultiline
+    ? { ...style, WebkitLineClamp: lines }
+    : style
 
   const handleClick = useCallback(
     (event: React.MouseEvent<HTMLElement>) => {

--- a/packages/picasso-lab/src/TypographyOverflow/TypographyOverflow.tsx
+++ b/packages/picasso-lab/src/TypographyOverflow/TypographyOverflow.tsx
@@ -1,5 +1,5 @@
 import cx from 'classnames'
-import React, { ReactNode, useCallback, useState } from 'react'
+import React, { ReactNode, useCallback, useMemo, useState } from 'react'
 import { makeStyles, Theme } from '@material-ui/core/styles'
 import { Tooltip, Typography, TypographyProps } from '@toptal/picasso'
 import { isOverflown } from '@toptal/picasso/utils'
@@ -38,6 +38,7 @@ export const TypographyOverflow = (props: Props) => {
     className,
     onClick,
     onMouseEnter,
+    style,
     ...rest
   } = props
 
@@ -47,6 +48,16 @@ export const TypographyOverflow = (props: Props) => {
   const [isTooltipAnimating, setIsTooltipAnimating] = useState(false)
   const isTooltipRendered = isTooltipActive || isTooltipAnimating
   const isMultiline = lines > 1
+
+  // We are paying a very high price when using dynamic JSS rules
+  // for a component that is used on a very large scale.
+  // It was causing a major UI freezes and unnecessary style recalculations,
+  // that's why we decided to go with inline styles:
+  // https://github.com/toptal/picasso/pull/2110
+  const extendedStyle = useMemo(
+    () => (isMultiline ? { ...style, WebkitLineClamp: lines } : style),
+    [style, isMultiline, lines]
+  )
 
   const handleClick = useCallback(
     (event: React.MouseEvent<HTMLElement>) => {
@@ -96,6 +107,7 @@ export const TypographyOverflow = (props: Props) => {
   const typography = (
     <Typography
       {...rest}
+      style={extendedStyle}
       className={cx(
         classes.wrapper,
         isMultiline ? classes.multiLine : classes.singleLine,

--- a/packages/picasso-lab/src/TypographyOverflow/styles.ts
+++ b/packages/picasso-lab/src/TypographyOverflow/styles.ts
@@ -11,8 +11,7 @@ export default () =>
       whiteSpace: 'initial',
       wordBreak: 'break-word'
     },
-    wrapper: ({ lines = 1 }: { lines?: number }) => ({
-      '-webkit-line-clamp': lines,
+    wrapper: {
       '-webkit-box-orient': 'vertical',
       overflow: 'hidden',
       textOverflow: 'ellipsis',
@@ -26,5 +25,5 @@ export default () =>
        * we have to to add some super-minor space at the end.
        */
       paddingRight: '0.9px'
-    })
+    }
   })


### PR DESCRIPTION
[SPC-1148]

### Description

TypographyOverflow is implemented in a way that it always spawns the new style tag whenever new component is rendered. E.g. on the talent list page more than 1000 style tags were spawned. It turned out those style tags were causing style recalculations and unnecessary reflows (and generally they are pretty expensive).

This was happening because we were using the dynamic styles (https://cssinjs.org/jss-plugin-rule-value-function/?v=v10.7.1). This plugin works in a way that it spawns a new stylesheet which holds all dynamic rules for any particular instance of the component. And then updates it with dynamic values when props are changing:
https://github.com/mui-org/material-ui/blob/next/packages/material-ui-styles/src/makeStyles/makeStyles.js#L107
https://github.com/mui-org/material-ui/blob/next/packages/material-ui-styles/src/makeStyles/makeStyles.js#L131

In our case we're not really changing the number of TypographyOverflow lines dynamically. We just use some initial lines value and that is enough.

In this PR I've changed the implementation to use inline styles for `-webkit-line-clamp` property since it is used very rarely and only for multiline typography overflows.

### How to test

- Make sure TypographyOverflow works as expected

### Screenshots

**Before**
![Снимок экрана 2021-07-06 в 0 08 57](https://user-images.githubusercontent.com/763624/124579404-bed3ba80-de57-11eb-90ac-17ffaca3b771.png)
![Снимок экрана 2021-07-06 в 0 14 02](https://user-images.githubusercontent.com/763624/124579417-c1361480-de57-11eb-8152-189cabbe5278.png)

**After**
![Снимок экрана 2021-07-06 в 13 25 40](https://user-images.githubusercontent.com/763624/124585121-a9618f00-de5d-11eb-9ab1-69abef119f33.png)

### Search form rendering on talents page
**Without the fix**
![Снимок экрана 2021-07-06 в 0 28 50](https://user-images.githubusercontent.com/763624/124579519-dc088900-de57-11eb-92ae-09e26ce92ca9.png)
![Снимок экрана 2021-07-06 в 0 28 55](https://user-images.githubusercontent.com/763624/124579525-ddd24c80-de57-11eb-990f-82df3623198f.png)

**With the fix**
![Снимок экрана 2021-07-06 в 0 26 56](https://user-images.githubusercontent.com/763624/124579579-ecb8ff00-de57-11eb-9d87-58e8edabd9fa.png)
![Снимок экрана 2021-07-06 в 0 26 59](https://user-images.githubusercontent.com/763624/124579586-ee82c280-de57-11eb-8669-0afb23247922.png)

### Single talent card rendering

**Without the fix**
![Снимок экрана 2021-07-06 в 0 31 49](https://user-images.githubusercontent.com/763624/124579665-03f7ec80-de58-11eb-9efc-1c2e9cf8199b.png)
![Снимок экрана 2021-07-06 в 0 31 52](https://user-images.githubusercontent.com/763624/124579671-05291980-de58-11eb-9642-a81b6b3034d6.png)

**With the fix**
![Снимок экрана 2021-07-06 в 0 32 03](https://user-images.githubusercontent.com/763624/124579687-09edcd80-de58-11eb-922a-88f926b7044f.png)
![Снимок экрана 2021-07-06 в 0 32 08](https://user-images.githubusercontent.com/763624/124579697-0bb79100-de58-11eb-8f2d-f1cb54fcfa16.png)

This fix affects the performance of almost all pages in SP project and cuts off seconds of UI freezes from some interactions. E.g. the talent list rendering is 5 seconds faster.

### Review

- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/api-principles.md)
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure that tests pass by running `yarn test`
- [x] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>


[SPC-1148]: https://toptal-core.atlassian.net/browse/SPC-1148