### PR TITLE
feat(modals): [FX-2338] add right padding to modal title

### DIFF
--- a/.changeset/kind-donkeys-think.md
+++ b/.changeset/kind-donkeys-think.md
@@ -1,0 +1,5 @@
+---
+'@toptal/picasso': patch
+---
+
+Fix `Modal`'s close button overflow by adding the right padding to `Modal.Title`.

--- a/packages/picasso/src/ModalTitle/styles.ts
+++ b/packages/picasso/src/ModalTitle/styles.ts
@@ -3,6 +3,7 @@ import { createStyles } from '@material-ui/core/styles'
 export default () =>
   createStyles({
     root: {
-      margin: '2em 2em 0'
+      margin: '2em 2em 0',
+      paddingRight: '1.5em'
     }
   })


### PR DESCRIPTION
<!---
Thanks for taking the time to contribute!

Please make sure to follow contribution process:
https://toptal-core.atlassian.net/wiki/spaces/FE/pages/2396094469/Handling+external+contribution
-->

[FX-2338]

### Description

Currently for in Modal Title we have no padding for the div that wraps Typography and if the text is too long it may go under the cross mark

### How to test

1. In Storybook: Overlays -> Modal
2. Open first modal
3. Add more text to the h2 tag using the developer tools
4. Text should not go under the cross mark

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
|![2021 12 07_18 16 36_shot](https://user-images.githubusercontent.com/59695245/145107493-7bf12565-3036-49d3-9afe-e7bf7918416e.png)|![2021 12 07_17 52 20_shot](https://user-images.githubusercontent.com/59695245/145107293-2edbb787-2b40-43c8-a928-d92f1132b164.png)|

### Review

- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- `N/A` Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that tests pass by running `yarn test`
- [ ] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
- [ ] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and
1. You have no extra requests.
2. You have optional requests.
   1. Add `nit: ` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because
1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:
1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-2338]: https://toptal-core.atlassian.net/browse/FX-2338?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ