### PR TITLE
fix(Select): fix number value has no display value

### DIFF
--- a/.changeset/angry-steaks-worry.md
+++ b/.changeset/angry-steaks-worry.md
@@ -1,0 +1,5 @@
+---
+'@toptal/picasso': patch
+---
+
+Fix option in Select cannot be selected when using number values.

--- a/packages/picasso/src/Select/utils/get-selected-options/get-selected-options.ts
+++ b/packages/picasso/src/Select/utils/get-selected-options/get-selected-options.ts
@@ -6,7 +6,7 @@ const getSelectedOptions = (
 ) => {
   const valuesSet = new Set(Array.isArray(value) ? value : [value])
 
-  return flatOptions.filter(option => valuesSet.has(String(option.value)))
+  return flatOptions.filter(option => valuesSet.has(option.value))
 }
 
 export default getSelectedOptions

--- a/packages/picasso/src/Select/utils/get-selected-options/test.ts
+++ b/packages/picasso/src/Select/utils/get-selected-options/test.ts
@@ -16,4 +16,20 @@ describe('getSelectedOptions', () => {
       options[1]
     ])
   })
+
+  it('works with numbers', () => {
+    const options = [
+      { text: 'One', value: 1 },
+      { text: 'Two', value: 2 },
+      { text: 'Three', value: '3' }
+    ]
+
+    expect(getSelectedOptions(options, [])).toEqual([])
+    expect(getSelectedOptions(options, 1)).toEqual([options[0]])
+    expect(getSelectedOptions(options, [1])).toEqual([options[0]])
+    expect(getSelectedOptions(options, [2, '3'])).toEqual([
+      options[1],
+      options[2]
+    ])
+  })
 })


### PR DESCRIPTION
[FX-2252](https://toptal-core.atlassian.net/browse/FX-2252)

### Description

Using values of type `number` in `Select` breaks option selection.

### How to test

1. Open `Custom options` example.
2. Pick an option.
3. Be sure that `Select`'s input has the correct value.

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| Insert screenshots or screen recordings | Insert screenshots or screen recordings |

### Review

- [ ] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/api-principles.md)
- [ ] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that tests pass by running `yarn test`
- [ ] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
- [ ] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>
