### PR TITLE
fix: remove material-ui/styles dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
   "lint-staged": {
     "*.{js,jsx,ts,tsx}": [
       "davinci syntax lint code",
-      "prettier-standard"
+      "prettier --write"
     ]
   },
   "config": {

--- a/packages/picasso-provider/package.json
+++ b/packages/picasso-provider/package.json
@@ -25,7 +25,6 @@
   },
   "dependencies": {
     "@material-ui/core": "4.11.0",
-    "@material-ui/styles": "4.10.0",
     "@material-ui/utils": "4.10.2",
     "classnames": "^2.3.1",
     "notistack": "1.0.5",

--- a/packages/picasso-provider/src/Picasso/Picasso.tsx
+++ b/packages/picasso-provider/src/Picasso/Picasso.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable complexity */
 import {
+  makeStyles,
   MuiThemeProvider,
   Theme,
   ThemeOptions,
@@ -15,7 +16,6 @@ import React, {
   ForwardRefExoticComponent,
   RefAttributes
 } from 'react'
-import { makeStyles } from '@material-ui/styles'
 import { Helmet } from 'react-helmet'
 import unsafeErrorLog from '@toptal/picasso/utils/unsafe-error-log'
 

--- a/packages/picasso/package.json
+++ b/packages/picasso/package.json
@@ -23,7 +23,6 @@
   "homepage": "https://github.com/toptal/picasso/tree/master/packages/picasso#readme",
   "peerDependencies": {
     "@material-ui/core": "4.11.0",
-    "@material-ui/styles": "4.10.0",
     "notistack": "1.0.5",
     "react": "^16.12.0",
     "react-dom": "^16.12.0",

--- a/packages/picasso/src/Link/Link.tsx
+++ b/packages/picasso/src/Link/Link.tsx
@@ -5,9 +5,8 @@ import React, {
   AnchorHTMLAttributes
 } from 'react'
 import MUILink from '@material-ui/core/Link'
-import { Theme } from '@material-ui/core/styles'
+import { Theme, makeStyles } from '@material-ui/core/styles'
 import cx from 'classnames'
-import { makeStyles } from '@material-ui/styles'
 import { BaseProps, OverridableComponent } from '@toptal/picasso-shared'
 
 import styles from './styles'

--- a/yarn.lock
+++ b/yarn.lock
@@ -2941,7 +2941,7 @@
     react-is "^16.8.0"
     react-transition-group "^4.4.0"
 
-"@material-ui/styles@4.10.0", "@material-ui/styles@^4.10.0":
+"@material-ui/styles@^4.10.0":
   version "4.10.0"
   resolved "https://registry.yarnpkg.com/@material-ui/styles/-/styles-4.10.0.tgz#2406dc23aa358217aa8cc772e6237bd7f0544071"
   integrity sha512-XPwiVTpd3rlnbfrgtEJ1eJJdFCXZkHxy8TrdieaTvwxNYj42VnnCyFzxYeNW9Lhj4V1oD8YtQ6S5Gie7bZDf7Q==


### PR DESCRIPTION
follow-up to #2148

### Description

Remove dependency on  "@material-ui/styles": "4.10.0" because we have this package installed already with "@material-ui/core" and not pinned to 4.10. This causes possible clash of dependencies, the project may depend on 2 version:
 - "@material-ui/styles": "4.10.0" from Picasso
 - "@material-ui/styles": "4.11.4" from material-ui/core
 
 Styled created with 4.10 can't access the theme created with 4.11.4 and crash.

This dependency is not needed as the material-ui core exports the same hooks, which are always compatible with it, so instead of that additional dependency we should have fixed the imports instead.

### Review

- [ ] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/api-principles.md)
- [ ] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that tests pass by running `yarn test`
- [ ] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
- [ ] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>
