### PR TITLE
chore: disable GHA for changesets PR

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -15,9 +15,9 @@ on:
 
 jobs:
   tests:
+    if: ${{ github.event.pull_request.head.ref != 'changeset-release/master' }}
     runs-on: ubuntu-latest
     timeout-minutes: 45
-
     env:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,7 +88,7 @@ jobs:
                 ]
               })
             }
-      - name: Edit "Version Pacakge" PR
+      - name: Edit "Version Package" PR
         if: ${{ steps.changesets.outputs.published != 'true' }}
         uses: actions/github-script@v5
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,7 +73,7 @@ jobs:
                 ]
               })
             }
-      - name: Add peerDependencies warning to "Version Package" PR
+      - name: Edit "Version Pacakge" PR
         if: ${{ steps.changesets.outputs.published != 'true' }}
         uses: actions/github-script@v5
         with:
@@ -88,18 +88,21 @@ jobs:
               state: 'open',
               head: 'toptal:changeset-release/master'
             })
-            // append PR body with peerDependencies warning
             for await (let pr of data) {
+              // append PR body with peerDependencies warning
               const hr = "\n_____"
               const warningTodo = "\n- [ ] ⚠️ "
               const message = "If major release, don't forget to check if peerDependencies needs to be also updated"
               const appendedMessage = hr + warningTodo + message
               const body = pr.body.includes(message) ? pr.body : pr.body + appendedMessage
+
+              // append title with [skip ci]
               github.rest.pulls.update({
                 owner: 'toptal',
                 repo: 'picasso',
                 pull_number: pr.number,
                 body: body,
+                title: pr.title.includes('[skip ci]') ? pr.title : `${pr.title} [skip ci]`,
               })
             }
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,13 +30,28 @@ jobs:
         with:
           node-version: 14.x
 
-      - name: Check yarn cache
-        uses: c-hive/gha-yarn-cache@v2
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
 
-      - name: Install Dependencies
+      - name: Check yarn cache
+        uses: actions/cache@v2.1.5
+        id: yarn-cache
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+      - name: Install Dependencies (from network)
+        if: ${{ steps.yarn-cache.outputs.cache-hit != 'true' }}
         run: |
           yarn policies set-version
           yarn install --frozen-lockfile --ignore-optional
+      - name: Install Dependencies (from cache)
+        if: ${{ steps.yarn-cache.outputs.cache-hit == 'true' }}
+        run: |
+          yarn policies set-version
+          yarn install --frozen-lockfile --ignore-optional --offline
 
       - name: Create Release Pull Request or Publish to npm
         id: changesets

--- a/.github/workflows/visual-testing.yml
+++ b/.github/workflows/visual-testing.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   tests:
+    if: ${{ github.event.pull_request.head.ref != 'changeset-release/master' }}
     runs-on: ubuntu-latest
     timeout-minutes: 45
 

--- a/ci/jobs/picasso-pr-specs/Jenkinsfile
+++ b/ci/jobs/picasso-pr-specs/Jenkinsfile
@@ -25,6 +25,13 @@ pipeline {
   stages {
     // Perform this only for PRs
     stage('Git checkout PR') {
+      when {
+        not {
+          expression {
+            ghprbSourceBranch == 'changeset-release/master'
+          }
+        }
+      }
       steps {
         info "== Checking out Git revision ${ghprbActualCommit}"
         gitCheckout(
@@ -47,6 +54,13 @@ pipeline {
     }//stage
 
     stage('Build image') {
+      when {
+        not {
+          expression {
+            ghprbSourceBranch == 'changeset-release/master'
+          }
+        }
+      }
       steps {
         script {
           buildWithParameters(
@@ -65,6 +79,11 @@ pipeline {
 
     stage('Deploy documentation') {
       when {
+        not {
+          expression {
+            ghprbSourceBranch == 'changeset-release/master'
+          }
+        }
         expression {
           ghprbMatchesComment(/deploy:documentation|all/)
         }
@@ -87,6 +106,11 @@ pipeline {
 
     stage('Run visual tests') {
       when {
+        not {
+          expression {
+            ghprbSourceBranch == 'changeset-release/master'
+          }
+        }
         expression {
           ghprbMatchesComment(/test:visual|visual|all/)
         }


### PR DESCRIPTION
### Description

We don't want to run tests in "Version Packages" PR from changesets and ideally, we want to be able merge "Version Packages" immediately.

- replaced yarn cache functionality, the old one never could find cache folder
- skip GHA
- skip Jenkins steps in build
- add [skip ci] to PR title automatically

**test run** - https://github.com/toptal/picasso/runs/4235712965?check_suite_focus=true
**test changeset PR** - https://github.com/toptal/picasso/pull/2251

### Screenshots
![image](https://user-images.githubusercontent.com/6830426/142166690-1671cd28-fdb4-42ca-8621-1a4ff24ce4f4.png)


### Review

- [ ] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/api-principles.md)
- [ ] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that tests pass by running `yarn test`
- [ ] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
- [ ] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and
1. You have no extra requests.
2. You have optional requests.
   1. Add `nit: ` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because
1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:
1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>
