### PR TITLE
chore: simplify types for components with static properties

### DIFF
--- a/packages/picasso-lab/src/Note/Note.tsx
+++ b/packages/picasso-lab/src/Note/Note.tsx
@@ -1,6 +1,6 @@
 import React, { forwardRef } from 'react'
 import { makeStyles, Theme } from '@material-ui/core/styles'
-import { BaseProps, CompoundedComponentWithRef } from '@toptal/picasso-shared'
+import { BaseProps } from '@toptal/picasso-shared'
 import cx from 'classnames'
 
 import NoteTitle from '../NoteTitle'
@@ -14,12 +14,6 @@ export interface Props extends BaseProps {
 
 const useStyles = makeStyles<Theme>(styles)
 
-export interface StaticProps {
-  Title: typeof NoteTitle
-  Subtitle: typeof NoteSubtitle
-  Content: typeof NoteContent
-}
-
 export const Note = forwardRef<HTMLDivElement, Props>(function Note (
   { children, className, ...rest },
   ref
@@ -31,13 +25,12 @@ export const Note = forwardRef<HTMLDivElement, Props>(function Note (
       {children}
     </div>
   )
-}) as CompoundedComponentWithRef<Props, HTMLDivElement, StaticProps>
-
-Note.defaultProps = {}
+})
 
 Note.displayName = 'Note'
-Note.Title = NoteTitle
-Note.Subtitle = NoteSubtitle
-Note.Content = NoteContent
 
-export default Note
+export default Object.assign(Note, {
+  Title: NoteTitle,
+  Subtitle: NoteSubtitle,
+  Content: NoteContent
+})

--- a/packages/picasso/src/Accordion/Accordion.tsx
+++ b/packages/picasso/src/Accordion/Accordion.tsx
@@ -9,10 +9,7 @@ import React, {
 import cx from 'classnames'
 import MUIAccordion from '@material-ui/core/Accordion'
 import { makeStyles, Theme } from '@material-ui/core/styles'
-import {
-  CompoundedComponentWithRef,
-  StandardProps
-} from '@toptal/picasso-shared'
+import { StandardProps } from '@toptal/picasso-shared'
 
 import { ArrowDownMinor16 } from '../Icon'
 import AccordionSummary from '../AccordionSummary'
@@ -95,7 +92,7 @@ const decorateWithExpandIconClasses = (
   })
 
 /* eslint-disable complexity */
-export const Accordion = forwardRef<HTMLElement, Props>(function Accordion(
+export const Accordion = forwardRef<HTMLElement, Props>(function Accordion (
   props,
   ref
 ) {
@@ -184,7 +181,7 @@ export const Accordion = forwardRef<HTMLElement, Props>(function Accordion(
       </AccordionDetails>
     </MUIAccordion>
   )
-}) as CompoundedComponentWithRef<Props, HTMLDivElement, StaticProps>
+})
 
 Accordion.defaultProps = {
   borders: 'all',
@@ -196,7 +193,7 @@ Accordion.defaultProps = {
 
 Accordion.displayName = 'Accordion'
 
-Accordion.Summary = Summary
-Accordion.Details = Details
-
-export default Accordion
+export default Object.assign(Accordion, {
+  Summary,
+  Details
+})

--- a/packages/picasso/src/Accordion/Accordion.tsx
+++ b/packages/picasso/src/Accordion/Accordion.tsx
@@ -57,11 +57,6 @@ export const Details = (props: DetailsProps) => {
   )
 }
 
-export interface StaticProps {
-  Summary: typeof Summary
-  Details: typeof Details
-}
-
 export interface Props
   extends StandardProps,
     Omit<HTMLAttributes<HTMLDivElement>, 'onChange'> {

--- a/packages/picasso/src/Alert/Alert.tsx
+++ b/packages/picasso/src/Alert/Alert.tsx
@@ -1,13 +1,9 @@
 import React, { forwardRef, MouseEvent } from 'react'
-import { CompoundedComponentWithRef } from '@toptal/picasso-shared'
 
 import AlertInline, { AlertInlineProps } from '../AlertInline'
 import Container from '../Container'
 import Button from '../Button'
 import { CloseMinor16 } from '../Icon'
-export interface StaticProps {
-  Inline: typeof AlertInline
-}
 
 export interface Props extends AlertInlineProps {
   /** Callback invoked when close is clicked */
@@ -48,7 +44,7 @@ export const Alert = forwardRef<HTMLDivElement, Props>(function Alert (
       {onClose && renderAlertCloseButton({ onClose })}
     </Container>
   )
-}) as CompoundedComponentWithRef<Props, HTMLDivElement, StaticProps>
+})
 
 Alert.defaultProps = {
   variant: 'yellow'
@@ -56,6 +52,6 @@ Alert.defaultProps = {
 
 Alert.displayName = 'Alert'
 
-Alert.Inline = AlertInline
-
-export default Alert
+export default Object.assign(Alert, {
+  Inline: AlertInline
+})

--- a/packages/picasso/src/Badge/Badge.tsx
+++ b/packages/picasso/src/Badge/Badge.tsx
@@ -1,12 +1,7 @@
 import React, { forwardRef } from 'react'
 import { makeStyles, Theme } from '@material-ui/core/styles'
 import cx from 'classnames'
-import {
-  BaseProps,
-  TextLabelProps,
-  CompoundedComponentWithRef,
-  useTitleCase
-} from '@toptal/picasso-shared'
+import { BaseProps, TextLabelProps, useTitleCase } from '@toptal/picasso-shared'
 import { Chip } from '@material-ui/core'
 import { toTitleCase } from '@toptal/picasso/utils'
 
@@ -55,7 +50,7 @@ export const Badge = forwardRef<HTMLDivElement, Props>(function Badge (
       data-testid={dataTestId}
     />
   )
-}) as CompoundedComponentWithRef<Props, HTMLDivElement>
+})
 
 Badge.defaultProps = {
   variant: 'white',

--- a/packages/picasso/src/Breadcrumbs/Breadcrumbs.tsx
+++ b/packages/picasso/src/Breadcrumbs/Breadcrumbs.tsx
@@ -1,14 +1,10 @@
 import React, { forwardRef, ReactNode } from 'react'
-import { BaseProps, CompoundedComponentWithRef } from '@toptal/picasso-shared'
+import { BaseProps } from '@toptal/picasso-shared'
 import { ChevronRight16 } from '@toptal/picasso/Icon'
 import { Breadcrumbs as MuiBreadcrumbs } from '@material-ui/core'
 
 import Item from '../BreadcrumbsItem'
 import './styles'
-
-export interface StaticProps {
-  Item: typeof Item
-}
 
 export interface Props extends BaseProps {
   /** Content of Breadcrumbs */
@@ -20,10 +16,10 @@ export const Breadcrumbs = forwardRef<HTMLElement, Props>(function Breadcrumbs (
   ref
 ) {
   return <MuiBreadcrumbs ref={ref} separator={<ChevronRight16 />} {...props} />
-}) as CompoundedComponentWithRef<Props, HTMLElement, StaticProps>
+})
 
 Breadcrumbs.displayName = 'Breadcrumbs'
 
-Breadcrumbs.Item = Item
-
-export default Breadcrumbs
+export default Object.assign(Breadcrumbs, {
+  Item
+})

--- a/packages/picasso/src/Button/Button.tsx
+++ b/packages/picasso/src/Button/Button.tsx
@@ -11,7 +11,6 @@ import {
   StandardProps,
   SizeType,
   ButtonOrAnchorProps,
-  CompoundedComponentWithRef,
   OverridableComponent,
   useTitleCase,
   TextLabelProps,
@@ -79,12 +78,6 @@ export interface Props
   type?: 'button' | 'reset' | 'submit'
 }
 
-export interface StaticProps {
-  Group: typeof Group
-  Circular: typeof Circular
-  Action: typeof Action
-}
-
 const getClickHandler = (loading?: boolean, handler?: Props['onClick']) =>
   loading ? noop : handler
 
@@ -113,10 +106,10 @@ const getIcon = (
   })
 }
 
-export const Button = forwardRef<HTMLButtonElement, Props>(function Button (
-  props,
-  ref
-) {
+export const Button: OverridableComponent<Props> = forwardRef<
+  HTMLButtonElement,
+  Props
+>(function Button (props, ref) {
   const {
     icon,
     iconPosition,
@@ -212,7 +205,7 @@ export const Button = forwardRef<HTMLButtonElement, Props>(function Button (
       )}
     </ButtonBase>
   )
-}) as CompoundedComponentWithRef<Props, HTMLButtonElement, StaticProps>
+})
 
 Button.defaultProps = {
   active: false,
@@ -232,8 +225,8 @@ Button.defaultProps = {
 
 Button.displayName = 'Button'
 
-Button.Group = Group
-Button.Circular = Circular
-Button.Action = Action
-
-export default Button as OverridableComponent<Props> & StaticProps
+export default Object.assign(Button, {
+  Group,
+  Circular,
+  Action
+})

--- a/packages/picasso/src/Checkbox/Checkbox.tsx
+++ b/packages/picasso/src/Checkbox/Checkbox.tsx
@@ -2,7 +2,6 @@ import MUICheckbox from '@material-ui/core/Checkbox'
 import { makeStyles, Theme } from '@material-ui/core/styles'
 import {
   ButtonOrAnchorProps,
-  CompoundedComponentWithRef,
   BaseProps,
   TextLabelProps
 } from '@toptal/picasso-shared'
@@ -14,10 +13,6 @@ import CheckboxGroup from '../CheckboxGroup'
 import Container from '../Container'
 import FormControlLabel from '../FormControlLabel'
 import styles from './styles'
-
-export interface StaticProps {
-  Group: typeof CheckboxGroup
-}
 
 const useStyles = makeStyles<Theme>(styles, { name: 'PicassoCheckbox' })
 
@@ -123,11 +118,7 @@ export const Checkbox = forwardRef<HTMLButtonElement | HTMLLabelElement, Props>(
       />
     )
   }
-) as CompoundedComponentWithRef<
-  Props,
-  HTMLButtonElement | HTMLLabelElement,
-  StaticProps
->
+)
 
 Checkbox.defaultProps = {
   disabled: false,
@@ -137,6 +128,6 @@ Checkbox.defaultProps = {
 
 Checkbox.displayName = 'Checkbox'
 
-Checkbox.Group = CheckboxGroup
-
-export default Checkbox
+export default Object.assign(Checkbox, {
+  Group: CheckboxGroup
+})

--- a/packages/picasso/src/Dropdown/Dropdown.tsx
+++ b/packages/picasso/src/Dropdown/Dropdown.tsx
@@ -15,8 +15,6 @@ import RootRef from '@material-ui/core/RootRef'
 import { makeStyles, Theme } from '@material-ui/core/styles'
 import cx from 'classnames'
 import {
-  CompoundedComponentWithRef,
-  PicassoComponentWithRef,
   spacingToRem,
   SpacingType,
   StandardProps
@@ -57,11 +55,6 @@ export interface Props extends StandardProps, HTMLAttributes<HTMLDivElement> {
   /** Sets the desired behavior for an element's overflow */
   contentOverflow?: ContentOverflowType
   popperContainer?: HTMLElement
-}
-
-export interface StaticProps {
-  Arrow: typeof DropdownArrow
-  useContext: () => ContextProps
 }
 
 interface ContextProps {
@@ -195,10 +188,10 @@ export const Dropdown = forwardRef<HTMLDivElement, Props>(function Dropdown (
   const paperMargins = useMemo(() => {
     if (offset) {
       return {
-        ...(offset?.top && { marginTop: spacingToRem(offset.top) }),
-        ...(offset?.bottom && { marginBottom: spacingToRem(offset.bottom) }),
-        ...(offset?.left && { marginLeft: spacingToRem(offset.left) }),
-        ...(offset?.right && { marginRight: spacingToRem(offset.right) })
+        ...(offset.top && { marginTop: spacingToRem(offset.top) }),
+        ...(offset.bottom && { marginBottom: spacingToRem(offset.bottom) }),
+        ...(offset.left && { marginLeft: spacingToRem(offset.left) }),
+        ...(offset.right && { marginRight: spacingToRem(offset.right) })
       }
     }
   }, [offset])
@@ -274,7 +267,7 @@ export const Dropdown = forwardRef<HTMLDivElement, Props>(function Dropdown (
       )}
     </div>
   )
-}) as CompoundedComponentWithRef<Props, HTMLDivElement, StaticProps>
+})
 
 Dropdown.defaultProps = {
   disableAutoClose: false,
@@ -288,11 +281,7 @@ Dropdown.defaultProps = {
 
 Dropdown.displayName = 'Dropdown'
 
-Dropdown.Arrow = DropdownArrow
-Dropdown.useContext = useDropdownContext
-
-export default Dropdown as PicassoComponentWithRef<
-  Props,
-  HTMLDivElement,
-  StaticProps
->
+export default Object.assign(Dropdown, {
+  Arrow: DropdownArrow,
+  useContext: useDropdownContext
+})

--- a/packages/picasso/src/Form/Form.tsx
+++ b/packages/picasso/src/Form/Form.tsx
@@ -4,7 +4,7 @@ import React, {
   ReactNode,
   FormHTMLAttributes
 } from 'react'
-import { BaseProps, CompoundedComponentWithRef } from '@toptal/picasso-shared'
+import { BaseProps } from '@toptal/picasso-shared'
 
 import FormField from '../FormField'
 import FormHint from '../FormHint'
@@ -18,15 +18,8 @@ export interface Props extends BaseProps, FormHTMLAttributes<HTMLFormElement> {
   onSubmit?: FormEventHandler<HTMLFormElement>
 }
 
-export interface StaticProps {
-  Field: typeof FormField
-  Hint: typeof FormHint
-  Label: typeof FormLabel
-  Error: typeof FormError
-}
-
 // eslint-disable-next-line react/display-name
-export const Form = forwardRef<HTMLFormElement, Props>(function Form(
+export const Form = forwardRef<HTMLFormElement, Props>(function Form (
   { onSubmit, className, style, children, ...rest },
   ref
 ) {
@@ -41,13 +34,13 @@ export const Form = forwardRef<HTMLFormElement, Props>(function Form(
       {children}
     </form>
   )
-}) as CompoundedComponentWithRef<Props, HTMLFormElement, StaticProps>
-
-Form.Field = FormField
-Form.Hint = FormHint
-Form.Label = FormLabel
-Form.Error = FormError
+})
 
 Form.displayName = 'Form'
 
-export default Form
+export default Object.assign(Form, {
+  Field: FormField,
+  Hint: FormHint,
+  Label: FormLabel,
+  Error: FormError
+})

--- a/packages/picasso/src/Grid/Grid.tsx
+++ b/packages/picasso/src/Grid/Grid.tsx
@@ -7,11 +7,7 @@ import MUIGrid, {
   GridJustification,
   GridWrap
 } from '@material-ui/core/Grid'
-import {
-  BaseProps,
-  PicassoComponentWithRef,
-  CompoundedComponentWithRef
-} from '@toptal/picasso-shared'
+import { BaseProps } from '@toptal/picasso-shared'
 
 import GridItem from '../GridItem'
 import styles from './styles'
@@ -31,10 +27,6 @@ export interface Props extends BaseProps, HTMLAttributes<HTMLElement> {
   wrap?: GridWrap
 }
 
-export interface StaticProps {
-  Item: typeof GridItem
-}
-
 const humanToMUISpacing = (spacing: number) => {
   /** Material Design margins and columns follow an 8px square baseline grid */
   return (spacing / 8) as GridSpacing
@@ -45,7 +37,7 @@ const useStyles = makeStyles<Theme>(styles, {
 })
 
 // eslint-disable-next-line react/display-name
-export const Grid = forwardRef<HTMLDivElement, Props>(function Grid(
+export const Grid = forwardRef<HTMLDivElement, Props>(function Grid (
   props,
   ref
 ) {
@@ -79,7 +71,7 @@ export const Grid = forwardRef<HTMLDivElement, Props>(function Grid(
       {children}
     </MUIGrid>
   )
-}) as CompoundedComponentWithRef<Props, HTMLDivElement, StaticProps>
+})
 
 Grid.defaultProps = {
   alignItems: 'flex-start',
@@ -89,10 +81,6 @@ Grid.defaultProps = {
   wrap: 'wrap'
 }
 
-Grid.Item = GridItem
+Grid.displayName = 'Grid'
 
-export default Grid as PicassoComponentWithRef<
-  Props,
-  HTMLDivElement,
-  StaticProps
->
+export default Object.assign(Grid, { Item: GridItem })

--- a/packages/picasso/src/Helpbox/Helpbox.tsx
+++ b/packages/picasso/src/Helpbox/Helpbox.tsx
@@ -1,11 +1,7 @@
 import React, { ReactNode, forwardRef, HTMLAttributes } from 'react'
 import { makeStyles, Theme } from '@material-ui/core/styles'
 import cx from 'classnames'
-import {
-  BaseProps,
-  PicassoComponentWithRef,
-  CompoundedComponentWithRef
-} from '@toptal/picasso-shared'
+import { BaseProps } from '@toptal/picasso-shared'
 
 import Container, { VariantType as ContainerVariantType } from '../Container'
 import HelpboxTitle from '../HelpboxTitle'
@@ -25,18 +21,12 @@ export interface Props extends BaseProps, HTMLAttributes<HTMLDivElement> {
   onClose?: (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void
 }
 
-export interface StaticProps {
-  Title: typeof HelpboxTitle
-  Content: typeof HelpboxContent
-  Actions: typeof HelpboxActions
-}
-
 const useStyles = makeStyles<Theme>(styles, {
   name: 'PicassoHelpbox'
 })
 
 // eslint-disable-next-line react/display-name
-export const Helpbox = forwardRef<HTMLDivElement, Props>(function Helpbox(
+export const Helpbox = forwardRef<HTMLDivElement, Props>(function Helpbox (
   props,
   ref
 ) {
@@ -66,20 +56,12 @@ export const Helpbox = forwardRef<HTMLDivElement, Props>(function Helpbox(
       )}
     </Container>
   )
-}) as CompoundedComponentWithRef<Props, HTMLDivElement, StaticProps>
-
-Helpbox.defaultProps = {}
+})
 
 Helpbox.displayName = 'Helpbox'
 
-Helpbox.Title = HelpboxTitle
-
-Helpbox.Content = HelpboxContent
-
-Helpbox.Actions = HelpboxActions
-
-export default Helpbox as PicassoComponentWithRef<
-  Props,
-  HTMLDivElement,
-  StaticProps
->
+export default Object.assign(Helpbox, {
+  Title: HelpboxTitle,
+  Content: HelpboxContent,
+  Actions: HelpboxActions
+})

--- a/packages/picasso/src/Menu/Menu.tsx
+++ b/packages/picasso/src/Menu/Menu.tsx
@@ -2,7 +2,7 @@ import React, { HTMLAttributes, forwardRef } from 'react'
 import cx from 'classnames'
 import MUIMenuList from '@material-ui/core/MenuList'
 import { makeStyles, Theme } from '@material-ui/core/styles'
-import { BaseProps, CompoundedComponentWithRef } from '@toptal/picasso-shared'
+import { BaseProps } from '@toptal/picasso-shared'
 
 import { BackMinor16 } from '../Icon'
 import MenuItem from '../MenuItem'
@@ -17,10 +17,6 @@ export interface Props extends BaseProps, HTMLAttributes<HTMLUListElement> {
   variant?: MenuVariant
   // Whether or not to handle nested navigation
   allowNestedNavigation?: boolean
-}
-
-export interface StaticProps {
-  Item: typeof MenuItem
 }
 
 const useStyles = makeStyles<Theme>(styles, {
@@ -66,7 +62,7 @@ export const Menu = forwardRef<HTMLUListElement, Props>(function Menu (
       )}
     </MenuContext.Provider>
   )
-}) as CompoundedComponentWithRef<Props, HTMLUListElement, StaticProps>
+})
 
 Menu.defaultProps = {
   variant: 'slide',
@@ -75,6 +71,4 @@ Menu.defaultProps = {
 
 Menu.displayName = 'Menu'
 
-Menu.Item = MenuItem
-
-export default Menu
+export default Object.assign(Menu, { Item: MenuItem })

--- a/packages/picasso/src/Modal/Modal.tsx
+++ b/packages/picasso/src/Modal/Modal.tsx
@@ -9,11 +9,7 @@ import { makeStyles, Theme } from '@material-ui/core/styles'
 import Dialog from '@material-ui/core/Dialog'
 import { PaperProps } from '@material-ui/core/Paper'
 import cx from 'classnames'
-import {
-  StandardProps,
-  CompoundedComponentWithRef,
-  SizeType
-} from '@toptal/picasso-shared'
+import { StandardProps, SizeType } from '@toptal/picasso-shared'
 import { usePicassoRoot, useBreakpoint } from '@toptal/picasso-provider'
 
 import { CloseMinor16 } from '../Icon'
@@ -52,12 +48,6 @@ export interface Props extends StandardProps, HTMLAttributes<HTMLDivElement> {
   testIds?: {
     closeButton?: string
   }
-}
-
-export interface StaticProps {
-  Content: typeof ModalContent
-  Actions: typeof ModalActions
-  Title: typeof ModalTitle
 }
 
 const useStyles = makeStyles<Theme, Props>(styles, {
@@ -240,7 +230,7 @@ export const Modal = forwardRef<HTMLElement, Props>(function Modal (
       )}
     </Dialog>
   )
-}) as CompoundedComponentWithRef<Props, HTMLElement, StaticProps>
+})
 
 Modal.defaultProps = {
   hideBackdrop: false,
@@ -251,8 +241,8 @@ Modal.defaultProps = {
 
 Modal.displayName = 'Modal'
 
-Modal.Content = ModalContent
-Modal.Actions = ModalActions
-Modal.Title = ModalTitle
-
-export default Modal
+export default Object.assign(Modal, {
+  Content: ModalContent,
+  Actions: ModalActions,
+  Title: ModalTitle
+})

--- a/packages/picasso/src/Notification/Notification.tsx
+++ b/packages/picasso/src/Notification/Notification.tsx
@@ -10,11 +10,7 @@ import { makeStyles, Theme } from '@material-ui/core/styles'
 import SnackbarContent from '@material-ui/core/SnackbarContent'
 import cx from 'classnames'
 import capitalize from '@material-ui/core/utils/capitalize'
-import {
-  StandardProps,
-  PicassoComponentWithRef,
-  CompoundedComponentWithRef
-} from '@toptal/picasso-shared'
+import { StandardProps } from '@toptal/picasso-shared'
 
 import {
   CloseMinor16,
@@ -48,10 +44,6 @@ export interface PrivateProps
 
 /** `elevated` and `icon` props are omitted from the public declaration, since they're only for internal use */
 export type PublicProps = Omit<PrivateProps, 'elevated' | 'icon'>
-
-export interface StaticProps {
-  Actions: typeof NotificationActions
-}
 
 const renderNotificationCloseButton = ({ onClose, classes }: PrivateProps) => (
   <Button.Circular
@@ -144,7 +136,7 @@ export const Notification = forwardRef<HTMLElement, PrivateProps>(
       />
     )
   }
-) as CompoundedComponentWithRef<PrivateProps, HTMLElement, StaticProps>
+)
 
 Notification.defaultProps = {
   elevated: false,
@@ -153,10 +145,4 @@ Notification.defaultProps = {
 
 Notification.displayName = 'Notification'
 
-Notification.Actions = NotificationActions
-
-export default Notification as PicassoComponentWithRef<
-  PublicProps,
-  HTMLElement,
-  StaticProps
->
+export default Object.assign(Notification, { Actions: NotificationActions })

--- a/packages/picasso/src/OverlayBadge/OverlayBadge.tsx
+++ b/packages/picasso/src/OverlayBadge/OverlayBadge.tsx
@@ -1,12 +1,7 @@
 import React, { forwardRef, ReactNode } from 'react'
 import { makeStyles, Theme } from '@material-ui/core/styles'
 import cx from 'classnames'
-import {
-  BaseProps,
-  TextLabelProps,
-  CompoundedComponentWithRef,
-  useTitleCase
-} from '@toptal/picasso-shared'
+import { BaseProps, TextLabelProps, useTitleCase } from '@toptal/picasso-shared'
 import { Badge as MuiBadge } from '@material-ui/core'
 import { toTitleCase } from '@toptal/picasso/utils'
 
@@ -62,7 +57,7 @@ export const OverlayBadge = forwardRef<HTMLDivElement, Props>(
       </MuiBadge>
     )
   }
-) as CompoundedComponentWithRef<Props, HTMLDivElement>
+)
 
 OverlayBadge.defaultProps = {
   variant: 'white',

--- a/packages/picasso/src/Page/Page.tsx
+++ b/packages/picasso/src/Page/Page.tsx
@@ -1,11 +1,7 @@
 import React, { forwardRef, ReactNode, HTMLAttributes } from 'react'
 import { makeStyles, Theme } from '@material-ui/core/styles'
 import cx from 'classnames'
-import {
-  BaseProps,
-  PicassoComponentWithRef,
-  CompoundedComponentWithRef
-} from '@toptal/picasso-shared'
+import { BaseProps } from '@toptal/picasso-shared'
 
 import PageHelmet from '../PageHelmet'
 import PageTopBar from '../PageTopBar'
@@ -30,18 +26,6 @@ export interface Props extends BaseProps, HTMLAttributes<HTMLDivElement> {
   children: ReactNode
 }
 
-export interface StaticProps {
-  Helmet: typeof PageHelmet
-  TopBar: typeof PageTopBar
-  TopBarMenu: typeof PageTopBarMenu
-  Content: typeof PageContent
-  Footer: typeof PageFooter
-  Sidebar: typeof PageSidebar
-  Banner: typeof PageBanner
-  Autocomplete: typeof PageAutocomplete
-  Article: typeof PageArticle
-}
-
 export const PageContext = React.createContext<PageContextProps>({})
 
 const useStyles = makeStyles<Theme>(styles, {
@@ -49,7 +33,7 @@ const useStyles = makeStyles<Theme>(styles, {
 })
 
 // eslint-disable-next-line react/display-name
-export const Page = forwardRef<HTMLDivElement, Props>(function Page(
+export const Page = forwardRef<HTMLDivElement, Props>(function Page (
   props,
   ref
 ) {
@@ -68,26 +52,18 @@ export const Page = forwardRef<HTMLDivElement, Props>(function Page(
       </PageContext.Provider>
     </div>
   )
-}) as CompoundedComponentWithRef<Props, HTMLDivElement, StaticProps>
+})
 
 Page.displayName = 'Page'
 
-Page.TopBar = PageTopBar
-
-Page.TopBarMenu = PageTopBarMenu
-
-Page.Content = PageContent
-
-Page.Footer = PageFooter
-
-Page.Sidebar = PageSidebar
-
-Page.Banner = PageBanner
-
-Page.Helmet = PageHelmet
-
-Page.Autocomplete = PageAutocomplete
-
-Page.Article = PageArticle
-
-export default Page as PicassoComponentWithRef<Props, HTMLElement, StaticProps>
+export default Object.assign(Page, {
+  TopBar: PageTopBar,
+  TopBarMenu: PageTopBarMenu,
+  Content: PageContent,
+  Footer: PageFooter,
+  Sidebar: PageSidebar,
+  Banner: PageBanner,
+  Helmet: PageHelmet,
+  Autocomplete: PageAutocomplete,
+  Article: PageArticle
+})

--- a/packages/picasso/src/PageBanner/PageBanner.tsx
+++ b/packages/picasso/src/PageBanner/PageBanner.tsx
@@ -1,5 +1,5 @@
 import React, { ReactNode, forwardRef, HTMLAttributes } from 'react'
-import { BaseProps, CompoundedComponentWithRef } from '@toptal/picasso-shared'
+import { BaseProps } from '@toptal/picasso-shared'
 
 import Notification from '../Notification'
 import NotificationActions from '../NotificationActions'
@@ -9,27 +9,20 @@ export interface Props extends BaseProps, HTMLAttributes<HTMLDivElement> {
   children: ReactNode
 }
 
-export interface StaticProps {
-  Actions: typeof NotificationActions
-}
+export const PageBanner = forwardRef<HTMLDivElement, Props>(
+  function PageBanner (props, ref) {
+    const { children, className, ...rest } = props
 
-export const PageBanner = forwardRef<HTMLDivElement, Props>(function PageBanner(
-  props,
-  ref
-) {
-  const { children, className, ...rest } = props
-
-  return (
-    <Notification {...rest} ref={ref} className={className}>
-      {children}
-    </Notification>
-  )
-}) as CompoundedComponentWithRef<Props, HTMLElement, StaticProps>
-
-PageBanner.defaultProps = {}
+    return (
+      <Notification {...rest} ref={ref} className={className}>
+        {children}
+      </Notification>
+    )
+  }
+)
 
 PageBanner.displayName = 'PageBanner'
 
-PageBanner.Actions = NotificationActions
-
-export default PageBanner
+export default Object.assign(PageBanner, {
+  Actions: NotificationActions
+})

--- a/packages/picasso/src/PageHead/PageHead.tsx
+++ b/packages/picasso/src/PageHead/PageHead.tsx
@@ -1,11 +1,7 @@
 import React, { forwardRef, FunctionComponent, ReactNode } from 'react'
 import { makeStyles } from '@material-ui/core/styles'
 import cx from 'classnames'
-import {
-  CompoundedComponentWithRef,
-  TextLabelProps,
-  BaseProps
-} from '@toptal/picasso-shared'
+import { TextLabelProps, BaseProps } from '@toptal/picasso-shared'
 
 import Container from '../Container'
 import Typography from '../Typography'
@@ -16,13 +12,6 @@ export interface Props extends BaseProps {
   children?: ReactNode
   /** Whether it should have right padding */
   rightPadding?: boolean
-}
-
-export interface StaticProps {
-  Title: FunctionComponent
-  Tabs: FunctionComponent
-  Main: FunctionComponent
-  Actions: FunctionComponent
 }
 
 const useStyles = makeStyles(styles, {
@@ -81,17 +70,17 @@ export const PageHead = forwardRef<HTMLDivElement, Props>(function PageHead (
       {children}
     </Container>
   )
-}) as CompoundedComponentWithRef<Props, HTMLDivElement, StaticProps>
+})
 
 PageHead.defaultProps = {
   rightPadding: false
 }
 
-PageHead.Title = Title
-PageHead.Tabs = Tabs
-PageHead.Main = Main
-PageHead.Actions = Actions
-
 PageHead.displayName = 'PageHead'
 
-export default PageHead
+export default Object.assign(PageHead, {
+  Title,
+  Tabs,
+  Main,
+  Actions
+})

--- a/packages/picasso/src/Radio/Radio.tsx
+++ b/packages/picasso/src/Radio/Radio.tsx
@@ -2,8 +2,6 @@ import React, { ComponentProps, forwardRef, ReactNode } from 'react'
 import MUIRadio from '@material-ui/core/Radio'
 import { makeStyles, Theme } from '@material-ui/core/styles'
 import {
-  PicassoComponentWithRef,
-  CompoundedComponentWithRef,
   StandardProps,
   ButtonOrAnchorProps,
   TextLabelProps
@@ -28,11 +26,6 @@ export interface Props
   checked?: boolean
   /** Callback invoked when `Radio` changes its state */
   onChange?: (event: object, checked: boolean) => void
-}
-
-// should be moved to some global interfaces place
-export interface StaticProps {
-  Group: typeof RadioGroup
 }
 
 const useStyles = makeStyles<Theme, Props>(styles, {
@@ -105,11 +98,7 @@ export const Radio = forwardRef<HTMLButtonElement | HTMLLabelElement, Props>(
       />
     )
   }
-) as CompoundedComponentWithRef<
-  Props,
-  HTMLButtonElement | HTMLLabelElement,
-  StaticProps
->
+)
 
 Radio.defaultProps = {
   disabled: false
@@ -117,10 +106,6 @@ Radio.defaultProps = {
 
 Radio.displayName = 'Radio'
 
-Radio.Group = RadioGroup
-
-export default Radio as PicassoComponentWithRef<
-  Props,
-  HTMLButtonElement | HTMLLabelElement,
-  StaticProps
->
+export default Object.assign(Radio, {
+  Group: RadioGroup
+})

--- a/packages/picasso/src/Sidebar/Sidebar.tsx
+++ b/packages/picasso/src/Sidebar/Sidebar.tsx
@@ -7,12 +7,7 @@ import React, {
 } from 'react'
 import { makeStyles, Theme } from '@material-ui/core/styles'
 import cx from 'classnames'
-import {
-  BaseProps,
-  StandardProps,
-  PicassoComponentWithRef,
-  CompoundedComponentWithRef
-} from '@toptal/picasso-shared'
+import { BaseProps, StandardProps } from '@toptal/picasso-shared'
 import { useSidebar } from '@toptal/picasso-provider'
 
 import Button from '../Button'
@@ -67,12 +62,8 @@ const SmallScreenSidebarWrapper: FunctionComponent<SmallScreenSidebarWrapperProp
 export interface Props extends BaseProps {
   /** Style variant of Sidebar and subcomponents */
   variant?: VariantType
-}
-
-export interface StaticProps {
-  Menu: typeof SidebarMenu
-  Item: typeof SidebarItem
-  Logo: typeof SidebarLogo
+  /** Content */
+  children?: ReactNode
 }
 
 export const SidebarContext = React.createContext<SidebarContextProps>({
@@ -132,7 +123,7 @@ export const Sidebar = forwardRef<HTMLDivElement, Props>(function Sidebar (
   ) : (
     sidebar
   )
-}) as CompoundedComponentWithRef<Props, HTMLDivElement, StaticProps>
+})
 
 Sidebar.defaultProps = {
   variant: 'light'
@@ -140,12 +131,8 @@ Sidebar.defaultProps = {
 
 Sidebar.displayName = 'Sidebar'
 
-Sidebar.Menu = SidebarMenu
-Sidebar.Item = SidebarItem
-Sidebar.Logo = SidebarLogo
-
-export default Sidebar as PicassoComponentWithRef<
-  Props,
-  HTMLDivElement,
-  StaticProps
->
+export default Object.assign(Sidebar, {
+  Menu: SidebarMenu,
+  Item: SidebarItem,
+  Logo: SidebarLogo
+})

--- a/packages/picasso/src/Table/Table.tsx
+++ b/packages/picasso/src/Table/Table.tsx
@@ -6,11 +6,7 @@ import React, {
 } from 'react'
 import { makeStyles, Theme } from '@material-ui/core/styles'
 import MUITable from '@material-ui/core/Table'
-import {
-  BaseProps,
-  PicassoComponentWithRef,
-  CompoundedComponentWithRef
-} from '@toptal/picasso-shared'
+import { BaseProps } from '@toptal/picasso-shared'
 
 import TableCell from '../TableCell'
 import TableBody from '../TableBody'
@@ -34,16 +30,6 @@ export interface Props
   spacing?: TableSpacing
   /** Appearance variant */
   variant?: TableVariant
-}
-
-export interface StaticProps {
-  Head: typeof TableHead
-  SectionHead: typeof TableSectionHead
-  Body: typeof TableBody
-  Row: typeof TableRow
-  Cell: typeof TableCell
-  Footer: typeof TableFooter
-  ExpandableRow: typeof TableExpandableRow
 }
 
 const useStyles = makeStyles<Theme>(styles, {
@@ -80,33 +66,21 @@ export const Table = forwardRef<HTMLTableElement, Props>(function Table (
       </MUITable>
     </TableContext.Provider>
   )
-}) as CompoundedComponentWithRef<Props, HTMLTableElement, StaticProps>
+})
 
 Table.defaultProps = {
   spacing: 'regular',
   variant: 'bordered'
 }
 
-Table.displayName = 'Table'
+Table.displayName = 'PicassoTable'
 
-Table.Body = TableBody
-
-Table.Cell = TableCell
-
-Table.Body = TableBody
-
-Table.Head = TableHead
-
-Table.SectionHead = TableSectionHead
-
-Table.Row = TableRow
-
-Table.ExpandableRow = TableExpandableRow
-
-Table.Footer = TableFooter
-
-export default Table as PicassoComponentWithRef<
-  Props,
-  HTMLTableElement,
-  StaticProps
->
+export default Object.assign(Table, {
+  Cell: TableCell,
+  Body: TableBody,
+  Head: TableHead,
+  SectionHead: TableSectionHead,
+  Row: TableRow,
+  ExpandableRow: TableExpandableRow,
+  Footer: TableFooter
+})

--- a/packages/picasso/src/Tabs/Tabs.tsx
+++ b/packages/picasso/src/Tabs/Tabs.tsx
@@ -1,12 +1,7 @@
 import React, { forwardRef, ReactNode } from 'react'
 import { makeStyles, Theme } from '@material-ui/core/styles'
 import MUITabs, { TabsProps } from '@material-ui/core/Tabs'
-import {
-  ButtonOrAnchorProps,
-  BaseProps,
-  PicassoComponentWithRef,
-  CompoundedComponentWithRef
-} from '@toptal/picasso-shared'
+import { ButtonOrAnchorProps, BaseProps } from '@toptal/picasso-shared'
 
 import Tab from '../Tab'
 import TabScrollButton from '../TabScrollButton'
@@ -26,16 +21,12 @@ export interface Props
   value: TabsProps['value']
 }
 
-export interface StaticProps {
-  Tab: typeof Tab
-}
-
 const useStyles = makeStyles<Theme>(styles, {
   name: 'Tabs'
 })
 
 // eslint-disable-next-line react/display-name
-export const Tabs = forwardRef<HTMLButtonElement, Props>(function Tabs(
+export const Tabs = forwardRef<HTMLButtonElement, Props>(function Tabs (
   props,
   ref
 ) {
@@ -58,16 +49,10 @@ export const Tabs = forwardRef<HTMLButtonElement, Props>(function Tabs(
       {children}
     </MUITabs>
   )
-}) as CompoundedComponentWithRef<Props, HTMLButtonElement, StaticProps>
-
-Tabs.defaultProps = {}
+})
 
 Tabs.displayName = 'Tabs'
 
-Tabs.Tab = Tab
-
-export default Tabs as PicassoComponentWithRef<
-  Props,
-  HTMLButtonElement,
-  StaticProps
->
+export default Object.assign(Tabs, {
+  Tab
+})

--- a/packages/picasso/src/Tag/Tag.tsx
+++ b/packages/picasso/src/Tag/Tag.tsx
@@ -9,12 +9,7 @@ import React, {
 } from 'react'
 import { makeStyles, Theme } from '@material-ui/core/styles'
 import cx from 'classnames'
-import {
-  BaseProps,
-  TextLabelProps,
-  CompoundedComponentWithRef,
-  useTitleCase
-} from '@toptal/picasso-shared'
+import { BaseProps, TextLabelProps, useTitleCase } from '@toptal/picasso-shared'
 
 import Chip from '../Chip'
 import { CloseMinor16 } from '../Icon'
@@ -46,15 +41,10 @@ export interface Props extends BaseProps, TextLabelProps, DivOrAnchorProps {
   variant?: VariantType
 }
 
-export interface StaticProps {
-  Group: typeof TagGroup
-  Rectangular: typeof TagRectangular
-}
-
 const useStyles = makeStyles<Theme>(styles, { name: 'PicassoLabel' })
 
 // eslint-disable-next-line react/display-name
-export const Tag = forwardRef<HTMLDivElement, Props>(function Tag(props, ref) {
+export const Tag = forwardRef<HTMLDivElement, Props>(function Tag (props, ref) {
   const {
     children,
     style,
@@ -114,7 +104,7 @@ export const Tag = forwardRef<HTMLDivElement, Props>(function Tag(props, ref) {
       onDelete={onDelete ? handleDelete : undefined}
     />
   )
-}) as CompoundedComponentWithRef<Props, HTMLDivElement, StaticProps>
+})
 
 Tag.defaultProps = {
   as: 'div',
@@ -124,7 +114,7 @@ Tag.defaultProps = {
 
 Tag.displayName = 'Tag'
 
-Tag.Group = TagGroup
-Tag.Rectangular = TagRectangular
-
-export default Tag
+export default Object.assign(Tag, {
+  Group: TagGroup,
+  Rectangular: TagRectangular
+})

--- a/packages/picasso/src/TagSelector/TagSelector.tsx
+++ b/packages/picasso/src/TagSelector/TagSelector.tsx
@@ -7,7 +7,7 @@ import React, {
   FocusEventHandler,
   Fragment
 } from 'react'
-import { BaseProps, CompoundedComponentWithRef } from '@toptal/picasso-shared'
+import { BaseProps } from '@toptal/picasso-shared'
 
 import Autocomplete, { Item as AutocompleteItem } from '../Autocomplete'
 import TagSelectorInput from '../TagSelectorInput'
@@ -80,10 +80,6 @@ export interface Props
   }) => ReactNode
   /** DOM element that wraps the Popper */
   popperContainer?: HTMLElement
-}
-
-export interface StaticProps {
-  Label: typeof TagSelectorLabel
 }
 
 export const TagSelector = forwardRef<HTMLInputElement, Props>(
@@ -218,7 +214,7 @@ export const TagSelector = forwardRef<HTMLInputElement, Props>(
       />
     )
   }
-) as CompoundedComponentWithRef<Props, HTMLInputElement, StaticProps>
+)
 
 TagSelector.defaultProps = {
   enableAutofill: false,
@@ -236,6 +232,6 @@ TagSelector.defaultProps = {
 
 TagSelector.displayName = 'TagSelector'
 
-TagSelector.Label = TagSelectorLabel
-
-export default TagSelector
+export default Object.assign(TagSelector, {
+  Label: TagSelectorLabel
+})

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -1,10 +1,7 @@
 import {
   CSSProperties,
-  FunctionComponent,
   AnchorHTMLAttributes,
   ButtonHTMLAttributes,
-  RefAttributes,
-  ForwardRefExoticComponent,
   ElementType,
   ComponentPropsWithRef
 } from 'react'
@@ -40,17 +37,6 @@ export type OmitInternalProps<T, K = ''> = Pick<
   T,
   Exclude<keyof T, keyof JssProps | K>
 >
-
-export type PicassoComponentWithRef<P, R, S = {}> = FunctionComponent<
-  P & RefAttributes<R>
-> &
-  S
-
-export type CompoundedComponentWithRef<
-  P,
-  R,
-  S = {}
-> = ForwardRefExoticComponent<P & RefAttributes<R>> & S
 
 type PropsWithOverridableAs<T extends ElementType, P> = Omit<P, 'as'> & {
   as?: T


### PR DESCRIPTION
[FX-NNNN]

### Description

@teimurjan found a cool approach (I saw a couple of times) to have proper typings of static props on compound components with no explicit type coercing. 

To me it makes sense to simplify our types and apply Teimur's idea for whole the codebase

### How to test

- FIXME: Add the steps describing how to verify your changes

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| Insert screenshots or screen recordings | Insert screenshots or screen recordings |

### Review

- [ ] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/api-principles.md)
- [ ] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that tests pass by running `yarn test`
- [ ] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
- [ ] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>


[FX-1969]: https://toptal-core.atlassian.net/browse/FX-1969