### PR TITLE
feat: [FX-2284] Add cancel callback for notifications

### DIFF
--- a/.changeset/witty-beds-do.md
+++ b/.changeset/witty-beds-do.md
@@ -2,4 +2,4 @@
 '@toptal/picasso': minor
 ---
 
-- When using `use-notification` hooks it started to call `onClose` callback when `Notification` is closing.
+- Pass `onClose` to the notifications opened by `use-notification` hooks.

--- a/.changeset/witty-beds-do.md
+++ b/.changeset/witty-beds-do.md
@@ -1,0 +1,5 @@
+---
+'@toptal/picasso': minor
+---
+
+- When using `use-notification` hooks it started to call `onClose` callback when `Notification` is closing.

--- a/packages/picasso/src/ApplicationUpdateNotification/story/InAction.example.tsx
+++ b/packages/picasso/src/ApplicationUpdateNotification/story/InAction.example.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { createElement } from 'react'
 import { Button, ApplicationUpdateNotification } from '@toptal/picasso'
 import { useNotifications } from '@toptal/picasso/utils'
 
@@ -10,7 +10,13 @@ const Example = () => {
       data-testid='trigger'
       variant='secondary'
       onClick={() =>
-        showCustom(<ApplicationUpdateNotification />, { persist: true })
+        showCustom(
+          createElement(ApplicationUpdateNotification, {
+            onReloadClick: () => console.log('reload click'),
+            onClose: () => console.log('close click')
+          }),
+          { persist: true }
+        )
       }
     >
       Show App Update Notification

--- a/packages/picasso/src/utils/Notifications/use-notifications.tsx
+++ b/packages/picasso/src/utils/Notifications/use-notifications.tsx
@@ -66,19 +66,23 @@ export const useNotifications = () => {
       notificationElement: React.ReactElement,
       options?: OptionsObject
     ) => {
-      const closeNotification = () => {
+      const closeNotification = (onClose?: () => void) => () => {
         if (!notificationId) {
           return
         }
 
         closeSnackbar(notificationId)
+
+        if (onClose) {
+          onClose()
+        }
       }
       const notificationId = enqueueSnackbar('', {
         anchorOrigin: defaultPosition,
         content: (key: string) =>
           React.cloneElement(notificationElement, {
             key,
-            onClose: closeNotification
+            onClose: closeNotification(notificationElement.props.onClose)
           }),
         ...options
       })

--- a/packages/picasso/src/utils/Notifications/use-notifications.tsx
+++ b/packages/picasso/src/utils/Notifications/use-notifications.tsx
@@ -66,15 +66,15 @@ export const useNotifications = () => {
       notificationElement: React.ReactElement,
       options?: OptionsObject
     ) => {
-      const closeNotification = (onClose?: () => void) => () => {
+      const closeNotification = () => {
         if (!notificationId) {
           return
         }
 
         closeSnackbar(notificationId)
 
-        if (onClose) {
-          onClose()
+        if (notificationElement.props.onClose) {
+          notificationElement.props.onClose()
         }
       }
       const notificationId = enqueueSnackbar('', {
@@ -82,7 +82,7 @@ export const useNotifications = () => {
         content: (key: string) =>
           React.cloneElement(notificationElement, {
             key,
-            onClose: closeNotification(notificationElement.props.onClose)
+            onClose: closeNotification
           }),
         ...options
       })


### PR DESCRIPTION
[FX-2284]

### Description

Add `onClose` to be fired when notification is closed. This is necessary for use cases when we need to react on the fact that the user has closed a notification, ex. `AppUpdateNotification`

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and
1. You have no extra requests.
2. You have optional requests.
   1. Add `nit: ` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because
1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:
1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-2284]: https://toptal-core.atlassian.net/browse/FX-2284?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ