### PR TITLE
chore: fix directory path in publishConfig

### DIFF
--- a/packages/picasso-charts/package.json
+++ b/packages/picasso-charts/package.json
@@ -12,7 +12,7 @@
   },
   "publishConfig": {
     "access": "public",
-    "directory": "./dist-package"
+    "directory": "dist-package"
   },
   "scripts": {
     "build:package": "cross-env NODE_ENV=production node ../../bin/build.js --tsConfig=./tsconfig.build.json",

--- a/packages/picasso-codemod/package.json
+++ b/packages/picasso-codemod/package.json
@@ -9,7 +9,7 @@
   "module": "index.js",
   "publishConfig": {
     "access": "public",
-    "directory": "./dist-package"
+    "directory": "dist-package"
   },
   "repository": {
     "type": "git",

--- a/packages/picasso-forms/package.json
+++ b/packages/picasso-forms/package.json
@@ -9,7 +9,7 @@
   "module": "index.js",
   "publishConfig": {
     "access": "public",
-    "directory": "./dist-package"
+    "directory": "dist-package"
   },
   "repository": {
     "type": "git",

--- a/packages/picasso-lab/package.json
+++ b/packages/picasso-lab/package.json
@@ -9,7 +9,7 @@
   "module": "index.js",
   "publishConfig": {
     "access": "public",
-    "directory": "./dist-package"
+    "directory": "dist-package"
   },
   "repository": {
     "type": "git",

--- a/packages/picasso-provider/package.json
+++ b/packages/picasso-provider/package.json
@@ -12,7 +12,7 @@
   },
   "publishConfig": {
     "access": "public",
-    "directory": "./dist-package"
+    "directory": "dist-package"
   },
   "scripts": {
     "build:package": "cross-env NODE_ENV=production node ./bin/build.js",

--- a/packages/picasso/package.json
+++ b/packages/picasso/package.json
@@ -4,7 +4,7 @@
   "description": "Toptal UI components library",
   "publishConfig": {
     "access": "public",
-    "directory": "./dist-package"
+    "directory": "dist-package"
   },
   "main": "index.js",
   "module": "index.js",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -9,7 +9,7 @@
   "module": "index.js",
   "publishConfig": {
     "access": "public",
-    "directory": "./dist-package"
+    "directory": "dist-package"
   },
   "repository": {
     "type": "git",

--- a/packages/topkit-analytics-charts/package.json
+++ b/packages/topkit-analytics-charts/package.json
@@ -12,7 +12,7 @@
   },
   "publishConfig": {
     "access": "public",
-    "directory": "./dist-package"
+    "directory": "dist-package"
   },
   "scripts": {
     "build:package": "cross-env NODE_ENV=production node ../../bin/build.js --tsConfig=./tsconfig.build.json",


### PR DESCRIPTION
[FX-NNNN]

### Description

Changeset publish has probably problem to find `./dist-package`, we are trying to set it without relative path.

### How to test

- FIXME: Add the steps describing how to verify your changes

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| Insert screenshots or screen recordings | Insert screenshots or screen recordings |

### Review

- [ ] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/api-principles.md)
- [ ] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that tests pass by running `yarn test`
- [ ] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
- [ ] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>
