### PR TITLE
fix: ensure Notification has allways alert role

### DIFF
--- a/packages/picasso/src/Notification/Notification.tsx
+++ b/packages/picasso/src/Notification/Notification.tsx
@@ -49,7 +49,6 @@ const renderNotificationCloseButton = ({ onClose, classes }: PrivateProps) => (
   <Button.Circular
     onClick={onClose}
     className={classes?.close}
-    title='Close Notification'
     icon={<CloseMinor16 className={classes?.closeIcon} />}
   />
 )

--- a/packages/picasso/src/Notification/test.tsx
+++ b/packages/picasso/src/Notification/test.tsx
@@ -1,46 +1,37 @@
-import React, { ReactNode } from 'react'
-import { render, RenderResult, fireEvent } from '@toptal/picasso/test-utils'
-import { OmitInternalProps } from '@toptal/picasso-shared'
+import React from 'react'
+import { render, fireEvent } from '@toptal/picasso/test-utils'
 
-import Notification, { PublicProps } from './Notification'
-
-const renderNotification = (
-  children: ReactNode,
-  props: OmitInternalProps<PublicProps, 'children'>
-) => {
-  const { onClose } = props
-
-  return render(<Notification onClose={onClose}>{children}</Notification>)
-}
+import Notification from './Notification'
 
 describe('Notification', () => {
-  let api: RenderResult
-
-  beforeEach(() => {
-    api = renderNotification('test example string', {})
-  })
-
   it('renders', () => {
-    const { container } = api
+    const { container } = render(
+      <Notification>test example string</Notification>
+    )
 
     expect(container).toMatchSnapshot()
   })
 
-  describe('with `prop.onClose` is passed', () => {
-    let onClose: () => void
+  it.each(['green', 'red', 'white', 'yellow'] as const)(
+    'has role "alert"',
+    variant => {
+      const api = render(<Notification variant={variant}>Error</Notification>)
 
-    beforeEach(() => {
-      onClose = jest.fn()
-      api = renderNotification('test example string', { onClose })
+      expect(api.getByRole('alert')).toBeDefined()
+    }
+  )
 
-      const { getByTitle } = api
-      const closeButton = getByTitle('Close Notification')
+  it('calls onClose', () => {
+    const onClose = jest.fn()
+    const { container } = render(
+      <Notification onClose={onClose}>test example string</Notification>
+    )
+    const closeButton = container.querySelector('button')
 
+    if (closeButton) {
       fireEvent.click(closeButton)
-    })
+    }
 
-    it('calls `prop.onClose`', () => {
-      expect(onClose).toHaveBeenCalledTimes(1)
-    })
+    expect(onClose).toHaveBeenCalledTimes(1)
   })
 })

--- a/packages/picasso/src/utils/Notifications/__snapshots__/test.tsx.snap
+++ b/packages/picasso/src/utils/Notifications/__snapshots__/test.tsx.snap
@@ -90,7 +90,6 @@ exports[`useNotifications error notification render 1`] = `
                       class="MuiButtonBase-root PicassoButton-small PicassoButton-primary PicassoButton-root PicassoButtonCircular-primary PicassoButtonCircular-root Notification-close"
                       data-component-type="button"
                       tabindex="0"
-                      title="Close Notification"
                       type="button"
                     >
                       <span
@@ -209,7 +208,6 @@ exports[`useNotifications info notification render 1`] = `
                       class="MuiButtonBase-root PicassoButton-small PicassoButton-primary PicassoButton-root PicassoButtonCircular-primary PicassoButtonCircular-root Notification-close"
                       data-component-type="button"
                       tabindex="0"
-                      title="Close Notification"
                       type="button"
                     >
                       <span
@@ -328,7 +326,6 @@ exports[`useNotifications success notification render 1`] = `
                       class="MuiButtonBase-root PicassoButton-small PicassoButton-primary PicassoButton-root PicassoButtonCircular-primary PicassoButtonCircular-root Notification-close"
                       data-component-type="button"
                       tabindex="0"
-                      title="Close Notification"
                       type="button"
                     >
                       <span


### PR DESCRIPTION
[FX-2204]

### Description

* remove the title from the close button on the notification. People start writing tests assuming that title.
* ensure there is a role on notification as a public contract
* cleaned up the test code

### How to test

- run `yarn test:unit`

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>


[FX-2204]: https://toptal-core.atlassian.net/browse/FX-2204?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ