### PR TITLE
feat(prompt modal): [FX-2217] add data-testid into PromptModal

### DIFF
--- a/packages/picasso/src/PromptModal/PromptModal.tsx
+++ b/packages/picasso/src/PromptModal/PromptModal.tsx
@@ -42,6 +42,12 @@ export interface Props extends Omit<ModalProps, 'children' | 'onSubmit'> {
   /** Callback on Cancel onClick event */
   onCancel?: () => void
   onClose?: () => void
+  testIds?: {
+    title?: string
+    message?: string
+    closeButton?: string
+    submitButton?: string
+  }
 }
 
 export const PromptModal = forwardRef<HTMLElement, Props>(function PromptModal(
@@ -59,6 +65,7 @@ export const PromptModal = forwardRef<HTMLElement, Props>(function PromptModal(
     onAfterSubmit = noop,
     onCancel = noop,
     onClose,
+    testIds,
     ...rest
   } = props
   const classes = useStyles()
@@ -106,9 +113,11 @@ export const PromptModal = forwardRef<HTMLElement, Props>(function PromptModal(
       classes={classes}
       {...rest}
     >
-      {title && <Modal.Title>{title}</Modal.Title>}
+      {title && <Modal.Title data-testid={testIds?.title}>{title}</Modal.Title>}
       <Modal.Content>
-        <Typography size='medium'>{message}</Typography>
+        <Typography size='medium' data-testid={testIds?.message}>
+          {message}
+        </Typography>
         {children && (
           <Container top='xsmall'>
             {children({
@@ -123,13 +132,19 @@ export const PromptModal = forwardRef<HTMLElement, Props>(function PromptModal(
         )}
       </Modal.Content>
       <Modal.Actions>
-        <Button disabled={loading} variant='secondary' onClick={handleCancel}>
+        <Button
+          disabled={loading}
+          variant='secondary'
+          onClick={handleCancel}
+          data-testid={testIds?.closeButton}
+        >
           {cancelText}
         </Button>
         <Button
           loading={loading}
           onClick={handleSubmit}
           variant={`${variant}` as ButtonVariantType}
+          data-testid={testIds?.submitButton}
         >
           {submitText}
         </Button>


### PR DESCRIPTION
[FX-2217](https://toptal-core.atlassian.net/browse/FX-2217)

### Description

Added data-testid's according to the https://toptal-core.atlassian.net/wiki/spaces/TA/pages/1528758363/Data-TestID+naming+convention

### Review

- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/api-principles.md)
- `N/A` Annotate all `props` in component with documentation
- `N/A` Create `examples` for component
- `N/A` Ensure that deployed demo has expected results and good examples
- [x] Ensure that tests pass by running `yarn test`
- [x] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
- `N/A` Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>
