### PR TITLE
feat(tag): [FX-2232] extended Tag props type

### DIFF
--- a/packages/picasso/src/Tag/Tag.tsx
+++ b/packages/picasso/src/Tag/Tag.tsx
@@ -4,7 +4,8 @@ import React, {
   ReactElement,
   HTMLAttributes,
   ElementType,
-  MouseEvent
+  MouseEvent,
+  AnchorHTMLAttributes
 } from 'react'
 import { makeStyles, Theme } from '@material-ui/core/styles'
 import cx from 'classnames'
@@ -19,10 +20,9 @@ import toTitleCase from '../utils/to-title-case'
 import TagConnection from '../TagConnection'
 import TagCheckable from '../TagCheckable'
 
-export interface Props
-  extends BaseProps,
-    TextLabelProps,
-    HTMLAttributes<HTMLDivElement> {
+export type DivOrAnchorProps = AnchorHTMLAttributes<HTMLAnchorElement> &
+  HTMLAttributes<HTMLDivElement>
+export interface Props extends BaseProps, TextLabelProps, DivOrAnchorProps {
   /** The component used for the root node. Either a string to use a DOM element or a component. */
   as?: ElementType
   /** Text content of the `Tag` component */

--- a/packages/picasso/src/Tag/__snapshots__/test.tsx.snap
+++ b/packages/picasso/src/Tag/__snapshots__/test.tsx.snap
@@ -7,6 +7,7 @@ exports[`Tag dismissable label should render dismissable label 1`] = `
   >
     <div
       class="MuiChip-root PicassoLabel-root MuiChip-deletable"
+      data-testid="tag"
       role="button"
       tabindex="0"
     >
@@ -46,6 +47,7 @@ exports[`Tag renders \`light\` variant 1`] = `
   >
     <div
       class="MuiChip-root PicassoLabel-root"
+      data-testid="tag"
     >
       <span
         class="MuiChip-label PicassoLabel-label"
@@ -68,6 +70,7 @@ exports[`Tag renders \`primary\` variant 1`] = `
   >
     <div
       class="MuiChip-root PicassoLabel-root PicassoLabel-primary"
+      data-testid="tag"
     >
       <span
         class="MuiChip-label PicassoLabel-label"
@@ -90,6 +93,7 @@ exports[`Tag renders with adornment 1`] = `
   >
     <div
       class="MuiChip-root PicassoLabel-root"
+      data-testid="tag"
     >
       <span
         class="MuiChip-label PicassoLabel-label"
@@ -126,6 +130,7 @@ exports[`Tag renders with connection and icon 1`] = `
   >
     <div
       class="MuiChip-root PicassoLabel-root"
+      data-testid="tag"
     >
       <svg
         class="PicassoSvgSettings16-root MuiChip-icon PicassoSvgSettings16-darkGrey"

--- a/packages/picasso/src/Tag/test.tsx
+++ b/packages/picasso/src/Tag/test.tsx
@@ -4,7 +4,7 @@ import { OmitInternalProps } from '@toptal/picasso-shared'
 import * as titleCaseModule from 'ap-style-title-case'
 
 import Tag, { Props } from './Tag'
-import { Settings16 } from '..'
+import { Link, Settings16 } from '..'
 
 jest.mock('ap-style-title-case')
 
@@ -13,16 +13,28 @@ const renderTag = (
   props: OmitInternalProps<Props, 'children'>,
   picassoConfig?: PicassoConfig
 ) => {
-  const { onDelete, disabled, variant, titleCase, endAdornment, icon } = props
+  const {
+    onDelete,
+    disabled,
+    variant,
+    titleCase,
+    endAdornment,
+    icon,
+    as,
+    href
+  } = props
 
   return render(
     <Tag
+      data-testid='tag'
       onDelete={onDelete}
       disabled={disabled}
       variant={variant}
       titleCase={titleCase}
       endAdornment={endAdornment}
       icon={icon}
+      as={as}
+      href={href}
     >
       {children}
     </Tag>,
@@ -96,6 +108,7 @@ describe('Tag', () => {
 
     expect(container).toMatchSnapshot()
   })
+
   it('renders with connection and icon', () => {
     const { container } = renderTag('foobar', {
       endAdornment: <Tag.Connection>0</Tag.Connection>,
@@ -103,5 +116,15 @@ describe('Tag', () => {
     })
 
     expect(container).toMatchSnapshot()
+  })
+
+  it('renders with Link', () => {
+    const href = 'test-href'
+    const { getByTestId } = renderTag('foobar', {
+      as: Link,
+      href
+    })
+
+    expect(getByTestId('tag')).toHaveAttribute('href', href)
   })
 })

--- a/packages/picasso/src/TagCheckable/TagCheckable.tsx
+++ b/packages/picasso/src/TagCheckable/TagCheckable.tsx
@@ -3,7 +3,7 @@ import { BaseProps, TextLabelProps } from '@toptal/picasso-shared'
 
 import Tag from '../Tag'
 
-type ClickType = MouseEventHandler<HTMLDivElement>
+type ClickType = MouseEventHandler<HTMLElement>
 
 export interface Props extends BaseProps, TextLabelProps {
   hovered?: boolean
@@ -29,7 +29,7 @@ const TagCheckable = ({
   onChange,
   ...rest
 }: Props) => {
-  const handleClick = (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
+  const handleClick = (e: React.MouseEvent<HTMLElement, MouseEvent>) => {
     onChange?.(!checked)
     onClick?.(e)
   }


### PR DESCRIPTION
[FX-2232](https://toptal-core.atlassian.net/browse/FX-2232)

### Description

Extended props type for the Tag, to allow Link

### How to test

should be possible to use

```
<Tag
 as={Link}
 href='http://toptal.com'
>
Toptal
</Tag>
```

### Review

- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/api-principles.md)
- `N/A` Annotate all `props` in component with documentation
- `N/A` Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure that tests pass by running `yarn test`
- [x] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>
