### PR TITLE
fix: updated generate-icons script with .prettierrc.js config

### DIFF
--- a/.changeset/famous-melons-check.md
+++ b/.changeset/famous-melons-check.md
@@ -1,0 +1,5 @@
+---
+'@toptal/picasso': patch
+---
+
+Updated generate-icons script to use our .prettierrc.js config

--- a/bin/generate-icons
+++ b/bin/generate-icons
@@ -19,5 +19,4 @@ mv $ICON_FULL_PATH/index.tsx $ICON_FULL_PATH/index.ts
 
 # format all generated code with prettier and eslint
 davinci syntax lint code $ICON_FULL_PATH
-yarn prettier-standard $ICON_FULL_PATH/**/*.tsx
-yarn prettier-standard $ICON_FULL_PATH/index.ts
+yarn prettier --write $ICON_FULL_PATH/*.tsx $ICON_FULL_PATH/**/*.tsx $ICON_FULL_PATH/index.ts

--- a/packages/picasso/src/Icon/Dialpad16.tsx
+++ b/packages/picasso/src/Icon/Dialpad16.tsx
@@ -9,9 +9,9 @@ const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
 export interface Props extends StandardProps {
-  scale?: ScaleType;
-  color?: string;
-  base?: number;
+  scale?: ScaleType
+  color?: string
+  base?: number
 }
 const useStyles = makeStyles(styles, { name: 'PicassoSvgDialpad16' })
 const SvgDialpad16 = forwardRef(function SvgDialpad16(


### PR DESCRIPTION
[FX-2181]

### Description

When new icons are generated via `yarn generate:icons`, there is a prettier command that updates all generated icons. This command however doesn't use our `.prettierrc.js` config, so the end result is that all icons are slightly changed (it adds semicolons to Props interface).
This change fixes it by running prettier with our config

[EDIT] I also updated one icon component `packages/picasso/src/Icon/Dialpad16.tsx` that didn't comply to our rules

### How to test

run `yarn generate:icons` locally and there shouldn't be any changes when the script is done (assuming you haven't updated or added any icons of course)

### Screenshots


### Review

- [ ] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/api-principles.md)
- [ ] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that tests pass by running `yarn test`
- [ ] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
- [ ] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>


[FX-2181]: https://toptal-core.atlassian.net/browse/FX-2181?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ