### PR TITLE
fix(TagSelector): closing when being scrolled

### DIFF
--- a/.changeset/dull-avocados-chew.md
+++ b/.changeset/dull-avocados-chew.md
@@ -1,0 +1,5 @@
+---
+'@toptal/picasso': minor
+---
+
+Fixed closing overlay when scrolling in TagSelector and Autocomplete

--- a/.changeset/dull-avocados-chew.md
+++ b/.changeset/dull-avocados-chew.md
@@ -1,5 +1,5 @@
 ---
-'@toptal/picasso': minor
+'@toptal/picasso': patch
 ---
 
 Fixed closing overlay when scrolling in TagSelector and Autocomplete

--- a/packages/picasso/src/Autocomplete/test.tsx
+++ b/packages/picasso/src/Autocomplete/test.tsx
@@ -290,7 +290,7 @@ describe('Autocomplete', () => {
 
       // calls onFocus handler
       expect(onFocus).toHaveBeenCalledTimes(1)
-      expect(queryByTestId('scroll-menu')).toBeNull()
+      expect(queryByTestId(testIds.scrollMenu)).toBeNull()
 
       fireEvent.click(input)
       expect(getByTestId(testIds.scrollMenu)).toMatchSnapshot()
@@ -329,6 +329,21 @@ describe('Autocomplete', () => {
       fireEvent.blur(input)
 
       expect(onBlur).toHaveBeenCalledTimes(1)
+    })
+
+    it('prevents mouseDown on ScrollMenu', () => {
+      const { getByTestId } = renderAutocomplete({
+        options: testOptions,
+        value: ''
+      })
+
+      const input = getByTestId('autocomplete')
+
+      fireEvent.click(input)
+      const scrollMenu = getByTestId(testIds.scrollMenu)
+      const isPrevented = !fireEvent.mouseDown(scrollMenu)
+
+      expect(isPrevented).toBeTruthy()
     })
 
     it('on select option', () => {

--- a/packages/picasso/src/ScrollMenu/ScrollMenu.tsx
+++ b/packages/picasso/src/ScrollMenu/ScrollMenu.tsx
@@ -75,12 +75,12 @@ const ScrollMenu: FunctionComponent<Props> = props => {
       className={classes.menu}
       style={style}
       role={role}
+      // eslint-disable-next-line react/jsx-props-no-spreading
+      {...rest}
       onMouseDown={e => {
         // ScrollMenu is used in dropdowns. Prevents blur --> dropdown close when scrolled.
         e.preventDefault()
       }}
-      // eslint-disable-next-line react/jsx-props-no-spreading
-      {...rest}
     >
       {fixedHeader}
       <div ref={menuRef} className={classes.scrollView} onBlur={onBlur}>

--- a/packages/picasso/src/ScrollMenu/ScrollMenu.tsx
+++ b/packages/picasso/src/ScrollMenu/ScrollMenu.tsx
@@ -75,6 +75,10 @@ const ScrollMenu: FunctionComponent<Props> = props => {
       className={classes.menu}
       style={style}
       role={role}
+      onMouseDown={e => {
+        // ScrollMenu is used in dropdowns. Prevents blur --> dropdown close when scrolled.
+        e.preventDefault()
+      }}
       // eslint-disable-next-line react/jsx-props-no-spreading
       {...rest}
     >


### PR DESCRIPTION
[FX-2068]

### Description

TagSelector and Autocomplete were closing when you clicked on scroll in its overlay. This bug is fixed.

### How to test

- Open https://picasso.toptal.net/fx-fix-closing-TagSelector-and-Autocomplete-when-scrolling/?path=/story/forms-tagselector--tagselector, Default example. 
- Scroll with the mouse by clicking on scroll now using the wheel.
- `TagSelector` should not close


### Review

- [ ] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/api-principles.md)
- [ ] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that tests pass by running `yarn test`
- [ ] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
- [ ] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>


[FX-2068]: https://toptal-core.atlassian.net/browse/FX-2068?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ