### PR TITLE
fix: allow default tooltip to be overwriten on slider

### DIFF
--- a/packages/picasso/src/Slider/Slider.tsx
+++ b/packages/picasso/src/Slider/Slider.tsx
@@ -117,8 +117,10 @@ export const Slider = forwardRef<HTMLElement, Props>(function Slider (
   )
 
   // From Workaround for https://github.com/mui-org/material-ui/issues/21889
-  const ValueLabelComponent = ((DefaultValueLabelComponent ||
-    UserDefinedTooltip) as unknown) as React.ElementType<MUIValueLabelProps>
+  const ValueLabelComponent = ((UserDefinedTooltip ||
+    DefaultValueLabelComponent) as unknown) as React.ElementType<
+    MUIValueLabelProps
+  >
 
   return (
     <SliderContextProvider>


### PR DESCRIPTION
[SP-1564]

### Description

Allow default tooltip to be overwritten by a user-defined one on a range slider.

### How to test

- FIXME: Add the steps describing how to verify your changes

### Review

- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/api-principles.md)
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure that tests pass by running `yarn test`
- [x] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>


[SP-1564]: https://toptal-core.atlassian.net/browse/SP-1564