### PR TITLE
fix(Autocomplete): [FX-2312] add separate testid for autocomplete autofill input

### DIFF
--- a/.changeset/tough-laws-pull.md
+++ b/.changeset/tough-laws-pull.md
@@ -1,0 +1,5 @@
+---
+'@toptal/picasso': patch
+---
+
+Added separate testid for Autocomplete autofill input

--- a/packages/picasso/src/Autocomplete/Autocomplete.tsx
+++ b/packages/picasso/src/Autocomplete/Autocomplete.tsx
@@ -110,7 +110,7 @@ export interface Props
     noOptions?: string
     loadingAdornment?: string
     input?: string
-    enableAutofillInput?: string
+    disableAutofillInput?: string
   }
 }
 
@@ -271,7 +271,7 @@ export const Autocomplete = forwardRef<HTMLInputElement, Props>(
               type='hidden'
               value={value}
               name={name}
-              data-testid={testIds?.enableAutofillInput}
+              data-testid={testIds?.disableAutofillInput}
             />
           )}
           <InputComponent

--- a/packages/picasso/src/Autocomplete/test.tsx
+++ b/packages/picasso/src/Autocomplete/test.tsx
@@ -26,7 +26,7 @@ const testIds = {
   loadingAdornment: 'loading-adornment',
   resetButton: 'reset-adornment',
   input: 'autocomplete',
-  enableAutofillInput: 'enableAutofillInput'
+  disableAutofillInput: 'disableAutofillInput'
 }
 
 const renderAutocomplete = (
@@ -81,7 +81,9 @@ describe('Autocomplete', () => {
         name
       })
 
-      const input = getByTestId(testIds.enableAutofillInput) as HTMLInputElement
+      const input = getByTestId(
+        testIds.disableAutofillInput
+      ) as HTMLInputElement
 
       expect(input.value).toEqual(value)
       expect(input.name).toEqual(name)


### PR DESCRIPTION
[FX-2312](https://toptal-core.atlassian.net/browse/FX-2312)

### Description

Updated testid for autocomplete autofill input

### Review

- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure that tests pass by running `yarn test`
- [x] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and
1. You have no extra requests.
2. You have optional requests.
   1. Add `nit: ` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because
1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:
1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>
