### PR TITLE
fix: failing master-release job when docs not deployed

### DIFF
--- a/ci/jobs/picasso-master-release/Jenkinsfile
+++ b/ci/jobs/picasso-master-release/Jenkinsfile
@@ -64,7 +64,7 @@ pipeline {
           imageCommitId = gitCommit()
           downStreamBuilds[0] = buildWithParameters(
             jobName: buildImageJobName,
-            propagate: false,
+            propagate: true,
             wait: true,
             parameters: [
               BRANCH: gitBranch(),

--- a/ci/jobs/picasso-master-release/Jenkinsfile
+++ b/ci/jobs/picasso-master-release/Jenkinsfile
@@ -134,7 +134,7 @@ pipeline {
         script {
           downStreamBuilds[1] = buildWithParameters(
             jobName: releaseDocsJobName,
-            propagate: false,
+            propagate: true,
             wait: true,
             parameters: [
               COMMIT_ID: imageCommitId


### PR DESCRIPTION
### Description

When docs job failed on Jenkins the master-release job has to fail as well, so slack notification will be reported

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>
