### PR TITLE
fix(Select): close Popper after disabling Select

### DIFF
--- a/packages/picasso/src/Select/hooks/use-select-state/test.ts
+++ b/packages/picasso/src/Select/hooks/use-select-state/test.ts
@@ -128,4 +128,20 @@ describe('useSelectState', () => {
     expect(result.current.selectedIndexes).toEqual([0])
     expect(result.current.displayValue).toEqual(DEFAULT_OPTIONS[0].text)
   })
+
+  describe('when select is opened but has became disabled', () => {
+    it('switches to closed state to false', () => {
+      const { result, rerender } = renderUseSelectState()
+
+      expect(result.current.isOpen).toBe(false)
+
+      result.current.open()
+
+      expect(result.current.isOpen).toBe(true)
+
+      rerender({ disabled: true })
+
+      expect(result.current.isOpen).toBe(false)
+    })
+  })
 })

--- a/packages/picasso/src/Select/hooks/use-select-state/use-select-state.ts
+++ b/packages/picasso/src/Select/hooks/use-select-state/use-select-state.ts
@@ -1,6 +1,11 @@
 import { useState, useCallback, useEffect, useMemo } from 'react'
 
-import { Option, OptionGroups, ValueType, UseSelectStateOutput } from '../../types'
+import {
+  Option,
+  OptionGroups,
+  ValueType,
+  UseSelectStateOutput
+} from '../../types'
 import {
   getSelection,
   removeDuplicatedOptions,
@@ -32,10 +37,9 @@ const useSelectState = (props: Props): UseSelectStateOutput => {
     searchThreshold = DEFAULT_SEARCH_THRESHOLD
   } = props
 
-  const flatOptions: Option[] = useMemo(
-    () => flattenOptions(options),
-    [options]
-  )
+  const flatOptions: Option[] = useMemo(() => flattenOptions(options), [
+    options
+  ])
 
   const [selectedOptions, setSelectedOptions] = useState(
     getSelectedOptions(options, value)
@@ -97,6 +101,13 @@ const useSelectState = (props: Props): UseSelectStateOutput => {
   const open = useCallback(() => {
     setOpen(true)
   }, [])
+
+  useEffect(() => {
+    // we have to close menu if select has became disabled
+    if (disabled && isOpen) {
+      close()
+    }
+  }, [disabled, isOpen, close])
 
   return {
     ...props,


### PR DESCRIPTION
### Description

As soon as the Select `disabled` state was switched to `true`, we have to close `Popper`

### How to test

it's mostly related to multiple options `Select`:
Reuse this code:

```
const Example = () => {
  const [values, setValues] = useState<string[]>([])
  const [disabled, setDisabledState] = useState<boolean>(false)
  const handleChange = (event: React.ChangeEvent<{ value: string[] }>) => {
    setValues(event.target.value)
    setDisabledState(true)
    setTimeout(() => {
      setDisabledState(false)
    }, 2000)
  }

  return (
    <Select
      onChange={handleChange}
      options={OPTIONS}
      value={values}
      placeholder='Choose an option...'
      width='auto'
      multiple
      disabled={disabled}
    />
  )
}
```


### Screenshots

before:
https://monosnap.com/file/ULYlXtLGMm31NY3mmGXX3o8YncWfrT

after:
https://monosnap.com/file/A6nRdBSfhXouBDjxm8tbXZ1vfhcXHJ


### Review

- [ ] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/api-principles.md)
- [ ] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that tests pass by running `yarn test`
- [ ] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
- [ ] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>
