### PR TITLE
fix(Tag): make checkable styles work only for Tag.Checkable

### DIFF
--- a/.changeset/empty-gorillas-walk.md
+++ b/.changeset/empty-gorillas-walk.md
@@ -1,0 +1,7 @@
+---
+'@toptal/picasso': patch
+'@toptal/picasso-forms': patch
+'@toptal/picasso-lab': patch
+---
+
+Fix styling of `Tag` when wrapped by `Tooltip`

--- a/packages/picasso/src/Tag/Tag.tsx
+++ b/packages/picasso/src/Tag/Tag.tsx
@@ -133,6 +133,8 @@ Tag.defaultProps = {
 
 Tag.displayName = 'Tag'
 
+export { useStyles }
+
 export default Object.assign(Tag, {
   Group: TagGroup,
   Rectangular: TagRectangular,

--- a/packages/picasso/src/Tag/story/Default.example.tsx
+++ b/packages/picasso/src/Tag/story/Default.example.tsx
@@ -1,5 +1,11 @@
 import React from 'react'
-import { Tag, Settings16, Container, Typography } from '@toptal/picasso'
+import {
+  Tag,
+  Settings16,
+  Container,
+  Typography,
+  Tooltip
+} from '@toptal/picasso'
 
 const handleDelete = () => {
   window.alert('You clicked the delete icon.')
@@ -54,6 +60,14 @@ const Example = () => (
         >
           Label
         </Tag>
+      </div>
+    </Container>
+    <Container flex direction='column' gap='xsmall'>
+      <Typography>With Tooltip</Typography>
+      <div>
+        <Tooltip variant='light' interactive content='ssddssdsdsd'>
+          <Tag>Label</Tag>
+        </Tooltip>
       </div>
     </Container>
   </Container>

--- a/packages/picasso/src/Tag/styles.ts
+++ b/packages/picasso/src/Tag/styles.ts
@@ -39,7 +39,13 @@ export default ({ palette, transitions }: Theme) =>
       height: 'auto'
     },
     clickable: {
-      '&:not($disabled)': {
+      cursor: 'default',
+      '&:hover, &:focus': {
+        backgroundColor: palette.common.white,
+        cursor: 'default'
+      },
+      '&$checkable:not($disabled)': {
+        cursor: 'pointer',
         '&:hover, &$hovered': {
           borderColor: palette.grey.dark,
           backgroundColor: palette.common.white,
@@ -60,7 +66,6 @@ export default ({ palette, transitions }: Theme) =>
       gap: '0.5rem'
     },
     hovered: {},
-
     // TagConnection styles
     connection: {
       display: 'inline-flex',
@@ -70,5 +75,8 @@ export default ({ palette, transitions }: Theme) =>
       '[aria-disabled="true"] &': {
         color: 'inherit'
       }
-    }
+    },
+
+    // TagCheckable
+    checkable: {}
   })

--- a/packages/picasso/src/TagCheckable/TagCheckable.tsx
+++ b/packages/picasso/src/TagCheckable/TagCheckable.tsx
@@ -1,7 +1,9 @@
-import React, { ReactElement, MouseEventHandler } from 'react'
+import cx from 'classnames'
+import React, { ReactElement, MouseEventHandler, forwardRef } from 'react'
 import { BaseProps, TextLabelProps } from '@toptal/picasso-shared'
 
 import Tag from '../Tag'
+import { useStyles } from '../Tag/Tag'
 
 type ClickType = MouseEventHandler<HTMLElement>
 
@@ -20,15 +22,12 @@ export interface Props extends BaseProps, TextLabelProps {
   onChange?: (checked: boolean) => void
 }
 
-const TagCheckable = ({
-  hovered,
-  checked = false,
-  children,
-  icon,
-  onClick,
-  onChange,
-  ...rest
-}: Props) => {
+const TagCheckable = forwardRef<HTMLDivElement, Props>(function TagCheckable(
+  { checked = false, children, icon, onClick, onChange, className, ...rest },
+  ref
+) {
+  const classes = useStyles()
+
   const handleClick = (e: React.MouseEvent<HTMLElement, MouseEvent>) => {
     onChange?.(!checked)
     onClick?.(e)
@@ -38,15 +37,16 @@ const TagCheckable = ({
 
   return (
     <Tag
+      className={cx(className, classes.checkable)}
       icon={icon}
-      variant={variant}
       onClick={handleClick}
-      hovered={hovered}
+      ref={ref}
+      variant={variant}
       {...rest}
     >
       {children}
     </Tag>
   )
-}
+})
 
 export default TagCheckable


### PR DESCRIPTION
<!---
Thanks for taking the time to contribute!

Please make sure to follow contribution process:
https://toptal-core.atlassian.net/wiki/spaces/FE/pages/2396094469/Handling+external+contribution
-->

[FX-2303]

### Description

When `Tag` accepts `onClick` prop it triggers native MUI `clickable` classname. This classname was changed to style Tag.Checkable. This PR makes sure, that these styles are used only for Tag.Checkable.

The main issue is when we wrap `Tag` to `Tooltip`, which adds internally `onClick` to `Tag`, I have added example to storybook as it seems it is widely used in other projects.

### How to test

- Open temploy and check 
  - new example `With Tooltip`, 
  - `Tag.Checkable` has correct styling

### Review

- [ ] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [ ] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that tests pass by running `yarn test`
- [ ] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
- [ ] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and
1. You have no extra requests.
2. You have optional requests.
   1. Add `nit: ` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because
1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:
1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-2303]: https://toptal-core.atlassian.net/browse/FX-2303?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ