### PR TITLE
fix(OutlinedInput): do not trigger onBlur event after clicking adornment

### DIFF
--- a/packages/picasso/src/OutlinedInput/OutlinedInput.tsx
+++ b/packages/picasso/src/OutlinedInput/OutlinedInput.tsx
@@ -98,6 +98,9 @@ const ResetButton = ({
       variant='flat'
       role='reset'
       onClick={onClick}
+      onMouseDown={(
+        event: React.MouseEvent<HTMLButtonElement | HTMLAnchorElement>
+      ) => event.preventDefault()}
       onFocus={(
         event: React.FocusEvent<HTMLButtonElement | HTMLAnchorElement>
       ) => event.stopPropagation()}
@@ -105,7 +108,7 @@ const ResetButton = ({
   </InputAdornment>
 )
 
-const OutlinedInput = forwardRef<HTMLElement, Props>(function OutlinedInput(
+const OutlinedInput = forwardRef<HTMLElement, Props>(function OutlinedInput (
   props,
   ref
 ) {


### PR DESCRIPTION
### Description

We do not trigger the `onBlur` event for the whole input after clicking start or end adornments.

### How to test

- set a focus on an input element
- try clicking the button adornment

expectation:
the input element must still be focused

actual:
focus is lost

### Screenshots

before:
https://monosnap.com/file/WXK4hkoCSjl19QfjnzbyQ3hexGPcdh

after:
https://monosnap.com/file/MmWgAp5TTOerigB3Qk8w6PU2IzyYfd


### Review

- [ ] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/api-principles.md)
- [ ] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that tests pass by running `yarn test`
- [ ] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
- [ ] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>
