### PR TITLE
feat: add title size for section component

### DIFF
--- a/packages/picasso-lab/src/Section/Section.tsx
+++ b/packages/picasso-lab/src/Section/Section.tsx
@@ -7,6 +7,7 @@ import {
   BaseProps,
   Button,
   Container,
+  SizeType,
   Typography
 } from '@toptal/picasso'
 import { Rotate180 } from '@toptal/picasso/utils/Transitions'
@@ -36,6 +37,10 @@ export interface Props extends BaseProps {
     collapse?: string
   }
   variant?: VariantType
+  /** Title size of the inner text */
+  titleSize?: SizeType<'small' | 'medium' | 'large' | 'xlarge'> | 'inherit'
+  /** Subtitle size of the inner text */
+  subtitleSize?: SizeType<'small' | 'medium' | 'large' | 'xlarge'> | 'inherit'
 }
 
 const useStyles = makeStyles(styles, {
@@ -57,6 +62,8 @@ export const Section = forwardRef<HTMLDivElement, Props>(function Section (
     collapsible = false,
     defaultCollapsed = true,
     variant,
+    titleSize = 'medium',
+    subtitleSize = 'medium',
     ...rest
   } = props
   const classes = useStyles()
@@ -72,7 +79,7 @@ export const Section = forwardRef<HTMLDivElement, Props>(function Section (
         className={classes.title}
         data-testid={testIds?.title}
         variant='heading'
-        size='medium'
+        size={titleSize}
       >
         {title}
       </Typography>
@@ -83,7 +90,7 @@ export const Section = forwardRef<HTMLDivElement, Props>(function Section (
       <Typography
         className={classes.subtitle}
         data-testid={testIds?.subtitle}
-        size='medium'
+        size={subtitleSize}
         color='dark-grey'
       >
         {subtitle}
@@ -143,6 +150,11 @@ export const Section = forwardRef<HTMLDivElement, Props>(function Section (
 })
 
 Section.displayName = 'Section'
-Section.defaultProps = { collapsible: false, defaultCollapsed: true }
+Section.defaultProps = {
+  collapsible: false,
+  defaultCollapsed: true,
+  titleSize: 'medium',
+  subtitleSize: 'medium'
+}
 
 export default Section

--- a/packages/picasso-lab/src/Section/Section.tsx
+++ b/packages/picasso-lab/src/Section/Section.tsx
@@ -38,9 +38,7 @@ export interface Props extends BaseProps {
   }
   variant?: VariantType
   /** Title size of the inner text */
-  titleSize?: SizeType<'small' | 'medium' | 'large' | 'xlarge'> | 'inherit'
-  /** Subtitle size of the inner text */
-  subtitleSize?: SizeType<'small' | 'medium' | 'large' | 'xlarge'> | 'inherit'
+  titleSize?: SizeType<'small' | 'medium'>
 }
 
 const useStyles = makeStyles(styles, {
@@ -63,7 +61,6 @@ export const Section = forwardRef<HTMLDivElement, Props>(function Section (
     defaultCollapsed = true,
     variant,
     titleSize = 'medium',
-    subtitleSize = 'medium',
     ...rest
   } = props
   const classes = useStyles()
@@ -90,7 +87,7 @@ export const Section = forwardRef<HTMLDivElement, Props>(function Section (
       <Typography
         className={classes.subtitle}
         data-testid={testIds?.subtitle}
-        size={subtitleSize}
+        size='medium'
         color='dark-grey'
       >
         {subtitle}
@@ -153,8 +150,7 @@ Section.displayName = 'Section'
 Section.defaultProps = {
   collapsible: false,
   defaultCollapsed: true,
-  titleSize: 'medium',
-  subtitleSize: 'medium'
+  titleSize: 'medium'
 }
 
 export default Section

--- a/packages/picasso-lab/src/Section/story/TitleSize.example.tsx
+++ b/packages/picasso-lab/src/Section/story/TitleSize.example.tsx
@@ -1,17 +1,33 @@
 import React from 'react'
-import { List } from '@toptal/picasso'
+import { Grid, List, Typography } from '@toptal/picasso'
 import { Section } from '@toptal/picasso-lab'
 
 const Example = () => {
   return (
-    <Section variant='bordered' title='Quotes' titleSize='small'>
-      <List variant='unordered'>
-        <List.Item>
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-        </List.Item>
-        <List.Item>In nec cursus lectus, nec malesuada tellus.</List.Item>
-      </List>
-    </Section>
+    <Grid>
+      <Grid.Item small={6}>
+        <Typography>Default title size</Typography>
+        <Section title='Quotes'>
+          <List variant='unordered'>
+            <List.Item>
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+            </List.Item>
+            <List.Item>In nec cursus lectus, nec malesuada tellus.</List.Item>
+          </List>
+        </Section>
+      </Grid.Item>
+      <Grid.Item small={6}>
+        <Typography>Small title size</Typography>
+        <Section title='Quotes' titleSize='small'>
+          <List variant='unordered'>
+            <List.Item>
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+            </List.Item>
+            <List.Item>In nec cursus lectus, nec malesuada tellus.</List.Item>
+          </List>
+        </Section>
+      </Grid.Item>
+    </Grid>
   )
 }
 

--- a/packages/picasso-lab/src/Section/story/TitleSize.example.tsx
+++ b/packages/picasso-lab/src/Section/story/TitleSize.example.tsx
@@ -1,0 +1,24 @@
+import React from 'react'
+import { List } from '@toptal/picasso'
+import { Section } from '@toptal/picasso-lab'
+
+const Example = () => {
+  return (
+    <Section
+      variant='bordered'
+      title='Quotes'
+      titleSize='small'
+      subtitle='2 quotes'
+      subtitleSize='small'
+    >
+      <List variant='unordered'>
+        <List.Item>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+        </List.Item>
+        <List.Item>In nec cursus lectus, nec malesuada tellus.</List.Item>
+      </List>
+    </Section>
+  )
+}
+
+export default Example

--- a/packages/picasso-lab/src/Section/story/TitleSize.example.tsx
+++ b/packages/picasso-lab/src/Section/story/TitleSize.example.tsx
@@ -4,13 +4,7 @@ import { Section } from '@toptal/picasso-lab'
 
 const Example = () => {
   return (
-    <Section
-      variant='bordered'
-      title='Quotes'
-      titleSize='small'
-      subtitle='2 quotes'
-      subtitleSize='small'
-    >
+    <Section variant='bordered' title='Quotes' titleSize='small'>
       <List variant='unordered'>
         <List.Item>
           Lorem ipsum dolor sit amet, consectetur adipiscing elit.

--- a/packages/picasso-lab/src/Section/story/index.jsx
+++ b/packages/picasso-lab/src/Section/story/index.jsx
@@ -29,3 +29,6 @@ page
   .createChapter()
   .addExample('Section/story/Collapsible.example.tsx', 'Collapsible') // picasso-skip-visuals
 page.createChapter().addExample('Section/story/Variant.example.tsx', 'Variant') // picasso-skip-visuals
+page
+  .createChapter()
+  .addExample('Section/story/TitleSize.example.tsx', 'Title Size') // picasso-skip-visuals


### PR DESCRIPTION
[SPT-1793](https://toptal-core.atlassian.net/browse/SPT-1793)

### Description

Add the possibility to change the title font size for the section component.

### How to test

- Check the title size example for the Section component

### Screenshots

![image](https://user-images.githubusercontent.com/2583281/128676950-4485ee0d-4500-4dcf-a2f5-8953156c270d.png)

### Review

- [ ] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/api-principles.md)
- [ ] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that tests pass by running `yarn test`
- [ ] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
- [ ] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>
