### PR TITLE
fix(Popper): fix popper shaking on each render

### DIFF
--- a/packages/picasso/src/Popper/Popper.tsx
+++ b/packages/picasso/src/Popper/Popper.tsx
@@ -58,7 +58,7 @@ const getAnchorEl = (
   anchorEl: null | ReferenceObject | (() => ReferenceObject)
 ) => (typeof anchorEl === 'function' ? anchorEl() : anchorEl)
 
-const getPopperOptions = (popperOptions: PopperOptions) => ({
+export const getPopperOptions = (popperOptions: PopperOptions) => ({
   ...popperOptions,
 
   modifiers: {
@@ -131,6 +131,11 @@ export const Popper = forwardRef<PopperJs, Props>(function Popper (props, ref) {
     }
   }, [isCompactLayout, open])
 
+  const memoizedPopperOptions = React.useMemo(
+    () => getPopperOptions(popperOptions),
+    [popperOptions]
+  )
+
   return (
     <MUIPopper
       open={open}
@@ -138,7 +143,7 @@ export const Popper = forwardRef<PopperJs, Props>(function Popper (props, ref) {
       anchorEl={anchorEl}
       className={cx(classes.root, className)}
       popperRef={ref}
-      popperOptions={getPopperOptions(popperOptions)}
+      popperOptions={memoizedPopperOptions}
       disablePortal={disablePortal}
       style={{
         ...style,

--- a/packages/picasso/src/Popper/test.tsx
+++ b/packages/picasso/src/Popper/test.tsx
@@ -1,63 +1,159 @@
-import React, { useState, FC, ReactNode, forwardRef } from 'react'
-import Picasso from '@toptal/picasso-provider'
-import { render, act, fireEvent } from '@toptal/picasso/test-utils'
+import React from 'react'
+import MUIPopper from '@material-ui/core/Popper'
+import { usePicassoRoot } from '@toptal/picasso-provider'
+import { makeStyles } from '@material-ui/core/styles'
+import { render } from '@testing-library/react'
 
-import Popper from './Popper'
+import Popper, { Props, getPopperOptions } from './Popper'
+import styles from './styles'
 
-// eslint-disable-next-line react/display-name
-const FakeRootNode = forwardRef<HTMLDivElement, { children?: ReactNode }>(
-  (props, ref) => {
-    const { children } = props
+jest.mock('@material-ui/core/Popper', () => jest.fn(() => null))
+jest.mock('@toptal/picasso-provider', () => ({
+  usePicassoRoot: jest.fn()
+}))
+jest.mock('@material-ui/core/styles', () => ({
+  makeStyles: jest.fn(() => () => ({ root: 'TEST_CLASS_NAME+1' }))
+}))
+jest.mock('../utils', () => ({
+  useBreakpoint: () => true,
+  useWidthOf: () => '300px'
+}))
 
-    return (
-      <div ref={ref} role='root'>
-        {children}
-      </div>
-    )
-  }
-)
+const mockedUsePicassoRoot = usePicassoRoot as jest.Mock<
+  ReturnType<typeof usePicassoRoot>
+>
+const mockedMakeStyles = makeStyles as jest.Mock<ReturnType<typeof makeStyles>>
+const mockedMUIPopper = MUIPopper as jest.Mock<ReturnType<typeof MUIPopper>>
 
-const PicassoWithFakeRootNode: FC = ({ children }) => {
-  return (
-    <Picasso
-      loadFonts={false}
-      loadFavicon={false}
-      fixViewport={false}
-      RootComponent={FakeRootNode}
-    >
-      {children}
-    </Picasso>
-  )
+const rootDiv = document.createElement('div')
+
+rootDiv.setAttribute('id', 'root')
+
+const anchorEl = document.body
+const children = 'some children'
+const className = 'TEST_CLASS_NAME+1'
+const disablePortal = false
+const open = true
+const placement = 'top'
+const defaultPopperProps = {
+  container: rootDiv,
+  anchorEl,
+  children,
+  className,
+  disablePortal,
+  open,
+  placement,
+  popperRef: null,
+  style: {
+    width: '300px'
+  },
+  popperOptions: getPopperOptions({})
 }
 
-const PopperRenderer = () => {
-  const [popoverIsOpen, setPopoverIsOpen] = useState(false)
-
-  return (
-    <>
-      <button onClick={() => setPopoverIsOpen(true)} role='action'>
-        Click
-      </button>
-      <Popper open={popoverIsOpen} anchorEl={document.body}>
-        some children
+const renderComponent = (props: Partial<Props> = {}) => {
+  return render(
+    <div id='root'>
+      <Popper
+        open={open}
+        anchorEl={anchorEl}
+        disablePortal={disablePortal}
+        placement={placement}
+        {...props}
+      >
+        {children}
       </Popper>
-    </>
+    </div>,
+    {
+      container: document.body.appendChild(rootDiv)
+    }
   )
 }
 
 describe('Popper', () => {
-  it('renders', () => {
-    const { getByRole } = render(<PopperRenderer />, {
-      wrapper: PicassoWithFakeRootNode
+  beforeEach(() => {
+    mockedMUIPopper.mockClear()
+    mockedUsePicassoRoot.mockReturnValue(rootDiv)
+  })
+
+  it('creates useStyle hook properly', () => {
+    expect(mockedMakeStyles).toHaveBeenCalledTimes(1)
+    expect(mockedMakeStyles).toHaveBeenCalledWith(styles, {
+      name: 'PicassoPopper'
     })
+  })
 
-    act(() => {
-      fireEvent.click(getByRole('action'))
+  describe('when container prop is passed', () => {
+    it('calls MUIPopper with passed container', () => {
+      const container = document.createElement('div')
+
+      renderComponent({
+        container
+      })
+
+      expect(mockedMUIPopper).toHaveBeenCalledTimes(1)
+      expect(mockedMUIPopper).toHaveBeenCalledWith(
+        {
+          ...defaultPopperProps,
+          container
+        },
+        {}
+      )
     })
+  })
 
-    const popper = getByRole('tooltip')
-    const root = getByRole('root')
+  describe('when container prop is NOT passed', () => {
+    it('calls MUIPopper with default root container', () => {
+      renderComponent({
+        container: undefined
+      })
 
-    expect(root).toContainElement(popper)
+      expect(mockedMUIPopper).toHaveBeenCalledTimes(1)
+      expect(mockedMUIPopper).toHaveBeenCalledWith(
+        {
+          ...defaultPopperProps,
+          container: rootDiv
+        },
+        {}
+      )
+    })
+  })
+
+  describe('when custom width prop is passed', () => {
+    it('calls MUIPopper with custom width style', () => {
+      renderComponent({
+        width: '400px'
+      })
+
+      expect(mockedMUIPopper).toHaveBeenCalledTimes(1)
+      expect(mockedMUIPopper).toHaveBeenCalledWith(
+        {
+          ...defaultPopperProps,
+          style: {
+            width: '400px'
+          }
+        },
+        {}
+      )
+    })
+  })
+
+  describe('when custom width prop is NOT passed', () => {
+    describe('when autoWidth prop is false', () => {
+      it('calls MUIPopper without assigning width style', () => {
+        renderComponent({
+          width: undefined,
+          autoWidth: false
+        })
+
+        expect(mockedMUIPopper).toHaveBeenCalledTimes(1)
+        expect(mockedMUIPopper).toHaveBeenCalledWith(
+          {
+            ...defaultPopperProps,
+            style: {}
+          },
+          {}
+        )
+      })
+    })
   })
 })


### PR DESCRIPTION
[TOP-1523]

### Description

Sometimes Menu is shaking when a user is walking across a menu items. It happens due to creating a completely new instance of `Popper.js` on each render of the Picasso's `Popper`. To avoid this, we should avoid creating new instances of props that are passed to `MUI`'s `Popper`.

### Video

#### Before

https://monosnap.com/file/WRc2TdNnsGtlZwCXIWoUegTO2xuyvx

#### After

https://monosnap.com/file/JFlgVWiqBIsgu1zQmRARoRDNZaVQ0f

### Review

- [ ] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/api-principles.md)
- [ ] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that tests pass by running `yarn test`
- [ ] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
- [ ] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>


[TOP-1523]: https://toptal-core.atlassian.net/browse/TOP-1523