### PR TITLE
feat: [FX-2167] Add large form label variant

### DIFF
--- a/packages/picasso-forms/src/Checkbox/__snapshots__/test.tsx.snap
+++ b/packages/picasso-forms/src/Checkbox/__snapshots__/test.tsx.snap
@@ -14,7 +14,7 @@ exports[`Form.Checkbox default render for checkboxes in a group 1`] = `
           data-field-has-error="false"
         >
           <label
-            class="PicassoFormLabel-root"
+            class="PicassoFormLabel-root PicassoFormLabel-textMedium"
             for="checkbox-group"
           >
             <span
@@ -62,7 +62,7 @@ exports[`Form.Checkbox default render for checkboxes in a group 1`] = `
                     </span>
                   </span>
                   <span
-                    class="PicassoFormLabel-root PicassoFormLabel-inline PicassoFormControlLabel-label PicassoCheckbox-label"
+                    class="PicassoFormLabel-root PicassoFormLabel-inline PicassoFormControlLabel-label PicassoCheckbox-label PicassoFormLabel-textMedium"
                   >
                     <span
                       class="PicassoFormLabel-text"
@@ -102,7 +102,7 @@ exports[`Form.Checkbox default render for checkboxes in a group 1`] = `
                     </span>
                   </span>
                   <span
-                    class="PicassoFormLabel-root PicassoFormLabel-inline PicassoFormControlLabel-label PicassoCheckbox-label"
+                    class="PicassoFormLabel-root PicassoFormLabel-inline PicassoFormControlLabel-label PicassoCheckbox-label PicassoFormLabel-textMedium"
                   >
                     <span
                       class="PicassoFormLabel-text"
@@ -163,7 +163,7 @@ exports[`Form.Checkbox default render for single checkbox 1`] = `
               </span>
             </span>
             <span
-              class="PicassoFormLabel-root PicassoFormLabel-inline PicassoFormControlLabel-label PicassoCheckbox-label"
+              class="PicassoFormLabel-root PicassoFormLabel-inline PicassoFormControlLabel-label PicassoCheckbox-label PicassoFormLabel-textMedium"
             >
               <span
                 class="PicassoFormLabel-text"
@@ -221,7 +221,7 @@ exports[`Form.Checkbox required with asterisk single checkbox 1`] = `
               </span>
             </span>
             <span
-              class="PicassoFormLabel-root PicassoFormLabel-inline PicassoFormControlLabel-label PicassoCheckbox-label"
+              class="PicassoFormLabel-root PicassoFormLabel-inline PicassoFormControlLabel-label PicassoCheckbox-label PicassoFormLabel-textMedium"
             >
               <span
                 class="PicassoFormLabel-asterisk"

--- a/packages/picasso-forms/src/Radio/__snapshots__/test.tsx.snap
+++ b/packages/picasso-forms/src/Radio/__snapshots__/test.tsx.snap
@@ -14,7 +14,7 @@ exports[`FormRadio renders 1`] = `
           data-field-has-error="false"
         >
           <label
-            class="PicassoFormLabel-root"
+            class="PicassoFormLabel-root PicassoFormLabel-textMedium"
             for="color"
           >
             <span
@@ -58,7 +58,7 @@ exports[`FormRadio renders 1`] = `
                     </span>
                   </span>
                   <span
-                    class="PicassoFormLabel-root PicassoFormLabel-inline PicassoFormControlLabel-label Radio-label"
+                    class="PicassoFormLabel-root PicassoFormLabel-inline PicassoFormControlLabel-label Radio-label PicassoFormLabel-textMedium"
                   >
                     <span
                       class="PicassoFormLabel-text"
@@ -94,7 +94,7 @@ exports[`FormRadio renders 1`] = `
                     </span>
                   </span>
                   <span
-                    class="PicassoFormLabel-root PicassoFormLabel-inline PicassoFormControlLabel-label Radio-label"
+                    class="PicassoFormLabel-root PicassoFormLabel-inline PicassoFormControlLabel-label Radio-label PicassoFormLabel-textMedium"
                   >
                     <span
                       class="PicassoFormLabel-text"
@@ -127,7 +127,7 @@ exports[`FormRadio required with asterisk 1`] = `
           data-field-has-error="false"
         >
           <label
-            class="PicassoFormLabel-root"
+            class="PicassoFormLabel-root PicassoFormLabel-textMedium"
             for="color"
           >
             <span
@@ -175,7 +175,7 @@ exports[`FormRadio required with asterisk 1`] = `
                     </span>
                   </span>
                   <span
-                    class="PicassoFormLabel-root PicassoFormLabel-inline PicassoFormControlLabel-label Radio-label"
+                    class="PicassoFormLabel-root PicassoFormLabel-inline PicassoFormControlLabel-label Radio-label PicassoFormLabel-textMedium"
                   >
                     <span
                       class="PicassoFormLabel-text"
@@ -211,7 +211,7 @@ exports[`FormRadio required with asterisk 1`] = `
                     </span>
                   </span>
                   <span
-                    class="PicassoFormLabel-root PicassoFormLabel-inline PicassoFormControlLabel-label Radio-label"
+                    class="PicassoFormLabel-root PicassoFormLabel-inline PicassoFormControlLabel-label Radio-label PicassoFormLabel-textMedium"
                   >
                     <span
                       class="PicassoFormLabel-text"

--- a/packages/picasso/src/Checkbox/__snapshots__/test.tsx.snap
+++ b/packages/picasso/src/Checkbox/__snapshots__/test.tsx.snap
@@ -40,7 +40,7 @@ exports[`Checkbox Checkbox.Group renders checkbox in a grid group 1`] = `
               </span>
             </span>
             <span
-              class="PicassoFormLabel-root PicassoFormLabel-inline PicassoFormControlLabel-label PicassoCheckbox-label"
+              class="PicassoFormLabel-root PicassoFormLabel-inline PicassoFormControlLabel-label PicassoCheckbox-label PicassoFormLabel-textMedium"
             >
               <span
                 class="PicassoFormLabel-text"
@@ -79,7 +79,7 @@ exports[`Checkbox Checkbox.Group renders checkbox in a grid group 1`] = `
               </span>
             </span>
             <span
-              class="PicassoFormLabel-root PicassoFormLabel-inline PicassoFormControlLabel-label PicassoCheckbox-label"
+              class="PicassoFormLabel-root PicassoFormLabel-inline PicassoFormControlLabel-label PicassoCheckbox-label PicassoFormLabel-textMedium"
             >
               <span
                 class="PicassoFormLabel-text"
@@ -118,7 +118,7 @@ exports[`Checkbox Checkbox.Group renders checkbox in a grid group 1`] = `
               </span>
             </span>
             <span
-              class="PicassoFormLabel-root PicassoFormLabel-inline PicassoFormControlLabel-label PicassoCheckbox-label"
+              class="PicassoFormLabel-root PicassoFormLabel-inline PicassoFormControlLabel-label PicassoCheckbox-label PicassoFormLabel-textMedium"
             >
               <span
                 class="PicassoFormLabel-text"
@@ -157,7 +157,7 @@ exports[`Checkbox Checkbox.Group renders checkbox in a grid group 1`] = `
               </span>
             </span>
             <span
-              class="PicassoFormLabel-root PicassoFormLabel-inline PicassoFormControlLabel-label PicassoCheckbox-label"
+              class="PicassoFormLabel-root PicassoFormLabel-inline PicassoFormControlLabel-label PicassoCheckbox-label PicassoFormLabel-textMedium"
             >
               <span
                 class="PicassoFormLabel-text"
@@ -196,7 +196,7 @@ exports[`Checkbox Checkbox.Group renders checkbox in a grid group 1`] = `
               </span>
             </span>
             <span
-              class="PicassoFormLabel-root PicassoFormLabel-inline PicassoFormControlLabel-label PicassoCheckbox-label"
+              class="PicassoFormLabel-root PicassoFormLabel-inline PicassoFormControlLabel-label PicassoCheckbox-label PicassoFormLabel-textMedium"
             >
               <span
                 class="PicassoFormLabel-text"
@@ -235,7 +235,7 @@ exports[`Checkbox Checkbox.Group renders checkbox in a grid group 1`] = `
               </span>
             </span>
             <span
-              class="PicassoFormLabel-root PicassoFormLabel-inline PicassoFormControlLabel-label PicassoCheckbox-label"
+              class="PicassoFormLabel-root PicassoFormLabel-inline PicassoFormControlLabel-label PicassoCheckbox-label PicassoFormLabel-textMedium"
             >
               <span
                 class="PicassoFormLabel-text"
@@ -282,7 +282,7 @@ exports[`Checkbox checkbox interaction should render checked checkbox 1`] = `
         </span>
       </span>
       <span
-        class="PicassoFormLabel-root PicassoFormLabel-inline PicassoFormControlLabel-label PicassoCheckbox-label"
+        class="PicassoFormLabel-root PicassoFormLabel-inline PicassoFormControlLabel-label PicassoCheckbox-label PicassoFormLabel-textMedium"
       >
         <span
           class="PicassoFormLabel-text"
@@ -483,7 +483,7 @@ exports[`Checkbox should render default checkbox with label 1`] = `
         </span>
       </span>
       <span
-        class="PicassoFormLabel-root PicassoFormLabel-inline PicassoFormControlLabel-label PicassoCheckbox-label"
+        class="PicassoFormLabel-root PicassoFormLabel-inline PicassoFormControlLabel-label PicassoCheckbox-label PicassoFormLabel-textMedium"
       >
         <span
           class="PicassoFormLabel-text"

--- a/packages/picasso/src/Checkbox/styles.ts
+++ b/packages/picasso/src/Checkbox/styles.ts
@@ -131,7 +131,7 @@ export default ({ palette, sizes, transitions }: Theme) =>
     },
     labelWithRightSpacing: {},
     checkboxWrapper: {
-      alignSelf: 'flex-start',
+      alignSelf: 'flex-center',
       verticalAlign: 'middle'
     }
   })

--- a/packages/picasso/src/FormError/__snapshots__/test.tsx.snap
+++ b/packages/picasso/src/FormError/__snapshots__/test.tsx.snap
@@ -11,7 +11,7 @@ exports[`FormError renders 1`] = `
         data-field-has-error="false"
       >
         <label
-          class="PicassoFormLabel-root"
+          class="PicassoFormLabel-root PicassoFormLabel-textMedium"
         >
           <span
             class="PicassoFormLabel-text"

--- a/packages/picasso/src/FormField/story/Sizes.example.tsx
+++ b/packages/picasso/src/FormField/story/Sizes.example.tsx
@@ -1,0 +1,24 @@
+import React from 'react'
+import { Form, Input, Grid } from '@toptal/picasso'
+
+const Example = () => (
+  <Grid>
+    <Grid.Item small={5}>
+      <Form>
+        <Form.Field>
+          <Form.Label htmlFor='medium'>Medium (default)</Form.Label>
+          <Input id='medium' width='full' placeholder='Medium' />
+        </Form.Field>
+
+        <Form.Field>
+          <Form.Label htmlFor='large' size='large'>
+            Large
+          </Form.Label>
+          <Input id='large' width='full' placeholder='Large' size='large' />
+        </Form.Field>
+      </Form>
+    </Grid.Item>
+  </Grid>
+)
+
+export default Example

--- a/packages/picasso/src/FormField/story/index.jsx
+++ b/packages/picasso/src/FormField/story/index.jsx
@@ -10,6 +10,7 @@ const chapter = PicassoBook.connectToPage(page =>
     the form structure`
     )
     .addExample('FormField/story/Default.example.tsx', 'Default')
+    .addExample('FormField/story/Sizes.example.tsx', 'Sizes')
     .addExample('FormField/story/Required.example.tsx', 'Required')
     .addExample('FormField/story/Error.example.tsx', 'Error')
     .addExample('FormField/story/Hint.example.tsx', 'Hint')

--- a/packages/picasso/src/FormLabel/FormLabel.tsx
+++ b/packages/picasso/src/FormLabel/FormLabel.tsx
@@ -1,7 +1,13 @@
 import React, { forwardRef, HTMLAttributes, ReactNode } from 'react'
 import { makeStyles, Theme } from '@material-ui/core/styles'
 import cx from 'classnames'
-import { useTitleCase, BaseProps, TextLabelProps } from '@toptal/picasso-shared'
+import {
+  useTitleCase,
+  BaseProps,
+  TextLabelProps,
+  SizeType
+} from '@toptal/picasso-shared'
+import capitalize from '@material-ui/core/utils/capitalize'
 
 import styles from './styles'
 import toTitleCase from '../utils/to-title-case'
@@ -25,6 +31,11 @@ export interface Props
   inline?: boolean
   /** Component used for the root node */
   as?: ComponentType
+  /**
+   * Size of component
+   * @default medium
+   */
+  size?: SizeType<'medium' | 'large'>
 }
 
 const useStyles = makeStyles<Theme>(styles, { name: 'PicassoFormLabel' })
@@ -43,6 +54,7 @@ export const FormLabel = forwardRef<HTMLLabelElement, Props>(function FormLabel(
     as: Component = 'label',
     titleCase: propsTitleCase,
     requiredDecoration,
+    size = 'medium',
     ...rest
   } = props
 
@@ -69,7 +81,7 @@ export const FormLabel = forwardRef<HTMLLabelElement, Props>(function FormLabel(
       {requiredDecoration === 'asterisk' && (
         <span className={classes.asterisk}>*</span>
       )}
-      <span className={classes.text}>
+      <span className={classes[`text${capitalize(size)}`]}>
         {titleCase ? toTitleCase(children) : children}
         {requiredDecoration === 'optional' && ' (optional)'}
       </span>

--- a/packages/picasso/src/FormLabel/__snapshots__/test.tsx.snap
+++ b/packages/picasso/src/FormLabel/__snapshots__/test.tsx.snap
@@ -11,7 +11,7 @@ exports[`FormLabel disabled 1`] = `
         data-field-has-error="false"
       >
         <label
-          class="PicassoFormLabel-root PicassoFormLabel-disabled"
+          class="PicassoFormLabel-root PicassoFormLabel-disabled PicassoFormLabel-textMedium"
         >
           <span
             class="PicassoFormLabel-text"
@@ -36,7 +36,7 @@ exports[`FormLabel renders 1`] = `
         data-field-has-error="false"
       >
         <label
-          class="PicassoFormLabel-root"
+          class="PicassoFormLabel-root PicassoFormLabel-textMedium"
         >
           <span
             class="PicassoFormLabel-text"
@@ -61,7 +61,7 @@ exports[`FormLabel required with (optional) 1`] = `
         data-field-has-error="false"
       >
         <label
-          class="PicassoFormLabel-root"
+          class="PicassoFormLabel-root PicassoFormLabel-textMedium"
         >
           <span
             class="PicassoFormLabel-text"
@@ -87,7 +87,7 @@ exports[`FormLabel required with asterisk 1`] = `
         data-field-has-error="false"
       >
         <label
-          class="PicassoFormLabel-root"
+          class="PicassoFormLabel-root PicassoFormLabel-textMedium"
         >
           <span
             class="PicassoFormLabel-asterisk"
@@ -98,6 +98,31 @@ exports[`FormLabel required with asterisk 1`] = `
             class="PicassoFormLabel-text"
           >
             Label
+          </span>
+        </label>
+      </div>
+    </form>
+  </div>
+</div>
+`;
+
+exports[`FormLabel should render large label 1`] = `
+<div>
+  <div
+    class="Picasso-root"
+  >
+    <form>
+      <div
+        class="PicassoFormField-root"
+        data-field-has-error="false"
+      >
+        <label
+          class="PicassoFormLabel-root PicassoFormLabel-textLarge"
+        >
+          <span
+            class="PicassoFormLabel-text"
+          >
+            I am a large label
           </span>
         </label>
       </div>

--- a/packages/picasso/src/FormLabel/styles.ts
+++ b/packages/picasso/src/FormLabel/styles.ts
@@ -14,8 +14,12 @@ export default ({ palette }: Theme) =>
       color: alpha(palette.grey[400], 0.48)
     },
 
-    text: {
-      fontSize: '0.875em'
+    textMedium: {
+      fontSize: '0.875rem'
+    },
+
+    textLarge: {
+      fontSize: '1rem'
     },
 
     asterisk: {
@@ -29,7 +33,6 @@ export default ({ palette }: Theme) =>
       marginBottom: 0,
 
       '& $text': {
-        fontSize: '0.8125rem',
         verticalAlign: 'top'
       },
 

--- a/packages/picasso/src/FormLabel/test.tsx
+++ b/packages/picasso/src/FormLabel/test.tsx
@@ -14,7 +14,8 @@ const TestFormLabel: FunctionComponent<OmitInternalProps<Props>> = ({
   disabled,
   titleCase,
   htmlFor,
-  inline
+  inline,
+  size
 }) => (
   <Form>
     <Form.Field>
@@ -24,6 +25,7 @@ const TestFormLabel: FunctionComponent<OmitInternalProps<Props>> = ({
         titleCase={titleCase}
         htmlFor={htmlFor}
         inline={inline}
+        size={size}
       >
         {children}
       </FormLabel>
@@ -89,5 +91,13 @@ describe('FormLabel', () => {
     )
 
     expect(spiedOnTitleCase).toHaveBeenCalledTimes(0)
+  })
+
+  it('should render large label', () => {
+    const { container } = render(
+      <TestFormLabel size='large'>I am a large label</TestFormLabel>
+    )
+
+    expect(container).toMatchSnapshot()
   })
 })

--- a/packages/picasso/src/Input/__snapshots__/test.tsx.snap
+++ b/packages/picasso/src/Input/__snapshots__/test.tsx.snap
@@ -102,7 +102,15 @@ exports[`Input renders large input 1`] = `
     >
       <input
         autocomplete="none"
+<<<<<<< HEAD
+<<<<<<< HEAD
         class="MuiInputBase-input MuiOutlinedInput-input PicassoOutlinedInput-input PicassoOutlinedInput-inputLarge MuiInputBase-inputAdornedStart MuiOutlinedInput-inputAdornedStart MuiInputBase-inputAdornedEnd MuiOutlinedInput-inputAdornedEnd"
+=======
+        class="MuiInputBase-input MuiOutlinedInput-input PicassoOutlinedInput-input MuiInputBase-inputAdornedStart MuiOutlinedInput-inputAdornedStart MuiInputBase-inputAdornedEnd MuiOutlinedInput-inputAdornedEnd"
+>>>>>>> eabc28e3 (test(Input): add test and snapshot of large variant)
+=======
+        class="MuiInputBase-input MuiOutlinedInput-input PicassoOutlinedInput-input PicassoOutlinedInput-inputLarge MuiInputBase-inputAdornedStart MuiOutlinedInput-inputAdornedStart MuiInputBase-inputAdornedEnd MuiOutlinedInput-inputAdornedEnd"
+>>>>>>> a42145eb (test: update unit test for Input variant)
         type="text"
         value=""
       />

--- a/packages/picasso/src/Radio/__snapshots__/test.tsx.snap
+++ b/packages/picasso/src/Radio/__snapshots__/test.tsx.snap
@@ -37,7 +37,7 @@ exports[`Radio Radio.Group renders radio in a grid group 1`] = `
               </span>
             </span>
             <span
-              class="PicassoFormLabel-root PicassoFormLabel-inline PicassoFormControlLabel-label Radio-label"
+              class="PicassoFormLabel-root PicassoFormLabel-inline PicassoFormControlLabel-label Radio-label PicassoFormLabel-textMedium"
             >
               <span
                 class="PicassoFormLabel-text"
@@ -72,7 +72,7 @@ exports[`Radio Radio.Group renders radio in a grid group 1`] = `
               </span>
             </span>
             <span
-              class="PicassoFormLabel-root PicassoFormLabel-inline PicassoFormControlLabel-label Radio-label"
+              class="PicassoFormLabel-root PicassoFormLabel-inline PicassoFormControlLabel-label Radio-label PicassoFormLabel-textMedium"
             >
               <span
                 class="PicassoFormLabel-text"
@@ -107,7 +107,7 @@ exports[`Radio Radio.Group renders radio in a grid group 1`] = `
               </span>
             </span>
             <span
-              class="PicassoFormLabel-root PicassoFormLabel-inline PicassoFormControlLabel-label Radio-label"
+              class="PicassoFormLabel-root PicassoFormLabel-inline PicassoFormControlLabel-label Radio-label PicassoFormLabel-textMedium"
             >
               <span
                 class="PicassoFormLabel-text"
@@ -142,7 +142,7 @@ exports[`Radio Radio.Group renders radio in a grid group 1`] = `
               </span>
             </span>
             <span
-              class="PicassoFormLabel-root PicassoFormLabel-inline PicassoFormControlLabel-label Radio-label"
+              class="PicassoFormLabel-root PicassoFormLabel-inline PicassoFormControlLabel-label Radio-label PicassoFormLabel-textMedium"
             >
               <span
                 class="PicassoFormLabel-text"
@@ -177,7 +177,7 @@ exports[`Radio Radio.Group renders radio in a grid group 1`] = `
               </span>
             </span>
             <span
-              class="PicassoFormLabel-root PicassoFormLabel-inline PicassoFormControlLabel-label Radio-label"
+              class="PicassoFormLabel-root PicassoFormLabel-inline PicassoFormControlLabel-label Radio-label PicassoFormLabel-textMedium"
             >
               <span
                 class="PicassoFormLabel-text"
@@ -212,7 +212,7 @@ exports[`Radio Radio.Group renders radio in a grid group 1`] = `
               </span>
             </span>
             <span
-              class="PicassoFormLabel-root PicassoFormLabel-inline PicassoFormControlLabel-label Radio-label"
+              class="PicassoFormLabel-root PicassoFormLabel-inline PicassoFormControlLabel-label Radio-label PicassoFormLabel-textMedium"
             >
               <span
                 class="PicassoFormLabel-text"
@@ -265,7 +265,7 @@ exports[`Radio Radio.Group renders radio in group 1`] = `
               </span>
             </span>
             <span
-              class="PicassoFormLabel-root PicassoFormLabel-inline PicassoFormControlLabel-label Radio-label"
+              class="PicassoFormLabel-root PicassoFormLabel-inline PicassoFormControlLabel-label Radio-label PicassoFormLabel-textMedium"
             >
               <span
                 class="PicassoFormLabel-text"
@@ -300,7 +300,7 @@ exports[`Radio Radio.Group renders radio in group 1`] = `
               </span>
             </span>
             <span
-              class="PicassoFormLabel-root PicassoFormLabel-inline PicassoFormControlLabel-label Radio-label"
+              class="PicassoFormLabel-root PicassoFormLabel-inline PicassoFormControlLabel-label Radio-label PicassoFormLabel-textMedium"
             >
               <span
                 class="PicassoFormLabel-text"

--- a/packages/picasso/src/Radio/styles.ts
+++ b/packages/picasso/src/Radio/styles.ts
@@ -95,7 +95,7 @@ export default ({ palette, sizes, transitions }: Theme) =>
   createStyles({
     root: {
       fontSize: '1rem',
-      alignItems: 'flex-start',
+      alignItems: 'center',
 
       '&:hover $uncheckedIcon:before': iconBeforeStyles({
         borderWidth: sizes.borderWidth,
@@ -143,8 +143,7 @@ export default ({ palette, sizes, transitions }: Theme) =>
     }),
     label: {
       // 1px is needed for safari
-      maxWidth: `calc(100% - ${CONTROL_WIDTH} - ${CONTROL_MARGIN_RIGHT} + 1px)`,
-      marginTop: RADIO_VERTICAL_MARGIN
+      maxWidth: `calc(100% - ${CONTROL_WIDTH} - ${CONTROL_MARGIN_RIGHT} + 1px)`
     },
     labelWithRightSpacing: {}
   })

--- a/packages/picasso/src/Switch/__snapshots__/test.tsx.snap
+++ b/packages/picasso/src/Switch/__snapshots__/test.tsx.snap
@@ -30,7 +30,7 @@ exports[`Switch behaves correctly when interacting 1`] = `
     />
   </span>
   <span
-    class="PicassoFormLabel-root PicassoFormLabel-inline PicassoFormControlLabel-label PicassoSwitch-label"
+    class="PicassoFormLabel-root PicassoFormLabel-inline PicassoFormControlLabel-label PicassoSwitch-label PicassoFormLabel-textMedium"
   >
     <span
       class="PicassoFormLabel-text"
@@ -107,7 +107,7 @@ exports[`Switch renders disabled state 1`] = `
     />
   </span>
   <span
-    class="PicassoFormLabel-root PicassoFormLabel-disabled PicassoFormLabel-inline PicassoFormControlLabel-label PicassoSwitch-label"
+    class="PicassoFormLabel-root PicassoFormLabel-disabled PicassoFormLabel-inline PicassoFormControlLabel-label PicassoSwitch-label PicassoFormLabel-textMedium"
   >
     <span
       class="PicassoFormLabel-text"

--- a/packages/picasso/src/Switch/styles.ts
+++ b/packages/picasso/src/Switch/styles.ts
@@ -4,7 +4,6 @@ import { PicassoProvider } from '@toptal/picasso-provider'
 
 const CONTROL_WIDTH = '1em'
 const LABEL_LEFT_MARGIN = '0.5em'
-const LABEL_TOP_MARGIN = '0.25em'
 
 const THUMB_SIZE = 22
 const TRACK_HEIGHT = THUMB_SIZE + 2
@@ -75,10 +74,9 @@ PicassoProvider.override(({ palette, transitions }) => ({
 
 export default () =>
   createStyles({
-    root: { alignItems: 'flex-start', fontSize: '1rem' },
+    root: { alignItems: 'center', fontSize: '1rem' },
     label: {
       marginLeft: LABEL_LEFT_MARGIN,
-      marginTop: LABEL_TOP_MARGIN,
       // 1px is needed for safari
       maxWidth: `calc(100% - ${CONTROL_WIDTH} - ${LABEL_LEFT_MARGIN} + 1px)`
     }


### PR DESCRIPTION
[FX-2167](https://toptal-core.atlassian.net/browse/FX-2167)

- [Text Field with Label](https://share.goabstract.com/7da352eb-9228-4888-a3ea-c741b256a886?mode=design&sha=d335874ff3dd8487bd8853d6e932ce2dbe23809b)
- [Text Field with Label and Icon](https://share.goabstract.com/03c8ad8c-7c1a-4568-9215-216e05beeb9b?mode=design&sha=d335874ff3dd8487bd8853d6e932ce2dbe23809b)

***This issue is related to [FX-2125](https://toptal-core.atlassian.net/browse/FX-2125)***

### Description

Add large variant for `FormLabel`.

### Screenshots

![form-field-sizes-snap](https://user-images.githubusercontent.com/72510037/136982832-92c24b5e-950f-4189-bdd9-1d0e12524ca8.png)

### Review

- [ ] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/api-principles.md)
- [ ] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that tests pass by running `yarn test`
- [ ] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
- [ ] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>
