### PR TITLE
fix: add data-testids to components

### DIFF
--- a/packages/picasso/src/Alert/Alert.tsx
+++ b/packages/picasso/src/Alert/Alert.tsx
@@ -12,6 +12,7 @@ export interface StaticProps {
 export interface Props extends AlertInlineProps {
   /** Callback invoked when close is clicked */
   onClose?: (event: MouseEvent<HTMLButtonElement>) => void
+  dataTestid?: string
 }
 
 const renderAlertCloseButton = ({ onClose }: Pick<Props, 'onClose'>) => (
@@ -29,7 +30,7 @@ export const Alert = forwardRef<HTMLDivElement, Props>(function Alert(
   props,
   ref
 ) {
-  const { children, variant, onClose, className } = props
+  const { children, variant, onClose, className, dataTestid } = props
 
   return (
     <Container
@@ -41,6 +42,7 @@ export const Alert = forwardRef<HTMLDivElement, Props>(function Alert(
       ref={ref}
       variant={variant}
       className={className}
+      data-testid={dataTestid}
     >
       <AlertInline variant={variant} iconPadding='small'>
         {children}

--- a/packages/picasso/src/PageTopBarMenu/PageTopBarMenu.tsx
+++ b/packages/picasso/src/PageTopBarMenu/PageTopBarMenu.tsx
@@ -35,7 +35,12 @@ export const PageTopBarMenu = forwardRef<HTMLDivElement, Props>(
 
     const metaContent =
       typeof meta === 'string' ? (
-        <Typography className={classes.truncateText} invert size='small'>
+        <Typography
+          className={classes.truncateText}
+          invert
+          size='small'
+          data-testid='top-bar-menu-meta-content'
+        >
           {meta}
         </Typography>
       ) : (


### PR DESCRIPTION
[SP-1629]

### Description
For cucumber we need additional data-testids on components.

### How to test
Can be tested locally with alpha package.

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| Insert screenshots or screen recordings | Insert screenshots or screen recordings |

### Review

- [ ] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/api-principles.md)
- [ ] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that tests pass by running `yarn test`
- [ ] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
- [ ] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>
