### PR TITLE
fix: bring back autocomplete to input

### DIFF
--- a/packages/picasso-forms/src/Input/Input.tsx
+++ b/packages/picasso-forms/src/Input/Input.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { Input as PicassoInput, InputProps } from '@toptal/picasso'
 
 import FieldWrapper, { FieldProps } from '../FieldWrapper'
+import getInputName from './utils/get-input-name'
 
 export type FormInputProps = Omit<InputProps, 'onResetClick'> & {
   /** Callback invoked when reset button was clicked */
@@ -11,9 +12,11 @@ export type Props = FormInputProps & FieldProps<InputProps['value']>
 
 export const Input = React.forwardRef<HTMLInputElement, Props>((props, ref) => (
   <FieldWrapper<FormInputProps> {...props}>
-    {(inputProps: InputProps) => {
-      return <PicassoInput {...inputProps} ref={ref} />
-    }}
+    {({ name, ...inputProps }: InputProps) => (
+      // TODO: remove getInputName completely when Chrome fixes autocomplete issue
+      // Link to the issue: https://bugs.chromium.org/p/chromium/issues/detail?id=1255609
+      <PicassoInput name={getInputName(name)} {...inputProps} ref={ref} />
+    )}
   </FieldWrapper>
 ))
 

--- a/packages/picasso-forms/src/Input/utils/get-input-name.test.ts
+++ b/packages/picasso-forms/src/Input/utils/get-input-name.test.ts
@@ -11,5 +11,6 @@ describe('#getInputName', () => {
   it('returns all other names', () => {
     expect(getInputName('name')).toBe('name')
     expect(getInputName('email')).toBe('email')
+    expect(getInputName(undefined)).toBeUndefined()
   })
 })

--- a/packages/picasso-forms/src/Input/utils/get-input-name.test.ts
+++ b/packages/picasso-forms/src/Input/utils/get-input-name.test.ts
@@ -1,0 +1,15 @@
+import getInputName from './get-input-name'
+
+describe('#getInputName', () => {
+  it.each(['title', 'field', 'input'] as const)(
+    'adds postfix to "%s"',
+    name => {
+      expect(getInputName(name)).toBe(`${name}-picasso`)
+    }
+  )
+
+  it('returns all other names', () => {
+    expect(getInputName('name')).toBe('name')
+    expect(getInputName('email')).toBe('email')
+  })
+})

--- a/packages/picasso-forms/src/Input/utils/get-input-name.ts
+++ b/packages/picasso-forms/src/Input/utils/get-input-name.ts
@@ -1,0 +1,9 @@
+const getInputName = (name?: string) => {
+  if (name && /^[field|input|title]$/.test(name)) {
+    return `${name}-picasso`
+  }
+
+  return name
+}
+
+export default getInputName

--- a/packages/picasso-forms/src/Input/utils/get-input-name.ts
+++ b/packages/picasso-forms/src/Input/utils/get-input-name.ts
@@ -1,5 +1,7 @@
+const NAMES_NEED_POSTFIX = ['field', 'input', 'title']
+
 const getInputName = (name?: string) => {
-  if (name && /^(field|input|title)$/.test(name)) {
+  if (name && NAMES_NEED_POSTFIX.includes(name)) {
     return `${name}-picasso`
   }
 

--- a/packages/picasso-forms/src/Input/utils/get-input-name.ts
+++ b/packages/picasso-forms/src/Input/utils/get-input-name.ts
@@ -1,5 +1,5 @@
 const getInputName = (name?: string) => {
-  if (name && /^[field|input|title]$/.test(name)) {
+  if (name && /^(field|input|title)$/.test(name)) {
     return `${name}-picasso`
   }
 


### PR DESCRIPTION
[SPT-2070](https://toptal-core.atlassian.net/browse/SPT-2070)
or [FX-2224](https://toptal-core.atlassian.net/browse/FX-2224)

### Description

Chrome introduced this bug recently https://bugs.chromium.org/p/chromium/issues/detail?id=1255609, so our users lost their autocomplete feature for `[name='title']` input. So we try to add a postfix `-picasso` to all inputs with `title|field|input` name.

### How to test

- Use Chrome browser
- Go to an example in picasso form
- Modify one input's name to `title`
- After submitting, the input's native autocomplete should work

### Screenshots

https://user-images.githubusercontent.com/18625278/140458763-383f68df-9f55-49c6-bcf1-bb5053acbe09.mp4

### Review

- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/api-principles.md)
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure that tests pass by running `yarn test`
- [x] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>
