### PR TITLE
fix(link): [FX-2278] add aria-disabled prop

### DIFF
--- a/.changeset/new-items-bake.md
+++ b/.changeset/new-items-bake.md
@@ -1,0 +1,5 @@
+---
+'@toptal/picasso': patch
+---
+
+Added aria-disabled prop into the Link, to prevent overriding of aria-disable, by the disabled prop

--- a/packages/picasso/src/Button/__snapshots__/test.tsx.snap
+++ b/packages/picasso/src/Button/__snapshots__/test.tsx.snap
@@ -1,5 +1,27 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Button disabled button as link renders disabled version 1`] = `
+<div>
+  <div
+    class="Picasso-root"
+  >
+    <a
+      aria-disabled="true"
+      class="MuiTypography-root MuiLink-root MuiLink-underlineHover PicassoLink-root MuiButtonBase-root PicassoButton-disabled PicassoButton-medium PicassoButton-primary PicassoButton-root Mui-disabled PicassoLink-fontSizeInitial MuiTypography-colorPrimary"
+      data-component-type="button"
+      role="button"
+      tabindex="-1"
+    >
+      <span
+        class="PicassoContainer-centerAlignItems PicassoContainer-flex PicassoContainer-inline PicassoButton-content"
+      >
+        Click me!
+      </span>
+    </a>
+  </div>
+</div>
+`;
+
 exports[`Button disabled button renders disabled version 1`] = `
 <div>
   <div

--- a/packages/picasso/src/Button/test.tsx
+++ b/packages/picasso/src/Button/test.tsx
@@ -9,6 +9,7 @@ import { OmitInternalProps } from '@toptal/picasso-shared'
 import * as titleCaseModule from 'ap-style-title-case'
 
 import Button, { Props } from './Button'
+import Link from '../Link'
 
 jest.mock('ap-style-title-case')
 
@@ -16,7 +17,7 @@ const renderButton = (
   props: OmitInternalProps<Props>,
   picassoConfig?: PicassoConfig
 ) => {
-  const { children, disabled, loading, onClick, titleCase } = props
+  const { children, disabled, loading, onClick, titleCase, as } = props
 
   return render(
     <Button
@@ -24,6 +25,7 @@ const renderButton = (
       loading={loading}
       onClick={onClick}
       titleCase={titleCase}
+      as={as}
     >
       {children}
     </Button>,
@@ -111,6 +113,18 @@ describe('Button', () => {
       fireEvent.click(getByText('Click me!'))
 
       expect(onClick).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('disabled button as link', () => {
+    it('renders disabled version', () => {
+      const { container } = renderButton({
+        children: 'Click me!',
+        disabled: true,
+        as: Link
+      })
+
+      expect(container).toMatchSnapshot()
     })
   })
 })

--- a/packages/picasso/src/Link/Link.tsx
+++ b/packages/picasso/src/Link/Link.tsx
@@ -61,6 +61,7 @@ export type Props = BaseProps &
      * If true, underline decoration never applies
      */
     noUnderline?: boolean
+    'aria-disabled'?: boolean
   }
 
 export const Link: OverridableComponent<Props> = forwardRef<
@@ -82,6 +83,7 @@ export const Link: OverridableComponent<Props> = forwardRef<
     disabled,
     fontSize,
     noUnderline,
+    'aria-disabled': ariaDisabled,
     ...rest
   } = props
   const nativeHTMLAttributes = rest
@@ -107,7 +109,7 @@ export const Link: OverridableComponent<Props> = forwardRef<
       style={style}
       component={as}
       tabIndex={tabIndex}
-      aria-disabled={disabled}
+      aria-disabled={disabled || ariaDisabled}
     >
       {children}
     </MUILink>


### PR DESCRIPTION
[FX-2278](https://toptal-core.atlassian.net/browse/FX-2278)

### Description

Added aria-disabled prop into the Link, to prevent overriding prop by the Disabled prop, which is undefined by default.

### How to test

Check that disabled Button with component as Link, contains aria-disabled='true'

### Review

- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/api-principles.md)
- `N/A` Annotate all `props` in component with documentation
- `N/A` Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure that tests pass by running `yarn test`
- [x] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and
1. You have no extra requests.
2. You have optional requests.
   1. Add `nit: ` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because
1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:
1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>
