### PR TITLE
feat: update visited state of link

### DIFF
--- a/.changeset/curvy-peas-confess.md
+++ b/.changeset/curvy-peas-confess.md
@@ -1,0 +1,5 @@
+---
+'@toptal/picasso': minor
+---
+
+Add visited state for Link component.

--- a/cypress/component/Link.spec.tsx
+++ b/cypress/component/Link.spec.tsx
@@ -190,4 +190,31 @@ describe('Link', () => {
         .should('have.css', 'text-decoration', 'none solid rgb(32, 78, 207)')
     })
   })
+
+  describe('when a Link has been visited', () => {
+    it('indicates itself by a proper color', () => {
+      mount(
+        <TestingPicasso>
+          <Link visited data-testid='blue-link' href='#'>
+            Link
+          </Link>
+          <Link visited color='white' data-testid='white-link' href='#'>
+            Link
+          </Link>
+        </TestingPicasso>
+      )
+
+      cy.get('[data-testid="blue-link"').should(
+        'have.css',
+        'color',
+        'rgb(15, 37, 110)'
+      )
+
+      cy.get('[data-testid="white-link"').should(
+        'have.css',
+        'color',
+        'rgb(196, 198, 202)'
+      )
+    })
+  })
 })

--- a/cypress/component/Link.spec.tsx
+++ b/cypress/component/Link.spec.tsx
@@ -10,6 +10,9 @@ import {
 import { mount } from '@cypress/react'
 import { TestingPicasso } from '@toptal/picasso/test-utils'
 
+const DARKER_BLUE = 'rgb(15, 37, 110)'
+const GREY = 'rgb(196, 198, 202)'
+
 const TestUserBadgeLink = () => {
   return (
     <TestingPicasso>
@@ -207,14 +210,10 @@ describe('Link', () => {
       cy.get('[data-testid="blue-link"').should(
         'have.css',
         'color',
-        'rgb(15, 37, 110)'
+        DARKER_BLUE
       )
 
-      cy.get('[data-testid="white-link"').should(
-        'have.css',
-        'color',
-        'rgb(196, 198, 202)'
-      )
+      cy.get('[data-testid="white-link"').should('have.css', 'color', GREY)
     })
   })
 })

--- a/packages/picasso/src/AccountSelect/__snapshots__/test.tsx.snap
+++ b/packages/picasso/src/AccountSelect/__snapshots__/test.tsx.snap
@@ -23,7 +23,7 @@ exports[`AccountSelect renders 1`] = `
             class="PicassoContainer-centerAlignItems PicassoContainer-flex"
           >
             <a
-              class="MuiTypography-root MuiLink-root MuiLink-underlineHover PicassoLink-root PicassoAccountSelect-accountLink PicassoLink-noUnderline MuiTypography-colorPrimary"
+              class="MuiTypography-root MuiLink-root MuiLink-underlineHover PicassoLink-root PicassoAccountSelect-accountLink PicassoLink-blue PicassoLink-noUnderline MuiTypography-colorPrimary"
             >
               <div
                 class="PicassoContainer-mediumPadding PicassoContainer-centerAlignItems PicassoContainer-spaceBetweenJustifyContent PicassoContainer-flex"
@@ -90,7 +90,7 @@ exports[`AccountSelect renders 1`] = `
             class="PicassoContainer-centerAlignItems PicassoContainer-flex"
           >
             <a
-              class="MuiTypography-root MuiLink-root MuiLink-underlineHover PicassoLink-root PicassoAccountSelect-accountLink PicassoLink-noUnderline MuiTypography-colorPrimary"
+              class="MuiTypography-root MuiLink-root MuiLink-underlineHover PicassoLink-root PicassoAccountSelect-accountLink PicassoLink-blue PicassoLink-noUnderline MuiTypography-colorPrimary"
               href="#"
             >
               <div
@@ -158,7 +158,7 @@ exports[`AccountSelect renders 1`] = `
             class="PicassoContainer-centerAlignItems PicassoContainer-flex"
           >
             <a
-              class="MuiTypography-root MuiLink-root MuiLink-underlineHover PicassoLink-root PicassoAccountSelect-accountLink PicassoLink-noUnderline MuiTypography-colorPrimary"
+              class="MuiTypography-root MuiLink-root MuiLink-underlineHover PicassoLink-root PicassoAccountSelect-accountLink PicassoLink-blue PicassoLink-noUnderline MuiTypography-colorPrimary"
               href="#"
             >
               <div

--- a/packages/picasso/src/Button/__snapshots__/test.tsx.snap
+++ b/packages/picasso/src/Button/__snapshots__/test.tsx.snap
@@ -7,7 +7,7 @@ exports[`Button disabled button as link renders disabled version 1`] = `
   >
     <a
       aria-disabled="true"
-      class="MuiTypography-root MuiLink-root MuiLink-underlineHover PicassoLink-root MuiButtonBase-root PicassoButton-disabled PicassoButton-medium PicassoButton-primary PicassoButton-root Mui-disabled MuiTypography-colorPrimary"
+      class="MuiTypography-root MuiLink-root MuiLink-underlineHover PicassoLink-root MuiButtonBase-root PicassoButton-disabled PicassoButton-medium PicassoButton-primary PicassoButton-root Mui-disabled PicassoLink-blue MuiTypography-colorPrimary"
       data-component-type="button"
       role="button"
       tabindex="-1"

--- a/packages/picasso/src/Button/styles.ts
+++ b/packages/picasso/src/Button/styles.ts
@@ -11,6 +11,7 @@ export const createOutlineCommons = ({ palette }: Theme) => ({
     borderColor: palette.common.black
   },
 
+  // when we use <Button as={Link} />
   '&&&:visited': {
     color: palette.common.black
   },
@@ -41,6 +42,7 @@ export const createVariant = (mainColor: string, { palette }: Theme) => ({
     backgroundColor: mix(mainColor, palette.common.black, 0.172)
   },
 
+  // when we use <Button as={Link} />
   '&&&:visited': {
     color: palette.common.white
   },
@@ -158,6 +160,7 @@ export default (theme: Theme) => {
       color: palette.common.white,
       border: `solid ${sizes.borderWidth} ${alpha(palette.common.white, 0.32)}`,
 
+      // when we use <Button as={Link} />
       '&&&:visited': {
         color: palette.common.white
       },

--- a/packages/picasso/src/Button/styles.ts
+++ b/packages/picasso/src/Button/styles.ts
@@ -29,6 +29,10 @@ export const createVariant = (mainColor: string, { palette }: Theme) => ({
   color: palette.common.white,
   backgroundColor: mainColor,
 
+  '&:visited': {
+    color: palette.grey.main
+  },
+
   '&:hover, &$hovered': {
     backgroundColor: mix(mainColor, palette.common.white, 0.152)
   },
@@ -150,6 +154,10 @@ export default (theme: Theme) => {
     transparent: {
       color: palette.common.white,
       border: `solid ${sizes.borderWidth} ${alpha(palette.common.white, 0.32)}`,
+
+      '&:visited': {
+        color: palette.grey.main
+      },
 
       '&$focusVisible, &$focused': {
         ...outline(palette.common.white)

--- a/packages/picasso/src/Button/styles.ts
+++ b/packages/picasso/src/Button/styles.ts
@@ -7,6 +7,10 @@ export const createOutlineCommons = ({ palette }: Theme) => ({
   color: palette.common.black,
   backgroundColor: palette.common.white,
 
+  '&:visited': {
+    color: palette.common.black
+  },
+
   '&:hover, &$hovered': {
     borderColor: palette.common.black
   },
@@ -29,10 +33,6 @@ export const createVariant = (mainColor: string, { palette }: Theme) => ({
   color: palette.common.white,
   backgroundColor: mainColor,
 
-  '&:visited': {
-    color: palette.grey.main
-  },
-
   '&:hover, &$hovered': {
     backgroundColor: mix(mainColor, palette.common.white, 0.152)
   },
@@ -43,6 +43,10 @@ export const createVariant = (mainColor: string, { palette }: Theme) => ({
 
   '&$disabled': {
     backgroundColor: palette.grey.light2
+  },
+
+  '&:visited': {
+    color: palette.common.white
   }
 })
 
@@ -155,12 +159,12 @@ export default (theme: Theme) => {
       color: palette.common.white,
       border: `solid ${sizes.borderWidth} ${alpha(palette.common.white, 0.32)}`,
 
-      '&:visited': {
-        color: palette.grey.main
-      },
-
       '&$focusVisible, &$focused': {
         ...outline(palette.common.white)
+      },
+
+      '&:visited': {
+        color: palette.common.white
       },
 
       '&:hover, &$hovered': {

--- a/packages/picasso/src/Button/styles.ts
+++ b/packages/picasso/src/Button/styles.ts
@@ -7,12 +7,12 @@ export const createOutlineCommons = ({ palette }: Theme) => ({
   color: palette.common.black,
   backgroundColor: palette.common.white,
 
-  '&:visited': {
-    color: palette.common.black
-  },
-
   '&:hover, &$hovered': {
     borderColor: palette.common.black
+  },
+
+  '&&&:visited': {
+    color: palette.common.black
   },
 
   '&$disabled': {
@@ -41,12 +41,11 @@ export const createVariant = (mainColor: string, { palette }: Theme) => ({
     backgroundColor: mix(mainColor, palette.common.black, 0.172)
   },
 
+  '&&&:visited': {
+    color: palette.common.white
+  },
   '&$disabled': {
     backgroundColor: palette.grey.light2
-  },
-
-  '&:visited': {
-    color: palette.common.white
   }
 })
 
@@ -159,12 +158,12 @@ export default (theme: Theme) => {
       color: palette.common.white,
       border: `solid ${sizes.borderWidth} ${alpha(palette.common.white, 0.32)}`,
 
-      '&$focusVisible, &$focused': {
-        ...outline(palette.common.white)
+      '&&&:visited': {
+        color: palette.common.white
       },
 
-      '&:visited': {
-        color: palette.common.white
+      '&$focusVisible, &$focused': {
+        ...outline(palette.common.white)
       },
 
       '&:hover, &$hovered': {

--- a/packages/picasso/src/Link/Link.tsx
+++ b/packages/picasso/src/Link/Link.tsx
@@ -51,6 +51,8 @@ export type Props = BaseProps &
     tabIndex?: number
     /** Indicates that the user cannot interact with the Link or its children */
     disabled?: boolean
+    /** Indicates that the link was opened before within this browser session */
+    visited?: boolean
     /**
      * If true, underline decoration never applies
      */
@@ -75,6 +77,7 @@ export const Link: OverridableComponent<Props> = forwardRef<
     target,
     rel,
     disabled,
+    visited = false,
     noUnderline,
     'aria-disabled': ariaDisabled,
     ...rest
@@ -94,6 +97,8 @@ export const Link: OverridableComponent<Props> = forwardRef<
       className={cx(classes.root, className, {
         [classes.action]: variant === 'action',
         [classes.white]: color === 'white',
+        [classes.blue]: color === 'blue',
+        [classes.visited]: visited,
         [classes.disabled]: disabled,
         [classes.noUnderline]: noUnderline
       })}

--- a/packages/picasso/src/Link/Link.tsx
+++ b/packages/picasso/src/Link/Link.tsx
@@ -51,7 +51,7 @@ export type Props = BaseProps &
     tabIndex?: number
     /** Indicates that the user cannot interact with the Link or its children */
     disabled?: boolean
-    /** Indicates that the link was opened before within this browser session */
+
     visited?: boolean
     /**
      * If true, underline decoration never applies

--- a/packages/picasso/src/Link/__snapshots__/test.tsx.snap
+++ b/packages/picasso/src/Link/__snapshots__/test.tsx.snap
@@ -6,7 +6,7 @@ exports[`Link renders 1`] = `
     class="Picasso-root"
   >
     <a
-      class="MuiTypography-root MuiLink-root MuiLink-underlineHover PicassoLink-root MuiTypography-colorPrimary"
+      class="MuiTypography-root MuiLink-root MuiLink-underlineHover PicassoLink-root PicassoLink-blue MuiTypography-colorPrimary"
     >
       Please verify your email
     </a>
@@ -21,7 +21,7 @@ exports[`Link renders a Link from react-router 1`] = `
   >
     <div>
       <a
-        class="MuiTypography-root MuiLink-root MuiLink-underlineHover PicassoLink-root MuiTypography-colorPrimary"
+        class="MuiTypography-root MuiLink-root MuiLink-underlineHover PicassoLink-root PicassoLink-blue MuiTypography-colorPrimary"
         href="/"
       >
         Please verify your email
@@ -38,7 +38,7 @@ exports[`Link renders disabled link 1`] = `
   >
     <a
       aria-disabled="true"
-      class="MuiTypography-root MuiLink-root MuiLink-underlineHover PicassoLink-root PicassoLink-disabled MuiTypography-colorPrimary"
+      class="MuiTypography-root MuiLink-root MuiLink-underlineHover PicassoLink-root PicassoLink-blue PicassoLink-disabled MuiTypography-colorPrimary"
       download="filename"
       rel="noopener"
     >
@@ -54,7 +54,7 @@ exports[`Link renders native attributes 1`] = `
     class="Picasso-root"
   >
     <a
-      class="MuiTypography-root MuiLink-root MuiLink-underlineHover PicassoLink-root MuiTypography-colorPrimary"
+      class="MuiTypography-root MuiLink-root MuiLink-underlineHover PicassoLink-root PicassoLink-blue MuiTypography-colorPrimary"
       download="filename"
       href="https://toptal.com/filename.txt"
       rel="noopener"

--- a/packages/picasso/src/Link/styles.ts
+++ b/packages/picasso/src/Link/styles.ts
@@ -40,13 +40,14 @@ export default ({ typography, palette }: Theme) =>
         color: palette.blue.main
       }
     },
+    visited: {},
     blue: {
-      '&:visited': {
+      '&:visited, &$visited': {
         color: palette.blue.darker
       }
     },
     white: {
-      '&:visited': {
+      '&:visited, &$visited': {
         color: palette.grey.main
       },
       color: palette.common.white,

--- a/packages/picasso/src/Link/styles.ts
+++ b/packages/picasso/src/Link/styles.ts
@@ -12,6 +12,9 @@ PicassoProvider.override(() => ({
 export default ({ typography, palette }: Theme) =>
   createStyles({
     root: {
+      '&:visited': {
+        color: palette.blue.darker
+      },
       '&:focus': {
         outline: 'none'
       },

--- a/packages/picasso/src/Link/styles.ts
+++ b/packages/picasso/src/Link/styles.ts
@@ -12,9 +12,6 @@ PicassoProvider.override(() => ({
 export default ({ typography, palette }: Theme) =>
   createStyles({
     root: {
-      '&:visited': {
-        color: palette.blue.darker
-      },
       '&:focus': {
         outline: 'none'
       },
@@ -43,7 +40,15 @@ export default ({ typography, palette }: Theme) =>
         color: palette.blue.main
       }
     },
+    blue: {
+      '&:visited': {
+        color: palette.blue.darker
+      }
+    },
     white: {
+      '&:visited': {
+        color: palette.grey.main
+      },
       color: palette.common.white,
       textDecoration: 'underline',
       '&$noUnderline': {

--- a/packages/picasso/src/Link/test.tsx
+++ b/packages/picasso/src/Link/test.tsx
@@ -98,4 +98,14 @@ describe('Link', () => {
 
     expect(getByTestId('foo')).not.toHaveAttribute('href')
   })
+
+  it('has proper color for `visited` status', async () => {
+    const { getByTestId } = render(
+      <Link visited data-testid='visited-link' href='#'>
+        Test
+      </Link>
+    )
+
+    expect(getByTestId('visited-link')).toHaveStyle('color: rgb(15 37 110);')
+  })
 })

--- a/packages/picasso/src/Link/test.tsx
+++ b/packages/picasso/src/Link/test.tsx
@@ -98,14 +98,4 @@ describe('Link', () => {
 
     expect(getByTestId('foo')).not.toHaveAttribute('href')
   })
-
-  it('has proper color for `visited` status', async () => {
-    const { getByTestId } = render(
-      <Link visited data-testid='visited-link' href='#'>
-        Test
-      </Link>
-    )
-
-    expect(getByTestId('visited-link')).toHaveStyle('color: rgb(15 37 110);')
-  })
 })

--- a/packages/picasso/src/PageTopBar/__snapshots__/test.tsx.snap
+++ b/packages/picasso/src/PageTopBar/__snapshots__/test.tsx.snap
@@ -21,7 +21,7 @@ exports[`Page.TopBar render with link 1`] = `
               class="PicassoContainer-centerAlignItems PicassoContainer-flex PicassoTopBar-logoContainer"
             >
               <a
-                class="MuiTypography-root MuiLink-root MuiLink-underlineHover PicassoLink-root MuiTypography-colorPrimary"
+                class="MuiTypography-root MuiLink-root MuiLink-underlineHover PicassoLink-root PicassoLink-blue MuiTypography-colorPrimary"
                 href="https://www.toptal.com"
               >
                 <svg


### PR DESCRIPTION
<!---
Thanks for taking the time to contribute!

Please make sure to follow contribution process:
https://toptal-core.atlassian.net/wiki/spaces/FE/pages/2396094469/Handling+external+contribution
-->

[FX-2328]

### Description

Add missing `visited` state of [Link](https://picasso.toptal.net/?path=/story/components-link--link)
Base docs: https://www.figma.com/file/q2nvjiyO2CLqBv4DeJnU3i/Product-Library-Documentation?node-id=218%3A4060

### How to test

You can verify the behaviour by opening `Link` page ([storybook link](https://picasso.toptal.net/fx-2328-add-visited-state-to-link/?path=/story/components-link--link)) and clicking a link. 
Its color should change to `#0F256E`

### Screenshots

<img width="544" alt="Screenshot 2021-12-01 at 14 46 15" src="https://user-images.githubusercontent.com/11461413/144237266-5bdc6a87-f319-4f80-98b4-2d8fceee9e39.png">

### Review

- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- n/a Annotate all `props` in component with documentation
- n/a Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure that tests pass by running `yarn test`
- [x] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and
1. You have no extra requests.
2. You have optional requests.
   1. Add `nit: ` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because
1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:
1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-2328]: https://toptal-core.atlassian.net/browse/FX-2328?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ