### PR TITLE
feat: add maxSearchItems for Form.Select

### DIFF
--- a/packages/picasso/src/NativeSelect/NativeSelect.tsx
+++ b/packages/picasso/src/NativeSelect/NativeSelect.tsx
@@ -58,6 +58,7 @@ export const NativeSelect = documentable(
         autoComplete,
         searchPlaceholder,
         searchThreshold,
+        maxSearchItems,
         native,
         /* eslint-enable @typescript-eslint/no-unused-vars */
         ...rest

--- a/packages/picasso/src/NativeSelect/NativeSelect.tsx
+++ b/packages/picasso/src/NativeSelect/NativeSelect.tsx
@@ -58,7 +58,7 @@ export const NativeSelect = documentable(
         autoComplete,
         searchPlaceholder,
         searchThreshold,
-        maxSearchItems,
+        limit,
         native,
         /* eslint-enable @typescript-eslint/no-unused-vars */
         ...rest

--- a/packages/picasso/src/NonNativeSelect/NonNativeSelect.tsx
+++ b/packages/picasso/src/NonNativeSelect/NonNativeSelect.tsx
@@ -19,7 +19,7 @@ import {
   ValueType,
   SelectProps,
   getOptionText,
-  DEFAULT_MAX_SEARCH_ITEMS,
+  DEFAULT_LIMIT,
   DEFAULT_SEARCH_THRESHOLD
 } from '../Select'
 import NonNativeSelectOptions from '../NonNativeSelectOptions'
@@ -60,7 +60,7 @@ export const NonNativeSelect = documentable(
         autoComplete,
         searchPlaceholder,
         searchThreshold = DEFAULT_SEARCH_THRESHOLD,
-        maxSearchItems = DEFAULT_MAX_SEARCH_ITEMS,
+        limit = DEFAULT_LIMIT,
         getDisplayValue = getOptionText,
         options,
         onChange,
@@ -196,7 +196,7 @@ export const NonNativeSelect = documentable(
                   multiple={multiple}
                   noOptionsText={noOptionsText}
                   fixedHeader={searchInput}
-                  maxSearchItems={maxSearchItems}
+                  limit={limit}
                 />
               )}
             </Popper>
@@ -237,7 +237,7 @@ NonNativeSelect.defaultProps = {
   size: 'medium',
   width: 'full',
   searchThreshold: DEFAULT_SEARCH_THRESHOLD,
-  maxSearchItems: DEFAULT_MAX_SEARCH_ITEMS,
+  limit: DEFAULT_LIMIT,
   enableAutofill: false,
   searchPlaceholder: 'Search'
 }

--- a/packages/picasso/src/NonNativeSelect/NonNativeSelect.tsx
+++ b/packages/picasso/src/NonNativeSelect/NonNativeSelect.tsx
@@ -19,6 +19,7 @@ import {
   ValueType,
   SelectProps,
   getOptionText,
+  DEFAULT_MAX_SEARCH_ITEMS,
   DEFAULT_SEARCH_THRESHOLD
 } from '../Select'
 import NonNativeSelectOptions from '../NonNativeSelectOptions'
@@ -59,6 +60,7 @@ export const NonNativeSelect = documentable(
         autoComplete,
         searchPlaceholder,
         searchThreshold = DEFAULT_SEARCH_THRESHOLD,
+        maxSearchItems = DEFAULT_MAX_SEARCH_ITEMS,
         getDisplayValue = getOptionText,
         options,
         onChange,
@@ -194,6 +196,7 @@ export const NonNativeSelect = documentable(
                   multiple={multiple}
                   noOptionsText={noOptionsText}
                   fixedHeader={searchInput}
+                  maxSearchItems={maxSearchItems}
                 />
               )}
             </Popper>
@@ -234,6 +237,7 @@ NonNativeSelect.defaultProps = {
   size: 'medium',
   width: 'full',
   searchThreshold: DEFAULT_SEARCH_THRESHOLD,
+  maxSearchItems: DEFAULT_MAX_SEARCH_ITEMS,
   enableAutofill: false,
   searchPlaceholder: 'Search'
 }

--- a/packages/picasso/src/NonNativeSelect/test.tsx
+++ b/packages/picasso/src/NonNativeSelect/test.tsx
@@ -647,7 +647,7 @@ describe('NonNativeSelect (multiple)', () => {
       options: Array.from({ length: 100 }, optionsGenerator),
       placeholder,
       searchPlaceholder,
-      maxSearchItems: 5,
+      limit: 5,
       searchThreshold: -1
     })
 

--- a/packages/picasso/src/NonNativeSelect/test.tsx
+++ b/packages/picasso/src/NonNativeSelect/test.tsx
@@ -172,7 +172,7 @@ describe('NonNativeSelect', () => {
     const placeholder = 'Choose an option...'
     const searchPlaceholder = 'Search for an option'
 
-    const { getByPlaceholderText, getAllByRole } = renderSelect({
+    const { getByPlaceholderText, getByRole, getAllByRole } = renderSelect({
       options: OPTIONS,
       placeholder,
       searchPlaceholder,
@@ -190,13 +190,17 @@ describe('NonNativeSelect', () => {
     fireEvent.change(searchInput, { target: { value: '3' } })
 
     expect(getAllByRole('option')).toHaveLength(1)
+
+    const menu = getByRole('menu')
+
+    expect(menu).not.toHaveTextContent('Showing only first')
   })
 
   it('shows all options when input value is wiped', () => {
     const placeholder = 'Choose an option...'
     const searchPlaceholder = 'Search for an option'
 
-    const { getByPlaceholderText, getAllByRole } = renderSelect({
+    const { getByPlaceholderText, getAllByRole, getByRole } = renderSelect({
       options: OPTIONS,
       placeholder,
       searchPlaceholder,
@@ -215,6 +219,10 @@ describe('NonNativeSelect', () => {
 
     fireEvent.change(searchInput, { target: { value: '' } })
     expect(getAllByRole('option')).toHaveLength(OPTIONS.length)
+
+    const menu = getByRole('menu')
+
+    expect(menu).not.toHaveTextContent('Showing only first')
   })
 
   it('focuses search input when tab is pressed', () => {
@@ -325,6 +333,8 @@ describe('NonNativeSelect', () => {
     const menu = getByRole('menu')
 
     expect(menu).toHaveTextContent(noOptionsText)
+
+    expect(menu).not.toHaveTextContent('Showing only first')
   })
 
   it('renders description', () => {
@@ -622,5 +632,39 @@ describe('NonNativeSelect (multiple)', () => {
     )
 
     expect(selectInput.value).toBe(selectedOption.text)
+  })
+
+  it('renders reduced list of options if there are too many items to display', () => {
+    const placeholder = 'Choose an option...'
+    const searchPlaceholder = 'Search for an option'
+
+    const optionsGenerator = (value: number, key: number) => ({
+      value: `${key + 1}`,
+      text: `Option ${key + 1}`
+    })
+
+    const { getByPlaceholderText, getByRole, getAllByRole } = renderSelect({
+      options: Array.from({ length: 100 }, optionsGenerator),
+      placeholder,
+      searchPlaceholder,
+      maxSearchItems: 5,
+      searchThreshold: -1
+    })
+
+    const selectInput = getByPlaceholderText(placeholder) as HTMLInputElement
+
+    fireEvent.focus(selectInput)
+    fireEvent.keyDown(selectInput, { key: 'Enter', code: 'Enter' })
+
+    const searchInput = getByPlaceholderText(searchPlaceholder)
+
+    fireEvent.focus(searchInput)
+    fireEvent.change(searchInput, { target: { value: 'Option' } })
+
+    expect(getAllByRole('option')).toHaveLength(5)
+
+    const menu = getByRole('menu')
+
+    expect(menu).toHaveTextContent('Showing only first 5 of 100 items')
   })
 })

--- a/packages/picasso/src/NonNativeSelectOptions/styles.ts
+++ b/packages/picasso/src/NonNativeSelectOptions/styles.ts
@@ -1,8 +1,14 @@
-import { createStyles } from '@material-ui/core/styles'
+import { createStyles, Theme } from '@material-ui/core/styles'
 
-export default () =>
+export default ({ palette, sizes }: Theme) =>
   createStyles({
     menuGroup: {
       padding: '16px 16px 10px'
+    },
+    fixedFooter: {
+      color: palette.grey.dark,
+      padding: '0.75rem 1rem',
+      borderTop: `${sizes.borderWidth} solid ${palette.grey.light}`,
+      fontSize: '0.6875rem'
     }
   })

--- a/packages/picasso/src/ScrollMenu/ScrollMenu.tsx
+++ b/packages/picasso/src/ScrollMenu/ScrollMenu.tsx
@@ -15,6 +15,7 @@ export interface Props extends BaseProps {
   selectedIndex?: number | null
   onBlur?: (event: React.FocusEvent<HTMLInputElement>) => void
   fixedHeader?: ReactNode
+  fixedFooter?: ReactNode
 }
 
 const useStyles = makeStyles<Theme>(styles, {
@@ -51,7 +52,15 @@ export const scrollToSelection = (
 }
 
 const ScrollMenu: FunctionComponent<Props> = props => {
-  const { selectedIndex, onBlur, children, style, fixedHeader, ...rest } = props
+  const {
+    selectedIndex,
+    onBlur,
+    children,
+    style,
+    fixedHeader,
+    fixedFooter,
+    ...rest
+  } = props
   const classes = useStyles()
   const menuRef = useRef<HTMLDivElement>(null)
 
@@ -70,6 +79,7 @@ const ScrollMenu: FunctionComponent<Props> = props => {
       <div ref={menuRef} className={classes.scrollView} onBlur={onBlur}>
         {children}
       </div>
+      {fixedFooter}
     </Menu>
   )
 }

--- a/packages/picasso/src/Select/Select.tsx
+++ b/packages/picasso/src/Select/Select.tsx
@@ -8,7 +8,12 @@ import disableUnsupportedProps, {
 import noop from '../utils/noop'
 import { usePropDeprecationWarning } from '../utils/use-deprecation-warnings'
 import { SelectProps, ValueType } from './types'
-import { DEFAULT_SEARCH_THRESHOLD, getOptionText, renderOption } from './utils'
+import {
+  DEFAULT_MAX_SEARCH_ITEMS,
+  DEFAULT_SEARCH_THRESHOLD,
+  getOptionText,
+  renderOption
+} from './utils'
 
 const purifyProps = (
   props: SelectProps<any, any>
@@ -60,6 +65,7 @@ Select.defaultProps = {
   size: 'medium',
   width: 'full',
   searchThreshold: DEFAULT_SEARCH_THRESHOLD,
+  maxSearchItems: DEFAULT_MAX_SEARCH_ITEMS,
   enableAutofill: false,
   searchPlaceholder: 'Search',
   native: false

--- a/packages/picasso/src/Select/Select.tsx
+++ b/packages/picasso/src/Select/Select.tsx
@@ -9,7 +9,7 @@ import noop from '../utils/noop'
 import { usePropDeprecationWarning } from '../utils/use-deprecation-warnings'
 import { SelectProps, ValueType } from './types'
 import {
-  DEFAULT_MAX_SEARCH_ITEMS,
+  DEFAULT_LIMIT,
   DEFAULT_SEARCH_THRESHOLD,
   getOptionText,
   renderOption
@@ -65,7 +65,7 @@ Select.defaultProps = {
   size: 'medium',
   width: 'full',
   searchThreshold: DEFAULT_SEARCH_THRESHOLD,
-  maxSearchItems: DEFAULT_MAX_SEARCH_ITEMS,
+  limit: DEFAULT_LIMIT,
   enableAutofill: false,
   searchPlaceholder: 'Search',
   native: false

--- a/packages/picasso/src/Select/hooks/use-select-state/test.ts
+++ b/packages/picasso/src/Select/hooks/use-select-state/test.ts
@@ -91,6 +91,21 @@ describe('useSelectState', () => {
     expect(result.current.emptySelectValue).toEqual([])
   })
 
+  it('show search when there is more items than threshold allows', () => {
+    const { result } = renderUseSelectState({ searchThreshold: 2 })
+
+    expect(result.current.showSearch).toEqual(true)
+  })
+
+  it('forces search when threshold is higher than max number of elements to show', () => {
+    const { result } = renderUseSelectState({
+      searchThreshold: 3,
+      maxSearchItems: 2
+    })
+
+    expect(result.current.showSearch).toEqual(true)
+  })
+
   it('toggles isOpen state', () => {
     const { result } = renderUseSelectState()
 
@@ -135,7 +150,9 @@ describe('useSelectState', () => {
 
       expect(result.current.isOpen).toBe(false)
 
-      result.current.open()
+      act(() => {
+        result.current.open()
+      })
 
       expect(result.current.isOpen).toBe(true)
 

--- a/packages/picasso/src/Select/hooks/use-select-state/test.ts
+++ b/packages/picasso/src/Select/hooks/use-select-state/test.ts
@@ -100,7 +100,7 @@ describe('useSelectState', () => {
   it('forces search when threshold is higher than max number of elements to show', () => {
     const { result } = renderUseSelectState({
       searchThreshold: 3,
-      maxSearchItems: 2
+      limit: 2
     })
 
     expect(result.current.showSearch).toEqual(true)

--- a/packages/picasso/src/Select/hooks/use-select-state/use-select-state.ts
+++ b/packages/picasso/src/Select/hooks/use-select-state/use-select-state.ts
@@ -11,6 +11,7 @@ import {
   removeDuplicatedOptions,
   getSelectedOptions,
   DEFAULT_SEARCH_THRESHOLD,
+  DEFAULT_MAX_SEARCH_ITEMS,
   filterOptions,
   flattenOptions
 } from '../../utils'
@@ -25,6 +26,7 @@ export interface Props {
   multiple?: boolean
   value?: ValueType | ValueType[]
   searchThreshold?: number
+  maxSearchItems?: number
 }
 
 const useSelectState = (props: Props): UseSelectStateOutput => {
@@ -34,7 +36,8 @@ const useSelectState = (props: Props): UseSelectStateOutput => {
     disabled = false,
     multiple,
     value,
-    searchThreshold = DEFAULT_SEARCH_THRESHOLD
+    searchThreshold = DEFAULT_SEARCH_THRESHOLD,
+    maxSearchItems = DEFAULT_MAX_SEARCH_ITEMS
   } = props
 
   const flatOptions: Option[] = useMemo(() => flattenOptions(options), [
@@ -75,7 +78,10 @@ const useSelectState = (props: Props): UseSelectStateOutput => {
     () => (multiple ? [] : ''),
     [multiple]
   )
-  const showSearch = flatOptions.length >= searchThreshold
+  // Search should be shown when maxSearchItems < searchThreshold
+  // otherwise user might not be able to search through long list
+  const showSearch =
+    flatOptions.length >= Math.min(searchThreshold, maxSearchItems)
   const [isOpen, setOpen] = useState<boolean>(false)
   const canOpen = !isOpen && !disabled
   const [highlightedIndex, setHighlightedIndex] = useHighlightedIndex({

--- a/packages/picasso/src/Select/hooks/use-select-state/use-select-state.ts
+++ b/packages/picasso/src/Select/hooks/use-select-state/use-select-state.ts
@@ -11,7 +11,7 @@ import {
   removeDuplicatedOptions,
   getSelectedOptions,
   DEFAULT_SEARCH_THRESHOLD,
-  DEFAULT_MAX_SEARCH_ITEMS,
+  DEFAULT_LIMIT,
   filterOptions,
   flattenOptions
 } from '../../utils'
@@ -26,7 +26,7 @@ export interface Props {
   multiple?: boolean
   value?: ValueType | ValueType[]
   searchThreshold?: number
-  maxSearchItems?: number
+  limit?: number
 }
 
 const useSelectState = (props: Props): UseSelectStateOutput => {
@@ -37,7 +37,7 @@ const useSelectState = (props: Props): UseSelectStateOutput => {
     multiple,
     value,
     searchThreshold = DEFAULT_SEARCH_THRESHOLD,
-    maxSearchItems = DEFAULT_MAX_SEARCH_ITEMS
+    limit = DEFAULT_LIMIT
   } = props
 
   const flatOptions: Option[] = useMemo(() => flattenOptions(options), [
@@ -78,10 +78,9 @@ const useSelectState = (props: Props): UseSelectStateOutput => {
     () => (multiple ? [] : ''),
     [multiple]
   )
-  // Search should be shown when maxSearchItems < searchThreshold
+  // Search should be shown when limit < searchThreshold
   // otherwise user might not be able to search through long list
-  const showSearch =
-    flatOptions.length >= Math.min(searchThreshold, maxSearchItems)
+  const showSearch = flatOptions.length >= Math.min(searchThreshold, limit)
   const [isOpen, setOpen] = useState<boolean>(false)
   const canOpen = !isOpen && !disabled
   const [highlightedIndex, setHighlightedIndex] = useHighlightedIndex({

--- a/packages/picasso/src/Select/story/Limit.example.tsx
+++ b/packages/picasso/src/Select/story/Limit.example.tsx
@@ -1,0 +1,89 @@
+import React, { useState, ChangeEvent } from 'react'
+import { Select, Form, Container, NumberInput } from '@toptal/picasso'
+
+const SelectSearchBehaviourExample = () => {
+  const [value, setValue] = useState<string>('')
+  const [multipleValues, setMultipleValues] = useState<string[]>([])
+  const [limit, setLimit] = useState(50)
+
+  const handlerForSelectChange = (setState: (state: string) => void) => (
+    event: ChangeEvent<{
+      name?: string
+      value: string
+    }>
+  ) => {
+    setState(event.target.value)
+  }
+
+  const handleMultipleChange = (setState: (state: string[]) => void) => (
+    event: React.ChangeEvent<{ value: string[] }>
+  ) => {
+    setState(event.target.value)
+  }
+
+  const handlerForInputChange = (setState: (state: number) => void) => (
+    event: React.ChangeEvent<HTMLInputElement>
+  ) => {
+    setState(parseInt(event.target.value, 10))
+  }
+
+  return (
+    <Container flex>
+      <Container right='small'>
+        <Form.Field>
+          <Form.Label>Flat options</Form.Label>
+          <Select
+            onChange={handlerForSelectChange(setValue)}
+            value={value}
+            options={LOTS_OF_OPTIONS}
+            placeholder='Choose an option...'
+            width='auto'
+            limit={limit}
+            data-testid='select'
+          />
+        </Form.Field>
+      </Container>
+      <Container right='small'>
+        <Form.Field>
+          <Form.Label>Grouped options</Form.Label>
+          <Select
+            onChange={handleMultipleChange(setMultipleValues)}
+            options={LOTS_OF_OPTION_GROUPS}
+            value={multipleValues}
+            placeholder='Choose an options...'
+            width='auto'
+            limit={limit}
+            multiple
+          />
+        </Form.Field>
+      </Container>
+      <Container>
+        <Form.Field>
+          <Form.Label>Limit</Form.Label>
+          <NumberInput
+            min={1}
+            value={limit}
+            onChange={handlerForInputChange(setLimit)}
+            data-testid='input-threshold'
+          />
+        </Form.Field>
+      </Container>
+    </Container>
+  )
+}
+
+const optionsGenerator = (start = 1) => (value: number, key: number) => ({
+  value: `${key + start}`,
+  text: `Option ${key + start}`
+})
+
+const LOTS_OF_OPTION_GROUPS = {
+  'Group 1': Array.from({ length: 200 }, optionsGenerator()),
+  'Group 2': Array.from({ length: 200 }, optionsGenerator(200)),
+  'Group 3': Array.from({ length: 200 }, optionsGenerator(400)),
+  'Group 4': Array.from({ length: 200 }, optionsGenerator(600))
+}
+
+const LOTS_OF_OPTIONS = Array.from({ length: 1000 }, optionsGenerator())
+
+export default SelectSearchBehaviourExample

--- a/packages/picasso/src/Select/story/SearchBehavior.example.tsx
+++ b/packages/picasso/src/Select/story/SearchBehavior.example.tsx
@@ -2,85 +2,49 @@ import React, { useState, ChangeEvent } from 'react'
 import { Select, Form, Container, NumberInput } from '@toptal/picasso'
 
 const SelectSearchBehaviourExample = () => {
-  const [value1, setValue1] = useState<string>('')
-  const [value2, setValue2] = useState<string>('')
+  const [value, setValue] = useState<string>('')
   const [threshold, setThreshold] = useState(4)
-  const [maxSearchItems, setMaxSearchItems] = useState(50)
 
-  const handlerForSelectChange = (setState: (state: string) => void) => (
+  const handleChange = (
     event: ChangeEvent<{
       name?: string
       value: string
     }>
   ) => {
-    setState(event.target.value)
+    setValue(event.target.value)
   }
 
-  const handlerForInputChange = (setState: (state: number) => void) => (
+  const handleThresholdChange = (
     event: React.ChangeEvent<HTMLInputElement>
   ) => {
-    setState(parseInt(event.target.value, 10))
+    setThreshold(parseInt(event.target.value, 10))
   }
 
   return (
-    <Container flex direction='column'>
-      <Container padded='small'>
-        <Container flex>
-          <Container right='small'>
-            <Form.Field>
-              <Form.Label>Search for an option</Form.Label>
-              <Select
-                onChange={handlerForSelectChange(setValue1)}
-                value={value1}
-                options={OPTIONS}
-                placeholder='Choose an option...'
-                width='auto'
-                searchThreshold={threshold}
-                maxSearchItems={5}
-                data-testid='select'
-              />
-            </Form.Field>
-          </Container>
-          <Container>
-            <Form.Field>
-              <Form.Label>Search threshold</Form.Label>
-              <NumberInput
-                value={threshold}
-                onChange={handlerForInputChange(setThreshold)}
-                data-testid='input-threshold'
-              />
-            </Form.Field>
-          </Container>
-        </Container>
+    <Container flex>
+      <Container right='small'>
+        <Form.Field>
+          <Form.Label>Search for an option</Form.Label>
+          <Select
+            onChange={handleChange}
+            value={value}
+            options={OPTIONS}
+            placeholder='Choose an option...'
+            width='auto'
+            searchThreshold={threshold}
+            data-testid='select'
+          />
+        </Form.Field>
       </Container>
-      <Container padded='small'>
-        <Container flex>
-          <Container right='small'>
-            <Form.Field>
-              <Form.Label>Search for an option</Form.Label>
-              <Select
-                onChange={handlerForSelectChange(setValue2)}
-                value={value2}
-                options={LOTS_OF_OPTIONS}
-                placeholder='Choose an option...'
-                width='auto'
-                searchThreshold={threshold}
-                maxSearchItems={maxSearchItems}
-                data-testid='select'
-              />
-            </Form.Field>
-          </Container>
-          <Container>
-            <Form.Field>
-              <Form.Label>Max Search Items</Form.Label>
-              <NumberInput
-                value={maxSearchItems}
-                onChange={handlerForInputChange(setMaxSearchItems)}
-                data-testid='input-threshold'
-              />
-            </Form.Field>
-          </Container>
-        </Container>
+      <Container>
+        <Form.Field>
+          <Form.Label>Search threshold</Form.Label>
+          <NumberInput
+            value={threshold}
+            onChange={handleThresholdChange}
+            data-testid='input-threshold'
+          />
+        </Form.Field>
       </Container>
     </Container>
   )
@@ -93,12 +57,5 @@ const OPTIONS = [
   { value: '4', text: 'Option 4' },
   { value: '5', text: 'Option 5' }
 ]
-
-const optionsGenerator = (value: number, key: number) => ({
-  value: `${key + 1}`,
-  text: `Option ${key + 1}`
-})
-
-const LOTS_OF_OPTIONS = Array.from({ length: 10000 }, optionsGenerator)
 
 export default SelectSearchBehaviourExample

--- a/packages/picasso/src/Select/story/SearchBehavior.example.tsx
+++ b/packages/picasso/src/Select/story/SearchBehavior.example.tsx
@@ -2,47 +2,85 @@ import React, { useState, ChangeEvent } from 'react'
 import { Select, Form, Container, NumberInput } from '@toptal/picasso'
 
 const SelectSearchBehaviourExample = () => {
-  const [value, setValue] = useState<string>('')
-  const [threshold, setTreshold] = useState(4)
+  const [value1, setValue1] = useState<string>('')
+  const [value2, setValue2] = useState<string>('')
+  const [threshold, setThreshold] = useState(4)
+  const [maxSearchItems, setMaxSearchItems] = useState(50)
 
-  const handleChange = (
+  const handlerForSelectChange = (setState: (state: string) => void) => (
     event: ChangeEvent<{
       name?: string
       value: string
     }>
   ) => {
-    setValue(event.target.value)
+    setState(event.target.value)
   }
 
-  const handleTresholdChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    setTreshold(parseInt(event.target.value, 10))
+  const handlerForInputChange = (setState: (state: number) => void) => (
+    event: React.ChangeEvent<HTMLInputElement>
+  ) => {
+    setState(parseInt(event.target.value, 10))
   }
 
   return (
-    <Container flex>
-      <Container right='small'>
-        <Form.Field>
-          <Form.Label>Search for an option</Form.Label>
-          <Select
-            onChange={handleChange}
-            value={value}
-            options={OPTIONS}
-            placeholder='Choose an option...'
-            width='auto'
-            searchThreshold={threshold}
-            data-testid='select'
-          />
-        </Form.Field>
+    <Container flex direction='column'>
+      <Container padded='small'>
+        <Container flex>
+          <Container right='small'>
+            <Form.Field>
+              <Form.Label>Search for an option</Form.Label>
+              <Select
+                onChange={handlerForSelectChange(setValue1)}
+                value={value1}
+                options={OPTIONS}
+                placeholder='Choose an option...'
+                width='auto'
+                searchThreshold={threshold}
+                maxSearchItems={5}
+                data-testid='select'
+              />
+            </Form.Field>
+          </Container>
+          <Container>
+            <Form.Field>
+              <Form.Label>Search threshold</Form.Label>
+              <NumberInput
+                value={threshold}
+                onChange={handlerForInputChange(setThreshold)}
+                data-testid='input-threshold'
+              />
+            </Form.Field>
+          </Container>
+        </Container>
       </Container>
-      <Container>
-        <Form.Field>
-          <Form.Label>Search threshold</Form.Label>
-          <NumberInput
-            value={threshold}
-            onChange={handleTresholdChange}
-            data-testid='input-threshold'
-          />
-        </Form.Field>
+      <Container padded='small'>
+        <Container flex>
+          <Container right='small'>
+            <Form.Field>
+              <Form.Label>Search for an option</Form.Label>
+              <Select
+                onChange={handlerForSelectChange(setValue2)}
+                value={value2}
+                options={LOTS_OF_OPTIONS}
+                placeholder='Choose an option...'
+                width='auto'
+                searchThreshold={threshold}
+                maxSearchItems={maxSearchItems}
+                data-testid='select'
+              />
+            </Form.Field>
+          </Container>
+          <Container>
+            <Form.Field>
+              <Form.Label>Max Search Items</Form.Label>
+              <NumberInput
+                value={maxSearchItems}
+                onChange={handlerForInputChange(setMaxSearchItems)}
+                data-testid='input-threshold'
+              />
+            </Form.Field>
+          </Container>
+        </Container>
       </Container>
     </Container>
   )
@@ -55,5 +93,12 @@ const OPTIONS = [
   { value: '4', text: 'Option 4' },
   { value: '5', text: 'Option 5' }
 ]
+
+const optionsGenerator = (value: number, key: number) => ({
+  value: `${key + 1}`,
+  text: `Option ${key + 1}`
+})
+
+const LOTS_OF_OPTIONS = Array.from({ length: 10000 }, optionsGenerator)
 
 export default SelectSearchBehaviourExample

--- a/packages/picasso/src/Select/story/index.jsx
+++ b/packages/picasso/src/Select/story/index.jsx
@@ -48,8 +48,12 @@ page
   .addExample('Select/story/SearchBehavior.example.tsx', {
     title: 'Search behavior',
     description:
-      'Search is enabled when the number of options is greater or equal to `searchThreshold`.' +
-      'Additionally you can control how many items should be displayed in the search result setting `maxSearchItems`'
+      'Search is enabled when the number of options is greater or equal to `searchThreshold`.'
+  }) // picasso-skip-visuals
+  .addExample('Select/story/Limit.example.tsx', {
+    title: 'Limit',
+    description:
+      'Maximum number of options on the list can be controlled through `limit` property'
   }) // picasso-skip-visuals
   .addExample('Select/story/Disabled.example.tsx', 'Disabled') // picasso-skip-visuals
   .addExample('Select/story/Error.example.tsx', 'Error') // picasso-skip-visuals

--- a/packages/picasso/src/Select/story/index.jsx
+++ b/packages/picasso/src/Select/story/index.jsx
@@ -48,7 +48,8 @@ page
   .addExample('Select/story/SearchBehavior.example.tsx', {
     title: 'Search behavior',
     description:
-      'Search is enabled when the number of options is greater or equal to `searchThreshold`.'
+      'Search is enabled when the number of options is greater or equal to `searchThreshold`.' +
+      'Additionally you can control how many items should be displayed in the search result setting `maxSearchItems`'
   }) // picasso-skip-visuals
   .addExample('Select/story/Disabled.example.tsx', 'Disabled') // picasso-skip-visuals
   .addExample('Select/story/Error.example.tsx', 'Error') // picasso-skip-visuals

--- a/packages/picasso/src/Select/types.ts
+++ b/packages/picasso/src/Select/types.ts
@@ -82,10 +82,10 @@ export interface SelectProps<
    * @default 10
    */
   searchThreshold?: number
-  /** Maximum number of elements to display in the search non native list
+  /** Limits number of options to display on the list
    * @default 200
    */
-  maxSearchItems?: number
+  limit?: number
   /** Specifies whether the autofill enabled or not, disabled by default */
   enableAutofill?: boolean
   ref?: React.Ref<HTMLInputElement>
@@ -128,7 +128,7 @@ export interface UseSelectStateProps {
   multiple?: boolean
   value?: ValueType | ValueType[]
   searchThreshold?: number
-  maxSearchItems?: number
+  limit?: number
 }
 
 export type UseSelectStateOutput = {

--- a/packages/picasso/src/Select/types.ts
+++ b/packages/picasso/src/Select/types.ts
@@ -78,8 +78,14 @@ export interface SelectProps<
   /** Whether to render reset icon which clears selected value */
   enableReset?: boolean
   popperContainer?: HTMLElement
-  /** Defines the minimum options number to show the search */
+  /** Defines the minimum options number to show the search
+   * @default 10
+   */
   searchThreshold?: number
+  /** Maximum number of elements to display in the search non native list
+   * @default 200
+   */
+  maxSearchItems?: number
   /** Specifies whether the autofill enabled or not, disabled by default */
   enableAutofill?: boolean
   ref?: React.Ref<HTMLInputElement>
@@ -122,6 +128,7 @@ export interface UseSelectStateProps {
   multiple?: boolean
   value?: ValueType | ValueType[]
   searchThreshold?: number
+  maxSearchItems?: number
 }
 
 export type UseSelectStateOutput = {

--- a/packages/picasso/src/Select/utils/constants.ts
+++ b/packages/picasso/src/Select/utils/constants.ts
@@ -1,3 +1,3 @@
 export const EMPTY_INPUT_VALUE = ''
 export const DEFAULT_SEARCH_THRESHOLD = 10
-export const DEFAULT_MAX_SEARCH_ITEMS = 200
+export const DEFAULT_LIMIT = 200

--- a/packages/picasso/src/Select/utils/constants.ts
+++ b/packages/picasso/src/Select/utils/constants.ts
@@ -1,2 +1,3 @@
 export const EMPTY_INPUT_VALUE = ''
 export const DEFAULT_SEARCH_THRESHOLD = 10
+export const DEFAULT_MAX_SEARCH_ITEMS = 200


### PR DESCRIPTION
[TACO-1037]

### Description

This PR introduces maxSearchItems property for Form.Select. It allows to render only first 200 (by default) elements of the searchable. This is more or less back port of functionality that we have in platform which allows us to render and search lists that contains more than 1000 elements easily. 

1. Flat and Grouped Selects are now going to be trimmed depending `maxSearchItems` property value
2. Search input is going to be shown whenever the list has to be trimmed
3. Information about trimming of the list will be shown when necessary  

### How to test

- Tests should pass
- Go to Form.Select story book and play around it
- 
![Screenshot 2021-09-03 at 16 22 25](https://user-images.githubusercontent.com/6011/132020963-fb3e103e-0bad-4fd1-82b9-6aa19848f554.png)

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| ![Screenshot 2021-09-03 at 16 15 31](https://user-images.githubusercontent.com/6011/132021080-e790dc8e-bac8-4229-8a37-4d396a211a88.png) | ![Screenshot 2021-09-03 at 16 13 13](https://user-images.githubusercontent.com/6011/132021120-88ffeb95-4062-4030-a89b-87252f2b087f.png) |

### Review

- [ ] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/api-principles.md)
- [ ] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that tests pass by running `yarn test`
- [ ] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
- [ ] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>


[TACO-1037]: https://toptal-core.atlassian.net/browse/TACO-1037