### PR TITLE
fix(Button): replace background of flat button

### DIFF
--- a/cypress/component/ButtonCircular.spec.tsx
+++ b/cypress/component/ButtonCircular.spec.tsx
@@ -1,0 +1,27 @@
+import React from 'react'
+import { mount } from '@cypress/react'
+import { Button, Container, Settings16 } from '@toptal/picasso'
+import { TestingPicasso } from '@toptal/picasso/test-utils'
+import { palette } from '@toptal/picasso/utils'
+
+describe('Button.Circular', () => {
+  it('renders flat variant', () => {
+    mount(
+      <TestingPicasso>
+        <Container
+          inline
+          style={{ backgroundColor: palette.blue.lighter }}
+          padded='small'
+        >
+          <Button.Circular variant='flat' icon={<Settings16 />} />
+          <Button.Circular variant='flat' hovered icon={<Settings16 />} />
+          <Button.Circular variant='flat' focused icon={<Settings16 />} />
+          <Button.Circular variant='flat' active icon={<Settings16 />} />
+          <Button.Circular variant='flat' loading icon={<Settings16 />} />
+          <Button.Circular variant='flat' disabled icon={<Settings16 />} />
+        </Container>
+      </TestingPicasso>
+    )
+    cy.get('body').happoScreenshot()
+  })
+})

--- a/packages/picasso/src/ButtonCircular/styles.ts
+++ b/packages/picasso/src/ButtonCircular/styles.ts
@@ -14,7 +14,7 @@ export default ({ palette }: Theme) =>
 
     flat: {
       color: palette.grey.dark,
-      backgroundColor: palette.common.white,
+      backgroundColor: 'initial',
 
       '&:hover, &$hovered': {
         backgroundColor: palette.grey.lighter2
@@ -27,7 +27,7 @@ export default ({ palette }: Theme) =>
       '&$disabled': {
         opacity: 0.48,
         color: palette.grey.dark,
-        backgroundColor: palette.common.white
+        backgroundColor: 'initial'
       },
 
       border: 'none'


### PR DESCRIPTION
[FX-2004](https://toptal-core.atlassian.net/browse/FX-2004)

### Description

Remove white background from flat Button. The background must be transparent by default.


### Screenshots


<img width="422" alt="Picasso | Button" src="https://user-images.githubusercontent.com/76203853/125045601-d7391480-e0a5-11eb-84b0-d791ba33d0a8.png">


### Review

- [ ] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/api-principles.md)
- [ ] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that tests pass by running `yarn test`
- [ ] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
- [ ] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>
