### PR TITLE
chore(Autocomplete): implement a disabled state of autocomplete

### DIFF
--- a/cypress/component/Autocomplete.spec.tsx
+++ b/cypress/component/Autocomplete.spec.tsx
@@ -167,6 +167,18 @@ describe('Autocomplete', () => {
 
     cy.get('body').happoScreenshot()
   })
+
+  it('renders disabled autocomplete', () => {
+    mount(
+      <TestingPicasso>
+        <TestAutocomplete disabled />
+        <TestAutocomplete value='Croatia' disabled />
+      </TestingPicasso>
+    )
+
+    cy.get('body').happoScreenshot()
+  })
+
   it('renders a reset button', () => {
     mount(
       <TestingPicasso>
@@ -228,15 +240,13 @@ describe('Autocomplete', () => {
     cy.get('body').happoScreenshot()
   })
 
-  it('renders loading, error and disabled states', () => {
+  it('renders loading and error states', () => {
     mount(
       <TestingPicasso>
         <TestAutocomplete error />
         <TestAutocomplete loading />
-        <TestAutocomplete disabled />
         <TestAutocomplete value='Croatia' error />
         <TestAutocomplete value='Croatia' loading />
-        <TestAutocomplete value='Croatia' disabled />
       </TestingPicasso>
     )
 

--- a/packages/picasso/src/Autocomplete/Autocomplete.tsx
+++ b/packages/picasso/src/Autocomplete/Autocomplete.tsx
@@ -42,6 +42,8 @@ export interface Props
   onChange?: (value: string, options: ChangedOptions) => void
   /** The value of the selected option, required for a controlled component. */
   value: string
+  /** Whether a component is disabled */
+  disabled?: boolean
   /**  Callback invoked when selection changes */
   onSelect?: (item: Item, event: MouseEvent | KeyboardEvent) => void
   /**  Callback invoked when other option selected */
@@ -117,7 +119,7 @@ const getItemText = (item: Item | null) =>
   (item && item.text) || EMPTY_INPUT_VALUE
 
 export const Autocomplete = forwardRef<HTMLInputElement, Props>(
-  function Autocomplete(props, ref) {
+  function Autocomplete (props, ref) {
     const {
       autoComplete,
       className,
@@ -151,6 +153,7 @@ export const Autocomplete = forwardRef<HTMLInputElement, Props>(
       testIds,
       value,
       width = 'auto',
+      disabled = false,
       ...rest
     } = props
     const classes = useStyles()
@@ -180,6 +183,7 @@ export const Autocomplete = forwardRef<HTMLInputElement, Props>(
       getInputProps
     } = useAutocomplete({
       value,
+      disabled,
       options,
       getDisplayValue,
       onSelect,
@@ -266,6 +270,7 @@ export const Autocomplete = forwardRef<HTMLInputElement, Props>(
             {...getInputProps()}
             error={error}
             icon={icon}
+            disabled={disabled}
             defaultValue={undefined}
             value={value}
             ref={ref}
@@ -312,7 +317,8 @@ Autocomplete.defaultProps = {
   showOtherOption: false,
   width: 'auto',
   enableReset: true,
-  poweredByGoogle: false
+  poweredByGoogle: false,
+  disabled: false
 }
 
 Autocomplete.displayName = 'Autocomplete'

--- a/packages/picasso/src/Autocomplete/story/Disabled.example.tsx
+++ b/packages/picasso/src/Autocomplete/story/Disabled.example.tsx
@@ -1,0 +1,36 @@
+import React, { useState } from 'react'
+import { Autocomplete, AutocompleteItem, Form } from '@toptal/picasso'
+
+const allOptions = [
+  { text: 'Belarus' },
+  { text: 'Croatia' },
+  { text: 'Lithuania' },
+  { text: 'Slovakia' },
+  { text: 'Ukraine' }
+]
+
+const EMPTY_INPUT_VALUE = ''
+const getDisplayValue = (item: AutocompleteItem | null) =>
+  item ? item.text || '' : EMPTY_INPUT_VALUE
+
+const Example = () => {
+  const [value] = useState(EMPTY_INPUT_VALUE)
+  const [options] = useState<AutocompleteItem[] | null>(allOptions)
+
+  return (
+    <div>
+      <Form autoComplete='off'>
+        <Autocomplete
+          disabled
+          placeholder='Start typing country...'
+          value={value}
+          options={options}
+          getDisplayValue={getDisplayValue}
+          data-testid='autocomplete'
+        />
+      </Form>
+    </div>
+  )
+}
+
+export default Example

--- a/packages/picasso/src/Autocomplete/story/index.jsx
+++ b/packages/picasso/src/Autocomplete/story/index.jsx
@@ -45,6 +45,7 @@ if needed.
     `
   )
   .addExample('Autocomplete/story/Default.example.tsx', 'Default') // picasso-skip-visuals
+  .addExample('Autocomplete/story/Disabled.example.tsx', 'Disabled') // picasso-skip-visuals
   .addExample('Autocomplete/story/OtherOption.example.tsx', {
     title: 'Other option',
     description: `By default Autocomplete allows any entered input value to stay after focus is removed from input,

--- a/packages/picasso/src/Autocomplete/use-autocomplete/use-autocomplete.ts
+++ b/packages/picasso/src/Autocomplete/use-autocomplete/use-autocomplete.ts
@@ -89,6 +89,7 @@ export interface Props {
   getDisplayValue: (item: Item | null) => string
   enableReset?: boolean
   showOtherOption?: boolean
+  disabled?: boolean
 }
 
 export const useAutocomplete = ({
@@ -102,7 +103,8 @@ export const useAutocomplete = ({
   onOtherOptionSelect = () => {},
   getDisplayValue,
   enableReset,
-  showOtherOption
+  showOtherOption,
+  disabled = false
 }: Props) => {
   const [isOpen, setOpen] = useState<boolean>(false)
   const [highlightedIndex, setHighlightedIndex] = useState<number>(
@@ -183,7 +185,7 @@ export const useAutocomplete = ({
   })
 
   const handleClick = () => {
-    if (isOpen) {
+    if (isOpen || disabled) {
       return
     }
 


### PR DESCRIPTION
### Description

We have to add the possibility to have Autocomplete disabled


### Screenshots

<img width="874" alt="Picasso | Autocomplete 🔊 2021-07-12 20-25-24" src="https://user-images.githubusercontent.com/76203853/125330391-60bf3f80-e34f-11eb-94a5-e816df39fe41.png">


### Review

- [ ] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/api-principles.md)
- [ ] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that tests pass by running `yarn test`
- [ ] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
- [ ] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>
