### PR TITLE
chore: synchronize picasso-shared library version across packages

### DIFF
--- a/packages/picasso-charts/package.json
+++ b/packages/picasso-charts/package.json
@@ -24,7 +24,7 @@
   "peerDependencies": {
     "@material-ui/core": "4.11.0",
     "@toptal/picasso": "^6",
-    "@toptal/picasso-shared": "6.0.0",
+    "@toptal/picasso-shared": "7.0.0",
     "react": "^16.12.0"
   },
   "devDependencies": {

--- a/packages/picasso-forms/package.json
+++ b/packages/picasso-forms/package.json
@@ -24,7 +24,7 @@
   "peerDependencies": {
     "@toptal/picasso": "^6",
     "@toptal/picasso-lab": "^4",
-    "@toptal/picasso-shared": "6.0.0",
+    "@toptal/picasso-shared": "7.0.0",
     "react": "^16.12.0",
     "react-dom": "^16.12.0"
   },

--- a/packages/picasso-lab/package.json
+++ b/packages/picasso-lab/package.json
@@ -24,7 +24,7 @@
   "peerDependencies": {
     "@material-ui/core": "4.11.0",
     "@toptal/picasso": "^6",
-    "@toptal/picasso-shared": "6.0.0",
+    "@toptal/picasso-shared": "7.0.0",
     "popper.js": "^1.16.1",
     "react": "^16.12.0",
     "react-dom": "^16.12.0"

--- a/packages/picasso/package.json
+++ b/packages/picasso/package.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@toptal/picasso-provider": "^0.3.0",
-    "@toptal/picasso-shared": "^7.0.0",
+    "@toptal/picasso-shared": "7.0.0",
     "ap-style-title-case": "^1.1.2",
     "classnames": "^2.3.1",
     "d3": "^6.6.2",


### PR DESCRIPTION
[FX-2185]

### Description

Use the same version of picasso-shared library in all packages so syncpack does not complain during a commit.

### How to test

- Try to commit anything to the repo
- See that everything else still works


### Review

- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/api-principles.md)
- n/a Annotate all `props` in component with documentation
- n/a Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure that tests pass by running `yarn test`
- [x] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
- n/a Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>


[FX-2185]: https://toptal-core.atlassian.net/browse/FX-2185?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ