### PR TITLE
fix(Autocomplete): do not render noOptions item when no options available

### DIFF
--- a/packages/picasso/src/Autocomplete/Autocomplete.tsx
+++ b/packages/picasso/src/Autocomplete/Autocomplete.tsx
@@ -66,7 +66,7 @@ export interface Props
   /** Allow to show the other option in the list of options */
   showOtherOption?: boolean
   /** Label to show when no options were found */
-  noOptionsText?: string
+  noOptionsText?: string | null
   /** List of options */
   options?: Item[] | null
   /** A function that takes a display value from the option item */
@@ -227,7 +227,7 @@ export const Autocomplete = forwardRef<HTMLInputElement, Props>(
             {...getOtherItemProps(optionsLength, value)}
           />
         )}
-        {!optionsLength && !shouldShowOtherOption && (
+        {!optionsLength && !shouldShowOtherOption && noOptionsText && (
           <NoOptionsMenuItem data-testid={testIds?.noOptions}>
             {noOptionsText}
           </NoOptionsMenuItem>

--- a/packages/picasso/src/Autocomplete/test.tsx
+++ b/packages/picasso/src/Autocomplete/test.tsx
@@ -167,6 +167,21 @@ describe('Autocomplete', () => {
       expect(getByTestId(testIds.noOptions)).not.toBeNull()
     })
 
+    it('hides no options text when disabled and no options are avialble', () => {
+      const { getByTestId, queryByTestId, queryByText } = renderAutocomplete({
+        noOptionsText: null,
+        value: 'Picasso'
+      })
+
+      const input = getByTestId('autocomplete')
+
+      fireEvent.focus(input)
+      fireEvent.keyDown(input, { key: 'Enter', code: 'Enter' })
+
+      expect(queryByText('No options')).toBeNull()
+      expect(queryByTestId(testIds.noOptions)).toBeNull()
+    })
+
     it('renders custom options with custom keys', async () => {
       const getDisplayValue = jest.fn()
       const renderOption = jest.fn(item => (


### PR DESCRIPTION
[TACO-1050]

### Description

This feature add ability to disable rendering of `NoOptionsMenuItem` by letting `null` value to be passed through `Autocomplete.noOptionsText`

### How to test

- In tests we trust

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| Insert screenshots or screen recordings | Insert screenshots or screen recordings |

### Review

- [ ] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/api-principles.md)
- [ ] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that tests pass by running `yarn test`
- [ ] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
- [ ] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>


[TACO-1050]: https://toptal-core.atlassian.net/browse/TACO-1050