### PR TITLE
fix(Forms): add ability to disabled auto-focus and auto-scroll on Form submission error

### DIFF
--- a/packages/picasso-forms/src/Form/Form.tsx
+++ b/packages/picasso-forms/src/Form/Form.tsx
@@ -35,6 +35,8 @@ import {
 } from './FormContext'
 
 export type Props<T = AnyObject> = FinalFormProps<T> & {
+  autoScrollOnErrors?: boolean
+  autoFocusOnScrollToErrors?: boolean
   autoComplete?: HTMLFormElement['autocomplete']
   successSubmitMessage?: ReactNode
   failedSubmitMessage?: ReactNode
@@ -71,6 +73,8 @@ export const Form = <T extends any = AnyObject>(props: Props<T>) => {
   const {
     children,
     autoComplete,
+    autoScrollOnErrors,
+    autoFocusOnScrollToErrors,
     onSubmit,
     successSubmitMessage,
     failedSubmitMessage,
@@ -80,7 +84,11 @@ export const Form = <T extends any = AnyObject>(props: Props<T>) => {
   } = props
   const { showSuccess, showError } = useNotifications()
   const scrollToErrorDecorator = useMemo(
-    () => createScrollToErrorDecorator(),
+    () =>
+      createScrollToErrorDecorator({
+        autoScrollOnErrors,
+        autoFocusOnScrollToErrors
+      }),
     []
   )
 


### PR DESCRIPTION
<!---
Thanks for taking the time to contribute!

Please make sure to follow contribution process:
https://toptal-core.atlassian.net/wiki/spaces/FE/pages/2396094469/Handling+external+contribution
-->

[SPB-2864]

### Description

1. If there multiple form on page and we submit them, we have to manually control auto-focus, since, Picasso is doing it wrong.
2. Sometimes you don't need an auto-focus for error fields or auto-sroll to error fields.

### How to test

Submit form with an error (try switching off internet connection), see no scroll or auto-focus.

### Screenshots

N/A

### Review

- [ ] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [ ] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that tests pass by running `yarn test`
- [ ] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
- [ ] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and
1. You have no extra requests.
2. You have optional requests.
   1. Add `nit: ` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because
1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:
1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[SPB-2864]: https://toptal-core.atlassian.net/browse/SPB-2864?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ