### PR TITLE
feat: expose vertical orientation property in tabs

### DIFF
--- a/packages/picasso/src/Tab/styles.ts
+++ b/packages/picasso/src/Tab/styles.ts
@@ -19,9 +19,7 @@ PicassoProvider.override(({ breakpoints, palette, typography }: Theme) => ({
 
       color: palette.grey.dark,
 
-      '&:not(:last-child)': {
-        marginRight: '2em'
-      },
+      marginRight: '2em',
 
       [breakpoints.up('md')]: {
         minWidth: 'auto',

--- a/packages/picasso/src/Tabs/Tabs.tsx
+++ b/packages/picasso/src/Tabs/Tabs.tsx
@@ -24,23 +24,28 @@ export interface Props
 
   /** The value of the currently selected Tab. If you don't want any selected Tab, you can set this property to false. */
   value: TabsProps['value']
+
+  /** The tabs orientation (layout flow direction)
+   *
+   * @default horizontal */
+  orientation?: TabsProps['orientation']
 }
 
 export interface StaticProps {
   Tab: typeof Tab
 }
 
-const useStyles = makeStyles<Theme>(styles, {
+const useStyles = makeStyles<Theme, Props>(styles, {
   name: 'Tabs'
 })
 
 // eslint-disable-next-line react/display-name
-export const Tabs = forwardRef<HTMLButtonElement, Props>(function Tabs(
+export const Tabs = forwardRef<HTMLButtonElement, Props>(function Tabs (
   props,
   ref
 ) {
-  const { children, onChange, value, ...rest } = props
-  const classes = useStyles()
+  const { children, onChange, value, orientation, ...rest } = props
+  const classes = useStyles(props)
   const action = useTabAction()
 
   return (
@@ -53,7 +58,10 @@ export const Tabs = forwardRef<HTMLButtonElement, Props>(function Tabs(
       variant='scrollable'
       action={action}
       scrollButtons='auto'
-      ScrollButtonComponent={TabScrollButton}
+      ScrollButtonComponent={
+        orientation === 'horizontal' ? TabScrollButton : undefined
+      }
+      orientation={orientation}
     >
       {children}
     </MUITabs>

--- a/packages/picasso/src/Tabs/Tabs.tsx
+++ b/packages/picasso/src/Tabs/Tabs.tsx
@@ -40,13 +40,15 @@ const useStyles = makeStyles<Theme, Props>(styles, {
 })
 
 // eslint-disable-next-line react/display-name
-export const Tabs = forwardRef<HTMLButtonElement, Props>(function Tabs (
+export const Tabs = forwardRef<HTMLButtonElement, Props>(function Tabs(
   props,
   ref
 ) {
   const { children, onChange, value, orientation, ...rest } = props
   const classes = useStyles(props)
   const action = useTabAction()
+  const scrollButtonComponent =
+    orientation === 'horizontal' ? TabScrollButton : undefined
 
   return (
     <MUITabs
@@ -58,9 +60,7 @@ export const Tabs = forwardRef<HTMLButtonElement, Props>(function Tabs (
       variant='scrollable'
       action={action}
       scrollButtons='auto'
-      ScrollButtonComponent={
-        orientation === 'horizontal' ? TabScrollButton : undefined
-      }
+      ScrollButtonComponent={scrollButtonComponent}
       orientation={orientation}
     >
       {children}
@@ -68,7 +68,9 @@ export const Tabs = forwardRef<HTMLButtonElement, Props>(function Tabs (
   )
 }) as CompoundedComponentWithRef<Props, HTMLButtonElement, StaticProps>
 
-Tabs.defaultProps = {}
+Tabs.defaultProps = {
+  orientation: 'horizontal'
+}
 
 Tabs.displayName = 'Tabs'
 

--- a/packages/picasso/src/Tabs/story/VerticalOrientation.example.tsx
+++ b/packages/picasso/src/Tabs/story/VerticalOrientation.example.tsx
@@ -1,0 +1,37 @@
+import React from 'react'
+import { Container, Tabs } from '@toptal/picasso'
+
+const Example = () => {
+  const [value, setValue] = React.useState(0)
+
+  const handleChange = (_: React.ChangeEvent<{}>, newValue: number) => {
+    setValue(newValue)
+  }
+
+  return (
+    <div style={{ flexGrow: 1, display: 'flex' }}>
+      <Tabs value={value} onChange={handleChange} orientation='vertical'>
+        <Tabs.Tab label='Label' />
+        <Tabs.Tab label='Label' />
+        <Tabs.Tab label='Label' />
+      </Tabs>
+      {value === 0 && (
+        <Container left='small' top='small'>
+          Content of the first tab
+        </Container>
+      )}
+      {value === 1 && (
+        <Container left='small' top='small'>
+          Content of the first tab
+        </Container>
+      )}
+      {value === 2 && (
+        <Container left='small' top='small'>
+          Content of the first tab
+        </Container>
+      )}
+    </div>
+  )
+}
+
+export default Example

--- a/packages/picasso/src/Tabs/story/VerticalScrollButtons.example.tsx
+++ b/packages/picasso/src/Tabs/story/VerticalScrollButtons.example.tsx
@@ -1,0 +1,49 @@
+import React from 'react'
+import { Container, Tabs } from '@toptal/picasso'
+
+const Example = () => {
+  const [value, setValue] = React.useState(0)
+
+  const handleChange = (_: React.ChangeEvent<{}>, newValue: number) => {
+    setValue(newValue)
+  }
+
+  return (
+    <div style={{ flexGrow: 1, display: 'flex', height: '150px' }}>
+      <Tabs value={value} onChange={handleChange} orientation='vertical'>
+        <Tabs.Tab label='Label' />
+        <Tabs.Tab label='Label' />
+        <Tabs.Tab label='Label' />
+        <Tabs.Tab label='Label' />
+        <Tabs.Tab label='Label' />
+      </Tabs>
+      {value === 0 && (
+        <Container left='small' top='small'>
+          Content of the first tab
+        </Container>
+      )}
+      {value === 1 && (
+        <Container left='small' top='small'>
+          Content of the first tab
+        </Container>
+      )}
+      {value === 2 && (
+        <Container left='small' top='small'>
+          Content of the first tab
+        </Container>
+      )}
+      {value === 3 && (
+        <Container left='small' top='small'>
+          Content of the first tab
+        </Container>
+      )}
+      {value === 4 && (
+        <Container left='small' top='small'>
+          Content of the first tab
+        </Container>
+      )}
+    </div>
+  )
+}
+
+export default Example

--- a/packages/picasso/src/Tabs/story/index.jsx
+++ b/packages/picasso/src/Tabs/story/index.jsx
@@ -16,4 +16,9 @@ page
   .createChapter()
   .addExample('Tabs/story/Default.example.tsx', 'Default')
   .addExample('Tabs/story/ScrollButtons.example.tsx', 'Scroll buttons') // picasso-skip-visuals
+  .addExample('Tabs/story/VerticalOrientation.example.tsx', 'Vertical')
+  .addExample(
+    'Tabs/story/VerticalScrollButtons.example.tsx',
+    'Vertical Scroll Buttons'
+  ) // picasso-skip-visuals
 page.connect(tabStory.chapter)

--- a/packages/picasso/src/Tabs/styles.ts
+++ b/packages/picasso/src/Tabs/styles.ts
@@ -1,19 +1,24 @@
 import { Theme, createStyles } from '@material-ui/core/styles'
 import { PicassoProvider } from '@toptal/picasso-provider'
 
+import { Props } from './Tabs'
+
 PicassoProvider.override(({ palette }: Theme) => ({
   MuiTabs: {
     root: {
       position: 'relative',
       minHeight: 0,
-
       '&::after': {
         position: 'absolute',
         content: '""',
         bottom: 0,
-        left: 0,
+        left: (props: Props) =>
+          props.orientation === 'vertical' ? undefined : 0,
         right: 0,
-        height: 1,
+        width: (props: Props) =>
+          props.orientation === 'vertical' ? 1 : undefined,
+        height: (props: Props) =>
+          props.orientation === 'vertical' ? '100%' : 1,
         backgroundColor: palette.grey.main,
         zIndex: 0
       }


### PR DESCRIPTION
Component: https://picasso.toptal.net/?path=/story/layout-tabs--tabs

### Description

This change exposes orientation property from MaterialUi Tabs component. 

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| Insert screenshots or screen recordings | Insert screenshots or screen recordings |

### Review

- [ ] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/api-principles.md)
- [ ] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that tests pass by running `yarn test`
- [ ] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
- [ ] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>
