### PR TITLE
chore(Button): add forwardRef to Augmentation example

### DIFF
--- a/packages/picasso/src/Button/story/Augmentation.example.tsx
+++ b/packages/picasso/src/Button/story/Augmentation.example.tsx
@@ -6,7 +6,7 @@ import { Settings16 } from '@toptal/picasso/Icon'
 type ActionLinkProps = Omit<LinkProps, 'variant' | 'noUnderline'>
 
 const ActionLink = forwardRef<HTMLAnchorElement, ActionLinkProps>(
-  (props: LinkProps) => <Link {...props} variant='action' noUnderline />
+  (props, ref) => <Link ref={ref} {...props} variant='action' noUnderline />
 )
 
 const ButtonAugmentationExample = () => (

--- a/packages/picasso/src/Button/story/Augmentation.example.tsx
+++ b/packages/picasso/src/Button/story/Augmentation.example.tsx
@@ -1,9 +1,12 @@
-import React from 'react'
+import React, { forwardRef } from 'react'
 import { Button, Link, LinkProps } from '@toptal/picasso'
 import { Settings16 } from '@toptal/picasso/Icon'
 
-const ActionLink = (props: LinkProps): React.ReactNode => (
-  <Link {...props} variant='action' noUnderline />
+// variant & noUnderline are statically set in ActionLink
+type ActionLinkProps = Omit<LinkProps, 'variant' | 'noUnderline'>
+
+const ActionLink = forwardRef<HTMLAnchorElement, ActionLinkProps>(
+  (props: LinkProps) => <Link {...props} variant='action' noUnderline />
 )
 
 const ButtonAugmentationExample = () => (


### PR DESCRIPTION
<!---
Thanks for taking the time to contribute!

Please make sure to follow contribution process:
https://toptal-core.atlassian.net/wiki/spaces/FE/pages/2396094469/Handling+external+contribution
-->

[FX-NNNN]

### Description

[Context](https://toptal-core.slack.com/archives/CERF5NHT3/p1638272318498300)

There is a bug when using Augmentation with Button - `variant` prop has incorrect typing. 
It happens because:

1. `OverridableComponent` merges base component props (`ButtonProps`) & `as` component props (`LinkProps`) internally.
2. When it tries to merge `variant` prop, the only type in common is `undefined` so it sets `variant` to undefined.

Check this example to understand:

```tsx
interface Props1 {
  variant?: 'foo'
}
  
interface Props2 {
  variant?: 'bar'
}
  
type Props = Props1 & Props2
  
Props['variant'] // undefined
```

To fix the problem we should omit `variant` from `LinkProps` because `ActionLink` has this prop set statically. It'll resolve the merge conflict and use `variant` prop from `ButtonProps`.

**ℹ️ I know the description is complicated. Ping me in Slack if you don't feel well about this change.**

### How to test

- Typecheck CI step should be green.

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| Insert screenshots or screen recordings | Insert screenshots or screen recordings |

### Review

- [ ] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [ ] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that tests pass by running `yarn test`
- [ ] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
- [ ] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and
1. You have no extra requests.
2. You have optional requests.
   1. Add `nit: ` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because
1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:
1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>
