### PR TITLE
fix: [SPT-1892] updated TypographyOverflow click event for tooltip

### DIFF
--- a/packages/picasso-lab/src/TypographyOverflow/TypographyOverflow.tsx
+++ b/packages/picasso-lab/src/TypographyOverflow/TypographyOverflow.tsx
@@ -60,7 +60,11 @@ export const TypographyOverflow = (props: Props) => {
 
   const handleClick = useCallback(
     (event: React.MouseEvent<HTMLElement>) => {
-      if (!isTooltipOpened && isOverflown(event.currentTarget)) {
+      if (
+        !isTooltipOpened &&
+        !disableTooltip &&
+        isOverflown(event.currentTarget)
+      ) {
         setIsTooltipOpened(true)
         setIsTooltipActive(true)
       }
@@ -69,7 +73,7 @@ export const TypographyOverflow = (props: Props) => {
         onClick(event)
       }
     },
-    [isTooltipOpened, onClick]
+    [isTooltipOpened, disableTooltip, onClick]
   )
 
   const handleMouseEnter = useCallback(


### PR DESCRIPTION
[SPT-1892](https://toptal-core.atlassian.net/browse/SPT-1892)

### Description

Had an issue, shown in the video below that when we passed `disableTooltip` prop to `TypographyOverflow` the tooltip would still show on click event and be stuck as there is no backdrop event

### How to test

1. Go to [TypographyOverflow](https://picasso.toptal.net/SPT-1892-disabled-tooltip-visible-on-click-for-typography-overflow/?path=/story/picasso-lab-typographyoverflow--typographyoverflow)
2. Add the 'disableTooltip' prop to one of the overflown components
3. Click on the overflown text, the tooltip should not be showing

### Screenshots

https://user-images.githubusercontent.com/79158829/132018858-a07f35d4-40bf-4b02-9c3f-b055c07979ed.mov

https://user-images.githubusercontent.com/79158829/132018865-7b2e06ab-c41f-4b05-b296-68905ea29e82.mov

### Review

- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/api-principles.md)
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure that tests pass by running `yarn test`
- [x] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>
