### PR TITLE
feat(List): make ListItem margin accessible for client code

### DIFF
--- a/.changeset/great-fans-punch.md
+++ b/.changeset/great-fans-punch.md
@@ -1,0 +1,7 @@
+---
+'@toptal/picasso': minor
+---
+
+## ListItem 
+
+- Make ListItem's marginBottom accessible for client code so that it can be overrided

--- a/packages/picasso/src/List/List.tsx
+++ b/packages/picasso/src/List/List.tsx
@@ -27,8 +27,6 @@ export const List = (props: Props) => {
   const classes = useStyles()
   const { variant, children, start = 1, className, ...rest } = props
 
-  const totalChildElements = React.Children.count(children)
-
   const listItems = React.Children.map(children, (child, index) => {
     if (!React.isValidElement(child)) {
       return child
@@ -36,7 +34,6 @@ export const List = (props: Props) => {
 
     return React.cloneElement(child, {
       variant,
-      isLastElement: totalChildElements === index + 1,
       index: index + start - 1
     })
   })

--- a/packages/picasso/src/List/__snapshots__/test.tsx.snap
+++ b/packages/picasso/src/List/__snapshots__/test.tsx.snap
@@ -9,7 +9,9 @@ exports[`List renders ordered list 1`] = `
       class="PicassoList-root"
       data-testid="ordered-list"
     >
-      <li>
+      <li
+        class="PicassoListItem-root"
+      >
         <div
           class="PicassoContainer-flex PicassoListItem-listContainer"
         >
@@ -30,7 +32,9 @@ exports[`List renders ordered list 1`] = `
           </div>
         </div>
       </li>
-      <li>
+      <li
+        class="PicassoListItem-root"
+      >
         <div
           class="PicassoContainer-flex PicassoListItem-listContainer"
         >
@@ -51,7 +55,9 @@ exports[`List renders ordered list 1`] = `
           </div>
         </div>
       </li>
-      <li>
+      <li
+        class="PicassoListItem-root"
+      >
         <div
           class="PicassoContainer-flex PicassoListItem-listContainer"
         >
@@ -72,7 +78,9 @@ exports[`List renders ordered list 1`] = `
           </div>
         </div>
       </li>
-      <li>
+      <li
+        class="PicassoListItem-root"
+      >
         <div
           class="PicassoContainer-flex PicassoListItem-listContainer"
         >
@@ -93,9 +101,11 @@ exports[`List renders ordered list 1`] = `
           </div>
         </div>
       </li>
-      <li>
+      <li
+        class="PicassoListItem-root"
+      >
         <div
-          class="PicassoContainer-flex PicassoListItem-listContainer PicassoListItem-lastElement"
+          class="PicassoContainer-flex PicassoListItem-listContainer"
         >
           <div
             class="PicassoContainer-rightsmallMargin PicassoContainer-flexEndJustifyContent PicassoContainer-inline PicassoListItem-ordered"
@@ -128,7 +138,9 @@ exports[`List renders unordered list 1`] = `
       class="PicassoList-root PicassoList-unordered"
       data-testid="unordered-list"
     >
-      <li>
+      <li
+        class="PicassoListItem-root"
+      >
         <div
           class="PicassoContainer-flex PicassoListItem-listContainer"
         >
@@ -152,7 +164,9 @@ exports[`List renders unordered list 1`] = `
           </div>
         </div>
       </li>
-      <li>
+      <li
+        class="PicassoListItem-root"
+      >
         <div
           class="PicassoContainer-flex PicassoListItem-listContainer"
         >
@@ -176,7 +190,9 @@ exports[`List renders unordered list 1`] = `
           </div>
         </div>
       </li>
-      <li>
+      <li
+        class="PicassoListItem-root"
+      >
         <div
           class="PicassoContainer-flex PicassoListItem-listContainer"
         >
@@ -200,7 +216,9 @@ exports[`List renders unordered list 1`] = `
           </div>
         </div>
       </li>
-      <li>
+      <li
+        class="PicassoListItem-root"
+      >
         <div
           class="PicassoContainer-flex PicassoListItem-listContainer"
         >
@@ -224,9 +242,11 @@ exports[`List renders unordered list 1`] = `
           </div>
         </div>
       </li>
-      <li>
+      <li
+        class="PicassoListItem-root"
+      >
         <div
-          class="PicassoContainer-flex PicassoListItem-listContainer PicassoListItem-lastElement"
+          class="PicassoContainer-flex PicassoListItem-listContainer"
         >
           <div
             class="PicassoContainer-rightsmallMargin PicassoContainer-flexEndJustifyContent PicassoContainer-inline PicassoListItem-unordered"

--- a/packages/picasso/src/List/story/CustomMargin.example.tsx
+++ b/packages/picasso/src/List/story/CustomMargin.example.tsx
@@ -1,0 +1,30 @@
+import React from 'react'
+import { List, Container } from '@toptal/picasso'
+import styled from 'styled-components'
+
+const StyledListItem = styled(List.Item)`
+  &:not(:last-child) {
+    margin-bottom: 0;
+  }
+`
+
+const DefaultExample = () => (
+  <Container>
+    <List>
+      <List.Item style={{ marginBottom: 0 }}>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua.
+      </List.Item>
+      <StyledListItem>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua.
+      </StyledListItem>
+      <StyledListItem>
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua.
+      </StyledListItem>
+    </List>
+  </Container>
+)
+
+export default DefaultExample

--- a/packages/picasso/src/List/story/index.jsx
+++ b/packages/picasso/src/List/story/index.jsx
@@ -40,3 +40,4 @@ page
   ) // picasso-skip-visuals
   .addExample('List/story/Unordered.example.tsx', 'Unordered') // picasso-skip-visuals
   .addExample('List/story/Custom.example.tsx', 'Custom') // picasso-skip-visuals
+  .addExample('List/story/CustomMargin.example.tsx', 'Custom margin') // picasso-skip-visuals

--- a/packages/picasso/src/ListItem/ListItem.tsx
+++ b/packages/picasso/src/ListItem/ListItem.tsx
@@ -1,6 +1,6 @@
 import React, { ReactNode } from 'react'
 import { BaseProps } from '@toptal/picasso-shared'
-import { Theme, makeStyles } from '@material-ui/core/styles'
+import { makeStyles } from '@material-ui/core/styles'
 import cx from 'classnames'
 
 import Container from '../Container'
@@ -15,7 +15,6 @@ export type Props = BaseProps & {
   index?: number
   /** Add a custom `<Icon />` to set a custom bullet in ordered lists */
   icon?: ReactNode
-  isLastElement?: boolean
 }
 
 const Index = ({ children }: { children: ReactNode }) => (
@@ -38,7 +37,7 @@ const getBulletOrNumber = (
   return <Index>{index + 1}</Index>
 }
 
-const useStyles = makeStyles<Theme>(styles, { name: 'PicassoListItem' })
+const useStyles = makeStyles(styles, { name: 'PicassoListItem' })
 
 export const ListItem = (props: Props) => {
   const classes = useStyles()
@@ -47,21 +46,15 @@ export const ListItem = (props: Props) => {
     icon,
     variant = 'unordered',
     index = 1,
-    isLastElement,
+    className,
     ...rest
   } = props
 
   const itemIcon = getBulletOrNumber(variant, index, icon)
 
   return (
-    <li {...rest}>
-      <Container
-        flex
-        direction='row'
-        className={cx(classes.listContainer, {
-          [classes.lastElement]: isLastElement
-        })}
-      >
+    <li className={cx(className, classes.root)} {...rest}>
+      <Container flex direction='row' className={cx(classes.listContainer)}>
         <Container
           inline
           right='small'

--- a/packages/picasso/src/ListItem/styles.ts
+++ b/packages/picasso/src/ListItem/styles.ts
@@ -13,9 +13,13 @@ PicassoProvider.override(() => ({
 
 export default () =>
   createStyles({
+    root: {
+      '&:not(:last-child)': {
+        marginBottom: '0.5em'
+      }
+    },
     listContainer: {
-      lineHeight: '1.375em',
-      marginBottom: '0.5em'
+      lineHeight: '1.375em'
     },
     ordered: {
       minWidth: '1.25em',
@@ -23,8 +27,5 @@ export default () =>
     },
     unordered: {
       minWidth: '1rem'
-    },
-    lastElement: {
-      marginBottom: 0
     }
   })


### PR DESCRIPTION
<!---
Thanks for taking the time to contribute!

Please make sure to follow contribution process:
https://toptal-core.atlassian.net/wiki/spaces/FE/pages/2396094469/Handling+external+contribution
-->

[FX-2369]

### Description

Moved margin from an inner container into `li` element itself so that client code can easily override that (e.g. to achieve dense list appearance if needed). 
### How to test

- Ensure existing list use-cases look unchanged
- Ensure margin override for list items works reliably 

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| Margin on an inner element <img width="521" alt="image" src="https://user-images.githubusercontent.com/903437/147261760-c1684f94-18d1-4e76-bd37-36675a927697.png"><img width="522" alt="image" src="https://user-images.githubusercontent.com/903437/147261792-bdbf0ef1-5848-4175-acfb-f9b72e197bd5.png"> | Margin on li element <img width="515" alt="image" src="https://user-images.githubusercontent.com/903437/147261646-d651fdef-43aa-47c4-820d-32e5cc1680e9.png"> |
| | Demo of the list with reduced margin <img width="573" alt="image" src="https://user-images.githubusercontent.com/903437/147261941-678b275c-98ff-4856-9f10-8a2a8643edcc.png"> |

### Review

- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure that tests pass by running `yarn test`
- [x] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
- [ ] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and
1. You have no extra requests.
2. You have optional requests.
   1. Add `nit: ` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because
1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:
1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-2369]: https://toptal-core.atlassian.net/browse/FX-2369?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ