### PR TITLE
feat(datepicker): add support for custom value

### DIFF
--- a/cypress/component/DatePicker.spec.tsx
+++ b/cypress/component/DatePicker.spec.tsx
@@ -1,6 +1,11 @@
 import { mount } from '@cypress/react'
 import { Container } from '@toptal/picasso'
-import DatePicker, { DatePickerProps } from '@toptal/picasso-lab/DatePicker'
+import {
+  DatePicker,
+  DatePickerProps,
+  DEFAULT_DATE_PICKER_EDIT_DATE_FORMAT,
+  datePickerParseDateString
+} from '@toptal/picasso-lab'
 import { TestingPicasso } from '@toptal/picasso/test-utils'
 import { noop } from '@toptal/picasso/utils'
 import React from 'react'
@@ -35,8 +40,21 @@ describe('DatePicker', () => {
     cy.get('body').happoScreenshot()
   })
 
-  it('renders allow custom value', () => {
-    mount(<TestDatePicker allowCustomValue value='some random text' />)
+  it('renders custom value', () => {
+    const parseInputValue = (value: string) => {
+      const result = datePickerParseDateString(value, {
+        dateFormat: DEFAULT_DATE_PICKER_EDIT_DATE_FORMAT
+      })
+
+      return result ?? value
+    }
+
+    mount(
+      <TestDatePicker
+        parseInputValue={parseInputValue}
+        value='some random text'
+      />
+    )
 
     cy.get('body').happoScreenshot()
   })

--- a/cypress/component/DatePicker.spec.tsx
+++ b/cypress/component/DatePicker.spec.tsx
@@ -1,0 +1,43 @@
+import { mount } from '@cypress/react'
+import { Container } from '@toptal/picasso'
+import DatePicker, { DatePickerProps } from '@toptal/picasso-lab/DatePicker'
+import { TestingPicasso } from '@toptal/picasso/test-utils'
+import { noop } from '@toptal/picasso/utils'
+import React from 'react'
+
+const TestDatePicker = (props: Partial<DatePickerProps>) => {
+  const value = props.value || new Date(2020, 11, 27)
+
+  return (
+    <TestingPicasso>
+      <Container padded='medium'>
+        <DatePicker onChange={noop} value={value} {...props} />
+      </Container>
+    </TestingPicasso>
+  )
+}
+
+describe('DatePicker', () => {
+  it('renders autofocus', () => {
+    mount(<TestDatePicker autoFocus />)
+
+    cy.get('body').happoScreenshot()
+  })
+
+  it('renders range', () => {
+    mount(
+      <TestDatePicker
+        range
+        value={[new Date(2020, 11, 23), new Date(2020, 11, 27)]}
+      />
+    )
+
+    cy.get('body').happoScreenshot()
+  })
+
+  it('renders allow custom value', () => {
+    mount(<TestDatePicker allowCustomValue value='some random text' />)
+
+    cy.get('body').happoScreenshot()
+  })
+})

--- a/packages/picasso-lab/src/DatePicker/constants.ts
+++ b/packages/picasso-lab/src/DatePicker/constants.ts
@@ -1,0 +1,2 @@
+export const DEFAULT_DATE_PICKER_EDIT_DATE_FORMAT = 'MM-dd-yyyy'
+export const DEFAULT_DATE_PICKER_DISPLAY_DATE_FORMAT = 'MMM d, yyyy'

--- a/packages/picasso-lab/src/DatePicker/index.ts
+++ b/packages/picasso-lab/src/DatePicker/index.ts
@@ -1,2 +1,2 @@
 export { default } from './DatePicker'
-export type { Props as DatePickerProps } from './DatePicker'
+export type { Props as DatePickerProps, DatePickerValue } from './DatePicker'

--- a/packages/picasso-lab/src/DatePicker/index.ts
+++ b/packages/picasso-lab/src/DatePicker/index.ts
@@ -1,2 +1,5 @@
 export { default } from './DatePicker'
-export type { Props as DatePickerProps, DatePickerValue } from './DatePicker'
+export type { Props as DatePickerProps } from './DatePicker'
+export type { DatePickerValue, DatePickerStringParser } from './types'
+export { datePickerParseDateString } from './utils'
+export { DEFAULT_DATE_PICKER_EDIT_DATE_FORMAT, DEFAULT_DATE_PICKER_DISPLAY_DATE_FORMAT } from './constants'

--- a/packages/picasso-lab/src/DatePicker/story/AllowCustomValue.example.tsx
+++ b/packages/picasso-lab/src/DatePicker/story/AllowCustomValue.example.tsx
@@ -1,16 +1,29 @@
+import {
+  DatePicker,
+  DatePickerValue,
+  DEFAULT_DATE_PICKER_EDIT_DATE_FORMAT,
+  datePickerParseDateString
+} from '@toptal/picasso-lab'
 import React, { useState } from 'react'
-import { DatePickerValue, DatePicker } from '@toptal/picasso-lab'
 
 const AllowCustomValue = () => {
   const [datepickerValue, setDatepickerValue] = useState<DatePickerValue>(
     'some custom value'
   )
 
+  const parseInputValue = (value: string) => {
+    const result = datePickerParseDateString(value, {
+      dateFormat: DEFAULT_DATE_PICKER_EDIT_DATE_FORMAT
+    })
+
+    return result ?? value
+  }
+
   return (
     <div style={{ height: '50vh' }}>
       <DatePicker
         value={datepickerValue}
-        allowCustomValue
+        parseInputValue={parseInputValue}
         onChange={setDatepickerValue}
       />
     </div>

--- a/packages/picasso-lab/src/DatePicker/story/AllowCustomValue.example.tsx
+++ b/packages/picasso-lab/src/DatePicker/story/AllowCustomValue.example.tsx
@@ -1,0 +1,20 @@
+import React, { useState } from 'react'
+import { DatePickerValue, DatePicker } from '@toptal/picasso-lab'
+
+const AllowCustomValue = () => {
+  const [datepickerValue, setDatepickerValue] = useState<DatePickerValue>(
+    'some custom value'
+  )
+
+  return (
+    <div style={{ height: '50vh' }}>
+      <DatePicker
+        value={datepickerValue}
+        allowCustomValue
+        onChange={setDatepickerValue}
+      />
+    </div>
+  )
+}
+
+export default AllowCustomValue

--- a/packages/picasso-lab/src/DatePicker/story/WithNoHideOnSelect.example.tsx
+++ b/packages/picasso-lab/src/DatePicker/story/WithNoHideOnSelect.example.tsx
@@ -1,18 +1,15 @@
 import React, { useState } from 'react'
-import { DatePicker, DateOrDateRangeType } from '@toptal/picasso-lab'
+import { DatePicker, DatePickerValue } from '@toptal/picasso-lab'
 
 const WithNoHideOnSelect = () => {
-  const [
-    datepickerValue,
-    setDatepickerValue
-  ] = useState<DateOrDateRangeType | null>()
+  const [datepickerValue, setDatepickerValue] = useState<DatePickerValue>()
 
   return (
     <div style={{ height: '50vh' }}>
       <DatePicker
         value={datepickerValue}
         hideOnSelect={false}
-        onChange={(date: DateOrDateRangeType | null) => {
+        onChange={(date: DatePickerValue) => {
           setDatepickerValue(date)
         }}
       />

--- a/packages/picasso-lab/src/DatePicker/story/WithOnBlurHandler.example.tsx
+++ b/packages/picasso-lab/src/DatePicker/story/WithOnBlurHandler.example.tsx
@@ -1,11 +1,8 @@
 import React, { useState } from 'react'
-import { DatePicker, DateOrDateRangeType } from '@toptal/picasso-lab'
+import { DatePicker, DatePickerValue } from '@toptal/picasso-lab'
 
 const WithOnBlurHandlerExample = () => {
-  const [
-    datepickerValue,
-    setDatepickerValue
-  ] = useState<DateOrDateRangeType | null>()
+  const [datepickerValue, setDatepickerValue] = useState<DatePickerValue>()
 
   return (
     <div style={{ height: '50vh' }}>
@@ -14,7 +11,7 @@ const WithOnBlurHandlerExample = () => {
         onBlur={() => {
           // handle on blur
         }}
-        onChange={(date: DateOrDateRangeType | null) => {
+        onChange={(date: DatePickerValue) => {
           setDatepickerValue(date)
         }}
       />

--- a/packages/picasso-lab/src/DatePicker/story/index.jsx
+++ b/packages/picasso-lab/src/DatePicker/story/index.jsx
@@ -44,3 +44,7 @@ page
     'With Custom Day rendering'
   ) // picasso-skip-visuals
   .addExample('DatePicker/story/WithTimezone.example.tsx', 'With Timezone') // picasso-skip-visuals
+  .addExample(
+    'DatePicker/story/AllowCustomValue.example.tsx',
+    'With custom value'
+  ) // picasso-skip-visuals

--- a/packages/picasso-lab/src/DatePicker/test.tsx
+++ b/packages/picasso-lab/src/DatePicker/test.tsx
@@ -1,7 +1,9 @@
-import React from 'react'
-import { render, fireEvent, act } from '@toptal/picasso/test-utils'
+/* eslint-disable max-lines-per-function */
 import { Tooltip } from '@toptal/picasso'
+import { act, fireEvent, render } from '@toptal/picasso/test-utils'
+import React, { useState } from 'react'
 
+import { DateOrDateRangeType } from '../Calendar'
 import DatePicker, { Props } from './DatePicker'
 
 // eslint-disable-next-line max-lines-per-function
@@ -241,6 +243,90 @@ describe('DatePicker', () => {
       // check max edge
       fireEvent.change(input, { target: { value: '07-25-2020' } })
       expect(handleChange).toHaveBeenCalledWith(new Date(2020, 6, 25))
+    })
+
+    describe('should work with `allowCustomValue`', () => {
+      it('emits `string` if value is not a valid date', () => {
+        const handleChange = jest.fn()
+
+        const { getByPlaceholderText } = renderDatePicker({
+          ...defaultProps,
+          allowCustomValue: true,
+          onChange: handleChange
+        })
+
+        const input = getByPlaceholderText(defaultProps.placeholder)
+
+        fireEvent.change(input, { target: { value: 'some random text' } })
+        expect(handleChange).toHaveBeenCalledWith('some random text')
+      })
+
+      it('emits `Date` if value is a valid date', () => {
+        const handleChange = jest.fn()
+
+        const { getByPlaceholderText } = renderDatePicker({
+          ...defaultProps,
+          allowCustomValue: true,
+          onChange: handleChange
+        })
+
+        const input = getByPlaceholderText(defaultProps.placeholder)
+
+        fireEvent.change(input, { target: { value: '07-25-2020' } })
+        expect(handleChange).toHaveBeenCalledWith(new Date(2020, 6, 25))
+      })
+
+      it('opens `Calendar` on `Input` focus with invalid date', () => {
+        const handleChange = jest.fn()
+
+        const { getByPlaceholderText, getByTestId } = renderDatePicker({
+          ...defaultProps,
+          allowCustomValue: true,
+          value: 'some random text',
+          onChange: handleChange
+        })
+
+        const input = getByPlaceholderText(defaultProps.placeholder)
+
+        fireEvent.focus(input)
+
+        expect(getByTestId('calendar')).toBeInTheDocument()
+      })
+
+      it("doesn't clear `Input` after `blur` with invalid date", () => {
+        const placeholder = 'Pick a date'
+        const TestComponent = () => {
+          const [value, setValue] = useState<
+            string | DateOrDateRangeType | null
+          >(new Date(2020, 6, 25))
+
+          return (
+            <DatePicker
+              placeholder={placeholder}
+              allowCustomValue
+              value={value}
+              onChange={setValue}
+            />
+          )
+        }
+
+        const renderTestComponentPicker = () => render(<TestComponent />)
+
+        const { getByPlaceholderText } = renderTestComponentPicker()
+
+        const input = getByPlaceholderText(placeholder)
+
+        fireEvent.focus(input)
+
+        fireEvent.change(input, { target: { value: 'some random text' } })
+
+        fireEvent.blur(input)
+
+        expect(getByPlaceholderText(placeholder)).toHaveAttribute(
+          'value',
+          `some random text`
+        )
+      })
     })
   })
 

--- a/packages/picasso-lab/src/DatePicker/test.tsx
+++ b/packages/picasso-lab/src/DatePicker/test.tsx
@@ -5,6 +5,10 @@ import React, { useState } from 'react'
 
 import { DateOrDateRangeType } from '../Calendar'
 import DatePicker, { Props } from './DatePicker'
+import {
+  datePickerParseDateString,
+  DEFAULT_DATE_PICKER_EDIT_DATE_FORMAT
+} from './'
 
 // eslint-disable-next-line max-lines-per-function
 describe('DatePicker', () => {
@@ -245,13 +249,21 @@ describe('DatePicker', () => {
       expect(handleChange).toHaveBeenCalledWith(new Date(2020, 6, 25))
     })
 
-    describe('should work with `allowCustomValue`', () => {
+    describe('should work with overwritten `parseInputValue`', () => {
+      const parseInputValue = (value: string) => {
+        const result = datePickerParseDateString(value, {
+          dateFormat: DEFAULT_DATE_PICKER_EDIT_DATE_FORMAT
+        })
+
+        return result ?? value
+      }
+
       it('emits `string` if value is not a valid date', () => {
         const handleChange = jest.fn()
 
         const { getByPlaceholderText } = renderDatePicker({
           ...defaultProps,
-          allowCustomValue: true,
+          parseInputValue,
           onChange: handleChange
         })
 
@@ -266,7 +278,7 @@ describe('DatePicker', () => {
 
         const { getByPlaceholderText } = renderDatePicker({
           ...defaultProps,
-          allowCustomValue: true,
+          parseInputValue,
           onChange: handleChange
         })
 
@@ -281,7 +293,7 @@ describe('DatePicker', () => {
 
         const { getByPlaceholderText, getByTestId } = renderDatePicker({
           ...defaultProps,
-          allowCustomValue: true,
+          parseInputValue,
           value: 'some random text',
           onChange: handleChange
         })
@@ -303,7 +315,7 @@ describe('DatePicker', () => {
           return (
             <DatePicker
               placeholder={placeholder}
-              allowCustomValue
+              parseInputValue={parseInputValue}
               value={value}
               onChange={setValue}
             />

--- a/packages/picasso-lab/src/DatePicker/types.ts
+++ b/packages/picasso-lab/src/DatePicker/types.ts
@@ -1,0 +1,68 @@
+import { InputProps } from '@toptal/picasso'
+import { BaseProps } from '@toptal/picasso-shared'
+import { ReactNode } from 'react'
+
+import { DateOrDateRangeType, DayProps } from '../Calendar'
+
+interface DatePickerBaseProps
+  extends BaseProps,
+    Omit<
+      InputProps,
+      | 'value'
+      | 'onSelect'
+      | 'type'
+      | 'multiline'
+      | 'rows'
+      | 'defaultValue'
+      | 'onChange'
+    > {
+  /** Invoked when user goes away from Datepicker input */
+  onBlur?: () => void
+  /** Earliest date available for selection */
+  minDate?: Date
+  /** Latest date available for selection */
+  maxDate?: Date
+  /** Whether calendar should be closed after date selection. True by default */
+  hideOnSelect?: boolean
+  /** Date format that user will see in the input */
+  displayDateFormat?: string
+  /** Date format that user will see during manual input */
+  editDateFormat?: string
+  /** Specify icon which should be rendered inside DatePicker */
+  icon?: ReactNode
+  /** Specify a value if want to enable browser autofill */
+  autoComplete?: string
+  /** Indicate whether `DatePicker`'s input is in error state */
+  error?: boolean
+  /** Function to override default markup to show Date */
+  renderDay?: (args: DayProps) => ReactNode
+  popperContainer?: HTMLElement
+  /** Index of the first day of the week (0 - Sunday). Default is 1 - Monday */
+  weekStartsOn?: number
+  /** IANA timezone to display and edit date(s) */
+  timezone?: string
+}
+
+export interface AllowCustomValue {
+  /** Whether custom values should be allowed or not. It doesn't support `range` mode */
+  allowCustomValue: true
+  onChange: (value: DateOrDateRangeType | string | null) => void
+  value?: DateOrDateRangeType | null | string
+  range?: undefined
+  disabledIntervals?: undefined
+}
+
+interface DisallowCustomValue {
+  allowCustomValue?: false
+  /** Method that will be invoked with selected values */
+  onChange: (value: DateOrDateRangeType | null) => void
+  /** Whether calendar supports single date selection or range */
+  range?: boolean
+  /** Date range where selection is not allowed */
+  disabledIntervals?: { start: Date; end: Date }[]
+  /** Date that will be selected in `DatePicker` */
+  value?: DateOrDateRangeType | null
+}
+
+export type DatePickerProps = DatePickerBaseProps &
+  (AllowCustomValue | DisallowCustomValue)

--- a/packages/picasso-lab/src/DatePicker/types.ts
+++ b/packages/picasso-lab/src/DatePicker/types.ts
@@ -1,68 +1,13 @@
-import { InputProps } from '@toptal/picasso'
-import { BaseProps } from '@toptal/picasso-shared'
-import { ReactNode } from 'react'
+import { DateOrDateRangeType } from '../Calendar'
 
-import { DateOrDateRangeType, DayProps } from '../Calendar'
+export type DatePickerValue = DateOrDateRangeType | string | null
 
-interface DatePickerBaseProps
-  extends BaseProps,
-    Omit<
-      InputProps,
-      | 'value'
-      | 'onSelect'
-      | 'type'
-      | 'multiline'
-      | 'rows'
-      | 'defaultValue'
-      | 'onChange'
-    > {
-  /** Invoked when user goes away from Datepicker input */
-  onBlur?: () => void
-  /** Earliest date available for selection */
-  minDate?: Date
-  /** Latest date available for selection */
-  maxDate?: Date
-  /** Whether calendar should be closed after date selection. True by default */
-  hideOnSelect?: boolean
-  /** Date format that user will see in the input */
-  displayDateFormat?: string
-  /** Date format that user will see during manual input */
-  editDateFormat?: string
-  /** Specify icon which should be rendered inside DatePicker */
-  icon?: ReactNode
-  /** Specify a value if want to enable browser autofill */
-  autoComplete?: string
-  /** Indicate whether `DatePicker`'s input is in error state */
-  error?: boolean
-  /** Function to override default markup to show Date */
-  renderDay?: (args: DayProps) => ReactNode
-  popperContainer?: HTMLElement
-  /** Index of the first day of the week (0 - Sunday). Default is 1 - Monday */
-  weekStartsOn?: number
-  /** IANA timezone to display and edit date(s) */
-  timezone?: string
-}
-
-export interface AllowCustomValue {
-  /** Whether custom values should be allowed or not. It doesn't support `range` mode */
-  allowCustomValue: true
-  onChange: (value: DateOrDateRangeType | string | null) => void
-  value?: DateOrDateRangeType | null | string
-  range?: undefined
-  disabledIntervals?: undefined
-}
-
-interface DisallowCustomValue {
-  allowCustomValue?: false
-  /** Method that will be invoked with selected values */
-  onChange: (value: DateOrDateRangeType | null) => void
-  /** Whether calendar supports single date selection or range */
-  range?: boolean
-  /** Date range where selection is not allowed */
-  disabledIntervals?: { start: Date; end: Date }[]
-  /** Date that will be selected in `DatePicker` */
-  value?: DateOrDateRangeType | null
-}
-
-export type DatePickerProps = DatePickerBaseProps &
-  (AllowCustomValue | DisallowCustomValue)
+export type DatePickerStringParser = (
+  value: string,
+  params: {
+    dateFormat: string
+    timezone?: string
+    minDate?: Date
+    maxDate?: Date
+  }
+) => DateOrDateRangeType | string | undefined

--- a/packages/picasso-lab/src/DatePicker/utils.ts
+++ b/packages/picasso-lab/src/DatePicker/utils.ts
@@ -7,6 +7,7 @@ import isBefore from 'date-fns/isBefore'
 import isAfter from 'date-fns/isAfter'
 import { utcToZonedTime, format as tzFormat } from 'date-fns-tz'
 
+import { DatePickerStringParser } from './types'
 import { DateOrDateRangeType, DateRangeType } from '../Calendar'
 
 // Convert date to given timezone. If timezone is undefined, return given date as is.
@@ -98,3 +99,25 @@ export const isDateWithinInterval = (
 
   return false
 }
+
+export const datePickerParseDateString: DatePickerStringParser = (
+  value,
+  { dateFormat, timezone, minDate, maxDate }
+) => {
+  if (!isDateValid(value, dateFormat)) {
+    return
+  }
+
+  const parsedNextValue = parse(value, dateFormat, new Date())
+  const nextTimezoneValue = timezoneFormat(parsedNextValue, timezone)
+
+  if (!isDateWithinInterval(nextTimezoneValue, minDate, maxDate)) {
+    return
+  }
+
+  return nextTimezoneValue
+}
+
+export const isValidDateValue = (
+  dateValue: DateOrDateRangeType | string
+): dateValue is DateOrDateRangeType => typeof dateValue !== 'string'

--- a/packages/picasso-lab/src/index.ts
+++ b/packages/picasso-lab/src/index.ts
@@ -1,7 +1,16 @@
 export { default as Calendar } from './Calendar'
 export type { DateOrDateRangeType } from './Calendar'
-export { default as DatePicker } from './DatePicker'
-export type { DatePickerProps, DatePickerValue } from './DatePicker'
+export {
+  default as DatePicker,
+  datePickerParseDateString,
+  DEFAULT_DATE_PICKER_DISPLAY_DATE_FORMAT,
+  DEFAULT_DATE_PICKER_EDIT_DATE_FORMAT
+} from './DatePicker'
+export type {
+  DatePickerValue,
+  DatePickerStringParser,
+  DatePickerProps
+} from './DatePicker'
 export { default as Drawer } from './Drawer'
 export type { DrawerProps } from './Drawer'
 export { default as Dropzone, ErrorCode as DropzoneErrorCode } from './Dropzone'

--- a/packages/picasso-lab/src/index.ts
+++ b/packages/picasso-lab/src/index.ts
@@ -1,7 +1,7 @@
 export { default as Calendar } from './Calendar'
 export type { DateOrDateRangeType } from './Calendar'
 export { default as DatePicker } from './DatePicker'
-export type { DatePickerProps } from './DatePicker'
+export type { DatePickerProps, DatePickerValue } from './DatePicker'
 export { default as Drawer } from './Drawer'
 export type { DrawerProps } from './Drawer'
 export { default as Dropzone, ErrorCode as DropzoneErrorCode } from './Dropzone'


### PR DESCRIPTION
[SPT-2061](https://toptal-core.atlassian.net/browse/SPT-2061)

Add a boolean flag that allows using string values. It is useful for Staff Portal's users because we have this behavior in [Platform](https://staging.toptal.net/platform/staff/engagements/283531)

https://user-images.githubusercontent.com/16545305/139810245-20266335-8fad-4da0-a059-c48cfb647071.mov


### Description

There is also a `DatePicker/types.ts` file. In this file, I tried to achieve a dynamic `Props` interface based on the value of `allowCustomValue`.
So I wanted to make it work like this:
If `allowCustomValue` is provided:
- `value` should have type `DateOrDateRangeType | null | string`. Extended with a `string` compared to default type
- `onCahnge` should have type `onChange: (value: DateOrDateRangeType | string | null) => void`. Extended with a `string` compared to default type
- `range` and `disabledIntervals` should not be supported and typescript should give an error if you specify `allowCustomValue` and `range`

It worked, but only for some cases. In several cases, it didn't work. So I decided to go a simpler way and just provide a comment to the `allowCustomValue` that it doesn't support `range` and `disabledIntervals`. 
If you have any suggestions on how we can achieve what I described I'll be very grateful. Otherwise i will delete this file before the merge

### How to test

- Open the storybook for the DatePicker and scroll down to the last example
- Play with it

### Screenshots

https://user-images.githubusercontent.com/16545305/139812134-8fd8ae67-8e46-4294-97b5-c0dd1878599b.mov

### Review

- [ ] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/api-principles.md)
- [ ] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that tests pass by running `yarn test`
- [ ] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
- [ ] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>
