### PR TITLE
refactor(Container): make gap to fuction as other size props

### DIFF
--- a/cypress/component/Badge.spec.tsx
+++ b/cypress/component/Badge.spec.tsx
@@ -136,7 +136,7 @@ describe('Badge', () => {
     it('renders medium', () => {
       mount(
         <TestingPicasso>
-          <Container flex style={{ gap: '1rem' }} padded='small'>
+          <Container flex padded='small'>
             <Container padded='small'>
               <Badge variant='red' size='medium' content={1} />
             </Container>
@@ -160,7 +160,7 @@ describe('Badge', () => {
     it('renders large', () => {
       mount(
         <TestingPicasso>
-          <Container flex style={{ gap: '1rem' }} padded='small'>
+          <Container flex padded='small'>
             <Container padded='small'>
               <Badge variant='red' size='large' content={1} />
             </Container>

--- a/cypress/component/Tag.spec.tsx
+++ b/cypress/component/Tag.spec.tsx
@@ -30,7 +30,13 @@ interface RectangularTagArgs {
 
 const renderRegularTag = ({ variant }: RegularTagArgs) => (
   <TestingPicasso>
-    <Container flex direction='column' gap='1rem' right='small' padded='medium'>
+    <Container
+      flex
+      direction='column'
+      gap='small'
+      right='small'
+      padded='medium'
+    >
       <div>
         <Tag variant={variant}>{variant}</Tag>
       </div>

--- a/packages/picasso/src/ButtonSplit/__snapshots__/test.tsx.snap
+++ b/packages/picasso/src/ButtonSplit/__snapshots__/test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`ButtonSplit closes menu on click to the item 1`] = `
 <svg
-  class="PicassoSvgArrowDownMinor24-root-95"
+  class="PicassoSvgArrowDownMinor24-root-100"
   style="min-width: 24px; min-height: 24px;"
   viewBox="0 0 24 24"
 >
@@ -67,7 +67,7 @@ exports[`ButtonSplit default render 1`] = `
 
 exports[`ButtonSplit renders arrow down icon for a closed menu 1`] = `
 <svg
-  class="PicassoSvgArrowDownMinor16-root-95"
+  class="PicassoSvgArrowDownMinor16-root-100"
   style="min-width: 16px; min-height: 16px;"
   viewBox="0 0 16 16"
 >
@@ -79,7 +79,7 @@ exports[`ButtonSplit renders arrow down icon for a closed menu 1`] = `
 
 exports[`ButtonSplit renders arrow up icon for an opened menu 1`] = `
 <svg
-  class="PicassoSvgArrowDownMinor16-root-95 PicassoButtonSplit-rotated-12"
+  class="PicassoSvgArrowDownMinor16-root-100 PicassoButtonSplit-rotated-12"
   style="min-width: 16px; min-height: 16px;"
   viewBox="0 0 16 16"
 >

--- a/packages/picasso/src/ButtonSplit/story/Sizes.example.tsx
+++ b/packages/picasso/src/ButtonSplit/story/Sizes.example.tsx
@@ -13,7 +13,7 @@ const Example = () => {
   )
 
   return (
-    <Container flex gap='1rem'>
+    <Container flex gap='small'>
       <Button.Split size='small' menu={menu}>
         Button
       </Button.Split>

--- a/packages/picasso/src/ButtonSplit/story/Variants.example.tsx
+++ b/packages/picasso/src/ButtonSplit/story/Variants.example.tsx
@@ -13,7 +13,7 @@ const Example = () => {
   )
 
   return (
-    <Container flex gap='1rem'>
+    <Container flex gap='small'>
       <Button.Split menu={menu} variant='primary'>
         Primary
       </Button.Split>

--- a/packages/picasso/src/Container/Container.tsx
+++ b/packages/picasso/src/Container/Container.tsx
@@ -55,7 +55,7 @@ export interface Props
   /** Style variant of Notification */
   variant?: VariantType
   /** Gap between elements for a flex container */
-  gap?: string
+  gap?: SpacingType
   /** Component used for the root node */
   as?: ContainerType
   /** Text align of the inner text */
@@ -112,6 +112,7 @@ export const Container = forwardRef<HTMLDivElement, Props>(function Container(
         classes[`${variant}Variant`],
         {
           [classes[`${padded}Padding`]]: typeof padded === 'string',
+          [classes[`${gap}Gap`]]: typeof gap === 'string',
 
           [classes[`top${top}Margin`]]: typeof top === 'string',
           [classes[`bottom${bottom}Margin`]]: typeof bottom === 'string',
@@ -139,7 +140,7 @@ export const Container = forwardRef<HTMLDivElement, Props>(function Container(
       style={{
         ...margins,
         ...(typeof padded === 'number' && { padding: spacingToRem(padded) }),
-        ...(typeof gap !== 'undefined' && { gap }),
+        ...(typeof gap === 'number' && { gap: spacingToRem(gap) }),
         ...style
       }}
     >

--- a/packages/picasso/src/Container/styles.ts
+++ b/packages/picasso/src/Container/styles.ts
@@ -55,6 +55,14 @@ const paddings = spacingVariants.reduce((acc, variant) => {
   return acc
 }, Object.create(null))
 
+const gaps = spacingVariants.reduce((acc, variant) => {
+  acc[`${variant}Gap`] = {
+    gap: spacingToRem(variant as SpacingType)
+  }
+
+  return acc
+}, Object.create(null))
+
 const colorVariant = (colorOptions?: SimplePaletteColorOptions | Color) => {
   if (!colorOptions) {
     return {}
@@ -158,5 +166,6 @@ export default ({ palette, sizes: { borderRadius } }: Theme) =>
     ...margins,
     ...alignItems,
     ...justifyContent,
-    ...textAlignItems
+    ...textAlignItems,
+    ...gaps
   })

--- a/packages/picasso/src/Select/story/Disabled.example.tsx
+++ b/packages/picasso/src/Select/story/Disabled.example.tsx
@@ -9,7 +9,7 @@ const Example = () => {
   }
 
   return (
-    <Container flex gap='1rem'>
+    <Container flex gap='small'>
       <Container>
         <Form.Field>
           <Form.Label>Select is disabled</Form.Label>

--- a/packages/picasso/src/Tag/story/Checkable.example.tsx
+++ b/packages/picasso/src/Tag/story/Checkable.example.tsx
@@ -6,8 +6,8 @@ const Example = () => {
   const [checked, setChecked] = useState<boolean>(false)
 
   return (
-    <Container flex gap='1rem'>
-      <Container flex direction='column' gap='0.5rem'>
+    <Container flex gap='small'>
+      <Container flex direction='column' gap='xsmall'>
         <Typography>Regular</Typography>
         <div>
           <Tag.Checkable
@@ -21,7 +21,7 @@ const Example = () => {
           </Tag.Checkable>
         </div>
       </Container>
-      <Container flex direction='column' gap='0.5rem'>
+      <Container flex direction='column' gap='xsmall'>
         <Typography>Hovered</Typography>
         <div>
           <Tag.Checkable icon={<Settings16 />} hovered onChange={noop}>
@@ -29,7 +29,7 @@ const Example = () => {
           </Tag.Checkable>
         </div>
       </Container>
-      <Container flex direction='column' gap='0.5rem'>
+      <Container flex direction='column' gap='xsmall'>
         <Typography>Checked</Typography>
         <div>
           <Tag.Checkable icon={<Settings16 />} checked onChange={noop}>
@@ -37,7 +37,7 @@ const Example = () => {
           </Tag.Checkable>
         </div>
       </Container>
-      <Container flex direction='column' gap='0.5rem'>
+      <Container flex direction='column' gap='xsmall'>
         <Typography>Hovered on Selected</Typography>
         <div>
           <Tag.Checkable icon={<Settings16 />} hovered checked onChange={noop}>
@@ -45,7 +45,7 @@ const Example = () => {
           </Tag.Checkable>
         </div>
       </Container>
-      <Container flex direction='column' gap='0.5rem'>
+      <Container flex direction='column' gap='xsmall'>
         <Typography>Disabled</Typography>
         <div>
           <Tag.Checkable

--- a/packages/picasso/src/Tag/story/Default.example.tsx
+++ b/packages/picasso/src/Tag/story/Default.example.tsx
@@ -6,26 +6,26 @@ const handleDelete = () => {
 }
 
 const Example = () => (
-  <Container flex gap='1rem'>
-    <Container flex direction='column' gap='0.5rem'>
+  <Container flex gap='small'>
+    <Container flex direction='column' gap='xsmall'>
       <Typography>Regular</Typography>
       <div>
         <Tag>Label</Tag>
       </div>
     </Container>
-    <Container flex direction='column' gap='0.5rem'>
+    <Container flex direction='column' gap='xsmall'>
       <Typography>With Icon</Typography>
       <div>
         <Tag icon={<Settings16 />}>Label</Tag>
       </div>
     </Container>
-    <Container flex direction='column' gap='0.5rem'>
+    <Container flex direction='column' gap='xsmall'>
       <Typography>With Remove</Typography>
       <div>
         <Tag onDelete={handleDelete}>Label</Tag>
       </div>
     </Container>
-    <Container flex direction='column' gap='0.5rem'>
+    <Container flex direction='column' gap='xsmall'>
       <Typography>Disabled</Typography>
       <div>
         <Tag disabled>Label</Tag>
@@ -45,7 +45,7 @@ const Example = () => (
         </Tag>
       </div>
     </Container>
-    <Container flex direction='column' gap='0.5rem'>
+    <Container flex direction='column' gap='xsmall'>
       <Typography>With Connection</Typography>
       <div>
         <Tag

--- a/packages/picasso/src/Tag/story/Variants.example.tsx
+++ b/packages/picasso/src/Tag/story/Variants.example.tsx
@@ -3,35 +3,35 @@ import { Container, Settings16, Tag } from '@toptal/picasso'
 
 const Example = () => (
   <Container flex>
-    <Container flex direction='column' gap='1rem' right='small' top={0.5}>
+    <Container flex direction='column' gap='small' right='small' top={0.5}>
       <Tag variant='light'>Light</Tag>
       <Tag icon={<Settings16 />} variant='light'>
         Light
       </Tag>
     </Container>
 
-    <Container flex direction='column' gap='1rem' right='small' top={0.5}>
+    <Container flex direction='column' gap='small' right='small' top={0.5}>
       <Tag variant='primary'>Primary</Tag>
       <Tag icon={<Settings16 />} variant='primary'>
         Primary
       </Tag>
     </Container>
 
-    <Container flex direction='column' gap='1rem' right='small' top={0.5}>
+    <Container flex direction='column' gap='small' right='small' top={0.5}>
       <Tag variant='positive'>Positive</Tag>
       <Tag icon={<Settings16 />} variant='positive'>
         Positive
       </Tag>
     </Container>
 
-    <Container flex direction='column' gap='1rem' right='small' top={0.5}>
+    <Container flex direction='column' gap='small' right='small' top={0.5}>
       <Tag variant='warning'>Warning</Tag>
       <Tag icon={<Settings16 />} variant='warning'>
         Warning
       </Tag>
     </Container>
 
-    <Container flex direction='column' gap='1rem' top={0.5}>
+    <Container flex direction='column' gap='small' top={0.5}>
       <Tag variant='negative'>Negative</Tag>
       <Tag icon={<Settings16 />} variant='negative'>
         Negative

--- a/packages/picasso/src/TagRectangular/story/Variants.example.tsx
+++ b/packages/picasso/src/TagRectangular/story/Variants.example.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { Container, Tag } from '@toptal/picasso'
 
 const Example = () => (
-  <Container flex gap='1rem'>
+  <Container flex gap='small'>
     <Tag.Rectangular variant='negative'>Negative</Tag.Rectangular>
     <Tag.Rectangular variant='warning'>Warning</Tag.Rectangular>
     <Tag.Rectangular variant='positive'>Positive</Tag.Rectangular>


### PR DESCRIPTION
### Description

Make `gap` property accept the same values as other size properties. For example `'small' | 'medium' | 'large'`.

It is a breaking change, but I believe that most users will not have to change anything because this property was introduced in the last major release.

### How to test

- no tests should be broken


### Review

- [ ] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/api-principles.md)
- [ ] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that tests pass by running `yarn test`
- [ ] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
- [ ] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>
