### PR TITLE
fix(menu): drilldown submenu hide on leaving the parent menu item

### DIFF
--- a/packages/picasso/src/Menu/hooks/use-drilldown-menu/use-drilldown-menu.ts
+++ b/packages/picasso/src/Menu/hooks/use-drilldown-menu/use-drilldown-menu.ts
@@ -1,18 +1,13 @@
-import { ReactElement, useCallback, useMemo, useState } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 
 import { MenuContextProps } from '../../../Menu/MenuContext'
 
 const useDrilldownMenu = () => {
   const [activeItemKey, setActiveItemKey] = useState<string>()
 
-  const handleItemMouseEnter = useCallback(
-    (key: string, menu?: ReactElement) => {
-      if (menu) {
-        setActiveItemKey(key)
-      }
-    },
-    []
-  )
+  const handleItemMouseEnter = useCallback((key: string) => {
+    setActiveItemKey(key)
+  }, [])
 
   const handleMenuMouseLeave = useCallback(() => {
     setActiveItemKey(undefined)


### PR DESCRIPTION

[FX-NNNN]

### Description

Submenu on drilldown menu does not hide if you move mouse to the siblings items


### How to test

Add Menu component with  'variant' prop  = drilldown and add two children as Menu.Items, one of which with 'menu' prop equal to the Menu Component. Try  to hover to item with drilldown submenu, it opens, then try to navigate to other menu.item. you will see that previosly opened submenu still open

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |


| https://user-images.githubusercontent.com/65539882/134786932-041c127e-4ec2-4958-9c08-4d90e2851e6a.mov | https://user-images.githubusercontent.com/65539882/134787161-0e5f39e8-4280-4b26-8e43-e1f20375881b.mov |

### Review

- [ X] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/api-principles.md)
- [ X] Annotate all `props` in component with documentation
- [X ] Create `examples` for component
- [ X] Ensure that deployed demo has expected results and good examples
- [X ] Ensure that tests pass by running `yarn test`
- [X ] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
- [ X] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>
