### PR TITLE
fix(DatePicker): normalize min/max dates before comparison

### DIFF
--- a/.changeset/fast-plums-try.md
+++ b/.changeset/fast-plums-try.md
@@ -1,0 +1,5 @@
+---
+'@toptal/picasso-lab': patch
+---
+
+Normalize `minDate`/`maxDate` before comparison

--- a/packages/picasso-lab/src/DatePicker/DatePicker.tsx
+++ b/packages/picasso-lab/src/DatePicker/DatePicker.tsx
@@ -18,6 +18,7 @@ import React, {
   ReactNode,
   useCallback,
   useLayoutEffect,
+  useMemo,
   useRef,
   useState
 } from 'react'
@@ -38,7 +39,8 @@ import {
   datePickerParseDateString,
   timezoneConvert,
   timezoneFormat,
-  isValidDateValue
+  isValidDateValue,
+  getStartOfTheDayDate
 } from './utils'
 
 const EMPTY_INPUT_VALUE = ''
@@ -128,6 +130,10 @@ export const DatePicker = (props: Props) => {
     calendarValue,
     setCalendarValue
   ] = useState<DateOrDateRangeType | null>(null)
+
+  const [normalizedMinDate, normalizedMaxDate] = useMemo(() => {
+    return [getStartOfTheDayDate(minDate), getStartOfTheDayDate(maxDate)]
+  }, [minDate, maxDate])
 
   const hideCalendar = () => setCalendarIsShown(false)
   const showCalendar = () => setCalendarIsShown(true)
@@ -222,8 +228,8 @@ export const DatePicker = (props: Props) => {
       const parsedInputValue = parseInputValue(nextValue, {
         dateFormat: editDateFormat,
         timezone,
-        minDate,
-        maxDate
+        minDate: normalizedMinDate,
+        maxDate: normalizedMaxDate
       })
 
       if (parsedInputValue) {
@@ -337,8 +343,8 @@ export const DatePicker = (props: Props) => {
             ref={calendarRef}
             range={range}
             value={calendarValue ?? undefined}
-            minDate={minDate}
-            maxDate={maxDate}
+            minDate={normalizedMinDate}
+            maxDate={normalizedMaxDate}
             disabledIntervals={disabledIntervals}
             renderDay={renderDay}
             onChange={handleCalendarChange}

--- a/packages/picasso-lab/src/DatePicker/test.tsx
+++ b/packages/picasso-lab/src/DatePicker/test.tsx
@@ -202,7 +202,7 @@ describe('DatePicker', () => {
     })
 
     it('should work with minDate only', () => {
-      const MIN_DATE = new Date(2020, 6, 10)
+      const MIN_DATE = new Date(2020, 6, 10, 15, 0, 0)
 
       const handleChange = jest.fn()
 
@@ -226,7 +226,7 @@ describe('DatePicker', () => {
     })
 
     it('should work with maxDate', () => {
-      const MAX_DATE = new Date(2020, 6, 25)
+      const MAX_DATE = new Date(2020, 6, 25, 15, 0, 0)
 
       const handleChange = jest.fn()
 

--- a/packages/picasso-lab/src/DatePicker/utils.ts
+++ b/packages/picasso-lab/src/DatePicker/utils.ts
@@ -5,7 +5,7 @@ import isWithinInterval from 'date-fns/isWithinInterval'
 import isEqual from 'date-fns/isEqual'
 import isBefore from 'date-fns/isBefore'
 import isAfter from 'date-fns/isAfter'
-import { utcToZonedTime, format as tzFormat } from 'date-fns-tz'
+import { utcToZonedTime, format as tzFormat, toDate } from 'date-fns-tz'
 
 import { DatePickerStringParser } from './types'
 import { DateOrDateRangeType, DateRangeType } from '../Calendar'
@@ -121,3 +121,16 @@ export const datePickerParseDateString: DatePickerStringParser = (
 export const isValidDateValue = (
   dateValue: DateOrDateRangeType | string
 ): dateValue is DateOrDateRangeType => typeof dateValue !== 'string'
+
+export const getStartOfTheDayDate = (date?: Date): Date | undefined => {
+  if (!date) {
+    return date
+  }
+
+  // to prevent mutation of the original date
+  const clonedDate = toDate(date)
+
+  clonedDate.setHours(0, 0, 0, 0)
+
+  return clonedDate
+}


### PR DESCRIPTION
[SPT-2117]

### Description

In staff-portal for many `DatePicker`'s we're using `minDate` property in the following way:
```
const minDate = useMemo(() => new Date(), [])
<DatePicker minDate={minDate} />
```

But currently, this causes a bug when the user manually entered the current date inside `DatePicker`'s input.

This is because internally in `isDateBefore` (and `isDateAfter`) we're comparing `date` and `dateToCompare` as is, so because of the `minDate={new Date()}`,  `dateToCompare` contains current time and helper returns `false`:
```
date: Thu Nov 18 2021 00:00:00 GMT+0300 
dateToCompare: Thu Nov 18 2021 15:23:46 GMT+0300
```

In this PR i added normalization of `min` and `max` dates, so just the resetting of the time to the `00:00:00:000` values

### How to test

#### To reproduce the bug:
- Open https://picasso.toptal.net/?path=/story/picasso-lab-datepicker--datepicker
- For any example add `minDate={new Date()}`
- Enter the current date to the date input
- The date won't be selected

#### To test the bug:
- Open https://picasso.toptal.net/SPT-2117-normalize-min-max-dates/?path=/story/picasso-lab-datepicker--datepicker
- For any example add `minDate={new Date()}`
- Enter the current date to the date input
- The date should be selected

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| ![image](https://user-images.githubusercontent.com/9210534/142421912-d5b17d1d-82d0-4537-8e22-8c5a48c4a888.png) | ![image](https://user-images.githubusercontent.com/9210534/142421793-b8d0dac1-f0cb-40a5-8e62-0adae6f86592.png) |

### Review

- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/api-principles.md)
- [n/a] Annotate all `props` in component with documentation
- [n/a] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure that tests pass by running `yarn test`
- [x] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and
1. You have no extra requests.
2. You have optional requests.
   1. Add `nit: ` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because
1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:
1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[SPT-2117]: https://toptal-core.atlassian.net/browse/SPT-2117?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ