### PR TITLE
fix(TagSelector): compare by value

### DIFF
--- a/cypress/component/TagSelector.spec.tsx
+++ b/cypress/component/TagSelector.spec.tsx
@@ -1,0 +1,62 @@
+import React from 'react'
+import { Form } from '@toptal/picasso-forms'
+import { mount } from '@cypress/react'
+import { TestingPicasso } from '@toptal/picasso/test-utils'
+import { noop } from '@toptal/picasso/utils'
+import { AutocompleteItem } from '@toptal/picasso'
+
+const options = [
+  {
+    text: 'Option 1',
+    value: 1
+  },
+  {
+    text: 'Option 2',
+    value: 2
+  },
+  {
+    text: 'Option 3',
+    value: 3
+  }
+] as AutocompleteItem[]
+
+const InitiallySelectedOptionExample = () => {
+  const initialValues = {
+    options: [
+      {
+        text: 'Option 2',
+        value: 2
+      }
+    ]
+  }
+
+  return (
+    <TestingPicasso>
+      <Form onSubmit={noop} initialValues={initialValues}>
+        <>
+          <Form.TagSelector name='options' options={options} />
+          <Form.SubmitButton>Submit</Form.SubmitButton>
+        </>
+      </Form>
+    </TestingPicasso>
+  )
+}
+
+const getOptions = () => cy.get('[role=option]')
+const getOption = (text: string) => getOptions().contains(text)
+const openTagSelector = () => cy.get('input[type="text"]').click()
+
+describe('TagSelector', () => {
+  it('filters options correctly in a form', () => {
+    mount(<InitiallySelectedOptionExample />)
+
+    openTagSelector()
+    getOptions().should('have.length', 2)
+    getOption('Option 2').should('not.exist')
+
+    getOption('Option 1').click()
+    openTagSelector()
+    getOptions().should('have.length', 1)
+    getOption('Option 1').should('not.exist')
+  })
+})

--- a/packages/picasso/src/TagSelector/TagSelector.tsx
+++ b/packages/picasso/src/TagSelector/TagSelector.tsx
@@ -22,8 +22,11 @@ export interface Item extends AutocompleteItem {
 
 const EMPTY_INPUT_VALUE = ''
 
-const isIncluded = (items: Item[], currentItem: Item) =>
-  items.some(item => item === currentItem)
+export const isIncluded = (items: Item[], currentItem: Item) =>
+  items.some(
+    ({ text, value }) =>
+      text === currentItem.text && value === currentItem.value
+  )
 
 const getItemText = (item: Item | null) =>
   (item && item.text) || EMPTY_INPUT_VALUE

--- a/packages/picasso/src/TagSelector/TagSelector.tsx
+++ b/packages/picasso/src/TagSelector/TagSelector.tsx
@@ -23,10 +23,7 @@ export interface Item extends AutocompleteItem {
 const EMPTY_INPUT_VALUE = ''
 
 export const isIncluded = (items: Item[], currentItem: Item) =>
-  items.some(
-    ({ text, value }) =>
-      text === currentItem.text && value === currentItem.value
-  )
+  items.some(({ value }) => value === currentItem.value)
 
 const getItemText = (item: Item | null) =>
   (item && item.text) || EMPTY_INPUT_VALUE

--- a/packages/picasso/src/TagSelector/test.tsx
+++ b/packages/picasso/src/TagSelector/test.tsx
@@ -126,7 +126,7 @@ describe('TagSelector', () => {
   })
 })
 
-describe('#isIncluded', () => {
+describe('isIncluded', () => {
   it('compares object by reference', () => {
     const actual = isIncluded(testOptions, testOptions[0])
 

--- a/packages/picasso/src/TagSelector/test.tsx
+++ b/packages/picasso/src/TagSelector/test.tsx
@@ -134,9 +134,9 @@ describe('isIncluded', () => {
   })
 
   it.each`
-    value   | text               | result
-    ${'AF'} | ${'Afghanistan'}   | ${true}
-    ${'AF'} | ${'Aland Islands'} | ${false}
+    value   | text              | result
+    ${'AF'} | ${'Afghanistan'}  | ${true}
+    ${'NO'} | ${'Non existing'} | ${false}
   `('compares object by value', ({ value, text, result }) => {
     const actual = isIncluded(testOptions, { text, value })
 

--- a/packages/picasso/src/TagSelector/test.tsx
+++ b/packages/picasso/src/TagSelector/test.tsx
@@ -7,7 +7,7 @@ import {
 } from '@toptal/picasso/test-utils'
 import { OmitInternalProps } from '@toptal/picasso-shared'
 
-import TagSelector, { Props } from './TagSelector'
+import TagSelector, { Props, isIncluded } from './TagSelector'
 
 const testOptions = [
   { value: 'AF', text: 'Afghanistan' },
@@ -123,5 +123,23 @@ describe('TagSelector', () => {
     await selectOption(renderResult, input, testOptions[0].text)
 
     expect(onChange).toHaveBeenCalledWith([testOptions[0]])
+  })
+})
+
+describe('#isIncluded', () => {
+  it('compares object by reference', () => {
+    const actual = isIncluded(testOptions, testOptions[0])
+
+    expect(actual).toEqual(true)
+  })
+
+  it.each`
+    value   | text               | result
+    ${'AF'} | ${'Afghanistan'}   | ${true}
+    ${'AF'} | ${'Aland Islands'} | ${false}
+  `('compares object by value', ({ value, text, result }) => {
+    const actual = isIncluded(testOptions, { text, value })
+
+    expect(actual).toEqual(result)
   })
 })


### PR DESCRIPTION
[FX-1995]

### Description

When setting initial values on `TagSelector` those (initial values) are not filtered out from the available choices.
[Sandbox example](https://codesandbox.io/s/tender-meadow-jjdol?file=/src/App.tsx)
This is happening because `isIncluded` function is comparing items by reference.

### How to test

- TagSelector component should work exactly the same as before

### Review

- [ ] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/api-principles.md)
- [ ] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that tests pass by running `yarn test`
- [ ] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
- [ ] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>


[FX-1995]: https://toptal-core.atlassian.net/browse/FX-1995