### PR TITLE
feat(Forms): add ability to disable auto-focus and auto-scroll on Form submission error

### DIFF
--- a/.changeset/curly-apricots-tease.md
+++ b/.changeset/curly-apricots-tease.md
@@ -1,5 +1,5 @@
 ---
-'@toptal/picasso-forms': major
+'@toptal/picasso-forms': minor
 ---
 
 Added `disableScrollOnError` prop for Form component do switch-off auto-scrolling on error if required

--- a/.changeset/curly-apricots-tease.md
+++ b/.changeset/curly-apricots-tease.md
@@ -1,0 +1,5 @@
+---
+'@toptal/picasso-forms': major
+---
+
+Added `disableScrollOnError` prop for Form component do switch-off auto-scrolling on error if required

--- a/packages/picasso-forms/src/Form/Form.tsx
+++ b/packages/picasso-forms/src/Form/Form.tsx
@@ -86,7 +86,7 @@ export const Form = <T extends any = AnyObject>(props: Props<T>) => {
       createScrollToErrorDecorator({
         disableScrollOnError
       }),
-    []
+    [disableScrollOnError]
   )
 
   const validationObject = useRef<FormContextProps>(createFormContext())

--- a/packages/picasso-forms/src/Form/Form.tsx
+++ b/packages/picasso-forms/src/Form/Form.tsx
@@ -35,6 +35,7 @@ import {
 } from './FormContext'
 
 export type Props<T = AnyObject> = FinalFormProps<T> & {
+  disableScrollOnError?: boolean
   autoComplete?: HTMLFormElement['autocomplete']
   successSubmitMessage?: ReactNode
   failedSubmitMessage?: ReactNode
@@ -71,6 +72,7 @@ export const Form = <T extends any = AnyObject>(props: Props<T>) => {
   const {
     children,
     autoComplete,
+    disableScrollOnError,
     onSubmit,
     successSubmitMessage,
     failedSubmitMessage,
@@ -80,7 +82,10 @@ export const Form = <T extends any = AnyObject>(props: Props<T>) => {
   } = props
   const { showSuccess, showError } = useNotifications()
   const scrollToErrorDecorator = useMemo(
-    () => createScrollToErrorDecorator(),
+    () =>
+      createScrollToErrorDecorator({
+        disableScrollOnError
+      }),
     []
   )
 

--- a/packages/picasso-forms/src/Form/__snapshots__/test.tsx.snap
+++ b/packages/picasso-forms/src/Form/__snapshots__/test.tsx.snap
@@ -109,7 +109,7 @@ exports[`Form renders with an error 1`] = `
             class="PicassoFormError-root PicassoFormField-error"
           >
             <p
-              class="MuiTypography-root PicassoTypography-bodyXsmall PicassoTypography-red PicassoFormError-error MuiTypography-body1"
+              class="MuiTypography-root PicassoTypography-bodyXxsmall PicassoTypography-red PicassoFormError-error MuiTypography-body1"
             >
               Please complete this field.
             </p>

--- a/packages/picasso-forms/src/Form/__snapshots__/test.tsx.snap
+++ b/packages/picasso-forms/src/Form/__snapshots__/test.tsx.snap
@@ -8,7 +8,9 @@ exports[`Form renders 1`] = `
     <div
       class=""
     >
-      <form>
+      <form
+        data-testid="form"
+      >
         <div
           class="PicassoFormField-root"
           data-field-has-error="false"
@@ -40,6 +42,77 @@ exports[`Form renders 1`] = `
                 </span>
               </legend>
             </fieldset>
+          </div>
+        </div>
+        <button
+          class="MuiButtonBase-root PicassoButton-medium PicassoButton-primary PicassoButton-root"
+          data-component-type="button"
+          tabindex="0"
+          type="submit"
+        >
+          <span
+            class="PicassoContainer-centerAlignItems PicassoContainer-flex PicassoContainer-inline PicassoButton-content"
+          >
+            Submit
+          </span>
+        </button>
+      </form>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Form renders with an error 1`] = `
+<div>
+  <div
+    class="Picasso-root"
+  >
+    <div
+      class=""
+    >
+      <form
+        data-testid="form"
+      >
+        <div
+          class="PicassoFormField-root"
+          data-field-has-error="true"
+        >
+          <div
+            class="MuiInputBase-root MuiOutlinedInput-root PicassoOutlinedInput-root PicassoInput-root PicassoOutlinedInput-rootAuto PicassoOutlinedInput-rootMedium Mui-error Mui-error MuiInputBase-adornedStart MuiOutlinedInput-adornedStart MuiInputBase-adornedEnd MuiOutlinedInput-adornedEnd"
+          >
+            <input
+              aria-invalid="true"
+              autocomplete="none"
+              class="MuiInputBase-input MuiOutlinedInput-input PicassoOutlinedInput-input PicassoOutlinedInput-inputMedium MuiInputBase-inputAdornedStart MuiOutlinedInput-inputAdornedStart MuiInputBase-inputAdornedEnd MuiOutlinedInput-inputAdornedEnd"
+              id="test"
+              name="test"
+              placeholder="test input"
+              type="text"
+              value=""
+            />
+            <fieldset
+              aria-hidden="true"
+              class="PrivateNotchedOutline-root MuiOutlinedInput-notchedOutline PicassoOutlinedInput-notchedOutline"
+              style="padding-left: 8px;"
+            >
+              <legend
+                class="PrivateNotchedOutline-legend"
+                style="width: 0.01px;"
+              >
+                <span>
+                  ​
+                </span>
+              </legend>
+            </fieldset>
+          </div>
+          <div
+            class="PicassoFormError-root PicassoFormField-error"
+          >
+            <p
+              class="MuiTypography-root PicassoTypography-bodyXsmall PicassoTypography-red PicassoFormError-error MuiTypography-body1"
+            >
+              Please complete this field.
+            </p>
           </div>
         </div>
         <button

--- a/packages/picasso-forms/src/Form/story/NoScrolling.example.tsx
+++ b/packages/picasso-forms/src/Form/story/NoScrolling.example.tsx
@@ -1,0 +1,41 @@
+import React from 'react'
+import { Container } from '@toptal/picasso'
+import { Form } from '@toptal/picasso-forms'
+
+const failWithAnError = () => ({
+  fieldName: 'This form will always blame on a wrong user name'
+})
+
+const NoScrollingExample = () => (
+  <Container>
+    <Container top='small'>
+      <Form onSubmit={failWithAnError}>
+        <Form.Input
+          required
+          name='fieldName'
+          label='With scrolling'
+          placeholder='Some field'
+        />
+        <Container top='small'>
+          <Form.SubmitButton>Submit</Form.SubmitButton>
+        </Container>
+      </Form>
+    </Container>
+
+    <Container top='small'>
+      <Form disableScrollOnError onSubmit={failWithAnError}>
+        <Form.Input
+          required
+          name='fieldName'
+          label='No scrolling'
+          placeholder='Some field'
+        />
+        <Container top='small'>
+          <Form.SubmitButton>Submit</Form.SubmitButton>
+        </Container>
+      </Form>
+    </Container>
+  </Container>
+)
+
+export default NoScrollingExample

--- a/packages/picasso-forms/src/Form/story/index.jsx
+++ b/packages/picasso-forms/src/Form/story/index.jsx
@@ -10,6 +10,14 @@ page
     component: Form,
     name: 'Form',
     additionalDocs: {
+      disableScrollOnError: {
+        name: 'disableScrollOnError',
+        type: {
+          name: 'boolean'
+        },
+        description: `Whether to scroll to the failed field on the form error.`,
+        defaultValue: 'false'
+      },
       autoComplete: {
         name: 'autoComplete',
         type: {
@@ -97,7 +105,7 @@ Tip: It is possible to have autocomplete 'on' for the form, and 'off' for specif
         type: 'boolean',
         description:
           'If true, validation will happen on blur. If false, validation will happen on change',
-        defaultValue: false
+        defaultValue: 'false'
       },
       successSubmitMessage: {
         name: 'successSubmitMessage',
@@ -205,4 +213,8 @@ however, you may need custom validators for more complex types of fields.
   .addExample('Form/story/TitleCase.example.tsx', {
     title: 'Title case',
     description: "Display the field's label in title case."
+  }) // picasso-skip-visuals
+  .addExample('Form/story/NoScrolling.example.tsx', {
+    title: 'No scrolling case',
+    description: "Showcase Form's behavior on form submission error."
   }) // picasso-skip-visuals

--- a/packages/picasso-forms/src/Form/test.tsx
+++ b/packages/picasso-forms/src/Form/test.tsx
@@ -79,7 +79,7 @@ describe('Form', () => {
     expect(container).toMatchSnapshot()
   })
 
-  it('does not auto-scroll form to the error field if `disableScrollOnError` is specified', async () => {
+  it('when `disableScrollOnError` is specified', async () => {
     const { findByTestId } = renderForm({
       onSubmit: () => ({ test: 'Some error' }),
       disableScrollOnError: true,

--- a/packages/picasso-forms/src/Form/test.tsx
+++ b/packages/picasso-forms/src/Form/test.tsx
@@ -1,27 +1,97 @@
 import React from 'react'
-import { render } from '@toptal/picasso/test-utils'
+import { fireEvent, render } from '@toptal/picasso/test-utils'
 import { OmitInternalProps } from '@toptal/picasso-shared'
 import { Button } from '@toptal/picasso'
 
 import Form, { Props } from './Form'
+import { scrollTo } from '../utils/scroll-to'
 
-const renderForm = (props: OmitInternalProps<Props>) => {
-  const { onSubmit } = props
+jest.mock('../utils', () => ({
+  ...jest.requireActual('../utils'),
+  createScrollToErrorDecorator: jest.requireActual(
+    '../utils/scroll-to-error-decorator'
+  ).default
+}))
+jest.mock('../utils/scroll-to', () => ({
+  scrollTo: jest.fn()
+}))
+
+const renderForm = (
+  props: OmitInternalProps<Props> & { mandatory?: boolean }
+) => {
+  const { onSubmit, disableScrollOnError, mandatory } = props
 
   return render(
-    <Form onSubmit={onSubmit}>
-      <Form.Input name='test' placeholder='test input' />
+    <Form
+      data-testid='form'
+      onSubmit={onSubmit}
+      disableScrollOnError={disableScrollOnError}
+    >
+      <Form.Input name='test' placeholder='test input' required={mandatory} />
       <Button type='submit'>Submit</Button>
     </Form>
   )
 }
 
+/**
+ * form submit is not linked to any process,
+ * so where is no other way to wait when error is gonna be displayed
+ */
+const waitForFormToDisplayErrors = () =>
+  new Promise(resolve => setTimeout(resolve, 100))
+
+const scrollToMock = scrollTo as jest.Mock
+
 describe('Form', () => {
-  it('renders', () => {
-    const { container } = renderForm({
-      onSubmit: () => {}
+  beforeEach(() => {
+    scrollToMock.mockReset()
+  })
+
+  it('renders', async () => {
+    const { container, findByTestId } = renderForm({
+      onSubmit: () => {},
+      mandatory: false
     })
 
+    const formElement = await findByTestId('form')
+
+    fireEvent.submit(formElement)
+
+    await waitForFormToDisplayErrors()
+
+    expect(scrollToMock).toHaveBeenCalledTimes(0)
     expect(container).toMatchSnapshot()
+  })
+
+  it('renders with an error', async () => {
+    const { container, findByTestId } = renderForm({
+      onSubmit: () => Promise.resolve({ test: 'Some error' }),
+      mandatory: true
+    })
+
+    const formElement = await findByTestId('form')
+
+    fireEvent.submit(formElement)
+
+    await waitForFormToDisplayErrors()
+
+    expect(scrollToMock).toHaveBeenCalledTimes(1)
+    expect(container).toMatchSnapshot()
+  })
+
+  it('does not auto-scroll form to the error field if `disableScrollOnError` is specified', async () => {
+    const { findByTestId } = renderForm({
+      onSubmit: () => ({ test: 'Some error' }),
+      disableScrollOnError: true,
+      mandatory: true
+    })
+
+    const formElement = await findByTestId('form')
+
+    fireEvent.submit(formElement)
+
+    await waitForFormToDisplayErrors()
+
+    expect(scrollToMock).not.toHaveBeenCalled()
   })
 })

--- a/packages/picasso-forms/src/Form/test.tsx
+++ b/packages/picasso-forms/src/Form/test.tsx
@@ -34,8 +34,8 @@ const renderForm = (
 }
 
 /**
- * form submit is not linked to any process,
- * so where is no other way to wait when error is gonna be displayed
+ * form submit does not return Promise or accept callback,
+ * so there is no way to know when an error is displayed
  */
 const waitForFormToDisplayErrors = () =>
   new Promise(resolve => setTimeout(resolve, 100))

--- a/packages/picasso-forms/src/utils/scroll-to.ts
+++ b/packages/picasso-forms/src/utils/scroll-to.ts
@@ -1,0 +1,11 @@
+const UNHIDDEN_INPUT_SELECTOR = 'input:not([type=hidden])'
+
+export const scrollTo = (field: HTMLElement) => {
+  // scrollIntoView is not defined for Jest
+  if (typeof field.scrollIntoView === 'function') {
+    field.scrollIntoView({ block: 'center', behavior: 'smooth' })
+  }
+  field
+    .querySelector<HTMLInputElement>(UNHIDDEN_INPUT_SELECTOR)
+    ?.focus({ preventScroll: true })
+}

--- a/packages/picasso-forms/src/utils/scroll-to.ts
+++ b/packages/picasso-forms/src/utils/scroll-to.ts
@@ -1,7 +1,6 @@
 const UNHIDDEN_INPUT_SELECTOR = 'input:not([type=hidden])'
 
 export const scrollTo = (field: HTMLElement) => {
-  // scrollIntoView is not defined for Jest
   if (typeof field.scrollIntoView === 'function') {
     field.scrollIntoView({ block: 'center', behavior: 'smooth' })
   }


### PR DESCRIPTION
<!---
Thanks for taking the time to contribute!

Please make sure to follow contribution process:
https://toptal-core.atlassian.net/wiki/spaces/FE/pages/2396094469/Handling+external+contribution
-->

[FX-2356]
[SPB-2864]

### Description

1. If there multiple form on page and we submit them, we have to manually control auto-focus, since, Picasso is doing it wrong.
2. Sometimes you don't need an auto-focus for error fields or auto-sroll to error fields.

### How to test

Submit form with an error (try switching off internet connection), see no scroll or auto-focus.

### Screenshots

N/A

### Review

- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure that tests pass by running `yarn test`
- [x] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and
1. You have no extra requests.
2. You have optional requests.
   1. Add `nit: ` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because
1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:
1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[SPB-2864]: https://toptal-core.atlassian.net/browse/SPB-2864?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[FX-2356]: https://toptal-core.atlassian.net/browse/FX-2356?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ