### PR TITLE
fix: fix path of generated component

### DIFF
--- a/_templates/component/example/example.ejs.t
+++ b/_templates/component/example/example.ejs.t
@@ -1,5 +1,5 @@
 ---
-to: src/components/<%= h.changeCase.pascalCase(component) %>/story/<%= h.changeCase.pascalCase(example) %>.example.jsx
+to: packages/<%= package %>/src/<%= h.changeCase.pascalCase(component) %>/story/<%= h.changeCase.pascalCase(example) %>.example.jsx
 ---
 <%
   Component = h.changeCase.pascalCase(component)

--- a/_templates/component/example/index.js
+++ b/_templates/component/example/index.js
@@ -1,19 +1,46 @@
+const AVAILABLE_PACKAGES = [
+  'picasso',
+  'picasso-lab',
+  'picasso-forms',
+  'picasso-charts',
+  'picasso-provider'
+]
+
 const DEFAULT_EXAMPLE_COMMAND = 'example'
 
+/**
+ * @example yarn generate:example ComponentName ExampleName Package
+ * @example yarn generate:example --component=ComponentName --example=ExampleName --package=Package
+ * @example yarn generate:example
+ */
 module.exports = {
   prompt: ({ prompter, args }) => {
-    const argvComponent = process.argv[process.argv.length - 2]
-    const argvExampleName = process.argv[process.argv.length - 1]
+    const argvComponent = process.argv[process.argv.length - 3]
+    const argvExampleName = process.argv[process.argv.length - 2]
+    const argvPackage = process.argv[process.argv.length - 1]
 
-    if (argvExampleName !== DEFAULT_EXAMPLE_COMMAND) {
+    const inputAsParams =
+      AVAILABLE_PACKAGES.includes(argvPackage) &&
+      argvExampleName !== DEFAULT_EXAMPLE_COMMAND
+
+    const inputsAsArgs =
+      args.component &&
+      args.example &&
+      args.package &&
+      AVAILABLE_PACKAGES.includes(args.package)
+
+    if (inputAsParams) {
       return Promise.resolve({
         component: argvComponent,
-        example: argvExampleName
+        example: argvExampleName,
+        package: argvPackage
       })
-    } else if (args.component && args.example) {
+    }
+    if (inputsAsArgs) {
       return Promise.resolve({
         component: args.component,
-        example: args.example
+        example: args.example,
+        package: args.package
       })
     }
 
@@ -27,6 +54,12 @@ module.exports = {
         type: 'input',
         name: 'example',
         message: "What's the example name?"
+      },
+      {
+        type: 'select',
+        name: 'package',
+        message: `To what package would you like to add component?`,
+        choices: AVAILABLE_PACKAGES
       }
     ])
   }

--- a/_templates/component/example/index.js
+++ b/_templates/component/example/index.js
@@ -2,8 +2,7 @@ const AVAILABLE_PACKAGES = [
   'picasso',
   'picasso-lab',
   'picasso-forms',
-  'picasso-charts',
-  'picasso-provider'
+  'picasso-charts'
 ]
 
 const DEFAULT_EXAMPLE_COMMAND = 'example'

--- a/_templates/component/example/story.ejs.t
+++ b/_templates/component/example/story.ejs.t
@@ -1,6 +1,6 @@
 ---
 inject: true
-to: src/components/<%= h.changeCase.pascalCase(component) %>/story/index.jsx
+to: packages/<%= package %>/src/<%= h.changeCase.pascalCase(component) %>/story/index.jsx
 append: true
 ---
 <%

--- a/_templates/component/new/component.ejs.t
+++ b/_templates/component/new/component.ejs.t
@@ -1,5 +1,5 @@
 ---
-to: src/components/<%= h.changeCase.pascalCase(name) %>/<%= h.changeCase.pascalCase(name) %>.tsx
+to: packages/picasso/src/<%= h.changeCase.pascalCase(name) %>/<%= h.changeCase.pascalCase(name) %>.tsx
 ---
 <%
   Name = h.changeCase.pascalCase(name)

--- a/_templates/component/new/component.ejs.t
+++ b/_templates/component/new/component.ejs.t
@@ -1,5 +1,5 @@
 ---
-to: packages/picasso/src/<%= h.changeCase.pascalCase(name) %>/<%= h.changeCase.pascalCase(name) %>.tsx
+to: packages/<%= package %>/src/<%= h.changeCase.pascalCase(name) %>/<%= h.changeCase.pascalCase(name) %>.tsx
 ---
 <%
   Name = h.changeCase.pascalCase(name)

--- a/_templates/component/new/componentsIndex.ejs.t
+++ b/_templates/component/new/componentsIndex.ejs.t
@@ -1,7 +1,7 @@
 ---
 inject: true
 to: packages/<%= package %>/src/index.ts
-before: // insert point for hypen
+before: export \* from './Icon'
 ---
 <%
   Name = h.changeCase.pascalCase(name)

--- a/_templates/component/new/componentsIndex.ejs.t
+++ b/_templates/component/new/componentsIndex.ejs.t
@@ -1,7 +1,7 @@
 ---
 inject: true
 to: packages/<%= package %>/src/index.ts
-before: export \* from './Icon'
+before: // placeholder for hygen generator. Genereates export before this comment.
 ---
 <%
   Name = h.changeCase.pascalCase(name)

--- a/_templates/component/new/componentsIndex.ejs.t
+++ b/_templates/component/new/componentsIndex.ejs.t
@@ -1,9 +1,10 @@
 ---
 inject: true
-to: src/components/index.ts
-before: export { default } from './Picasso'
+to: packages/picasso/src/index.ts
+before: // insert point for hypen
 ---
 <%
   Name = h.changeCase.pascalCase(name)
 -%>
 export { default as <%= Name %> } from './<%= Name %>'
+export type { <%= Name %>Props } from './<%= Name %>'

--- a/_templates/component/new/componentsIndex.ejs.t
+++ b/_templates/component/new/componentsIndex.ejs.t
@@ -1,6 +1,6 @@
 ---
 inject: true
-to: packages/picasso/src/index.ts
+to: packages/<%= package %>/src/index.ts
 before: // insert point for hypen
 ---
 <%

--- a/_templates/component/new/componentsIndex.ejs.t
+++ b/_templates/component/new/componentsIndex.ejs.t
@@ -1,7 +1,7 @@
 ---
 inject: true
 to: packages/<%= package %>/src/index.ts
-before: // placeholder for hygen generator. Genereates export before this comment.
+before: // hygen code generator inserts export statements above this comment.
 ---
 <%
   Name = h.changeCase.pascalCase(name)

--- a/_templates/component/new/index.ejs.t
+++ b/_templates/component/new/index.ejs.t
@@ -1,7 +1,12 @@
 ---
-to: src/components/<%= h.changeCase.pascalCase(name) %>/index.ts
+to: packages/picasso/src/<%= h.changeCase.pascalCase(name) %>/index.ts
 ---
 <%
   Name = h.changeCase.pascalCase(name)
 -%>
+import { OmitInternalProps } from '@toptal/picasso-shared'
+
+import { Props } from './<%= Name %>'
+
 export { default } from './<%= Name %>'
+export type <%= Name %>Props = OmitInternalProps<Props>

--- a/_templates/component/new/index.ejs.t
+++ b/_templates/component/new/index.ejs.t
@@ -1,5 +1,5 @@
 ---
-to: packages/picasso/src/<%= h.changeCase.pascalCase(name) %>/index.ts
+to: packages/<%= package %>/src/<%= h.changeCase.pascalCase(name) %>/index.ts
 ---
 <%
   Name = h.changeCase.pascalCase(name)

--- a/_templates/component/new/index.js
+++ b/_templates/component/new/index.js
@@ -10,10 +10,24 @@ module.exports = {
       return Promise.resolve({ name: args.name })
     }
 
-    return prompter.prompt({
-      type: 'input',
-      name: 'name',
-      message: "What's the component name?"
-    })
+    return prompter.prompt([
+      {
+        type: 'input',
+        name: 'name',
+        message: "What's the component name?"
+      },
+      {
+        type: 'select',
+        name: 'package',
+        message: `To what package would you like to add component?`,
+        choices: [
+          'picasso',
+          'picasso-lab',
+          'picasso-forms',
+          'picasso-charts',
+          'picasso-provider'
+        ]
+      }
+    ])
   }
 }

--- a/_templates/component/new/index.js
+++ b/_templates/component/new/index.js
@@ -1,13 +1,36 @@
 const DEFAULT_NEWCOMPONENT_COMMAND = 'new'
 
+const AVAILABLE_PACKAGES = [
+  'picasso',
+  'picasso-lab',
+  'picasso-forms',
+  'picasso-charts',
+  'picasso-provider'
+]
+
+/**
+ * @example yarn generate:component ComponentName picasso
+ * @example yarn generate:component --name=ComponentName --package=picasso
+ * @example yarn generate:component
+ */
 module.exports = {
   prompt: ({ prompter, args }) => {
-    const argvName = process.argv[process.argv.length - 1]
+    const argvPackage = process.argv[process.argv.length - 1]
+    const argvName = process.argv[process.argv.length - 2]
 
-    if (argvName !== DEFAULT_NEWCOMPONENT_COMMAND) {
-      return Promise.resolve({ name: argvName })
-    } else if (args.name) {
-      return Promise.resolve({ name: args.name })
+    const inputsAsParams =
+      AVAILABLE_PACKAGES.includes(argvPackage) &&
+      argvName !== DEFAULT_NEWCOMPONENT_COMMAND
+
+    const inputsAsArgs =
+      args.name && args.package && AVAILABLE_PACKAGES.includes(args.package)
+
+    if (inputsAsParams) {
+      return Promise.resolve({ name: argvName, package: argvPackage })
+    }
+
+    if (inputsAsArgs) {
+      return Promise.resolve({ name: args.name, package: args.package })
     }
 
     return prompter.prompt([
@@ -20,13 +43,7 @@ module.exports = {
         type: 'select',
         name: 'package',
         message: `To what package would you like to add component?`,
-        choices: [
-          'picasso',
-          'picasso-lab',
-          'picasso-forms',
-          'picasso-charts',
-          'picasso-provider'
-        ]
+        choices: AVAILABLE_PACKAGES
       }
     ])
   }

--- a/_templates/component/new/index.js
+++ b/_templates/component/new/index.js
@@ -4,8 +4,7 @@ const AVAILABLE_PACKAGES = [
   'picasso',
   'picasso-lab',
   'picasso-forms',
-  'picasso-charts',
-  'picasso-provider'
+  'picasso-charts'
 ]
 
 /**

--- a/_templates/component/new/story.ejs.t
+++ b/_templates/component/new/story.ejs.t
@@ -1,5 +1,5 @@
 ---
-to: src/components/<%= h.changeCase.pascalCase(name) %>/story/index.jsx
+to: packages/picasso/src/<%= h.changeCase.pascalCase(name) %>/story/index.jsx
 ---
 <%
   Name = h.changeCase.pascalCase(name)

--- a/_templates/component/new/story.ejs.t
+++ b/_templates/component/new/story.ejs.t
@@ -1,5 +1,5 @@
 ---
-to: packages/picasso/src/<%= h.changeCase.pascalCase(name) %>/story/index.jsx
+to: packages/<%= package %>/src/<%= h.changeCase.pascalCase(name) %>/story/index.jsx
 ---
 <%
   Name = h.changeCase.pascalCase(name)

--- a/_templates/component/new/styles.ejs.t
+++ b/_templates/component/new/styles.ejs.t
@@ -1,5 +1,5 @@
 ---
-to: packages/picasso/src/<%= h.changeCase.pascalCase(name) %>/styles.ts
+to: packages/<%= package %>/src/<%= h.changeCase.pascalCase(name) %>/styles.ts
 ---
 <%
   Name = h.changeCase.pascalCase(name)

--- a/_templates/component/new/styles.ejs.t
+++ b/_templates/component/new/styles.ejs.t
@@ -1,10 +1,10 @@
 ---
-to: src/components/<%= h.changeCase.pascalCase(name) %>/styles.ts
+to: packages/picasso/src/<%= h.changeCase.pascalCase(name) %>/styles.ts
 ---
 <%
   Name = h.changeCase.pascalCase(name)
 -%>
-import { PicassoProvider } from '../Picasso'
+import { PicassoProvider } from '@toptal/picasso-provider'
 import { Theme, createStyles } from '@material-ui/core/styles'
 
 PicassoProvider.override(({ palette }: Theme) => ({

--- a/_templates/component/new/test.ejs.t
+++ b/_templates/component/new/test.ejs.t
@@ -1,13 +1,13 @@
 ---
-to: src/components/<%= h.changeCase.pascalCase(name) %>/test.tsx
+to: packages/picasso/src/<%= h.changeCase.pascalCase(name) %>/test.tsx
 ---
 <%
   Name = h.changeCase.pascalCase(name)
 -%>
 import React, { ReactNode } from 'react'
 import { render } from '@toptal/picasso/test-utils'
+import { OmitInternalProps } from '@toptal/picasso-shared'
 
-import { OmitInternalProps } from '../Picasso'
 import <%= Name %>, { Props } from './<%= Name %>'
 
 const render<%= Name %> = (

--- a/_templates/component/new/test.ejs.t
+++ b/_templates/component/new/test.ejs.t
@@ -1,5 +1,5 @@
 ---
-to: packages/picasso/src/<%= h.changeCase.pascalCase(name) %>/test.tsx
+to: packages/<%= package %>/src/<%= h.changeCase.pascalCase(name) %>/test.tsx
 ---
 <%
   Name = h.changeCase.pascalCase(name)

--- a/packages/picasso-charts/src/index.ts
+++ b/packages/picasso-charts/src/index.ts
@@ -7,3 +7,4 @@ export type {
 export { default as BarChart } from './BarChart'
 export type { BarChartProps } from './BarChart'
 export type { BaseChartProps, BaseLineChartProps, LineConfig, ChartDataPoint, OrderedChartDataPoint } from './types'
+// placeholder for hygen generator. Genereates export before this comment.

--- a/packages/picasso-charts/src/index.ts
+++ b/packages/picasso-charts/src/index.ts
@@ -7,4 +7,4 @@ export type {
 export { default as BarChart } from './BarChart'
 export type { BarChartProps } from './BarChart'
 export type { BaseChartProps, BaseLineChartProps, LineConfig, ChartDataPoint, OrderedChartDataPoint } from './types'
-// placeholder for hygen generator. Genereates export before this comment.
+// hygen code generator inserts export statements above this comment.

--- a/packages/picasso-forms/src/index.ts
+++ b/packages/picasso-forms/src/index.ts
@@ -12,4 +12,4 @@ export { OnChange, OnFocus, ExternallyChanged, OnBlur } from 'react-final-form-l
 export { default as Form } from './Form'
 export { default as FieldWrapper } from './FieldWrapper'
 export type { FormConfigProps, RequiredVariant } from './FormConfig'
-// placeholder for hygen generator. Genereates export before this comment.
+// hygen code generator inserts export statements above this comment.

--- a/packages/picasso-forms/src/index.ts
+++ b/packages/picasso-forms/src/index.ts
@@ -12,3 +12,4 @@ export { OnChange, OnFocus, ExternallyChanged, OnBlur } from 'react-final-form-l
 export { default as Form } from './Form'
 export { default as FieldWrapper } from './FieldWrapper'
 export type { FormConfigProps, RequiredVariant } from './FormConfig'
+// placeholder for hygen generator. Genereates export before this comment.

--- a/packages/picasso-lab/src/index.ts
+++ b/packages/picasso-lab/src/index.ts
@@ -13,3 +13,4 @@ export { default as Section } from './Section'
 export type { SectionProps } from './Section'
 export { default as Note } from './Note'
 export type { NoteProps } from './Note'
+// placeholder for hygen generator. Genereates export before this comment.

--- a/packages/picasso-lab/src/index.ts
+++ b/packages/picasso-lab/src/index.ts
@@ -13,4 +13,4 @@ export { default as Section } from './Section'
 export type { SectionProps } from './Section'
 export { default as Note } from './Note'
 export type { NoteProps } from './Note'
-// placeholder for hygen generator. Genereates export before this comment.
+// hygen code generator inserts export statements above this comment.

--- a/packages/picasso/src/index.ts
+++ b/packages/picasso/src/index.ts
@@ -136,6 +136,7 @@ export type { BadgeProps } from './Badge'
 export { default as Breadcrumbs } from './Breadcrumbs'
 export type { BreadcrumbsProps } from './Breadcrumbs'
 
+// insert point for hypen
 export * from './Icon'
 
 // TODO: Remove in @toptal/picasso@11.x.x version

--- a/packages/picasso/src/index.ts
+++ b/packages/picasso/src/index.ts
@@ -136,7 +136,6 @@ export type { BadgeProps } from './Badge'
 export { default as Breadcrumbs } from './Breadcrumbs'
 export type { BreadcrumbsProps } from './Breadcrumbs'
 
-// insert point for hypen
 export * from './Icon'
 
 // TODO: Remove in @toptal/picasso@11.x.x version

--- a/packages/picasso/src/index.ts
+++ b/packages/picasso/src/index.ts
@@ -136,6 +136,7 @@ export type { BadgeProps } from './Badge'
 export { default as Breadcrumbs } from './Breadcrumbs'
 export type { BreadcrumbsProps } from './Breadcrumbs'
 
+// placeholder for hygen generator. Genereates export before this comment.
 export * from './Icon'
 
 // TODO: Remove in @toptal/picasso@11.x.x version

--- a/packages/picasso/src/index.ts
+++ b/packages/picasso/src/index.ts
@@ -136,7 +136,7 @@ export type { BadgeProps } from './Badge'
 export { default as Breadcrumbs } from './Breadcrumbs'
 export type { BreadcrumbsProps } from './Breadcrumbs'
 
-// placeholder for hygen generator. Genereates export before this comment.
+// hygen code generator inserts export statements above this comment.
 export * from './Icon'
 
 // TODO: Remove in @toptal/picasso@11.x.x version


### PR DESCRIPTION
[FX-2040]

### Description

I was trying to generate empty components (as it is recommended in the storybook) with `yarn generate:component` and it created files in the wrong folder and files were outdated. So this PR updates path and template files

### How to test

- try to generate some component using `yarn generate:component TestComponent`
- it should create files in Picasso package


### Review

- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/api-principles.md)
- n/a Annotate all `props` in component with documentation
- n/a Create `examples` for component
- n/a Ensure that deployed demo has expected results and good examples
- n/a Ensure that tests pass by running `yarn test`
- n/a Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
- n/a Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>


[FX-2040]: https://toptal-core.atlassian.net/browse/FX-2040