### PR TITLE
fix(Section): removes header padding when collapsed

### DIFF
--- a/packages/picasso-lab/src/Section/Section.tsx
+++ b/packages/picasso-lab/src/Section/Section.tsx
@@ -124,7 +124,8 @@ export const Section = forwardRef<HTMLDivElement, Props>(function Section (
       ref={ref}
       className={cx(
         {
-          [classes.borderedVariant]: variant === 'bordered'
+          [classes.bordered]: variant === 'bordered',
+          [classes.collapsed]: variant !== 'bordered' && collapsed
         },
         classes.root,
         className
@@ -133,7 +134,12 @@ export const Section = forwardRef<HTMLDivElement, Props>(function Section (
       {...rest}
     >
       {hasHeader && (
-        <Container data-testid={testIds?.header} className={classes.header}>
+        <Container
+          data-testid={testIds?.header}
+          className={cx(classes.header, {
+            [classes.collapsedHeader]: collapsed
+          })}
+        >
           {renderTitle()}
           {renderSubtitle()}
           {renderActions()}

--- a/packages/picasso-lab/src/Section/__snapshots__/test.tsx.snap
+++ b/packages/picasso-lab/src/Section/__snapshots__/test.tsx.snap
@@ -6,10 +6,10 @@ exports[`Section renders collapsible initially collapsed 1`] = `
     class="Picasso-root"
   >
     <div
-      class="PicassoSection-root"
+      class="PicassoSection-collapsed PicassoSection-root"
     >
       <div
-        class="PicassoSection-header"
+        class="PicassoSection-header PicassoSection-collapsedHeader"
         data-testid="header"
       >
         <div

--- a/packages/picasso-lab/src/Section/styles.ts
+++ b/packages/picasso-lab/src/Section/styles.ts
@@ -20,12 +20,18 @@ export default ({ sizes, palette }: Theme) =>
       display: 'flex',
       marginLeft: 'auto'
     },
-    borderedVariant: {
+    bordered: {
       borderRadius: sizes.borderRadius.medium,
       border: `solid ${sizes.borderWidth} ${palette.grey.light}`,
       padding: '2rem',
       '& > :last-child': {
         paddingBottom: '0'
       }
+    },
+    collapsedHeader: {
+      paddingBottom: '0'
+    },
+    collapsed: {
+      paddingBottom: '2rem'
     }
   })


### PR DESCRIPTION
### Description

Section component: removes header padding if collapsed

### How to test

Collapse Section, header should have 0 padding bottom

### Review

- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/api-principles.md)
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure that tests pass by running `yarn test`
- [x] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>
