### PR TITLE
fix: subpixel calculations for table separators

### DIFF
--- a/packages/picasso/src/Table/__snapshots__/test.tsx.snap
+++ b/packages/picasso/src/Table/__snapshots__/test.tsx.snap
@@ -6,7 +6,7 @@ exports[`Table renders 1`] = `
     class="Picasso-root"
   >
     <table
-      class="MuiTable-root"
+      class="MuiTable-root Table-root"
     >
       <thead
         class="MuiTableHead-root PicassoTableHead-root"
@@ -15,7 +15,7 @@ exports[`Table renders 1`] = `
           class="MuiTableRow-root PicassoTableRow-root PicassoTableRow-bordered MuiTableRow-head"
         >
           <th
-            class="MuiTableCell-root PicassoTableCell-root MuiTableCell-head PicassoTableCell-header"
+            class="MuiTableCell-root PicassoTableCell-root MuiTableCell-head PicassoTableCell-header PicassoTableCell-bordered"
             scope="col"
           >
             Table test
@@ -29,7 +29,7 @@ exports[`Table renders 1`] = `
           class="MuiTableRow-root PicassoTableRow-root PicassoTableRow-bordered"
         >
           <td
-            class="MuiTableCell-root PicassoTableCell-root MuiTableCell-body PicassoTableCell-body"
+            class="MuiTableCell-root PicassoTableCell-root MuiTableCell-body PicassoTableCell-body PicassoTableCell-bordered"
           >
             Table test
           </td>
@@ -42,7 +42,7 @@ exports[`Table renders 1`] = `
           class="MuiTableRow-root PicassoTableRow-root PicassoTableRow-bordered MuiTableRow-footer"
         >
           <td
-            class="MuiTableCell-root PicassoTableCell-root MuiTableCell-footer PicassoTableCell-footer"
+            class="MuiTableCell-root PicassoTableCell-root MuiTableCell-footer PicassoTableCell-footer PicassoTableCell-bordered"
           >
             Table test
           </td>

--- a/packages/picasso/src/Table/styles.ts
+++ b/packages/picasso/src/Table/styles.ts
@@ -3,4 +3,9 @@ import { PicassoProvider } from '@toptal/picasso-provider'
 
 PicassoProvider.override(() => ({}))
 
-export default () => createStyles({})
+export default () =>
+  createStyles({
+    root: {
+      borderCollapse: 'separate'
+    }
+  })

--- a/packages/picasso/src/TableBody/__snapshots__/test.tsx.snap
+++ b/packages/picasso/src/TableBody/__snapshots__/test.tsx.snap
@@ -6,7 +6,7 @@ exports[`TableCell renders 1`] = `
     class="Picasso-root"
   >
     <table
-      class="MuiTable-root"
+      class="MuiTable-root Table-root"
     >
       <tbody
         class="MuiTableBody-root"
@@ -15,7 +15,7 @@ exports[`TableCell renders 1`] = `
           class="MuiTableRow-root PicassoTableRow-root PicassoTableRow-bordered"
         >
           <td
-            class="MuiTableCell-root PicassoTableCell-root MuiTableCell-body PicassoTableCell-body"
+            class="MuiTableCell-root PicassoTableCell-root MuiTableCell-body PicassoTableCell-body PicassoTableCell-bordered"
           >
             Body test
           </td>

--- a/packages/picasso/src/TableCell/TableCell.tsx
+++ b/packages/picasso/src/TableCell/TableCell.tsx
@@ -42,12 +42,14 @@ export const TableCell = forwardRef<HTMLTableCellElement, Props>(
       footer: footerClass,
       header: headerClass,
       narrow: narrowClass,
+      bordered: borderedClass,
       ...muiClasses
     } = useStyles()
-    const { spacing } = useContext(TableContext)
+    const { spacing, variant } = useContext(TableContext)
     const tableSection = useContext(TableSectionContext)
     const isHead = tableSection === TableSection.HEAD
     const isFooter = tableSection === TableSection.FOOTER
+    const isBordered = variant === 'bordered' || variant === 'striped'
     const titleCase = useTitleCase(propsTitleCase)
 
     const renderChildren = () =>
@@ -63,7 +65,8 @@ export const TableCell = forwardRef<HTMLTableCellElement, Props>(
           [compactClass]: spacing === 'compact',
           [narrowClass]: spacing === 'narrow',
           [footerClass]: isFooter,
-          [headerClass]: isHead
+          [headerClass]: isHead,
+          [borderedClass]: isBordered
         })}
         style={style}
         colSpan={colSpan}

--- a/packages/picasso/src/TableCell/__snapshots__/test.tsx.snap
+++ b/packages/picasso/src/TableCell/__snapshots__/test.tsx.snap
@@ -12,7 +12,7 @@ exports[`TableCell renders 1`] = `
         class="MuiTableRow-root PicassoTableRow-root PicassoTableRow-bordered"
       >
         <td
-          class="MuiTableCell-root PicassoTableCell-root MuiTableCell-body PicassoTableCell-body"
+          class="MuiTableCell-root PicassoTableCell-root MuiTableCell-body PicassoTableCell-body PicassoTableCell-bordered"
         >
           Cell
         </td>
@@ -34,7 +34,7 @@ exports[`TableCell renders compact 1`] = `
         class="MuiTableRow-root PicassoTableRow-root PicassoTableRow-bordered"
       >
         <td
-          class="MuiTableCell-root PicassoTableCell-root MuiTableCell-body PicassoTableCell-body PicassoTableCell-compact"
+          class="MuiTableCell-root PicassoTableCell-root MuiTableCell-body PicassoTableCell-body PicassoTableCell-compact PicassoTableCell-bordered"
         >
           Cell
         </td>
@@ -56,7 +56,7 @@ exports[`TableCell renders narrow 1`] = `
         class="MuiTableRow-root PicassoTableRow-root PicassoTableRow-bordered"
       >
         <td
-          class="MuiTableCell-root PicassoTableCell-root MuiTableCell-body PicassoTableCell-body PicassoTableCell-narrow"
+          class="MuiTableCell-root PicassoTableCell-root MuiTableCell-body PicassoTableCell-body PicassoTableCell-narrow PicassoTableCell-bordered"
         >
           Cell
         </td>

--- a/packages/picasso/src/TableCell/styles.ts
+++ b/packages/picasso/src/TableCell/styles.ts
@@ -33,11 +33,14 @@ const narrowCellStyles = {
   paddingRight: '0.5rem'
 }
 
-export default ({ palette, typography }: Theme) =>
+export default ({ sizes, palette, typography }: Theme) =>
   createStyles({
     root: regularCellStyles,
     compact: compactCellStyles,
     narrow: narrowCellStyles,
+    bordered: {
+      borderBottom: `${sizes.borderWidth} solid ${palette.grey.lighter2}`
+    },
     header: {
       fontWeight: typography.fontWeights.semibold,
       color: palette.text.primary,

--- a/packages/picasso/src/TableFooter/__snapshots__/test.tsx.snap
+++ b/packages/picasso/src/TableFooter/__snapshots__/test.tsx.snap
@@ -6,7 +6,7 @@ exports[`TableFooter renders 1`] = `
     class="Picasso-root"
   >
     <table
-      class="MuiTable-root"
+      class="MuiTable-root Table-root"
     >
       <tfoot
         class="MuiTableFooter-root PicassoTableFooter-root"
@@ -15,7 +15,7 @@ exports[`TableFooter renders 1`] = `
           class="MuiTableRow-root PicassoTableRow-root PicassoTableRow-bordered MuiTableRow-footer"
         >
           <td
-            class="MuiTableCell-root PicassoTableCell-root MuiTableCell-footer PicassoTableCell-footer"
+            class="MuiTableCell-root PicassoTableCell-root MuiTableCell-footer PicassoTableCell-footer PicassoTableCell-bordered"
           >
             Footer test
           </td>

--- a/packages/picasso/src/TableHead/__snapshots__/test.tsx.snap
+++ b/packages/picasso/src/TableHead/__snapshots__/test.tsx.snap
@@ -6,7 +6,7 @@ exports[`TableHead renders 1`] = `
     class="Picasso-root"
   >
     <table
-      class="MuiTable-root"
+      class="MuiTable-root Table-root"
     >
       <thead
         class="MuiTableHead-root PicassoTableHead-root"
@@ -15,7 +15,7 @@ exports[`TableHead renders 1`] = `
           class="MuiTableRow-root PicassoTableRow-root PicassoTableRow-bordered MuiTableRow-head"
         >
           <th
-            class="MuiTableCell-root PicassoTableCell-root MuiTableCell-head PicassoTableCell-header"
+            class="MuiTableCell-root PicassoTableCell-root MuiTableCell-head PicassoTableCell-header PicassoTableCell-bordered"
             scope="col"
           >
             Head test

--- a/packages/picasso/src/TableRow/TableRow.tsx
+++ b/packages/picasso/src/TableRow/TableRow.tsx
@@ -43,6 +43,7 @@ export const TableRow = forwardRef<HTMLTableRowElement, Props>(
     const {
       stripeEven: stripeEvenClass,
       bordered: borderedClass,
+      clear: clearClass,
       ...muiClasses
     } = useStyles()
     const { variant } = useContext(TableContext)
@@ -55,7 +56,8 @@ export const TableRow = forwardRef<HTMLTableRowElement, Props>(
         classes={muiClasses}
         className={cx(className, {
           [stripeEvenClass]: stripeEven,
-          [borderedClass]: isBordered
+          [borderedClass]: isBordered,
+          [clearClass]: !isBordered
         })}
         style={style}
         hover={hover}

--- a/packages/picasso/src/TableRow/__snapshots__/test.tsx.snap
+++ b/packages/picasso/src/TableRow/__snapshots__/test.tsx.snap
@@ -6,7 +6,7 @@ exports[`TableRow renders 1`] = `
     class="Picasso-root"
   >
     <table
-      class="MuiTable-root"
+      class="MuiTable-root Table-root"
     >
       <tbody
         class="MuiTableBody-root"
@@ -15,7 +15,7 @@ exports[`TableRow renders 1`] = `
           class="MuiTableRow-root PicassoTableRow-root PicassoTableRow-bordered"
         >
           <td
-            class="MuiTableCell-root PicassoTableCell-root MuiTableCell-body PicassoTableCell-body"
+            class="MuiTableCell-root PicassoTableCell-root MuiTableCell-body PicassoTableCell-body PicassoTableCell-bordered"
           >
             Row test
           </td>

--- a/packages/picasso/src/TableRow/styles.ts
+++ b/packages/picasso/src/TableRow/styles.ts
@@ -20,7 +20,11 @@ export default ({ palette, sizes, transitions }: Theme) =>
       }
     },
     bordered: {
-      borderBottom: `${sizes.borderWidth} solid ${palette.grey.lighter2}`
+      borderBottom: `${sizes.borderWidth} solid ${palette.grey.lighter2}`,
+      borderCollapse: 'inherit'
+    },
+    clear: {
+      borderBottom: 'none'
     },
     stripeEven: {
       background: palette.grey.lighter

--- a/packages/picasso/src/TableRow/styles.ts
+++ b/packages/picasso/src/TableRow/styles.ts
@@ -3,7 +3,7 @@ import { PicassoProvider } from '@toptal/picasso-provider'
 
 PicassoProvider.override(() => ({}))
 
-export default ({ palette, sizes, transitions }: Theme) =>
+export default ({ palette, transitions }: Theme) =>
   createStyles({
     root: {
       height: 'auto',
@@ -20,7 +20,6 @@ export default ({ palette, sizes, transitions }: Theme) =>
       }
     },
     bordered: {
-      borderBottom: `${sizes.borderWidth} solid ${palette.grey.lighter2}`,
       borderCollapse: 'inherit'
     },
     clear: {

--- a/packages/picasso/src/TableSectionHead/__snapshots__/test.tsx.snap
+++ b/packages/picasso/src/TableSectionHead/__snapshots__/test.tsx.snap
@@ -6,7 +6,7 @@ exports[`TableSectionHead renders 1`] = `
     class="Picasso-root"
   >
     <table
-      class="MuiTable-root"
+      class="MuiTable-root Table-root"
     >
       <tbody
         class="MuiTableBody-root"
@@ -15,7 +15,7 @@ exports[`TableSectionHead renders 1`] = `
           class="MuiTableRow-root PicassoTableRow-root PicassoTableSectionHead-sectionHeaderRow PicassoTableRow-bordered"
         >
           <td
-            class="MuiTableCell-root PicassoTableCell-root MuiTableCell-body PicassoTableCell-body PicassoTableSectionHead-sectionHeaderCell"
+            class="MuiTableCell-root PicassoTableCell-root MuiTableCell-body PicassoTableCell-body PicassoTableSectionHead-sectionHeaderCell PicassoTableCell-bordered"
             colspan="100"
           >
             Test


### PR DESCRIPTION
[FX-2260]
[SPT-2114](https://toptal-core.atlassian.net/browse/SPT-2114)

### Description

### This is a **POC**, open discussion to possible alternatives (current PR implementation is not definitive)

Chromium based browsers have a different rendering engine that handles the subpixel calculations different than other browsers, meaning they don't really support subpixel rendering and this leads to integer approximations on random elements that, in our case for the table rows borders, will become inconsistent.

For some users, depending on their monitor this will also happen without needing to zoom into the page, reason for which we should try and find a workaround for this until chromium will accept subpixel rendering.

With this approach we can add the borders to the table cells that will adjust based on the adjacent borders, so at least now, when they adjust while zooming, they should adjust all at once

### How to test

1. Go to [deploy](https://picasso.toptal.net/SPT-2114-inconsistent-table-separators/?path=/story/components-table--table) on a chromium based browser (Chrome, Brave, Edge, Vivaldi etc.)
2. Use all zoom variants provided by the browser and check if there are any discrepancies between the table separators
3. Compare to [current](https://picasso.toptal.net/?path=/story/components-table--table) as in the video below

https://user-images.githubusercontent.com/79158829/141304105-3fd779fe-01fd-417e-8064-0613db4aa8e4.mov

### Review

- [ ] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/api-principles.md)
- [ ] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that tests pass by running `yarn test`
- [ ] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
- [ ] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>


[FX-2260]: https://toptal-core.atlassian.net/browse/FX-2260?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ