### PR TITLE
[FX-2204] chore: add data-testid for Notification

### DIFF
--- a/packages/picasso/src/Notification/Notification.tsx
+++ b/packages/picasso/src/Notification/Notification.tsx
@@ -83,7 +83,11 @@ const renderNotificationContent = (props: PrivateProps) => {
   const { classes, children, onClose } = props
 
   return (
-    <Container flex className={classes?.contentWrapper}>
+    <Container
+      flex
+      className={classes?.contentWrapper}
+      data-testid='notification'
+    >
       <Container flex alignItems='center' className={classes?.iconWrapper}>
         {renderNotificationIcon(props)}
       </Container>

--- a/packages/picasso/src/Notification/__snapshots__/test.tsx.snap
+++ b/packages/picasso/src/Notification/__snapshots__/test.tsx.snap
@@ -14,6 +14,7 @@ exports[`Notification renders 1`] = `
       >
         <div
           class="PicassoContainer-flex"
+          data-testid="notification"
         >
           <div
             class="PicassoContainer-centerAlignItems PicassoContainer-flex Notification-iconWrapper"

--- a/packages/picasso/src/NotificationActions/__snapshots__/test.tsx.snap
+++ b/packages/picasso/src/NotificationActions/__snapshots__/test.tsx.snap
@@ -14,6 +14,7 @@ exports[`NotificationActions renders 1`] = `
       >
         <div
           class="PicassoContainer-flex"
+          data-testid="notification"
         >
           <div
             class="PicassoContainer-centerAlignItems PicassoContainer-flex Notification-iconWrapper"

--- a/packages/picasso/src/utils/Notifications/__snapshots__/test.tsx.snap
+++ b/packages/picasso/src/utils/Notifications/__snapshots__/test.tsx.snap
@@ -67,6 +67,7 @@ exports[`useNotifications error notification render 1`] = `
                 >
                   <div
                     class="PicassoContainer-flex"
+                    data-testid="notification"
                   >
                     <div
                       class="PicassoContainer-centerAlignItems PicassoContainer-flex Notification-iconWrapper"
@@ -186,6 +187,7 @@ exports[`useNotifications info notification render 1`] = `
                 >
                   <div
                     class="PicassoContainer-flex"
+                    data-testid="notification"
                   >
                     <div
                       class="PicassoContainer-centerAlignItems PicassoContainer-flex Notification-iconWrapper"
@@ -305,6 +307,7 @@ exports[`useNotifications success notification render 1`] = `
                 >
                   <div
                     class="PicassoContainer-flex"
+                    data-testid="notification"
                   >
                     <div
                       class="PicassoContainer-centerAlignItems PicassoContainer-flex Notification-iconWrapper"


### PR DESCRIPTION
[FX-2204]

### Description

Add data-testid for Notification

### Review

- [ ] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/api-principles.md)
- [ ] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that tests pass by running `yarn test`
- [ ] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
- [ ] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>


[FX-2204]: https://toptal-core.atlassian.net/browse/FX-2204?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ