### PR TITLE
chore: fix release through changesets

### DIFF
--- a/bin/prepublish.js
+++ b/bin/prepublish.js
@@ -1,8 +1,0 @@
-#!/usr/bin/env node
-
-const path = require('path')
-const packageRootDir = path.resolve('.')
-
-const { copyPackageJson } = require('./utils')
-
-copyPackageJson(packageRootDir)

--- a/packages/picasso-charts/package.json
+++ b/packages/picasso-charts/package.json
@@ -15,8 +15,7 @@
     "directory": "dist-package"
   },
   "scripts": {
-    "build:package": "cross-env NODE_ENV=production node ../../bin/build.js --tsConfig=./tsconfig.build.json",
-    "prepublishOnly": "../../../bin/prepublish.js"
+    "build:package": "cross-env NODE_ENV=production node ../../bin/build.js --tsConfig=./tsconfig.build.json"
   },
   "bugs": {
     "url": "https://github.com/toptal/picasso/issues"

--- a/packages/picasso-codemod/package.json
+++ b/packages/picasso-codemod/package.json
@@ -16,8 +16,7 @@
     "url": "git+https://github.com/toptal/picasso.git"
   },
   "scripts": {
-    "build:package": "cross-env NODE_ENV=production node ../../bin/build.js --tsConfig=./tsconfig.build.json",
-    "prepublishOnly": "../../../bin/prepublish.js"
+    "build:package": "cross-env NODE_ENV=production node ../../bin/build.js --tsConfig=./tsconfig.build.json"
   },
   "bugs": {
     "url": "https://github.com/toptal/picasso/issues"

--- a/packages/picasso-forms/package.json
+++ b/packages/picasso-forms/package.json
@@ -16,8 +16,7 @@
     "url": "git+https://github.com/toptal/picasso.git"
   },
   "scripts": {
-    "build:package": "cross-env NODE_ENV=production node ../../bin/build.js --tsConfig=./tsconfig.build.json",
-    "prepublishOnly": "../../../bin/prepublish.js"
+    "build:package": "cross-env NODE_ENV=production node ../../bin/build.js --tsConfig=./tsconfig.build.json"
   },
   "bugs": {
     "url": "https://github.com/toptal/picasso/issues"

--- a/packages/picasso-lab/package.json
+++ b/packages/picasso-lab/package.json
@@ -16,8 +16,7 @@
     "url": "git+https://github.com/toptal/picasso.git"
   },
   "scripts": {
-    "build:package": "cross-env NODE_ENV=production node ../../bin/build.js --tsConfig=./tsconfig.build.json",
-    "prepublishOnly": "../../../bin/prepublish.js"
+    "build:package": "cross-env NODE_ENV=production node ../../bin/build.js --tsConfig=./tsconfig.build.json"
   },
   "bugs": {
     "url": "https://github.com/toptal/picasso/issues"

--- a/packages/picasso-provider/package.json
+++ b/packages/picasso-provider/package.json
@@ -15,8 +15,7 @@
     "directory": "dist-package"
   },
   "scripts": {
-    "build:package": "cross-env NODE_ENV=production node ./bin/build.js",
-    "prepublishOnly": "../../../bin/prepublish.js"
+    "build:package": "cross-env NODE_ENV=production node ./bin/build.js"
   },
   "bugs": {
     "url": "https://github.com/toptal/picasso/issues"

--- a/packages/picasso/package.json
+++ b/packages/picasso/package.json
@@ -9,8 +9,7 @@
   "main": "index.js",
   "module": "index.js",
   "scripts": {
-    "build:package": "cross-env NODE_ENV=production node ../../bin/build.js --tsConfig=./tsconfig.build.json",
-    "prepublishOnly": "../../../bin/prepublish.js"
+    "build:package": "cross-env NODE_ENV=production node ../../bin/build.js --tsConfig=./tsconfig.build.json"
   },
   "repository": {
     "type": "git",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -16,8 +16,7 @@
     "url": "git+https://github.com/toptal/picasso.git"
   },
   "scripts": {
-    "build:package": "cross-env NODE_ENV=production node ../../bin/build.js --tsConfig=./tsconfig.build.json",
-    "prepublishOnly": "../../../bin/prepublish.js"
+    "build:package": "cross-env NODE_ENV=production node ../../bin/build.js --tsConfig=./tsconfig.build.json"
   },
   "bugs": {
     "url": "https://github.com/toptal/picasso/issues"

--- a/packages/topkit-analytics-charts/package.json
+++ b/packages/topkit-analytics-charts/package.json
@@ -15,8 +15,7 @@
     "directory": "dist-package"
   },
   "scripts": {
-    "build:package": "cross-env NODE_ENV=production node ../../bin/build.js --tsConfig=./tsconfig.build.json",
-    "prepublishOnly": "../../../bin/prepublish.js"
+    "build:package": "cross-env NODE_ENV=production node ../../bin/build.js --tsConfig=./tsconfig.build.json"
   },
   "bugs": {
     "url": "https://github.com/toptal/picasso/issues"


### PR DESCRIPTION
### Description

`prepublish` should copy `packages/picasso/package.json` to `packages/picasso/dist-package`, but this is already done by `yarn build:packages`

so the issue was, that `prepublish` was being called from `dist-package/package.json`


### How to test

- run `yarn build:packages` and check, that generated `dist-package` has package.json inside


### Review

- [ ] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/api-principles.md)
- [ ] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that tests pass by running `yarn test`
- [ ] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
- [ ] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>
