### PR TITLE
feat: add title case for radio or checkbox groups

### DIFF
--- a/packages/picasso-forms/src/Checkbox/Checkbox.tsx
+++ b/packages/picasso-forms/src/Checkbox/Checkbox.tsx
@@ -58,7 +58,11 @@ export const Checkbox = ({
       name={name!}
     >
       {(input: CheckboxProps) => (
-        <PicassoCheckbox {...input} requiredDecoration={requiredDecoration} />
+        <PicassoCheckbox
+          {...input}
+          titleCase={restProps.titleCase}
+          requiredDecoration={requiredDecoration}
+        />
       )}
     </FieldWrapper>
   )

--- a/packages/picasso-forms/src/Checkbox/__snapshots__/test.tsx.snap
+++ b/packages/picasso-forms/src/Checkbox/__snapshots__/test.tsx.snap
@@ -168,7 +168,7 @@ exports[`Form.Checkbox default render for single checkbox 1`] = `
               <span
                 class="PicassoFormLabel-text"
               >
-                checkbox-label
+                The checkbox label
               </span>
             </span>
           </label>
@@ -231,7 +231,7 @@ exports[`Form.Checkbox required with asterisk single checkbox 1`] = `
               <span
                 class="PicassoFormLabel-text"
               >
-                checkbox-label
+                The checkbox label
               </span>
             </span>
           </label>

--- a/packages/picasso-forms/src/Checkbox/test.tsx
+++ b/packages/picasso-forms/src/Checkbox/test.tsx
@@ -7,7 +7,7 @@ import CheckboxGroup from '../CheckboxGroup'
 import Checkbox, { Props } from './Checkbox'
 
 const renderCheckbox = (
-  { required }: Props,
+  { required, titleCase }: Props,
   formConfig: FormConfigProps = {}
 ) =>
   render(
@@ -15,10 +15,11 @@ const renderCheckbox = (
       <Form onSubmit={() => {}}>
         <Checkbox
           name='single-checkbox'
-          label='checkbox-label'
+          label='The checkbox label'
           value='checkbox-value'
           data-testid='single-checkbox'
           required={required}
+          titleCase={titleCase}
         />
       </Form>
     </Form.ConfigProvider>
@@ -74,5 +75,17 @@ describe('Form.Checkbox', () => {
     const { getByTestId } = renderCheckbox({})
 
     expect(getByTestId('single-checkbox')).not.toHaveTextContent('(optional)')
+  })
+
+  it('shows the label in default case', () => {
+    const { getByLabelText } = renderCheckbox({})
+
+    expect(getByLabelText('The checkbox label')).toBeInTheDocument()
+  })
+
+  it('shows the label in title case', () => {
+    const { getByLabelText } = renderCheckbox({ titleCase: true })
+
+    expect(getByLabelText('The Checkbox Label')).toBeInTheDocument()
   })
 })

--- a/packages/picasso-forms/src/CheckboxGroup/CheckboxGroup.tsx
+++ b/packages/picasso-forms/src/CheckboxGroup/CheckboxGroup.tsx
@@ -12,11 +12,11 @@ import CheckboxGroupContext from './CheckboxGroupContext'
 export type Props = CheckboxGroupProps & FieldProps<CheckboxProps['value']>
 
 export const CheckboxGroup = (props: Props) => {
-  const { children, ...rest } = props
+  const { children, titleCase, ...rest } = props
 
   return (
     <CheckboxGroupContext.Provider value={props.name}>
-      <FieldWrapper {...rest} type='checkbox'>
+      <FieldWrapper titleCase={titleCase} {...rest} type='checkbox'>
         {() => (
           <PicassoCheckbox.Group {...rest}>{children}</PicassoCheckbox.Group>
         )}

--- a/packages/picasso-forms/src/CheckboxGroup/test.tsx
+++ b/packages/picasso-forms/src/CheckboxGroup/test.tsx
@@ -1,0 +1,35 @@
+import { render } from '@toptal/picasso/test-utils'
+import React from 'react'
+
+import Checkbox from '../Checkbox'
+import Form from '../Form'
+import CheckboxGroup, { Props } from './CheckboxGroup'
+
+const arrangeTest = ({ titleCase }: Partial<Props> = {}) =>
+  render(
+    <Form onSubmit={() => {}}>
+      <CheckboxGroup
+        required
+        name='checkbox-group'
+        label='Checkbox group label'
+        titleCase={titleCase}
+      >
+        <Checkbox label='checkbox-label-0' value='checkbox-value-0' />
+        <Checkbox label='checkbox-label-1' value='checkbox-value-1' />
+      </CheckboxGroup>
+    </Form>
+  )
+
+describe('CheckboxGroup', () => {
+  it('shows the label in default case', () => {
+    const { getByText } = arrangeTest()
+
+    expect(getByText('Checkbox group label')).toBeInTheDocument()
+  })
+
+  it('shows the label in title case', () => {
+    const { getByText } = arrangeTest({ titleCase: true })
+
+    expect(getByText('Checkbox Group Label')).toBeInTheDocument()
+  })
+})

--- a/packages/picasso-forms/src/FieldWrapper/FieldWrapper.tsx
+++ b/packages/picasso-forms/src/FieldWrapper/FieldWrapper.tsx
@@ -9,6 +9,7 @@ import { Form as PicassoForm, RequiredDecoration } from '@toptal/picasso'
 import { Item } from '@toptal/picasso/Autocomplete'
 import { FileUpload } from '@toptal/picasso/FileInput'
 import { DateOrDateRangeType } from '@toptal/picasso-lab'
+import { TextLabelProps } from '@toptal/picasso-shared'
 
 import { useFormContext } from '../Form/FormContext'
 import { useFormConfig, FormConfigProps, RequiredVariant } from '../FormConfig'
@@ -32,13 +33,15 @@ export type FieldProps<TInputValue> = FinalFieldProps<
   TInputValue,
   FieldRenderProps<TInputValue, HTMLInputElement>,
   HTMLInputElement
->
+> &
+  TextLabelProps
 
 export type Props<
   TInputValue,
   TWrappedComponentProps
 > = TWrappedComponentProps &
-  FieldProps<TInputValue> & {
+  FieldProps<TInputValue> &
+  TextLabelProps & {
     name: string
     type?: string
     hideFieldLabel?: boolean
@@ -167,6 +170,7 @@ const FieldWrapper = <
     validate,
     validateFields,
     value,
+    titleCase,
     //
     ...rest
   } = props
@@ -266,6 +270,7 @@ const FieldWrapper = <
           requiredDecoration={requiredDecoration}
           htmlFor={id}
           disabled={rest.disabled}
+          titleCase={titleCase}
         >
           {label}
         </PicassoForm.Label>

--- a/packages/picasso-forms/src/Form/story/TitleCase.example.tsx
+++ b/packages/picasso-forms/src/Form/story/TitleCase.example.tsx
@@ -1,0 +1,167 @@
+import React, { useState } from 'react'
+import { Container } from '@toptal/picasso'
+import { Item } from '@toptal/picasso/Autocomplete'
+import { isSubstring } from '@toptal/picasso/utils'
+import { Form } from '@toptal/picasso-forms'
+
+const countries = [
+  { value: 'Afghanistan', text: 'Afghanistan' },
+  { value: 'Albania', text: 'Albania' },
+  { value: 'Algeria', text: 'Algeria' },
+  { value: 'Belarus', text: 'Belarus' },
+  { value: 'Croatia', text: 'Croatia' },
+  { value: 'Lithuania', text: 'Lithuania' },
+  { value: 'Slovakia', text: 'Slovakia' },
+  { value: 'Spain', text: 'Spain' },
+  { value: 'Ukraine', text: 'Ukraine' }
+]
+
+const skills = [
+  { value: 0, text: 'HTML' },
+  { value: 1, text: 'CSS' },
+  { value: 2, text: 'Javascript' }
+]
+
+const EMPTY_INPUT_VALUE = ''
+const getAutocompleteDisplayValue = (item: Item | null) =>
+  item?.text || EMPTY_INPUT_VALUE
+
+const filterOptions = (str = '', options: Item[] = []): Item[] | null => {
+  if (!str) {
+    return options
+  }
+  const result = options.filter(option =>
+    option?.text ? isSubstring(str, option.text) : false
+  )
+
+  return result.length > 0 ? result : null
+}
+
+const Example = () => {
+  const [skillInputValue, setSkillInputValue] = useState<string>(
+    EMPTY_INPUT_VALUE
+  )
+  const skillOptions = filterOptions(skillInputValue, skills)
+
+  const [autocompleteValue, setAutocompleteValue] = useState<string>(
+    EMPTY_INPUT_VALUE
+  )
+  const [autocompleteOptions, setAutocompleteOptions] = useState<Item[] | null>(
+    countries
+  )
+
+  return (
+    <Form
+      autoComplete='off'
+      onSubmit={values => window.alert(values)}
+      initialValues={{ gender: 'female' }}
+    >
+      <Form.Input
+        titleCase
+        enableReset
+        onResetClick={(set: (value: string) => void) => {
+          set('')
+        }}
+        required
+        name='firstName'
+        label='First name'
+        placeholder='e.g. Bruce'
+      />
+      <Form.NumberInput
+        titleCase
+        enableReset
+        required
+        name='age'
+        label="What's your age?"
+        placeholder='e.g. 25'
+      />
+      <Form.RadioGroup titleCase name='gender' label='Select gender'>
+        <Form.Radio label='Male' value='male' />
+        <Form.Radio label='Female' value='female' />
+      </Form.RadioGroup>
+      <Form.DatePicker titleCase name='dateOfBirth' label='Date of birth' />
+      <Form.TimePicker titleCase name='timeOfBirth' label='Time of birth' />
+      <Form.TagSelector
+        titleCase
+        name='skills'
+        label='Your skills'
+        inputValue={skillInputValue}
+        options={skillOptions}
+        onInputChange={setSkillInputValue}
+      />
+      <Form.CheckboxGroup titleCase name='hobbies' label='Your hobbies'>
+        <Form.Checkbox label='Skiing' value='skiing' />
+        <Form.Checkbox titleCase label='Free diving' value='freeDiving' />
+        <Form.Checkbox label='Dancing' value='dancing' />
+      </Form.CheckboxGroup>
+      <Form.Select
+        titleCase
+        enableReset
+        required
+        name='businessType'
+        label='Business type'
+        width='auto'
+        options={[
+          { value: 0, text: 'Company' },
+          { value: 1, text: 'Individual' }
+        ]}
+      />
+      <Form.Autocomplete
+        titleCase
+        name='current_country'
+        label='Current country'
+        placeholder='Start typing country...'
+        width='auto'
+        value={autocompleteValue}
+        options={autocompleteOptions}
+        onSelect={(item: Item) => {
+          console.log('onSelect returns item object:', item)
+
+          const itemValue = getAutocompleteDisplayValue(item)
+
+          if (autocompleteValue !== itemValue) {
+            setAutocompleteValue(itemValue)
+          }
+        }}
+        onChange={(newValue: string) => {
+          console.log('onChange returns just item value:', newValue)
+
+          setAutocompleteOptions(filterOptions(newValue, countries))
+          setAutocompleteValue(newValue)
+        }}
+        getDisplayValue={getAutocompleteDisplayValue}
+      />
+      <Form.Rating
+        titleCase
+        name='rating'
+        label='How much do you love Picasso?'
+        required
+      />
+      <Form.FileInput
+        titleCase
+        required
+        name='avatar'
+        label='Your avatar'
+        status='No file selected.'
+      />
+      <Form.Checkbox
+        titleCase
+        required
+        name='legal'
+        label='I confirm that I have legal permission from the client to feature this project.'
+      />
+      <Form.Switch
+        titleCase
+        name='publicProfile'
+        label='Public profile'
+        width='auto'
+      />
+
+      <Container top='small'>
+        <Form.SubmitButton>Submit</Form.SubmitButton>
+      </Container>
+    </Form>
+  )
+}
+
+export default Example

--- a/packages/picasso-forms/src/Form/story/index.jsx
+++ b/packages/picasso-forms/src/Form/story/index.jsx
@@ -197,3 +197,7 @@ however, you may need custom validators for more complex types of fields.
     title: 'File input on a Form',
     description: 'Showcase how to upload files on the form submission'
   }) // picasso-skip-visuals
+  .addExample('Form/story/TitleCase.example.tsx', {
+    title: 'Title case',
+    description: "Display the field's label in title case."
+  }) // picasso-skip-visuals

--- a/packages/picasso-forms/src/RadioGroup/test.tsx
+++ b/packages/picasso-forms/src/RadioGroup/test.tsx
@@ -1,0 +1,35 @@
+import { render } from '@toptal/picasso/test-utils'
+import React from 'react'
+
+import Radio from '../Radio'
+import Form from '../Form'
+import RadioGroup, { Props } from './RadioGroup'
+
+const arrangeTest = ({ titleCase }: Partial<Props> = {}) =>
+  render(
+    <Form onSubmit={() => {}}>
+      <RadioGroup
+        required
+        name='radio-group'
+        label='Radio group label'
+        titleCase={titleCase}
+      >
+        <Radio label='radio-label-0' value='radio-value-0' />
+        <Radio label='radio-label-1' value='radio-value-1' />
+      </RadioGroup>
+    </Form>
+  )
+
+describe('RadioGroup', () => {
+  it('shows the label in default case', () => {
+    const { getByText } = arrangeTest()
+
+    expect(getByText('Radio group label')).toBeInTheDocument()
+  })
+
+  it('shows the label in title case', () => {
+    const { getByText } = arrangeTest({ titleCase: true })
+
+    expect(getByText('Radio Group Label')).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
[SPT-1830](https://toptal-core.atlassian.net/browse/SPT-1830)

### Description

Add support to display the checkbox group or the radio button group label in the title case.

### How to test

- Check the title case form examples - https://picasso.toptal.net/SPT-1830-add-title-case-for-radio-group/?path=/story/picasso-forms-form--form#title-case

### Screenshots

![image](https://user-images.githubusercontent.com/2583281/128981882-bc1b15d2-b796-47e5-8293-c4e18ead0f89.png)

### Review

- [ ] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/api-principles.md)
- [ ] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that tests pass by running `yarn test`
- [ ] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
- [ ] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>
