### PR TITLE
feat(Select): add disabled option item

### DIFF
--- a/packages/picasso/src/NativeSelectOptions/NativeSelectOptions.tsx
+++ b/packages/picasso/src/NativeSelectOptions/NativeSelectOptions.tsx
@@ -20,6 +20,7 @@ const NativeSelectOptions = <T extends ValueType>({
         <option
           key={(option?.key ?? option.value).toString()}
           value={option.value.toString()}
+          disabled={option.disabled}
           // eslint-disable-next-line react/jsx-props-no-spreading
           {...getItemProps(option, index)}
         >
@@ -35,7 +36,7 @@ const NativeSelectOptions = <T extends ValueType>({
 
   return (
     <>
-      {Object.keys(options).map((group) => (
+      {Object.keys(options).map(group => (
         <optgroup key={group} label={group}>
           {renderOptions(options[group])}
         </optgroup>

--- a/packages/picasso/src/NonNativeSelectOption/NonNativeSelectOption.tsx
+++ b/packages/picasso/src/NonNativeSelectOption/NonNativeSelectOption.tsx
@@ -1,8 +1,11 @@
 import React, { ReactNode } from 'react'
 import { SizeType } from '@toptal/picasso-shared'
+import cx from 'classnames'
+import { Theme, makeStyles } from '@material-ui/core/styles'
 
 import MenuItem from '../MenuItem'
 import { Option, ValueType } from '../Select'
+import styles from './styles'
 
 export interface Props<T extends ValueType> {
   children?: ReactNode
@@ -16,6 +19,10 @@ export interface Props<T extends ValueType> {
   option: Option<T>
 }
 
+const useStyles = makeStyles<Theme>(styles, {
+  name: 'PicassoNonNativeSelectOption'
+})
+
 const NonNativeSelectOption = React.memo(
   <T extends ValueType>({
     option,
@@ -28,6 +35,8 @@ const NonNativeSelectOption = React.memo(
     description,
     children
   }: Props<T>) => {
+    const classes = useStyles()
+
     return (
       <MenuItem
         role='option'
@@ -41,6 +50,10 @@ const NonNativeSelectOption = React.memo(
         onClick={onClick}
         titleCase={false}
         description={description}
+        disabled={option.disabled}
+        className={cx({
+          [classes.disabled]: option.disabled
+        })}
       >
         {children}
       </MenuItem>

--- a/packages/picasso/src/NonNativeSelectOption/__snapshots__/test.tsx.snap
+++ b/packages/picasso/src/NonNativeSelectOption/__snapshots__/test.tsx.snap
@@ -1,6 +1,96 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`NonNativeSelectOption renders 1`] = `
+exports[`NonNativeSelectOption when option is disabled renders 1`] = `
+<div>
+  <div
+    class="Picasso-root"
+  >
+    <li
+      aria-disabled="true"
+      aria-selected="false"
+      class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root PicassoMenuItem-root PicassoMenuItem-light PicassoNonNativeSelectOption-disabled MuiMenuItem-gutters MuiListItem-gutters Mui-disabled MuiListItem-button Mui-disabled"
+      role="option"
+      tabindex="-1"
+      value="option1"
+    >
+      <div
+        class="PicassoContainer-flex PicassoContainer-column PicassoMenuItem-content"
+      >
+        <div
+          class="PicassoContainer-centerAlignItems PicassoContainer-flex"
+        >
+          <div
+            class="PicassoContainer-rightxsmallMargin PicassoContainer-flex PicassoContainer-inline PicassoMenuItem-iconContainer"
+          />
+          <span
+            class="PicassoMenuItem-stringContent"
+          >
+            Test
+          </span>
+        </div>
+        <div
+          class="PicassoContainer-leftmediumMargin PicassoMenuItem-description"
+          style="margin-top: 0.25rem;"
+        >
+          Test description
+        </div>
+      </div>
+    </li>
+  </div>
+</div>
+`;
+
+exports[`NonNativeSelectOption when option is disabled sets attributes correctly 1`] = `
+<div>
+  <div
+    class="Picasso-root"
+  >
+    <li
+      aria-disabled="true"
+      aria-selected="true"
+      class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root PicassoMenuItem-root PicassoMenuItem-light PicassoNonNativeSelectOption-disabled Mui-selected PicassoMenuItem-selected MuiMenuItem-gutters MuiListItem-gutters Mui-disabled MuiListItem-button Mui-selected Mui-disabled"
+      role="option"
+      tabindex="-1"
+      value="option1"
+    >
+      <div
+        class="PicassoContainer-flex PicassoContainer-column PicassoMenuItem-content"
+      >
+        <div
+          class="PicassoContainer-centerAlignItems PicassoContainer-flex"
+        >
+          <div
+            class="PicassoContainer-rightxsmallMargin PicassoContainer-flex PicassoContainer-inline PicassoMenuItem-iconContainer"
+          >
+            <svg
+              class="PicassoSvgCheckMinor16-root"
+              style="min-width: 16px; min-height: 16px;"
+              viewBox="0 0 16 16"
+            >
+              <path
+                d="M6.5 9.793l4-4 .707.707-4 4-.707.707L3.793 8.5l.707-.707 2 2z"
+              />
+            </svg>
+          </div>
+          <span
+            class="PicassoMenuItem-stringContent PicassoMenuItem-stringContentSemibold"
+          >
+            Test
+          </span>
+        </div>
+        <div
+          class="PicassoContainer-leftmediumMargin PicassoMenuItem-description"
+          style="margin-top: 0.25rem;"
+        >
+          Test description
+        </div>
+      </div>
+    </li>
+  </div>
+</div>
+`;
+
+exports[`NonNativeSelectOption when option is enabled renders 1`] = `
 <div>
   <div
     class="Picasso-root"
@@ -40,7 +130,7 @@ exports[`NonNativeSelectOption renders 1`] = `
 </div>
 `;
 
-exports[`NonNativeSelectOption sets attributes correctly 1`] = `
+exports[`NonNativeSelectOption when option is enabled sets attributes correctly 1`] = `
 <div>
   <div
     class="Picasso-root"

--- a/packages/picasso/src/NonNativeSelectOption/styles.ts
+++ b/packages/picasso/src/NonNativeSelectOption/styles.ts
@@ -1,0 +1,9 @@
+import { createStyles, Theme } from '@material-ui/core/styles'
+
+export default ({ palette }: Theme) =>
+  createStyles({
+    disabled: {
+      opacity: '1 !important',
+      color: palette.grey.main2
+    }
+  })

--- a/packages/picasso/src/NonNativeSelectOption/test.tsx
+++ b/packages/picasso/src/NonNativeSelectOption/test.tsx
@@ -6,7 +6,8 @@ import noop from '../utils/noop'
 
 const CHILDREN = 'Test'
 const DESCRIPTION = 'Test description'
-const OPTION = { text: '', value: '' }
+const OPTION = { text: 'Option #1', value: 'option1' }
+const DISABLED_OPTION = { ...OPTION, disabled: true }
 
 const renderNonNativeSelectOption = ({
   children = CHILDREN,
@@ -35,46 +36,73 @@ const renderNonNativeSelectOption = ({
   )
 
 describe('NonNativeSelectOption', () => {
-  it('renders', () => {
-    const { container } = renderNonNativeSelectOption()
+  describe('when option is enabled', () => {
+    it('renders', () => {
+      const { container } = renderNonNativeSelectOption()
 
-    expect(container).toMatchSnapshot()
-  })
-
-  it('sets attributes correctly', () => {
-    const { container, getByRole } = renderNonNativeSelectOption({
-      selected: true,
-      highlighted: true,
-      option: { text: 'Option #1', value: 'option1' }
+      expect(container).toMatchSnapshot()
     })
 
-    const option = getByRole('option')
+    it('sets attributes correctly', () => {
+      const { container, getByRole } = renderNonNativeSelectOption({
+        selected: true,
+        highlighted: true
+      })
 
-    expect(option.getAttribute('aria-selected')).toEqual('true')
-    expect(option.getAttribute('value')).toEqual('option1')
+      const option = getByRole('option')
 
-    expect(container).toMatchSnapshot()
-  })
+      expect(option.getAttribute('aria-selected')).toEqual('true')
+      expect(option.getAttribute('value')).toEqual('option1')
 
-  it('fires events correctly', () => {
-    const onMouseDown = jest.fn()
-    const onMouseEnter = jest.fn()
-    const onClick = jest.fn()
-    const { getByRole } = renderNonNativeSelectOption({
-      onMouseDown,
-      onMouseEnter,
-      onClick
+      expect(container).toMatchSnapshot()
     })
 
-    const option = getByRole('option')
+    it('fires events correctly', () => {
+      const onMouseDown = jest.fn()
+      const onMouseEnter = jest.fn()
+      const onClick = jest.fn()
+      const { getByRole } = renderNonNativeSelectOption({
+        onMouseDown,
+        onMouseEnter,
+        onClick
+      })
 
-    fireEvent.mouseDown(option)
-    expect(onMouseDown).toHaveBeenCalledTimes(1)
+      const option = getByRole('option')
 
-    fireEvent.mouseEnter(option)
-    expect(onMouseEnter).toHaveBeenCalledTimes(1)
+      fireEvent.mouseDown(option)
+      expect(onMouseDown).toHaveBeenCalledTimes(1)
 
-    fireEvent.click(option)
-    expect(onClick).toHaveBeenCalledTimes(1)
+      fireEvent.mouseEnter(option)
+      expect(onMouseEnter).toHaveBeenCalledTimes(1)
+
+      fireEvent.click(option)
+      expect(onClick).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('when option is disabled', () => {
+    it('renders', () => {
+      const { container } = renderNonNativeSelectOption({
+        option: DISABLED_OPTION
+      })
+
+      expect(container).toMatchSnapshot()
+    })
+
+    it('sets attributes correctly', () => {
+      const { container, getByRole } = renderNonNativeSelectOption({
+        selected: true,
+        highlighted: true,
+        option: DISABLED_OPTION
+      })
+
+      const option = getByRole('option')
+
+      expect(option.getAttribute('aria-selected')).toEqual('true')
+      expect(option.getAttribute('aria-disabled')).toEqual('true')
+      expect(option.getAttribute('value')).toEqual('option1')
+
+      expect(container).toMatchSnapshot()
+    })
   })
 })

--- a/packages/picasso/src/Select/hooks/use-highlighted-index/test.ts
+++ b/packages/picasso/src/Select/hooks/use-highlighted-index/test.ts
@@ -3,34 +3,108 @@ import { renderHook, act } from '@testing-library/react-hooks'
 import useHighlightedIndex from './use-highlighted-index'
 
 describe('useHighlightedIndex', () => {
-  it('sets a highlighted index', () => {
-    const { result } = renderHook(() =>
-      useHighlightedIndex({ selectedIndexes: [1, 2, 3], isOpen: true })
-    )
+  describe('when all indexes are enabled', () => {
+    it('sets a highlighted index', () => {
+      const { result } = renderHook(() =>
+        useHighlightedIndex({
+          selectedIndexes: [1, 2, 3],
+          isOpen: true,
+          indexes: [0, 1, 2, 3]
+        })
+      )
 
-    expect(result.current[0]).toBe(0)
-    act(() => {
-      result.current[1](2)
+      expect(result.current[0]).toBe(0)
+      act(() => {
+        result.current[1](2)
+      })
+      expect(result.current[0]).toBe(2)
     })
-    expect(result.current[0]).toBe(2)
+
+    it('resets highlighted index when closed', () => {
+      const { result, rerender } = renderHook(
+        (isOpen: boolean) =>
+          useHighlightedIndex({
+            selectedIndexes: [1, 2, 3],
+            isOpen,
+            indexes: [0, 1, 2, 3]
+          }),
+        {
+          initialProps: true
+        }
+      )
+
+      expect(result.current[0]).toBe(0)
+      act(() => {
+        result.current[1](2)
+      })
+      expect(result.current[0]).toBe(2)
+
+      rerender(false)
+      expect(result.current[0]).toBe(0)
+    })
   })
 
-  it('resets highlighted index when closed', () => {
-    const { result, rerender } = renderHook(
-      (isOpen: boolean) =>
-        useHighlightedIndex({ selectedIndexes: [1, 2, 3], isOpen }),
-      {
-        initialProps: true
-      }
-    )
+  describe('when no enabled indexes', () => {
+    it('sets highlighted index as null', () => {
+      const { result } = renderHook(() =>
+        useHighlightedIndex({
+          selectedIndexes: [],
+          isOpen: true,
+          indexes: []
+        })
+      )
 
-    expect(result.current[0]).toBe(0)
-    act(() => {
-      result.current[1](2)
+      expect(result.current[0]).toBeNull()
     })
-    expect(result.current[0]).toBe(2)
+  })
 
-    rerender(false)
-    expect(result.current[0]).toBe(0)
+  describe('when first index is not enabled', () => {
+    it('should return the first available index', () => {
+      const { result, rerender } = renderHook(
+        (isOpen: boolean) =>
+          useHighlightedIndex({
+            selectedIndexes: [2, 3, 4],
+            isOpen,
+            indexes: [1, 2, 3, 4]
+          }),
+        {
+          initialProps: true
+        }
+      )
+
+      expect(result.current[0]).toBe(1)
+      act(() => {
+        result.current[1](4)
+      })
+      expect(result.current[0]).toBe(4)
+
+      rerender(false)
+      expect(result.current[0]).toBe(1)
+    })
+  })
+
+  describe('when the last index enabled only', () => {
+    it('should return the last index', () => {
+      const { result, rerender } = renderHook(
+        (isOpen: boolean) =>
+          useHighlightedIndex({
+            selectedIndexes: [2, 3, 4],
+            isOpen,
+            indexes: [4]
+          }),
+        {
+          initialProps: true
+        }
+      )
+
+      expect(result.current[0]).toBe(4)
+      act(() => {
+        result.current[1](4)
+      })
+      expect(result.current[0]).toBe(4)
+
+      rerender(false)
+      expect(result.current[0]).toBe(4)
+    })
   })
 })

--- a/packages/picasso/src/Select/hooks/use-highlighted-index/use-highlighted-index.ts
+++ b/packages/picasso/src/Select/hooks/use-highlighted-index/use-highlighted-index.ts
@@ -2,24 +2,31 @@ import { useState, useEffect } from 'react'
 
 interface Props {
   selectedIndexes: number[]
+  indexes: number[]
   isOpen: boolean
 }
 
-const useHighlightedIndex = ({ selectedIndexes, isOpen }: Props) => {
-  const [highlightedIndex, setHighlightedIndex] = useState<number>(0)
+const useHighlightedIndex = ({ selectedIndexes, isOpen, indexes }: Props) => {
+  const [highlightedIndex, setHighlightedIndex] = useState<number | null>(
+    indexes.length ? indexes[0] : null
+  )
 
   useEffect(() => {
     if (!isOpen) {
+      if (!indexes.length) {
+        return
+      }
+
       const nextHighlightedIndex =
-        selectedIndexes.length === 1 ? selectedIndexes[0] : 0
+        selectedIndexes.length === 1 ? selectedIndexes[0] : indexes[0]
 
       setHighlightedIndex(nextHighlightedIndex)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isOpen, selectedIndexes.length, selectedIndexes[0]])
+  }, [isOpen, selectedIndexes.length, selectedIndexes[0], indexes.length, indexes[0]])
 
   return [highlightedIndex, setHighlightedIndex] as [
-    number,
+    number | null,
     (value: number) => void
   ]
 }

--- a/packages/picasso/src/Select/hooks/use-select-props/use-arrows-keydown-handler/use-arrows-keydown-handler.ts
+++ b/packages/picasso/src/Select/hooks/use-select-props/use-arrows-keydown-handler/use-arrows-keydown-handler.ts
@@ -1,4 +1,7 @@
-import { flattenOptions, getNextWrappingIndex } from '@toptal/picasso/Select/utils'
+import {
+  flattenOptions,
+  getNextWrappingIndex
+} from '@toptal/picasso/Select/utils'
 import { KeyboardEvent, useCallback } from 'react'
 
 import { ValueType, UseSelectProps } from '../../../types'
@@ -24,7 +27,16 @@ const useArrowsKeyDownHandler = <
           getNextWrappingIndex(
             key === 'ArrowDown' ? 1 : -1,
             highlightedIndex,
-            flattenOptions(filteredOptions).length
+            flattenOptions(filteredOptions).reduce(
+              (indexes: number[], option, currentIndex) => {
+                if (!option.disabled) {
+                  return [...indexes, currentIndex]
+                }
+
+                return indexes
+              },
+              []
+            )
           )
         )
       } else {

--- a/packages/picasso/src/Select/hooks/use-select-props/use-enter-or-space-keydown-handler/test.ts
+++ b/packages/picasso/src/Select/hooks/use-select-props/use-enter-or-space-keydown-handler/test.ts
@@ -33,12 +33,12 @@ describe('useEnterOrSpaceKeydownHandler', () => {
     expect(handleSelect).toHaveBeenCalledTimes(0)
   })
 
-  it('closes if open and an option selected', () => {
+  it('does nothing if open and highlighted index is null', () => {
     const handleSelect = jest.fn()
     const props = { ...getUseSelectPropsMock(), handleSelect }
 
     props.selectState.canOpen = false
-    props.selectState.highlightedIndex = 1
+    props.selectState.highlightedIndex = null
     props.selectState.filteredOptions = [
       {
         text: 'One',
@@ -59,10 +59,75 @@ describe('useEnterOrSpaceKeydownHandler', () => {
 
     result.current(event)
 
-    expect(props.selectState.close).toHaveBeenCalledTimes(1)
-    expect(handleSelect).toHaveBeenCalledWith(event, {
-      text: 'Two',
-      value: '2'
+    expect(props.selectState.open).toHaveBeenCalledTimes(0)
+    expect(props.selectState.close).toHaveBeenCalledTimes(0)
+    expect(handleSelect).toHaveBeenCalledTimes(0)
+  })
+
+  describe('when used basic options', () => {
+    it('closes if open and an option selected', () => {
+      const handleSelect = jest.fn()
+      const props = { ...getUseSelectPropsMock(), handleSelect }
+
+      props.selectState.canOpen = false
+      props.selectState.highlightedIndex = 1
+      props.selectState.filteredOptions = [
+        {
+          text: 'One',
+          value: '1'
+        },
+        {
+          text: 'Two',
+          value: '2'
+        },
+        {
+          text: 'Three',
+          value: '3'
+        }
+      ]
+
+      const { result } = renderHook(() => useEnterOrSpaceKeydownHandler(props))
+      const event = new KeyboardEvent('keydown') as any
+
+      result.current(event)
+
+      expect(props.selectState.close).toHaveBeenCalledTimes(1)
+      expect(handleSelect).toHaveBeenCalledWith(event, {
+        text: 'Two',
+        value: '2'
+      })
+    })
+  })
+
+  describe('when used group options', () => {
+    it('closes if open and an option selected', () => {
+      const handleSelect = jest.fn()
+      const props = { ...getUseSelectPropsMock(), handleSelect }
+
+      props.selectState.canOpen = false
+      props.selectState.highlightedIndex = 1
+      props.selectState.filteredOptions = {
+        'Group 1': [
+          { value: '1', text: 'Option 1' },
+          { value: '2', text: 'Option 2' }
+        ],
+        'Group 2': [
+          { value: '3', text: 'Option 3' },
+          { value: '4', text: 'Option 4' },
+          { value: '5', text: 'Option 5' }
+        ]
+      }
+
+      const { result } = renderHook(() => useEnterOrSpaceKeydownHandler(props))
+      const event = new KeyboardEvent('keydown') as any
+
+      result.current(event)
+
+      expect(props.selectState.close).toHaveBeenCalledTimes(1)
+      expect(handleSelect).toHaveBeenCalledWith(event, {
+        text: 'Option 1',
+        value: '1'
+      })
     })
   })
 })

--- a/packages/picasso/src/Select/hooks/use-select-props/use-enter-or-space-keydown-handler/use-enter-or-space-keydown-handler.ts
+++ b/packages/picasso/src/Select/hooks/use-select-props/use-enter-or-space-keydown-handler/use-enter-or-space-keydown-handler.ts
@@ -30,6 +30,10 @@ const useEnterOrSpaceKeyDownHandler = <
         return
       }
 
+      if (highlightedIndex === null) {
+        return
+      }
+
       const item = flattenOptions(filteredOptions)[highlightedIndex]
 
       if (!item) {

--- a/packages/picasso/src/Select/hooks/use-select-state/test.ts
+++ b/packages/picasso/src/Select/hooks/use-select-state/test.ts
@@ -161,4 +161,89 @@ describe('useSelectState', () => {
       expect(result.current.isOpen).toBe(false)
     })
   })
+
+  describe('when all the options are disabled', () => {
+    it('should not highlight options when options are selected', () => {
+      const OPTIONS = DEFAULT_OPTIONS.map(option => ({
+        ...option,
+        disabled: true
+      }))
+      const { result } = renderUseSelectState({
+        options: OPTIONS,
+        value: OPTIONS.map(({ value }) => value)
+      })
+
+      expect(result.current.selectedOptions).toEqual(OPTIONS)
+      expect(result.current.highlightedIndex).toBeNull()
+      expect(result.current.selectedIndexes).toEqual(OPTIONS.map((_, index) => index))
+      expect(result.current.displayValue).toEqual(OPTIONS.map(({ text }) => text).join(', '))
+    })
+  })
+
+  describe('when part of the options are disabled', () => {
+    describe('when first option is disabled', () => {
+      it('should highlight the first enabled option', () => {
+        const OPTIONS = [
+          { text: 'One', value: '1', disabled: true },
+          { text: 'Two', value: '2', disabled: true },
+          { text: 'Three', value: '3' }
+        ]
+        const DISABLED_OPTIONS = OPTIONS.slice(0, -1)
+        const { result } = renderUseSelectState({
+          options: OPTIONS,
+          value: DISABLED_OPTIONS.map(({ value }) => value)
+        })
+
+        expect(result.current.selectedOptions).toEqual(DISABLED_OPTIONS)
+        expect(result.current.highlightedIndex).toEqual(2)
+        expect(result.current.selectedIndexes).toEqual(DISABLED_OPTIONS.map((_, index) => index))
+        expect(result.current.displayValue).toEqual(DISABLED_OPTIONS.map(({ text }) => text).join(', '))
+      })
+    })
+  })
+
+  describe('when all the group options are disabled', () => {
+    it('should not highlight options when options are selected', () => {
+      const OPTIONS = {
+        'Group 1': [
+          { value: '1', text: 'Option 1', disabled: true },
+          { value: '2', text: 'Option 2', disabled: true }
+        ],
+        'Group 2': [
+          { value: '3', text: 'Option 3', disabled: true },
+          { value: '4', text: 'Option 4', disabled: true }
+        ]
+      }
+      const { result } = renderUseSelectState({
+        options: OPTIONS,
+        value: ['1', '2', '3', '4']
+      })
+
+      expect(result.current.selectedOptions).toEqual([...OPTIONS['Group 1'], ...OPTIONS['Group 2']])
+      expect(result.current.highlightedIndex).toBeNull()
+      expect(result.current.selectedIndexes).toEqual([1, 2, 4, 5])
+    })
+  })
+
+  describe('when part of the group options are disabled', () => {
+    it('should not highlight options when options are selected', () => {
+      const OPTIONS = {
+        'Group 1': [
+          { value: '1', text: 'Option 1', disabled: true },
+          { value: '2', text: 'Option 2', disabled: true }
+        ],
+        'Group 2': [
+          { value: '3', text: 'Option 3', disabled: true },
+          { value: '4', text: 'Option 4' }
+        ]
+      }
+      const { result } = renderUseSelectState({
+        options: OPTIONS,
+        value: ['1', '2', '3']
+      })
+
+      expect(result.current.selectedOptions).toEqual([...OPTIONS['Group 1'], OPTIONS['Group 2'][0]])
+      expect(result.current.highlightedIndex).toEqual(3)
+    })
+  })
 })

--- a/packages/picasso/src/Select/hooks/use-select-state/use-select-state.ts
+++ b/packages/picasso/src/Select/hooks/use-select-state/use-select-state.ts
@@ -40,9 +40,7 @@ const useSelectState = (props: Props): UseSelectStateOutput => {
     limit = DEFAULT_LIMIT
   } = props
 
-  const flatOptions: Option[] = useMemo(() => flattenOptions(options), [
-    options
-  ])
+  const flatOptions = useMemo(() => flattenOptions(options), [options])
 
   const [selectedOptions, setSelectedOptions] = useState(
     getSelectedOptions(options, value)
@@ -74,6 +72,15 @@ const useSelectState = (props: Props): UseSelectStateOutput => {
       ),
     [flatOptions, selection]
   )
+  const enabledIndexes = useMemo(
+    () =>
+      flatOptions.reduce(
+        (enabled: number[], option: Option, index: number) =>
+          !option.disabled ? [...enabled, index] : enabled,
+        []
+      ),
+    [flatOptions]
+  )
   const emptySelectValue: string | string[] = useMemo(
     () => (multiple ? [] : ''),
     [multiple]
@@ -84,7 +91,10 @@ const useSelectState = (props: Props): UseSelectStateOutput => {
   const [isOpen, setOpen] = useState<boolean>(false)
   const canOpen = !isOpen && !disabled
   const [highlightedIndex, setHighlightedIndex] = useHighlightedIndex({
-    selectedIndexes,
+    selectedIndexes: selectedIndexes.filter(index =>
+      enabledIndexes.includes(index)
+    ),
+    indexes: enabledIndexes,
     isOpen
   })
 

--- a/packages/picasso/src/Select/story/DisabledOption.example.tsx
+++ b/packages/picasso/src/Select/story/DisabledOption.example.tsx
@@ -1,0 +1,49 @@
+import React, { useState } from 'react'
+import { Container, Select, Typography } from '@toptal/picasso'
+
+const Example = () => {
+  const [value, setValue] = useState<string>(OPTIONS[0].value)
+
+  const handleChange = (event: React.ChangeEvent<{ value: string }>) => {
+    setValue(event.target.value)
+  }
+
+  return (
+    <Container flex inline>
+      <Container right='small'>
+        <Typography variant='heading' size='small'>
+          Native
+        </Typography>
+        <Select
+          onChange={handleChange}
+          options={OPTIONS}
+          value={value}
+          placeholder='Choose an option...'
+          width='auto'
+          native
+        />
+      </Container>
+      <Container right='small'>
+        <Typography variant='heading' size='small'>
+          Non native
+        </Typography>
+        <Select
+          onChange={handleChange}
+          options={OPTIONS}
+          value={value}
+          placeholder='Choose an option...'
+          width='auto'
+        />
+      </Container>
+    </Container>
+  )
+}
+
+const OPTIONS = [
+  { value: '1', text: 'Option 1', disabled: true },
+  { value: '2', text: 'Option 2' },
+  { value: '3', text: 'Option 3', disabled: true },
+  { value: '4', text: 'Option 4' }
+]
+
+export default Example

--- a/packages/picasso/src/Select/story/index.jsx
+++ b/packages/picasso/src/Select/story/index.jsx
@@ -17,7 +17,8 @@ page.createTabChapter('Props').addComponentDocs({
         description: `
     [\n
       { text: string, value: string },\n
-      { text: string, value: string }\n
+      { text: string, value: string,
+         disabled: true }\n
     }\n
 or\n
     {\n
@@ -26,7 +27,8 @@ or\n
         { text: string, value: string }\n
       ],\n
       string: [\n
-        { text: string, value: string },\n
+        { text: string, value: string,
+           disabled: true },\n
         { text: string, value: string }\n
       ]\n
     }
@@ -93,3 +95,7 @@ page
   }) // picasso-skip-visuals
   .addExample('Select/story/ResetButton.example.tsx', 'With reset button') // picasso-skip-visuals
   .addExample('Select/story/Autofill.example.tsx', 'Disable autofilling') // picasso-skip-visuals
+  .addExample('Select/story/DisabledOption.example.tsx', {
+    title: 'Disabled options',
+    description: 'Select component allows to define disabled options'
+  }) // picasso-skip-visuals

--- a/packages/picasso/src/Select/types.ts
+++ b/packages/picasso/src/Select/types.ts
@@ -21,8 +21,7 @@ export interface SelectProps<
   T extends ValueType = ValueType,
   M extends boolean = boolean,
   V = M extends true ? T[] : T
->
-  extends BaseProps,
+> extends BaseProps,
     Omit<
       InputHTMLAttributes<HTMLInputElement>,
       'onChange' | 'size' | 'color' | 'value'
@@ -97,8 +96,9 @@ export type Option<T extends string | number = string | number> = {
   key?: number
   text: string
   description?: string
+  disabled?: boolean
   value: T
-  [prop: string]: string | number | undefined
+  [prop: string]: string | number | boolean | undefined
 }
 
 export type OptionGroups<T extends string | number = string | number> = {
@@ -137,7 +137,7 @@ export type UseSelectStateOutput = {
   canOpen: boolean
   open: () => void
   close: () => void
-  highlightedIndex: number
+  highlightedIndex: number | null
   closeOnEnter: boolean
   setHighlightedIndex: (index: number) => void
   setFilterOptionsValue: (value: string) => void

--- a/packages/picasso/src/Select/utils/flatten-options/flatten-options.ts
+++ b/packages/picasso/src/Select/utils/flatten-options/flatten-options.ts
@@ -1,3 +1,4 @@
+import { generateRandomString } from '../../../utils'
 import { Option, OptionGroups } from '../../types'
 import { isOptionsType } from '../../utils'
 
@@ -6,8 +7,18 @@ const flattenOptions = (options: Option[] | OptionGroups): Option[] => {
     return options
   }
 
-  return Object.values(options)
-    .reduce((result: Option[], optionList) => result.concat(optionList), [])
+  return Object.entries(options).reduce(
+    (result: Option[], [title, optionList]) =>
+      result.concat([
+        {
+          disabled: true,
+          text: title,
+          value: generateRandomString()
+        },
+        ...optionList
+      ]),
+    []
+  )
 }
 
 export default flattenOptions

--- a/packages/picasso/src/Select/utils/get-next-wrapping-index/get-next-wrapping-index.ts
+++ b/packages/picasso/src/Select/utils/get-next-wrapping-index/get-next-wrapping-index.ts
@@ -11,29 +11,34 @@
 const getNextWrappingIndex = (
   moveAmount: number,
   initialIndex: number | null,
-  itemCount: number
+  itemIndexes: number[]
 ) => {
-  const itemsLastIndex = itemCount - 1
-
-  if (
-    typeof initialIndex !== 'number' ||
-    initialIndex < 0 ||
-    initialIndex >= itemCount
-  ) {
-    initialIndex = moveAmount > 0 ? -1 : itemsLastIndex + 1
+  if (initialIndex === null) {
+    return itemIndexes[0]
   }
 
-  const newIndex = initialIndex + moveAmount
+  const itemsLastIndex = itemIndexes.length - 1
+  let itemIndex = itemIndexes.indexOf(initialIndex)
+
+  if (
+    typeof itemIndex !== 'number' ||
+    itemIndex < 0 ||
+    itemIndex >= itemIndexes.length
+  ) {
+    itemIndex = moveAmount > 0 ? -1 : 1
+  }
+
+  const newIndex = itemIndex + moveAmount
 
   if (newIndex < 0) {
-    return itemsLastIndex
+    return itemIndexes[itemsLastIndex]
   }
 
   if (newIndex > itemsLastIndex) {
-    return 0
+    return itemIndexes[0]
   }
 
-  return newIndex
+  return itemIndexes[newIndex]
 }
 
 export default getNextWrappingIndex

--- a/packages/picasso/src/Select/utils/get-next-wrapping-index/test.ts
+++ b/packages/picasso/src/Select/utils/get-next-wrapping-index/test.ts
@@ -2,9 +2,9 @@ import getNextWrappingIndex from './get-next-wrapping-index'
 
 describe('getNextWrappingIndex', () => {
   it('gets correctly', () => {
-    expect(getNextWrappingIndex(2, 0, 3)).toEqual(2)
-    expect(getNextWrappingIndex(2, null, 3)).toEqual(1)
-    expect(getNextWrappingIndex(3, 1, 2)).toEqual(0)
-    expect(getNextWrappingIndex(1, 1, 5)).toEqual(2)
+    expect(getNextWrappingIndex(2, 0, [])).toEqual(2)
+    expect(getNextWrappingIndex(2, null, [])).toEqual(1)
+    expect(getNextWrappingIndex(3, 1, [])).toEqual(0)
+    expect(getNextWrappingIndex(1, 1, [])).toEqual(2)
   })
 })


### PR DESCRIPTION
[FX-2160](https://toptal-core.atlassian.net/browse/FX-2160)

### Description

Add disabled option.

[Design](https://app.abstract.com/projects/b1f3de70-6dad-11e9-9dee-bf2e00ce2146/branches/6338a154-1370-45df-9b19-90df05407aa6/commits/7ec975563ce0120b136c8ed95acae44a8f8d1364/files/53C67ECB-816C-4C53-9200-4B7F5C9F8C9E/layers/C6F0D716-DC2D-45E1-B4B2-FCC3EEE9B72B?mode=design&present=true&sha=7ec975563ce0120b136c8ed95acae44a8f8d1364) of the disabled option in the Select

### Screenshots

![image](https://user-images.githubusercontent.com/55978500/136810750-e303d305-b68f-4e96-8c62-749ba19c1e49.png)
![image](https://user-images.githubusercontent.com/55978500/136810795-b4553d61-a066-423b-aab1-a10e5849d137.png)


### Review

- [X] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/api-principles.md)
- [ ] Annotate all `props` in component with documentation
- [X] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that tests pass by running `yarn test`
- [ ] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
- [ ] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>
