### PR TITLE
chore: fix autofocus

### DIFF
--- a/packages/picasso-lab/src/TextEditor/hooks/useHandleAutofocus.tsx
+++ b/packages/picasso-lab/src/TextEditor/hooks/useHandleAutofocus.tsx
@@ -13,11 +13,8 @@ const useHandleAutofocus = (
     const editorApi = editorRef?.current
 
     if (firstRender?.current && editorApi && autofocus) {
-      // without setTimeout is focus called on last instance🤷‍♂️
-      setTimeout(() => {
-        editorApi.focus()
-        firstRender.current = false
-      }, 0)
+      editorApi.focus()
+      firstRender.current = false
     }
   }, [autofocus, editorRef])
 }

--- a/packages/picasso-lab/src/TextEditor/hooks/useHandleChangeFromController.tsx
+++ b/packages/picasso-lab/src/TextEditor/hooks/useHandleChangeFromController.tsx
@@ -20,9 +20,12 @@ const useHandleChangeFromController = (
 
       // is value set from outside
       if (editorValue !== controllerValue) {
-        // TODO discuss with others, if we should sanitize here
-        // usecase - editing current job description
-        clipboard.dangerouslyPasteHTML(controllerValue)
+        // @types/quill has incorrect convert typing
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        const delta = clipboard.convert(controllerValue)
+
+        editorRef.current.setContents(delta, 'silent')
       }
     }
   }, [controllerValue, editorRef])

--- a/packages/picasso-lab/src/TextEditor/story/Default.example.tsx
+++ b/packages/picasso-lab/src/TextEditor/story/Default.example.tsx
@@ -15,6 +15,7 @@ const Example = () => {
           onChange={handleChange}
           placeholder='Write some cool rich text'
           value={value}
+          autofocus
         />
       </Container>
       <Container


### PR DESCRIPTION
<!---
Thanks for taking the time to contribute!

Please make sure to follow contribution process:
https://toptal-core.atlassian.net/wiki/spaces/FE/pages/2396094469/Handling+external+contribution
-->

[FX-2293](https://toptal-core.atlassian.net/browse/FX-2293)

### Description

There was a problem with `autofocus`. `dangerouslyPasteHTML` was [stealing the focus](https://github.com/quilljs/quill/issues/2156).

### How to test

1. Go to temploy.
2. Open `TextEditor` page.
3. Be sure that the first editor has focus.
4. Be sure that the second editor has a default value.

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| Insert screenshots or screen recordings | Insert screenshots or screen recordings |

### Review

- [ ] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [ ] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that tests pass by running `yarn test`
- [ ] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
- [ ] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and
1. You have no extra requests.
2. You have optional requests.
   1. Add `nit: ` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because
1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:
1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>
