### PR TITLE
refactor: [FX-2205] Remove hardcoded data testid values

### DIFF
--- a/.changeset/orange-kids-approve.md
+++ b/.changeset/orange-kids-approve.md
@@ -1,8 +1,8 @@
 ---
-'@toptal/picasso': minor
-'@toptal/picasso-charts': minor
-'@toptal/picasso-lab': minor
-'@topkit/analytics-charts': minor
+'@toptal/picasso': major
+'@toptal/picasso-charts': major
+'@toptal/picasso-lab': major
+'@topkit/analytics-charts': major
 ---
 
 Removed static `data-testid` values and replaced them with dynamic ones, which

--- a/.changeset/orange-kids-approve.md
+++ b/.changeset/orange-kids-approve.md
@@ -1,0 +1,134 @@
+---
+'@toptal/picasso': minor
+'@toptal/picasso-charts': minor
+'@toptal/picasso-lab': minor
+'@topkit/analytics-charts': minor
+---
+
+Removed static `data-testid` values and replaced them with dynamic ones, which
+means that now you should manually provide values for them.
+
+##### Autocomplete
+
+`picasso/src/Autocomplete/Autocomplete.tsx`
+
+Has 2 new dynamic `data-testid`s for `Input` and `InputAdornment`. To add
+custom `data-testid`s user should set values for `testIds.input` or
+`testIds.InputAdornment`. For example:
+
+```jsx
+<Autocomplete
+  testIds={{ input: 'custom-name-1', loadingAdornment: 'custom-name-2' }}
+  {...props}
+/>
+```
+
+##### PageAutocomplete
+
+`picasso/src/PageAutocomplete/PageAutocomplete.tsx`
+
+Has 2 new dynamic `data-testid`s like `Autocomplete` does.
+
+##### Menu
+
+`picasso/src/Menu/Menu.tsx`
+
+Has 1 new dynamic `data-testid` for `MenuItem`. To add custom `data-testid`
+user should set value for `testIds.menuItem`. For example:
+
+```jsx
+<Menu testIds={{ menuItem: 'custom-name-1' }} {...props} />
+```
+
+##### BarChart
+
+`picasso-charts/src/BarChart/BarChart.tsx`
+
+Has 1 new dynamic `data-testid` for `Tooltip`. To add custom `data-testitd`
+user should set value for `testIds.tooltip`. For example:
+
+```jsx
+<BarChart testIds={{ tooltip: 'custom-name-1' }} {...props} />
+```
+
+##### DatePicker
+
+`picasso-lab/src/DatePicker/DatePicker.tsx`
+
+Has 2 new dynamic `data-testid`s for `Input` and `Calendar`. To add custom
+`data-testid` user should set values for `testIds.input` or `testIds.calendar`.
+For example:
+
+```jsx
+<DatePicker
+  testIds={{ input: 'custom-name-1', calendar: 'custom-name-2' }}
+  {...props}
+/>
+```
+
+##### Accordion
+
+`picasso/src/Accordion/Accordion.tsx`
+
+Has 2 new dynamic `data-testid`s for `EmptyAccordionSummary` and
+`AccordionSummary`. To add custom `data-testid`s user shold set values for
+`testIds.emptyAccordionSummary` or `testIds.accordionSummary`. For example:
+
+```jsx
+<Accordion
+  testIds={{
+    emptyAccordionSummary: 'custom-name-1',
+    calendar: 'custom-name-2'
+  }}
+  {...props}
+/>
+```
+
+##### FileListItem
+
+`picasso/src/FileListItem/FileListItem.tsx`
+
+Has 1 new dynamic `data-testid` for `ProgressBar`. To add custom `data-testid`
+user should set value for `testIds.progressBar`. For example:
+
+```jsx
+<FileListItem testIds={{ progressBar: 'custom-name-1' }} {...props} />
+```
+
+##### OutlinedInput
+
+`picasso/src/OutlinedInput/OutlinedInput.tsx`
+
+Has 1 new dynamic `data-testid` for `InputAdornment`. To add custom
+`data-testid` user should set value for `testIds.resetButton`. For example:
+
+```jsx
+<OutlinedInput testIds={{ resetButton: 'custom-name-1' }} {...props} />
+```
+
+##### Input
+
+`picasso/src/Input/Input.tsx`
+
+Has 2 new dynamic `data-testid`s for `InputAdornment` and for `OutlinedInput`
+component's child component - `InputAdornment`. To add custom `data-testid`
+user should set values for `testIds.inputAdornment` or `testIds.resetButton`.
+For example:
+
+```jsx
+<Input
+  testIds={{ inputAdornment: 'custom-name-1', resetButton: 'custom-name-2' }}
+  {...props}
+/>
+```
+
+##### CategoriesChartTooltip
+
+`topkit-analytics-charts/src/CategoriesChartTooltip/CategoriesChartTooltip.tsx`
+
+Has 1 new dynamic `data-testid` for `Paper`. To add custom `data-testid` user
+should set value for `testIds.paper`. For example:
+
+```jsx
+<CategoriesChartTooltip testIds={{ paper: 'custom-name-1' }} {...props} />
+```

--- a/cypress/component/Autocomplete.spec.tsx
+++ b/cypress/component/Autocomplete.spec.tsx
@@ -56,7 +56,7 @@ export const StaticOptionsAutocompleteExample = () => {
         value={value}
         options={options}
         placeholder='Start typing Mongolia...'
-        data-testid='autocomplete'
+        testIds={testIds}
       />
     </TestingPicasso>
   )
@@ -106,7 +106,7 @@ export const DynamicOptionsAutocompleteExample = () => {
         options={options}
         loading={loading}
         placeholder='Start typing Mongolia...'
-        data-testid='autocomplete'
+        testIds={testIds}
       />
     </TestingPicasso>
   )
@@ -117,16 +117,12 @@ const openAutocompleteWithTab = () => {
 }
 
 const testIds = {
-  resetButton: 'reset-adornment'
+  resetButton: 'reset-adornment',
+  input: 'autocomplete'
 }
 
 const TestAutocomplete = (props: Partial<AutocompleteProps>) => (
-  <Autocomplete
-    data-testid='autocomplete'
-    value=''
-    options={OPTIONS}
-    {...props}
-  />
+  <Autocomplete value='' options={OPTIONS} {...props} />
 )
 
 describe('Autocomplete', () => {
@@ -308,6 +304,7 @@ describe('Autocomplete', () => {
           showOtherOption
           options={[]}
           noOptionsText='Nothing found'
+          testIds={testIds}
         />
       </TestingPicasso>
     )

--- a/cypress/component/Autocomplete.spec.tsx
+++ b/cypress/component/Autocomplete.spec.tsx
@@ -116,6 +116,10 @@ const openAutocompleteWithTab = () => {
   cy.get('body').tab()
 }
 
+const testIds = {
+  resetButton: 'reset-adornment'
+}
+
 const TestAutocomplete = (props: Partial<AutocompleteProps>) => (
   <Autocomplete
     data-testid='autocomplete'
@@ -184,14 +188,14 @@ describe('Autocomplete', () => {
   it('renders a reset button', () => {
     mount(
       <TestingPicasso>
-        <TestAutocomplete enableReset value='Croatia' />
+        <TestAutocomplete enableReset value='Croatia' testIds={testIds} />
       </TestingPicasso>
     )
 
     // Cypress does not go well with :hover CSS selectors
     // It can fire mouse events via JS, but can't simulate browser cursor behaviour
     // To fix this issue we're using a force method to show the button so the screenshot is correct
-    cy.get('[data-testid="reset-adornment"]').invoke(
+    cy.get(`[data-testid="${testIds.resetButton}"]`).invoke(
       'attr',
       'style',
       'visibility: visible'

--- a/cypress/component/Menu.spec.tsx
+++ b/cypress/component/Menu.spec.tsx
@@ -3,11 +3,11 @@ import { mount } from '@cypress/react'
 import { Container, Menu, MenuProps } from '@toptal/picasso'
 import { TestingPicasso } from '@toptal/picasso/test-utils'
 
-const MenuExample = (props: MenuProps) => {
-  const testIds = {
-    menuItem: 'menu-back'
-  }
+const testIds = {
+  menuItem: 'menu-back'
+}
 
+const MenuExample = (props: MenuProps) => {
   const menuForItemB1 = (
     <Menu data-testid='menu-b1' testIds={testIds}>
       <Menu.Item data-testid='item-b1-1'>Item B1-1</Menu.Item>
@@ -51,7 +51,7 @@ describe('Menu', () => {
   it('navigates slide menu', () => {
     mount(<MenuExample />)
     cy.get('[data-testid="menu-b"]').should('not.exist')
-    cy.get('[data-testid="menu-back"]').should('not.exist')
+    cy.get(`[data-testid="${testIds.menuItem}"]`).should('not.exist')
     cy.get('body').happoScreenshot()
 
     cy.get('[data-testid="item-b"').click()
@@ -64,14 +64,14 @@ describe('Menu', () => {
     cy.get('[data-testid="menu-b2"]').should('not.exist')
     cy.get('body').happoScreenshot()
 
-    cy.get('[data-testid="menu-back"').last().click()
+    cy.get(`[data-testid="${testIds.menuItem}"`).last().click()
     cy.get('[data-testid="menu-b"]').should('be.visible')
     cy.get('[data-testid="menu-b1"]').should('not.exist')
     cy.get('body').happoScreenshot()
 
-    cy.get('[data-testid="menu-back"').click()
+    cy.get(`[data-testid="${testIds.menuItem}"`).click()
     cy.get('[data-testid="menu-b"]').should('not.exist')
-    cy.get('[data-testid="menu-back"]').should('not.exist')
+    cy.get(`[data-testid="${testIds.menuItem}"]`).should('not.exist')
     cy.get('body').happoScreenshot()
   })
 

--- a/cypress/component/Menu.spec.tsx
+++ b/cypress/component/Menu.spec.tsx
@@ -4,8 +4,12 @@ import { Container, Menu, MenuProps } from '@toptal/picasso'
 import { TestingPicasso } from '@toptal/picasso/test-utils'
 
 const MenuExample = (props: MenuProps) => {
+  const testIds = {
+    menuItem: 'menu-back'
+  }
+
   const menuForItemB1 = (
-    <Menu data-testid='menu-b1'>
+    <Menu data-testid='menu-b1' testIds={testIds}>
       <Menu.Item data-testid='item-b1-1'>Item B1-1</Menu.Item>
       <Menu.Item data-testid='item-b1-2'>Item B1-2</Menu.Item>
     </Menu>
@@ -19,7 +23,7 @@ const MenuExample = (props: MenuProps) => {
   )
 
   const menuForItemB = (
-    <Menu data-testid='menu-b'>
+    <Menu data-testid='menu-b' testIds={testIds}>
       <Menu.Item menu={menuForItemB1} data-testid='item-b1'>
         Item B1
       </Menu.Item>

--- a/cypress/component/Select.spec.tsx
+++ b/cypress/component/Select.spec.tsx
@@ -11,6 +11,10 @@ import { TestingPicasso } from '@toptal/picasso/test-utils'
 import { noop, palette } from '@toptal/picasso/utils'
 import { ValueType } from '@toptal/picasso/Select'
 
+const testIds = {
+  resetButton: 'reset-adornment'
+}
+
 const TestSelect = ({
   onChange = noop,
   value = undefined,
@@ -27,7 +31,8 @@ const TestSelect = ({
   iconPosition,
   icon,
   menuWidth,
-  limit
+  limit,
+  testIds
 }: Partial<SelectProps> = {}) => (
   <Select
     data-testid='select'
@@ -47,6 +52,7 @@ const TestSelect = ({
     iconPosition={iconPosition}
     searchThreshold={searchThreshold}
     limit={limit}
+    testIds={testIds}
   />
 )
 
@@ -291,14 +297,14 @@ describe('Select', () => {
   it('renders reset button', () => {
     mount(
       <TestingPicasso>
-        <TestSelect enableReset value={OPTIONS[0].value} />
+        <TestSelect enableReset value={OPTIONS[0].value} testIds={testIds} />
       </TestingPicasso>
     )
 
     // Cypress does not go well with :hover CSS selectors
     // It can fire mouse events via JS, but can't simulate browser cursor behaviour
     // To fix this issue we're using a force method to show the button so the screenshot is correct
-    cy.get('[data-testid="reset-adornment"]').invoke(
+    cy.get(`[data-testid="${testIds.resetButton}"]`).invoke(
       'attr',
       'style',
       'visibility: visible'

--- a/cypress/component/Tooltip.spec.tsx
+++ b/cypress/component/Tooltip.spec.tsx
@@ -19,6 +19,10 @@ import { TestingPicasso } from '@toptal/picasso/test-utils'
 
 const TOOLTIP_LONG_TEXT = 'Content '.repeat(10)
 
+const testIds = {
+  input: 'autocomplete'
+}
+
 const BasicTooltipExample = () => {
   const tooltipContent = <span data-testid='tooltip-content'>Content</span>
 
@@ -212,7 +216,7 @@ const AutocompleteTooltipExample = () => {
           </Tooltip>
         )}
         onChange={setValue}
-        data-testid='autocomplete'
+        testIds={testIds}
       />
     </TestingPicasso>
   )

--- a/packages/picasso-charts/src/BarChart/BarChart.tsx
+++ b/packages/picasso-charts/src/BarChart/BarChart.tsx
@@ -42,6 +42,9 @@ export interface Props<K extends string | number | symbol>
     index?: number
   }) => string
   getBarLabelColor?: (params: { dataKey: string; index?: number }) => string
+  testIds?: {
+    tooltip?: string
+  }
 }
 
 const StyleOverrides = () => (
@@ -85,6 +88,7 @@ const BarChart = <K extends string>({
   getBarColor = defaultGetBarColor,
   labelKey,
   getBarLabelColor = defaultGetBarLabelColor,
+  testIds,
   ...rest
 }: Props<K>) => {
   const dataKeys = Object.keys(data[0].value) as K[]
@@ -95,6 +99,7 @@ const BarChart = <K extends string>({
     () =>
       tooltip ? (
         <Tooltip
+          data-testid={testIds?.tooltip}
           allowEscapeViewBox={
             allowTooltipEscapeViewBox ? { x: true, y: true } : undefined
           }

--- a/packages/picasso-charts/src/BarChart/BarChart.tsx
+++ b/packages/picasso-charts/src/BarChart/BarChart.tsx
@@ -95,7 +95,6 @@ const BarChart = <K extends string>({
     () =>
       tooltip ? (
         <Tooltip
-          data-testid='tooltip'
           allowEscapeViewBox={
             allowTooltipEscapeViewBox ? { x: true, y: true } : undefined
           }

--- a/packages/picasso-lab/src/DatePicker/DatePicker.tsx
+++ b/packages/picasso-lab/src/DatePicker/DatePicker.tsx
@@ -97,8 +97,9 @@ export interface Props
   timezone?: string
   /* Invoked when input value has been changed. If method failed to parse a value, it must return undefined. Used to process input value before passing it to the `onChange` */
   parseInputValue?: DatePickerStringParser
-  testIds?: {
+  testIds?: InputProps['testIds'] & {
     calendar?: string
+    input?: string
   }
 }
 export const DatePicker = (props: Props) => {
@@ -331,6 +332,8 @@ export const DatePicker = (props: Props) => {
           size={size}
           startAdornment={startAdornment}
           width={width}
+          testIds={testIds}
+          data-testid={testIds?.input}
         />
       </Container>
       {inputWrapperRef.current && (

--- a/packages/picasso-lab/src/DatePicker/DatePicker.tsx
+++ b/packages/picasso-lab/src/DatePicker/DatePicker.tsx
@@ -60,6 +60,7 @@ export interface Props
       | 'rows'
       | 'defaultValue'
       | 'onChange'
+      | 'testIds'
     > {
   /** Date that will be selected in `DatePicker` */
   value?: DatePickerValue
@@ -96,6 +97,9 @@ export interface Props
   timezone?: string
   /* Invoked when input value has been changed. If method failed to parse a value, it must return undefined. Used to process input value before passing it to the `onChange` */
   parseInputValue?: DatePickerStringParser
+  testIds?: {
+    calendar?: string
+  }
 }
 export const DatePicker = (props: Props) => {
   const {
@@ -117,6 +121,7 @@ export const DatePicker = (props: Props) => {
     timezone,
     size,
     parseInputValue = datePickerParseDateString,
+    testIds,
     ...rest
   } = props
   const classes = useStyles()
@@ -339,6 +344,7 @@ export const DatePicker = (props: Props) => {
           ref={popperRef}
         >
           <Calendar
+            data-testid={testIds?.calendar}
             ref={calendarRef}
             range={range}
             value={calendarValue ?? undefined}

--- a/packages/picasso-lab/src/DatePicker/DatePicker.tsx
+++ b/packages/picasso-lab/src/DatePicker/DatePicker.tsx
@@ -339,7 +339,6 @@ export const DatePicker = (props: Props) => {
           ref={popperRef}
         >
           <Calendar
-            data-testid='calendar'
             ref={calendarRef}
             range={range}
             value={calendarValue ?? undefined}

--- a/packages/picasso-lab/src/DatePicker/test.tsx
+++ b/packages/picasso-lab/src/DatePicker/test.tsx
@@ -10,6 +10,10 @@ import {
   DEFAULT_DATE_PICKER_EDIT_DATE_FORMAT
 } from './'
 
+const testIds = {
+  calendar: 'calendar'
+}
+
 // eslint-disable-next-line max-lines-per-function
 describe('DatePicker', () => {
   beforeAll(() => {
@@ -302,7 +306,7 @@ describe('DatePicker', () => {
 
         fireEvent.focus(input)
 
-        expect(getByTestId('calendar')).toBeInTheDocument()
+        expect(getByTestId(testIds.calendar)).toBeInTheDocument()
       })
 
       it("doesn't clear `Input` after `blur` with invalid date", () => {
@@ -365,6 +369,6 @@ describe('DatePicker', () => {
   }
 
   const renderDatePicker = (props: Props = defaultProps) => {
-    return render(<DatePicker {...props} />)
+    return render(<DatePicker testIds={testIds} {...props} />)
   }
 })

--- a/packages/picasso/src/Accordion/Accordion.tsx
+++ b/packages/picasso/src/Accordion/Accordion.tsx
@@ -23,9 +23,7 @@ const useStyles = makeStyles<Theme>(styles, {
   name: 'PicassoAccordion'
 })
 
-export const EmptyAccordionSummary = () => (
-  <div data-testid='picasso-empty-accordion-summary' />
-)
+export const EmptyAccordionSummary = () => <div />
 
 interface SummaryProps extends Partial<StandardProps> {
   children: ReactNode

--- a/packages/picasso/src/Accordion/Accordion.tsx
+++ b/packages/picasso/src/Accordion/Accordion.tsx
@@ -23,7 +23,9 @@ const useStyles = makeStyles<Theme>(styles, {
   name: 'PicassoAccordion'
 })
 
-export const EmptyAccordionSummary = () => <div />
+export const EmptyAccordionSummary = ({ testId }: { testId?: string }) => (
+  <div data-testid={testId} />
+)
 
 interface SummaryProps extends Partial<StandardProps> {
   children: ReactNode
@@ -74,6 +76,9 @@ export interface Props
   borders?: Borders
   /** Callback invoked when `Accordion` item is toggled */
   onChange?: (event: ChangeEvent<{}>, expanded: boolean) => void
+  testIds?: {
+    emptyAccordionSummary?: string
+  }
 }
 
 const decorateWithExpandIconClasses = (
@@ -100,6 +105,7 @@ export const Accordion = forwardRef<HTMLElement, Props>(function Accordion(
     className,
     style,
     onChange,
+    testIds,
     ...rest
   } = props
 
@@ -163,7 +169,7 @@ export const Accordion = forwardRef<HTMLElement, Props>(function Accordion(
           )}
         </AccordionSummary>
       ) : (
-        <EmptyAccordionSummary />
+        <EmptyAccordionSummary testId={testIds?.emptyAccordionSummary} />
       )}
       <AccordionDetails
         classes={{

--- a/packages/picasso/src/Accordion/Accordion.tsx
+++ b/packages/picasso/src/Accordion/Accordion.tsx
@@ -23,9 +23,11 @@ const useStyles = makeStyles<Theme>(styles, {
   name: 'PicassoAccordion'
 })
 
-export const EmptyAccordionSummary = ({ testId }: { testId?: string }) => (
-  <div data-testid={testId} />
-)
+export const EmptyAccordionSummary = ({
+  'data-testid': dataTestId
+}: {
+  'data-testid'?: string
+}) => <div data-testid={dataTestId} />
 
 interface SummaryProps extends Partial<StandardProps> {
   children: ReactNode
@@ -78,6 +80,7 @@ export interface Props
   onChange?: (event: ChangeEvent<{}>, expanded: boolean) => void
   testIds?: {
     emptyAccordionSummary?: string
+    accordionSummary?: string
   }
 }
 
@@ -156,6 +159,7 @@ export const Accordion = forwardRef<HTMLElement, Props>(function Accordion(
           }}
           expandIcon={null}
           onClick={handleSummaryClick}
+          data-testid={testIds?.accordionSummary}
         >
           {children}
           {expandIcon ? (
@@ -169,7 +173,7 @@ export const Accordion = forwardRef<HTMLElement, Props>(function Accordion(
           )}
         </AccordionSummary>
       ) : (
-        <EmptyAccordionSummary testId={testIds?.emptyAccordionSummary} />
+        <EmptyAccordionSummary data-testid={testIds?.emptyAccordionSummary} />
       )}
       <AccordionDetails
         classes={{

--- a/packages/picasso/src/Accordion/test.tsx
+++ b/packages/picasso/src/Accordion/test.tsx
@@ -19,6 +19,10 @@ const TestSummary = () => (
   </Accordion.Summary>
 )
 
+const testIds = {
+  emptyAccordionSummary: 'picasso-empty-accordion-summary'
+}
+
 const renderAccordion = (props?: Partial<OmitInternalProps<Props>>) =>
   render(
     <Accordion content={<TestDetails />} {...props}>
@@ -48,10 +52,10 @@ describe('Accordion', () => {
 
   it('renders empty summary when one is not provided', () => {
     const { getByTestId, queryByTestId } = render(
-      <Accordion content={<TestDetails />} />
+      <Accordion content={<TestDetails />} testIds={testIds} />
     )
 
-    expect(getByTestId('picasso-empty-accordion-summary')).toBeVisible()
+    expect(getByTestId(testIds.emptyAccordionSummary)).toBeVisible()
     expect(queryByTestId('accordion-summary')).toBeNull()
     expect(getByTestId('accordion-details')).not.toBeVisible()
   })

--- a/packages/picasso/src/Autocomplete/Autocomplete.tsx
+++ b/packages/picasso/src/Autocomplete/Autocomplete.tsx
@@ -109,6 +109,7 @@ export interface Props
     otherOption?: string
     noOptions?: string
     loadingAdornment?: string
+    input?: string
   }
 }
 
@@ -283,6 +284,7 @@ export const Autocomplete = forwardRef<HTMLInputElement, Props>(
             name={enableAutofill ? name : undefined}
             autoComplete={enableAutofill ? autoComplete : autoComplete || 'off'}
             testIds={testIds}
+            data-testid={testIds?.input}
           />
         </Container>
         <div role='listbox'>

--- a/packages/picasso/src/Autocomplete/Autocomplete.tsx
+++ b/packages/picasso/src/Autocomplete/Autocomplete.tsx
@@ -266,7 +266,12 @@ export const Autocomplete = forwardRef<HTMLInputElement, Props>(
       >
         <Container flex ref={inputWrapperRef}>
           {!enableAutofill && name && (
-            <input type='hidden' value={value} name={name} />
+            <input
+              type='hidden'
+              value={value}
+              name={name}
+              data-testid={testIds?.input}
+            />
           )}
           <InputComponent
             {...rest}

--- a/packages/picasso/src/Autocomplete/Autocomplete.tsx
+++ b/packages/picasso/src/Autocomplete/Autocomplete.tsx
@@ -103,7 +103,7 @@ export interface Props
   inputProps?: BaseInputProps
   /** Show the "Powered By Google" label */
   poweredByGoogle?: boolean
-  testIds?: {
+  testIds?: InputProps['testIds'] & {
     menuItem?: string
     scrollMenu?: string
     otherOption?: string
@@ -241,7 +241,7 @@ export const Autocomplete = forwardRef<HTMLInputElement, Props>(
     const InputComponent = inputComponent || Input
     const loadingComponent = (
       <InputAdornment
-        testId={testIds?.loadingAdornment}
+        data-testid={testIds?.loadingAdornment}
         position='end'
         disablePointerEvents
       >
@@ -282,6 +282,7 @@ export const Autocomplete = forwardRef<HTMLInputElement, Props>(
             width={width}
             name={enableAutofill ? name : undefined}
             autoComplete={enableAutofill ? autoComplete : autoComplete || 'off'}
+            testIds={testIds}
           />
         </Container>
         <div role='listbox'>

--- a/packages/picasso/src/Autocomplete/Autocomplete.tsx
+++ b/packages/picasso/src/Autocomplete/Autocomplete.tsx
@@ -239,11 +239,7 @@ export const Autocomplete = forwardRef<HTMLInputElement, Props>(
 
     const InputComponent = inputComponent || Input
     const loadingComponent = (
-      <InputAdornment
-        data-testid='loading-adornment'
-        position='end'
-        disablePointerEvents
-      >
+      <InputAdornment position='end' disablePointerEvents>
         <Loader size='small' />
       </InputAdornment>
     )

--- a/packages/picasso/src/Autocomplete/Autocomplete.tsx
+++ b/packages/picasso/src/Autocomplete/Autocomplete.tsx
@@ -108,6 +108,7 @@ export interface Props
     scrollMenu?: string
     otherOption?: string
     noOptions?: string
+    loadingAdornment?: string
   }
 }
 
@@ -239,7 +240,11 @@ export const Autocomplete = forwardRef<HTMLInputElement, Props>(
 
     const InputComponent = inputComponent || Input
     const loadingComponent = (
-      <InputAdornment position='end' disablePointerEvents>
+      <InputAdornment
+        testId={testIds?.loadingAdornment}
+        position='end'
+        disablePointerEvents
+      >
         <Loader size='small' />
       </InputAdornment>
     )

--- a/packages/picasso/src/Autocomplete/test.tsx
+++ b/packages/picasso/src/Autocomplete/test.tsx
@@ -23,7 +23,8 @@ const testIds = {
   scrollMenu: 'scroll-menu',
   otherOption: 'other-option',
   noOptions: 'no-options',
-  loadingAdornment: 'loading-adornment'
+  loadingAdornment: 'loading-adornment',
+  resetButton: 'reset-adornment'
 }
 
 const renderAutocomplete = (

--- a/packages/picasso/src/Autocomplete/test.tsx
+++ b/packages/picasso/src/Autocomplete/test.tsx
@@ -24,7 +24,8 @@ const testIds = {
   otherOption: 'other-option',
   noOptions: 'no-options',
   loadingAdornment: 'loading-adornment',
-  resetButton: 'reset-adornment'
+  resetButton: 'reset-adornment',
+  input: 'autocomplete'
 }
 
 const renderAutocomplete = (
@@ -32,7 +33,7 @@ const renderAutocomplete = (
   picassoConfig?: PicassoConfig
 ) =>
   render(
-    <Autocomplete data-testid='autocomplete' testIds={testIds} {...props} />,
+    <Autocomplete testIds={testIds} {...props} />,
     undefined,
     picassoConfig
   )

--- a/packages/picasso/src/Autocomplete/test.tsx
+++ b/packages/picasso/src/Autocomplete/test.tsx
@@ -22,7 +22,8 @@ const testIds = {
   menuItem: 'menu-item',
   scrollMenu: 'scroll-menu',
   otherOption: 'other-option',
-  noOptions: 'no-options'
+  noOptions: 'no-options',
+  loadingAdornment: 'loading-adornment'
 }
 
 const renderAutocomplete = (
@@ -74,7 +75,7 @@ describe('Autocomplete', () => {
         loading: true
       })
 
-      const loader = getByTestId('loading-adornment')
+      const loader = getByTestId(testIds.loadingAdornment)
 
       expect(loader).not.toBeNull()
       expect(loader).toMatchSnapshot()

--- a/packages/picasso/src/FileListItem/FileListItem.tsx
+++ b/packages/picasso/src/FileListItem/FileListItem.tsx
@@ -17,13 +17,16 @@ export interface Props {
   index: number
   disabled?: boolean
   onRemove?: (fileName: string, index: number) => void
+  testIds?: {
+    progressBar?: string
+  }
 }
 
 const useStyles = makeStyles<Theme>(styles, {
   name: 'FileListItem'
 })
 
-const FileListItem = ({ file, index, disabled, onRemove }: Props) => {
+const FileListItem = ({ file, index, disabled, onRemove, testIds }: Props) => {
   const {
     uploading,
     progress,
@@ -48,7 +51,7 @@ const FileListItem = ({ file, index, disabled, onRemove }: Props) => {
         Uploading...
       </Typography>
       {progress !== undefined ? (
-        <ProgressBar value={progress} />
+        <ProgressBar testId={testIds?.progressBar} value={progress} />
       ) : (
         <Loader className={classes.loader} size='small' />
       )}

--- a/packages/picasso/src/FileListItem/FileListItem.tsx
+++ b/packages/picasso/src/FileListItem/FileListItem.tsx
@@ -48,10 +48,7 @@ const FileListItem = ({ file, index, disabled, onRemove }: Props) => {
         Uploading...
       </Typography>
       {progress !== undefined ? (
-        <ProgressBar
-          value={progress}
-          data-testid='file-list-item-progressbar'
-        />
+        <ProgressBar value={progress} />
       ) : (
         <Loader className={classes.loader} size='small' />
       )}

--- a/packages/picasso/src/FileListItem/FileListItem.tsx
+++ b/packages/picasso/src/FileListItem/FileListItem.tsx
@@ -51,7 +51,7 @@ const FileListItem = ({ file, index, disabled, onRemove, testIds }: Props) => {
         Uploading...
       </Typography>
       {progress !== undefined ? (
-        <ProgressBar testId={testIds?.progressBar} value={progress} />
+        <ProgressBar data-testid={testIds?.progressBar} value={progress} />
       ) : (
         <Loader className={classes.loader} size='small' />
       )}

--- a/packages/picasso/src/FileListItem/test.tsx
+++ b/packages/picasso/src/FileListItem/test.tsx
@@ -4,8 +4,12 @@ import { render, fireEvent } from '@toptal/picasso/test-utils'
 
 import FileListItem, { Props } from './FileListItem'
 
+const testIds = {
+  progressBar: 'file-list-item-progressbar'
+}
+
 const renderFileListItem = (props: OmitInternalProps<Props>) =>
-  render(<FileListItem {...props} />)
+  render(<FileListItem testIds={testIds} {...props} />)
 
 describe('FileListItem', () => {
   const file = {
@@ -47,7 +51,7 @@ describe('FileListItem', () => {
       })
 
       expect(queryByText('Uploading...')).toBeInTheDocument()
-      expect(queryByTestId('file-list-item-progressbar')).toBeInTheDocument()
+      expect(queryByTestId(testIds.progressBar)).toBeInTheDocument()
     })
 
     describe('when error exists', () => {

--- a/packages/picasso/src/Input/Input.tsx
+++ b/packages/picasso/src/Input/Input.tsx
@@ -160,7 +160,6 @@ const LimitAdornment = (props: LimitAdornmentProps) => {
 
   return (
     <InputAdornment
-      data-testid='limit-adornment-multiline-label'
       position='end'
       className={cx({
         [classes.limiterMultiline]: multiline

--- a/packages/picasso/src/Input/Input.tsx
+++ b/packages/picasso/src/Input/Input.tsx
@@ -83,9 +83,13 @@ export interface Props
   ) => void
   /** Ref of the input outline */
   outlineRef?: React.Ref<HTMLElement>
+  testIds?: {
+    limit?: string
+    outlined?: string
+  }
 }
 
-type LimitAdornmentProps = Pick<Props, 'multiline' | 'limit'> & {
+type LimitAdornmentProps = Pick<Props, 'multiline' | 'limit' | 'testIds'> & {
   counter: NonNullable<Props['counter']>
   charsLength: number
 }
@@ -98,7 +102,13 @@ type StartAdornmentProps = Pick<Props, 'icon' | 'iconPosition' | 'disabled'>
 
 type EndAdornmentProps = Pick<
   Props,
-  'icon' | 'iconPosition' | 'disabled' | 'multiline' | 'limit' | 'counter'
+  | 'icon'
+  | 'iconPosition'
+  | 'disabled'
+  | 'multiline'
+  | 'limit'
+  | 'counter'
+  | 'testIds'
 > & { charsLength?: number }
 
 const useStyles = makeStyles<Theme>(styles, { name: 'PicassoInput' })
@@ -144,7 +154,7 @@ const getMultilineLabel = ({
 
 const LimitAdornment = (props: LimitAdornmentProps) => {
   const classes = useStyles()
-  const { multiline, charsLength, counter, limit } = props
+  const { multiline, charsLength, counter, limit, testIds } = props
 
   const charsTillLimit = getCharsTillLimit({
     counter,
@@ -160,6 +170,7 @@ const LimitAdornment = (props: LimitAdornmentProps) => {
 
   return (
     <InputAdornment
+      testId={testIds?.limit}
       position='end'
       className={cx({
         [classes.limiterMultiline]: multiline
@@ -217,6 +228,7 @@ const EndAdornment = (props: EndAdornmentProps) => {
     limit,
     multiline,
     charsLength,
+    testIds,
     counter
   } = props
 
@@ -232,6 +244,7 @@ const EndAdornment = (props: EndAdornmentProps) => {
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         counter={counter!}
         limit={limit}
+        testIds={testIds}
       />
     )
   }
@@ -291,6 +304,7 @@ export const Input = forwardRef<HTMLInputElement, Props>(function Input(
     enableReset,
     onResetClick,
     outlineRef,
+    testIds,
     ...rest
   } = purifyProps(props)
 
@@ -353,12 +367,14 @@ export const Input = forwardRef<HTMLInputElement, Props>(function Input(
             charsLength={charsLength}
             multiline={multiline}
             counter={counter}
+            testIds={testIds}
           />
         )
       }
       onChange={onChange}
       enableReset={enableReset}
       onResetClick={onResetClick}
+      testId={testIds?.outlined}
     >
       {children}
     </OutlinedInput>

--- a/packages/picasso/src/Input/Input.tsx
+++ b/packages/picasso/src/Input/Input.tsx
@@ -84,7 +84,8 @@ export interface Props
   /** Ref of the input outline */
   outlineRef?: React.Ref<HTMLElement>
   testIds?: {
-    limit?: string
+    inputAdornment?: string
+    resetButton?: string
   }
 }
 
@@ -169,7 +170,7 @@ const LimitAdornment = (props: LimitAdornmentProps) => {
 
   return (
     <InputAdornment
-      testId={testIds?.limit}
+      data-testid={testIds?.inputAdornment}
       position='end'
       className={cx({
         [classes.limiterMultiline]: multiline
@@ -373,6 +374,7 @@ export const Input = forwardRef<HTMLInputElement, Props>(function Input(
       onChange={onChange}
       enableReset={enableReset}
       onResetClick={onResetClick}
+      testIds={testIds}
     >
       {children}
     </OutlinedInput>

--- a/packages/picasso/src/Input/Input.tsx
+++ b/packages/picasso/src/Input/Input.tsx
@@ -373,7 +373,6 @@ export const Input = forwardRef<HTMLInputElement, Props>(function Input(
       onChange={onChange}
       enableReset={enableReset}
       onResetClick={onResetClick}
-      testId={testIds?.outlined}
     >
       {children}
     </OutlinedInput>

--- a/packages/picasso/src/Input/Input.tsx
+++ b/packages/picasso/src/Input/Input.tsx
@@ -85,7 +85,6 @@ export interface Props
   outlineRef?: React.Ref<HTMLElement>
   testIds?: {
     limit?: string
-    outlined?: string
   }
 }
 

--- a/packages/picasso/src/Input/__snapshots__/test.tsx.snap
+++ b/packages/picasso/src/Input/__snapshots__/test.tsx.snap
@@ -24,6 +24,7 @@ exports[`Input renders icon in the beginning 1`] = `
       <input
         autocomplete="none"
         class="MuiInputBase-input MuiOutlinedInput-input PicassoOutlinedInput-input PicassoOutlinedInput-inputMedium MuiInputBase-inputAdornedStart MuiOutlinedInput-inputAdornedStart MuiInputBase-inputAdornedEnd MuiOutlinedInput-inputAdornedEnd"
+        data-testid="input"
         type="text"
         value=""
       />
@@ -70,6 +71,7 @@ exports[`Input renders icon in the end 1`] = `
       <input
         autocomplete="none"
         class="MuiInputBase-input MuiOutlinedInput-input PicassoOutlinedInput-input PicassoOutlinedInput-inputMedium MuiInputBase-inputAdornedStart MuiOutlinedInput-inputAdornedStart MuiInputBase-inputAdornedEnd MuiOutlinedInput-inputAdornedEnd"
+        data-testid="input"
         type="text"
         value=""
       />
@@ -103,6 +105,7 @@ exports[`Input should show manual resize handler 1`] = `
       <textarea
         autocomplete="none"
         class="MuiInputBase-input MuiOutlinedInput-input PicassoOutlinedInput-input PicassoInput-inputMultilineResizable PicassoOutlinedInput-inputMedium MuiInputBase-inputMultiline MuiOutlinedInput-inputMultiline PicassoOutlinedInput-inputMultiline MuiInputBase-inputAdornedStart MuiOutlinedInput-inputAdornedStart MuiInputBase-inputAdornedEnd MuiOutlinedInput-inputAdornedEnd"
+        data-testid="input"
         rows="4"
       >
         Some value
@@ -137,6 +140,7 @@ exports[`Input should show reset button 1`] = `
       <input
         autocomplete="none"
         class="MuiInputBase-input MuiOutlinedInput-input PicassoOutlinedInput-input PicassoOutlinedInput-inputMedium MuiInputBase-inputAdornedStart MuiOutlinedInput-inputAdornedStart MuiInputBase-inputAdornedEnd MuiOutlinedInput-inputAdornedEnd"
+        data-testid="input"
         type="text"
         value="Some value"
       />
@@ -196,6 +200,7 @@ exports[`Input shows counter for multiline input 1`] = `
       <textarea
         autocomplete="none"
         class="MuiInputBase-input MuiOutlinedInput-input PicassoOutlinedInput-input PicassoOutlinedInput-inputMedium MuiInputBase-inputMultiline MuiOutlinedInput-inputMultiline PicassoOutlinedInput-inputMultiline MuiInputBase-inputAdornedStart MuiOutlinedInput-inputAdornedStart MuiInputBase-inputAdornedEnd MuiOutlinedInput-inputAdornedEnd"
+        data-testid="input"
         rows="4"
       />
       <fieldset
@@ -228,6 +233,7 @@ exports[`Input shows counter for regular input 1`] = `
       <input
         autocomplete="none"
         class="MuiInputBase-input MuiOutlinedInput-input PicassoOutlinedInput-input PicassoOutlinedInput-inputMedium MuiInputBase-inputAdornedStart MuiOutlinedInput-inputAdornedStart MuiInputBase-inputAdornedEnd MuiOutlinedInput-inputAdornedEnd"
+        data-testid="input"
         type="text"
         value=""
       />

--- a/packages/picasso/src/Input/__snapshots__/test.tsx.snap
+++ b/packages/picasso/src/Input/__snapshots__/test.tsx.snap
@@ -24,7 +24,6 @@ exports[`Input renders icon in the beginning 1`] = `
       <input
         autocomplete="none"
         class="MuiInputBase-input MuiOutlinedInput-input PicassoOutlinedInput-input PicassoOutlinedInput-inputMedium MuiInputBase-inputAdornedStart MuiOutlinedInput-inputAdornedStart MuiInputBase-inputAdornedEnd MuiOutlinedInput-inputAdornedEnd"
-        data-testid="input"
         type="text"
         value=""
       />
@@ -71,7 +70,6 @@ exports[`Input renders icon in the end 1`] = `
       <input
         autocomplete="none"
         class="MuiInputBase-input MuiOutlinedInput-input PicassoOutlinedInput-input PicassoOutlinedInput-inputMedium MuiInputBase-inputAdornedStart MuiOutlinedInput-inputAdornedStart MuiInputBase-inputAdornedEnd MuiOutlinedInput-inputAdornedEnd"
-        data-testid="input"
         type="text"
         value=""
       />
@@ -105,7 +103,6 @@ exports[`Input should show manual resize handler 1`] = `
       <textarea
         autocomplete="none"
         class="MuiInputBase-input MuiOutlinedInput-input PicassoOutlinedInput-input PicassoInput-inputMultilineResizable PicassoOutlinedInput-inputMedium MuiInputBase-inputMultiline MuiOutlinedInput-inputMultiline PicassoOutlinedInput-inputMultiline MuiInputBase-inputAdornedStart MuiOutlinedInput-inputAdornedStart MuiInputBase-inputAdornedEnd MuiOutlinedInput-inputAdornedEnd"
-        data-testid="input"
         rows="4"
       >
         Some value
@@ -140,7 +137,6 @@ exports[`Input should show reset button 1`] = `
       <input
         autocomplete="none"
         class="MuiInputBase-input MuiOutlinedInput-input PicassoOutlinedInput-input PicassoOutlinedInput-inputMedium MuiInputBase-inputAdornedStart MuiOutlinedInput-inputAdornedStart MuiInputBase-inputAdornedEnd MuiOutlinedInput-inputAdornedEnd"
-        data-testid="input"
         type="text"
         value="Some value"
       />
@@ -200,7 +196,6 @@ exports[`Input shows counter for multiline input 1`] = `
       <textarea
         autocomplete="none"
         class="MuiInputBase-input MuiOutlinedInput-input PicassoOutlinedInput-input PicassoOutlinedInput-inputMedium MuiInputBase-inputMultiline MuiOutlinedInput-inputMultiline PicassoOutlinedInput-inputMultiline MuiInputBase-inputAdornedStart MuiOutlinedInput-inputAdornedStart MuiInputBase-inputAdornedEnd MuiOutlinedInput-inputAdornedEnd"
-        data-testid="input"
         rows="4"
       />
       <fieldset
@@ -233,7 +228,6 @@ exports[`Input shows counter for regular input 1`] = `
       <input
         autocomplete="none"
         class="MuiInputBase-input MuiOutlinedInput-input PicassoOutlinedInput-input PicassoOutlinedInput-inputMedium MuiInputBase-inputAdornedStart MuiOutlinedInput-inputAdornedStart MuiInputBase-inputAdornedEnd MuiOutlinedInput-inputAdornedEnd"
-        data-testid="input"
         type="text"
         value=""
       />

--- a/packages/picasso/src/Input/test.tsx
+++ b/packages/picasso/src/Input/test.tsx
@@ -10,7 +10,7 @@ const testIds = {
 }
 
 const renderInput = (props: OmitInternalProps<Props>) => {
-  return render(<Input data-testid='input' testIds={testIds} {...props} />)
+  return render(<Input {...props} />)
 }
 
 describe('Input', () => {
@@ -45,7 +45,8 @@ describe('Input', () => {
     const { getByTestId } = renderInput({
       multiline: true,
       limit: 1,
-      value: 'A'
+      value: 'A',
+      testIds: { limit: testIds.limit }
     })
 
     expect(getByTestId(testIds.limit)).toMatchSnapshot()
@@ -55,7 +56,8 @@ describe('Input', () => {
     const { getByTestId } = renderInput({
       multiline: true,
       limit: 1,
-      value: 'AB'
+      value: 'AB',
+      testIds: { limit: testIds.limit }
     })
 
     expect(getByTestId(testIds.limit)).toMatchSnapshot()
@@ -66,7 +68,8 @@ describe('Input', () => {
       multiline: true,
       counter: 'entered',
       limit: 1,
-      value: 'AB'
+      value: 'AB',
+      testIds: { limit: testIds.limit }
     })
 
     const inputText = getByTestId(testIds.limit).textContent
@@ -109,7 +112,8 @@ describe('Input', () => {
   it('handles clicks', () => {
     const handleClick = jest.fn()
     const { getByTestId } = renderInput({
-      onClick: handleClick
+      onClick: handleClick,
+      'data-testid': 'input'
     })
 
     const input = getByTestId('input')

--- a/packages/picasso/src/Input/test.tsx
+++ b/packages/picasso/src/Input/test.tsx
@@ -6,12 +6,11 @@ import Input, { Props } from './Input'
 import Search16 from '../Icon/Search16'
 
 const testIds = {
-  limit: 'limit-adornment-multiline-label',
-  outlined: 'reset-adornment'
+  limit: 'limit-adornment-multiline-label'
 }
 
 const renderInput = (props: OmitInternalProps<Props>) => {
-  return render(<Input testIds={testIds} {...props} />)
+  return render(<Input data-testid='input' testIds={testIds} {...props} />)
 }
 
 describe('Input', () => {
@@ -107,7 +106,7 @@ describe('Input', () => {
     expect(container).toMatchSnapshot()
   })
 
-  it.skip('handles clicks', () => {
+  it('handles clicks', () => {
     const handleClick = jest.fn()
     const { getByTestId } = renderInput({
       onClick: handleClick

--- a/packages/picasso/src/Input/test.tsx
+++ b/packages/picasso/src/Input/test.tsx
@@ -6,7 +6,8 @@ import Input, { Props } from './Input'
 import Search16 from '../Icon/Search16'
 
 const testIds = {
-  limit: 'limit-adornment-multiline-label'
+  inputAdornment: 'limit-adornment-multiline-label',
+  resetButton: 'reset-adornment'
 }
 
 const renderInput = (props: OmitInternalProps<Props>) => {
@@ -46,10 +47,10 @@ describe('Input', () => {
       multiline: true,
       limit: 1,
       value: 'A',
-      testIds: { limit: testIds.limit }
+      testIds: { inputAdornment: testIds.inputAdornment }
     })
 
-    expect(getByTestId(testIds.limit)).toMatchSnapshot()
+    expect(getByTestId(testIds.inputAdornment)).toMatchSnapshot()
   })
 
   it('shows excess chars for multiline input with exceeded limit', () => {
@@ -57,10 +58,10 @@ describe('Input', () => {
       multiline: true,
       limit: 1,
       value: 'AB',
-      testIds: { limit: testIds.limit }
+      testIds: { inputAdornment: testIds.inputAdornment }
     })
 
-    expect(getByTestId(testIds.limit)).toMatchSnapshot()
+    expect(getByTestId(testIds.inputAdornment)).toMatchSnapshot()
   })
 
   it('shows entered characters for multiline input with `counter: entered`, ignoring the limit', () => {
@@ -69,10 +70,10 @@ describe('Input', () => {
       counter: 'entered',
       limit: 1,
       value: 'AB',
-      testIds: { limit: testIds.limit }
+      testIds: { inputAdornment: testIds.inputAdornment }
     })
 
-    const inputText = getByTestId(testIds.limit).textContent
+    const inputText = getByTestId(testIds.inputAdornment).textContent
 
     expect(inputText).toContain('2 characters entered')
     expect(inputText).not.toContain('limit')
@@ -92,7 +93,8 @@ describe('Input', () => {
   it('should show reset button', () => {
     const { container } = renderInput({
       enableReset: true,
-      value: 'Some value'
+      value: 'Some value',
+      testIds: { resetButton: testIds.resetButton }
     })
 
     expect(container).toMatchSnapshot()

--- a/packages/picasso/src/Input/test.tsx
+++ b/packages/picasso/src/Input/test.tsx
@@ -1,63 +1,86 @@
 import React from 'react'
 import { render, fireEvent } from '@toptal/picasso/test-utils'
+import { OmitInternalProps } from '@toptal/shared'
 
-import Input from './Input'
+import Input, { Props } from './Input'
 import Search16 from '../Icon/Search16'
+
+const testIds = {
+  limit: 'limit-adornment-multiline-label',
+  outlined: 'reset-adornment'
+}
+
+const renderInput = (props: OmitInternalProps<Props>) => {
+  return render(<Input testIds={testIds} {...props} />)
+}
 
 describe('Input', () => {
   it('renders icon in the end', () => {
-    const { container } = render(<Input icon={<Search16 />} />)
+    const { container } = renderInput({ icon: <Search16 /> })
 
     expect(container).toMatchSnapshot()
   })
 
   it('renders icon in the beginning', () => {
-    const { container } = render(
-      <Input icon={<Search16 />} iconPosition='start' />
-    )
+    const { container } = renderInput({
+      icon: <Search16 />,
+      iconPosition: 'start'
+    })
 
     expect(container).toMatchSnapshot()
   })
 
   it('shows counter for regular input', () => {
-    const { container } = render(<Input limit={10} />)
+    const { container } = renderInput({ limit: 10 })
 
     expect(container).toMatchSnapshot()
   })
 
   it('shows counter for multiline input', () => {
-    const { container } = render(<Input multiline rows={4} limit={10} />)
+    const { container } = renderInput({ multiline: true, rows: 4, limit: 10 })
 
     expect(container).toMatchSnapshot()
   })
 
   it('shows remaining chars for for multiline input with limit', () => {
-    const { getByTestId } = render(<Input multiline limit={1} value='A' />)
+    const { getByTestId } = renderInput({
+      multiline: true,
+      limit: 1,
+      value: 'A'
+    })
 
-    expect(getByTestId('limit-adornment-multiline-label')).toMatchSnapshot()
+    expect(getByTestId(testIds.limit)).toMatchSnapshot()
   })
 
   it('shows excess chars for multiline input with exceeded limit', () => {
-    const { getByTestId } = render(<Input multiline limit={1} value='AB' />)
+    const { getByTestId } = renderInput({
+      multiline: true,
+      limit: 1,
+      value: 'AB'
+    })
 
-    expect(getByTestId('limit-adornment-multiline-label')).toMatchSnapshot()
+    expect(getByTestId(testIds.limit)).toMatchSnapshot()
   })
 
   it('shows entered characters for multiline input with `counter: entered`, ignoring the limit', () => {
-    const { getByTestId } = render(
-      <Input multiline counter='entered' limit={1} value='AB' />
-    )
+    const { getByTestId } = renderInput({
+      multiline: true,
+      counter: 'entered',
+      limit: 1,
+      value: 'AB'
+    })
 
-    const inputText = getByTestId('limit-adornment-multiline-label').textContent
+    const inputText = getByTestId(testIds.limit).textContent
 
     expect(inputText).toContain('2 characters entered')
     expect(inputText).not.toContain('limit')
   })
 
   it('is focused when autoFocus', () => {
-    const { getByPlaceholderText } = render(
-      <Input autoFocus placeholder='test input' />
-    )
+    const { getByPlaceholderText } = renderInput({
+      autoFocus: true,
+      placeholder: 'test input'
+    })
 
     const input = getByPlaceholderText('test input')
 
@@ -65,24 +88,30 @@ describe('Input', () => {
   })
 
   it('should show reset button', () => {
-    const { container } = render(<Input enableReset value='Some value' />)
+    const { container } = renderInput({
+      enableReset: true,
+      value: 'Some value'
+    })
 
     expect(container).toMatchSnapshot()
   })
 
   it('should show manual resize handler', () => {
-    const { container } = render(
-      <Input multiline multilineResizable rows={4} value='Some value' />
-    )
+    const { container } = renderInput({
+      multiline: true,
+      multilineResizable: true,
+      rows: 4,
+      value: 'Some value'
+    })
 
     expect(container).toMatchSnapshot()
   })
 
-  it('handles clicks', () => {
+  it.skip('handles clicks', () => {
     const handleClick = jest.fn()
-    const { getByTestId } = render(
-      <Input data-testid='input' onClick={handleClick} />
-    )
+    const { getByTestId } = renderInput({
+      onClick: handleClick
+    })
 
     const input = getByTestId('input')
     const inputWrapper = input.parentElement

--- a/packages/picasso/src/InputAdornment/InputAdornment.tsx
+++ b/packages/picasso/src/InputAdornment/InputAdornment.tsx
@@ -21,7 +21,7 @@ export interface Props extends BaseProps, HTMLAttributes<HTMLDivElement> {
   disabled?: boolean
   disablePointerEvents?: boolean
   stopPropagation?: boolean
-  testId?: string
+  'data-testid'?: string
 }
 
 const useStyles = makeStyles<Theme>(styles, {
@@ -37,7 +37,7 @@ const InputAdornment: FunctionComponent<Props> = props => {
     disabled,
     disablePointerEvents,
     stopPropagation,
-    testId,
+    'data-testid': dataTestId,
     onClick = noop,
     ...rest
   } = props
@@ -67,7 +67,7 @@ const InputAdornment: FunctionComponent<Props> = props => {
       position={position}
       disablePointerEvents={disablePointerEvents}
       onClick={handleClick}
-      data-testid={testId}
+      data-testid={dataTestId}
     >
       {children}
     </MUIInputAdornment>

--- a/packages/picasso/src/InputAdornment/InputAdornment.tsx
+++ b/packages/picasso/src/InputAdornment/InputAdornment.tsx
@@ -67,7 +67,7 @@ const InputAdornment: FunctionComponent<Props> = props => {
       position={position}
       disablePointerEvents={disablePointerEvents}
       onClick={handleClick}
-      data-testId={testId}
+      data-testid={testId}
     >
       {children}
     </MUIInputAdornment>

--- a/packages/picasso/src/InputAdornment/InputAdornment.tsx
+++ b/packages/picasso/src/InputAdornment/InputAdornment.tsx
@@ -21,6 +21,7 @@ export interface Props extends BaseProps, HTMLAttributes<HTMLDivElement> {
   disabled?: boolean
   disablePointerEvents?: boolean
   stopPropagation?: boolean
+  testId?: string
 }
 
 const useStyles = makeStyles<Theme>(styles, {
@@ -36,6 +37,7 @@ const InputAdornment: FunctionComponent<Props> = props => {
     disabled,
     disablePointerEvents,
     stopPropagation,
+    testId,
     onClick = noop,
     ...rest
   } = props
@@ -65,6 +67,7 @@ const InputAdornment: FunctionComponent<Props> = props => {
       position={position}
       disablePointerEvents={disablePointerEvents}
       onClick={handleClick}
+      data-testId={testId}
     >
       {children}
     </MUIInputAdornment>

--- a/packages/picasso/src/Menu/Menu.tsx
+++ b/packages/picasso/src/Menu/Menu.tsx
@@ -17,6 +17,9 @@ export interface Props extends BaseProps, HTMLAttributes<HTMLUListElement> {
   variant?: MenuVariant
   /** Whether or not to handle nested navigation */
   allowNestedNavigation?: boolean
+  testIds?: {
+    menuItem?: string
+  }
 }
 
 const useStyles = makeStyles<Theme>(styles, {
@@ -33,6 +36,7 @@ export const Menu = forwardRef<HTMLUListElement, Props>(function Menu(
     style,
     variant,
     allowNestedNavigation,
+    testIds,
     ...rest
   } = props
   const classes = useStyles()
@@ -50,7 +54,11 @@ export const Menu = forwardRef<HTMLUListElement, Props>(function Menu(
           onMouseLeave={onMenuMouseLeave}
         >
           {hasBackButton && allowNestedNavigation && (
-            <MenuItem key='back' onClick={onBackClick}>
+            <MenuItem
+              key='back'
+              data-testid={testIds?.menuItem}
+              onClick={onBackClick}
+            >
               <Typography size='small' color='dark-grey' variant='body'>
                 <BackMinor16 className={classes.backButtonIcon} />
                 Back

--- a/packages/picasso/src/Menu/Menu.tsx
+++ b/packages/picasso/src/Menu/Menu.tsx
@@ -50,7 +50,7 @@ export const Menu = forwardRef<HTMLUListElement, Props>(function Menu(
           onMouseLeave={onMenuMouseLeave}
         >
           {hasBackButton && allowNestedNavigation && (
-            <MenuItem key='back' data-testid='menu-back' onClick={onBackClick}>
+            <MenuItem key='back' onClick={onBackClick}>
               <Typography size='small' color='dark-grey' variant='body'>
                 <BackMinor16 className={classes.backButtonIcon} />
                 Back

--- a/packages/picasso/src/NativeSelect/NativeSelect.tsx
+++ b/packages/picasso/src/NativeSelect/NativeSelect.tsx
@@ -60,6 +60,7 @@ export const NativeSelect = documentable(
         searchThreshold,
         limit,
         native,
+        testIds,
         /* eslint-enable @typescript-eslint/no-unused-vars */
         ...rest
       } = props
@@ -117,6 +118,7 @@ export const NativeSelect = documentable(
               inputProps={{ multiple }}
               size={size}
               className={classes.nativeInput}
+              testIds={testIds}
               // eslint-disable-next-line react/jsx-props-no-spreading
               {...getInputProps()}
             />

--- a/packages/picasso/src/NonNativeSelect/NonNativeSelect.tsx
+++ b/packages/picasso/src/NonNativeSelect/NonNativeSelect.tsx
@@ -122,6 +122,7 @@ export const NonNativeSelect = documentable(
             placeholder={searchPlaceholder}
             size={size}
             value={filterOptionsValue}
+            testIds={testIds}
             aria-autocomplete='list'
             /* eslint-disable-next-line react/jsx-props-no-spreading */
             {...getSearchInputProps()}
@@ -172,6 +173,7 @@ export const NonNativeSelect = documentable(
                 enableAutofill ? autoComplete : autoComplete || 'off'
               }
               name={enableAutofill ? name : undefined}
+              testIds={testIds}
             />
             <SelectCaret disabled={disabled} />
           </div>

--- a/packages/picasso/src/OutlinedInput/OutlinedInput.tsx
+++ b/packages/picasso/src/OutlinedInput/OutlinedInput.tsx
@@ -70,6 +70,7 @@ export interface Props
   ) => void
   /** Ref of the input element */
   inputRef?: React.Ref<HTMLInputElement>
+  testId?: string
 }
 
 const useStyles = makeStyles<Theme, Props>(styles, {
@@ -79,13 +80,16 @@ const useStyles = makeStyles<Theme, Props>(styles, {
 const ResetButton = ({
   classes,
   hasValue,
-  onClick
+  onClick,
+  testId
 }: {
   classes: Classes
   hasValue: boolean
   onClick: (event: MouseEvent<HTMLButtonElement & HTMLAnchorElement>) => void
+  testId?: string
 }) => (
   <InputAdornment
+    testId={testId}
     position='end'
     className={cx(classes.resetButton, {
       [classes.resetButtonDirty]: hasValue
@@ -133,6 +137,7 @@ const OutlinedInput = forwardRef<HTMLElement, Props>(function OutlinedInput(
     disabled,
     onResetClick = noop,
     inputRef,
+    testId,
     ...rest
   } = props
 
@@ -145,6 +150,7 @@ const OutlinedInput = forwardRef<HTMLElement, Props>(function OutlinedInput(
         classes={classes}
         hasValue={Boolean(value)}
         onClick={onResetClick}
+        testId={testId}
       />
       {userDefinedEndAdornment}
     </>

--- a/packages/picasso/src/OutlinedInput/OutlinedInput.tsx
+++ b/packages/picasso/src/OutlinedInput/OutlinedInput.tsx
@@ -81,7 +81,7 @@ const ResetButton = ({
   classes,
   hasValue,
   onClick,
-  testId
+  testId = 'reset-adornment'
 }: {
   classes: Classes
   hasValue: boolean

--- a/packages/picasso/src/OutlinedInput/OutlinedInput.tsx
+++ b/packages/picasso/src/OutlinedInput/OutlinedInput.tsx
@@ -86,7 +86,6 @@ const ResetButton = ({
   onClick: (event: MouseEvent<HTMLButtonElement & HTMLAnchorElement>) => void
 }) => (
   <InputAdornment
-    data-testid='reset-adornment'
     position='end'
     className={cx(classes.resetButton, {
       [classes.resetButtonDirty]: hasValue

--- a/packages/picasso/src/OutlinedInput/OutlinedInput.tsx
+++ b/packages/picasso/src/OutlinedInput/OutlinedInput.tsx
@@ -70,7 +70,9 @@ export interface Props
   ) => void
   /** Ref of the input element */
   inputRef?: React.Ref<HTMLInputElement>
-  testId?: string
+  testIds?: {
+    resetButton?: string
+  }
 }
 
 const useStyles = makeStyles<Theme, Props>(styles, {
@@ -81,15 +83,15 @@ const ResetButton = ({
   classes,
   hasValue,
   onClick,
-  testId = 'reset-adornment'
+  testIds
 }: {
   classes: Classes
   hasValue: boolean
   onClick: (event: MouseEvent<HTMLButtonElement & HTMLAnchorElement>) => void
-  testId?: string
+  testIds?: Props['testIds']
 }) => (
   <InputAdornment
-    testId={testId}
+    data-testid={testIds?.resetButton}
     position='end'
     className={cx(classes.resetButton, {
       [classes.resetButtonDirty]: hasValue
@@ -137,7 +139,7 @@ const OutlinedInput = forwardRef<HTMLElement, Props>(function OutlinedInput(
     disabled,
     onResetClick = noop,
     inputRef,
-    testId,
+    testIds,
     ...rest
   } = props
 
@@ -150,7 +152,7 @@ const OutlinedInput = forwardRef<HTMLElement, Props>(function OutlinedInput(
         classes={classes}
         hasValue={Boolean(value)}
         onClick={onResetClick}
-        testId={testId}
+        testIds={testIds}
       />
       {userDefinedEndAdornment}
     </>

--- a/packages/picasso/src/PageAutocomplete/PageAutocomplete.tsx
+++ b/packages/picasso/src/PageAutocomplete/PageAutocomplete.tsx
@@ -5,14 +5,16 @@ import Autocomplete, { AutocompleteProps } from '../Autocomplete'
 export interface Props extends AutocompleteProps {
   /** The variant to use */
   variant?: 'light' | 'dark'
+  testIds?: AutocompleteProps['testIds']
 }
 
-export const PageAutocomplete = ({ variant, ...rest }: Props) => (
+export const PageAutocomplete = ({ variant, testIds, ...rest }: Props) => (
   <Autocomplete
     inputProps={{
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       variant: variant!
     }}
+    testIds={testIds}
     {...rest}
   />
 )

--- a/packages/picasso/src/PageAutocomplete/test.tsx
+++ b/packages/picasso/src/PageAutocomplete/test.tsx
@@ -12,6 +12,10 @@ const testOptions = [
   { text: 'Ukraine', value: 'UA' }
 ]
 
+const testIds = {
+  resetButton: 'reset-adornment'
+}
+
 const renderAutocomplete = (props: OmitInternalProps<Props>) =>
   render(<PageAutocomplete data-testid='autocomplete' {...props} />)
 
@@ -19,7 +23,8 @@ describe('PageAutocomplete', () => {
   it('renders', () => {
     const { container } = renderAutocomplete({
       options: testOptions,
-      value: ''
+      value: '',
+      testIds: { resetButton: testIds.resetButton }
     })
 
     expect(container).toMatchSnapshot()

--- a/packages/picasso/src/PageAutocomplete/test.tsx
+++ b/packages/picasso/src/PageAutocomplete/test.tsx
@@ -13,18 +13,18 @@ const testOptions = [
 ]
 
 const testIds = {
-  resetButton: 'reset-adornment'
+  resetButton: 'reset-adornment',
+  input: 'autocomplete'
 }
 
 const renderAutocomplete = (props: OmitInternalProps<Props>) =>
-  render(<PageAutocomplete data-testid='autocomplete' {...props} />)
+  render(<PageAutocomplete testIds={testIds} {...props} />)
 
 describe('PageAutocomplete', () => {
   it('renders', () => {
     const { container } = renderAutocomplete({
       options: testOptions,
-      value: '',
-      testIds: { resetButton: testIds.resetButton }
+      value: ''
     })
 
     expect(container).toMatchSnapshot()

--- a/packages/picasso/src/Paper/Paper.tsx
+++ b/packages/picasso/src/Paper/Paper.tsx
@@ -9,6 +9,7 @@ export interface Props extends BaseProps, HTMLAttributes<HTMLDivElement> {
   /** Content of component */
   elevation?: number
   children: ReactNode
+  'data-testid'?: string
 }
 
 const useStyles = makeStyles<Theme>(styles, { name: 'PicassoPaper' })
@@ -17,7 +18,14 @@ export const Paper = forwardRef<HTMLDivElement, Props>(function Paper(
   props,
   ref
 ) {
-  const { className, style, elevation, children, ...rest } = props
+  const {
+    className,
+    style,
+    elevation,
+    children,
+    'data-testid': dataTestId,
+    ...rest
+  } = props
   const classes = useStyles()
 
   return (
@@ -28,6 +36,7 @@ export const Paper = forwardRef<HTMLDivElement, Props>(function Paper(
       className={className}
       style={style}
       elevation={elevation}
+      data-testid={dataTestId}
       square
     >
       {children}

--- a/packages/picasso/src/ProgressBar/ProgressBar.tsx
+++ b/packages/picasso/src/ProgressBar/ProgressBar.tsx
@@ -15,7 +15,7 @@ export interface Props extends BaseProps {
   value: number
   /** Whether to show percentage value */
   showPercentage?: boolean
-  testId?: string
+  'data-testid'?: string
 }
 
 const useStyles = makeStyles<Theme, Props>(styles, {
@@ -27,7 +27,12 @@ const normalizeValue = (value: number) =>
 
 export const ProgressBar = forwardRef<HTMLDivElement, Props>(
   function ProgressBar(props, ref) {
-    const { value, showPercentage, testId, ...restProps } = props
+    const {
+      value,
+      showPercentage,
+      'data-testid': dataTestId,
+      ...restProps
+    } = props
     const classes = useStyles(props)
 
     const percentage = normalizeValue(value)
@@ -37,7 +42,7 @@ export const ProgressBar = forwardRef<HTMLDivElement, Props>(
         flex
         direction='row'
         alignItems='center'
-        data-testid={testId}
+        data-testid={dataTestId}
         {...restProps}
         ref={ref}
       >

--- a/packages/picasso/src/ProgressBar/ProgressBar.tsx
+++ b/packages/picasso/src/ProgressBar/ProgressBar.tsx
@@ -15,6 +15,7 @@ export interface Props extends BaseProps {
   value: number
   /** Whether to show percentage value */
   showPercentage?: boolean
+  testId?: string
 }
 
 const useStyles = makeStyles<Theme, Props>(styles, {
@@ -26,7 +27,7 @@ const normalizeValue = (value: number) =>
 
 export const ProgressBar = forwardRef<HTMLDivElement, Props>(
   function ProgressBar(props, ref) {
-    const { value, showPercentage, ...restProps } = props
+    const { value, showPercentage, testId, ...restProps } = props
     const classes = useStyles(props)
 
     const percentage = normalizeValue(value)
@@ -36,6 +37,7 @@ export const ProgressBar = forwardRef<HTMLDivElement, Props>(
         flex
         direction='row'
         alignItems='center'
+        data-testid={testId}
         {...restProps}
         ref={ref}
       >

--- a/packages/picasso/src/Select/types.ts
+++ b/packages/picasso/src/Select/types.ts
@@ -7,6 +7,8 @@ import {
 import PopperJs from 'popper.js'
 import { BaseProps, SizeType } from '@toptal/picasso-shared'
 
+import { OutlinedInputProps } from '../OutlinedInput'
+
 /**
  * Select props are generalized over possible values in the component and whether
  * Select should be a multiselect. If you want `onChange` to take a handler that
@@ -88,7 +90,7 @@ export interface SelectProps<
   /** Specifies whether the autofill enabled or not, disabled by default */
   enableAutofill?: boolean
   ref?: React.Ref<HTMLInputElement>
-  testIds?: {
+  testIds?: OutlinedInputProps['testIds'] & {
     noOptions?: string
     loader?: string
     limitFooter?: string

--- a/packages/topkit-analytics-charts/src/CategoriesChartTooltip/CategoriesChartTooltip.tsx
+++ b/packages/topkit-analytics-charts/src/CategoriesChartTooltip/CategoriesChartTooltip.tsx
@@ -9,13 +9,17 @@ export type Props = {
   payload: { payload: { name: string; team: number; user: number } }[]
   tooltips: TooltipMap
   originalData: DataItem[]
+  testIds?: {
+    paper?: string
+  }
 }
 
 const CategoriesChartTooltip: FC<Props> = ({
   active,
   payload,
   tooltips,
-  originalData
+  originalData,
+  testIds
 }) => {
   if (active && payload && payload.length > 0) {
     const currentData = originalData.find(
@@ -33,7 +37,7 @@ const CategoriesChartTooltip: FC<Props> = ({
     })
 
     return (
-      <Paper>
+      <Paper data-testid={testIds?.paper}>
         <Container padded='xsmall'>
           {teamTexts.map(({ key, label, value, color }) => (
             <Typography size='medium' style={{ color }} key={key}>

--- a/packages/topkit-analytics-charts/src/CategoriesChartTooltip/CategoriesChartTooltip.tsx
+++ b/packages/topkit-analytics-charts/src/CategoriesChartTooltip/CategoriesChartTooltip.tsx
@@ -33,7 +33,7 @@ const CategoriesChartTooltip: FC<Props> = ({
     })
 
     return (
-      <Paper data-testid='tooltip-content'>
+      <Paper>
         <Container padded='xsmall'>
           {teamTexts.map(({ key, label, value, color }) => (
             <Typography size='medium' style={{ color }} key={key}>

--- a/packages/topkit-analytics-charts/src/CategoriesChartTooltip/test.tsx
+++ b/packages/topkit-analytics-charts/src/CategoriesChartTooltip/test.tsx
@@ -3,6 +3,10 @@ import { render, screen, TestingPicasso } from '@toptal/picasso/test-utils'
 
 import CategoriesChartTooltip, { Props } from './CategoriesChartTooltip'
 
+const testIds = {
+  paper: 'tooltip-content'
+}
+
 const renderTooltip = (props: Partial<Props>) => {
   const defaultProps = {
     active: true,
@@ -23,5 +27,24 @@ describe('CategoriesChartTooltip', () => {
     renderTooltip({ active: false })
 
     expect(screen.queryByTestId('tooltip')).not.toBeInTheDocument()
+  })
+
+  it('renders tooltip when active and has payload', () => {
+    const { getByTestId } = renderTooltip({
+      active: true,
+      originalData: [
+        {
+          id: 'payload-name',
+          values: [
+            { id: 'value1', values: [] },
+            { id: 'value2', values: [] }
+          ]
+        }
+      ],
+      payload: [{ payload: { name: 'payload-name', team: 0, user: 0 } }],
+      testIds: { paper: testIds.paper }
+    })
+
+    expect(getByTestId(testIds.paper)).not.toBeNull()
   })
 })


### PR DESCRIPTION
[FX-2205](https://toptal-core.atlassian.net/browse/FX-2205)

### Description

- Replace hardcoded data testid values with dynamic ones

> This PR is done, even though team hasn't yet decided which property to use to test components. Answer will be available after survey.

### How to test

- For example, in `packages/picasso/src/Input/test.tsx`, change `testIds.inputAdornment` to whatever value you want. The tests should not fail.

```javascript
const testIds = {
  // inputAdornment: 'limit-adornment-multiline-label', // original
  inputAdornment: "something-else"
}
```

### Screenshots

![image](https://user-images.githubusercontent.com/72510037/141429312-b87a89bc-cb6e-4f89-b988-5830e408eb9f.png)

### Review

- [ ] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/api-principles.md)
- [ ] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that tests pass by running `yarn test`
- [ ] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
- [ ] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>
