### PR TITLE
fix(List): add font-size to List root to fix bullets alignment

### DIFF
--- a/.changeset/witty-brooms-sin.md
+++ b/.changeset/witty-brooms-sin.md
@@ -1,0 +1,7 @@
+---
+'@toptal/picasso': patch
+---
+
+## List 
+
+- set List's root element font-size to 1rem to fix unordered list bullets alignment

--- a/cypress/component/List.spec.tsx
+++ b/cypress/component/List.spec.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { List, Referrals16 } from '@toptal/picasso'
+import { Container, List, Referrals16 } from '@toptal/picasso'
 import { mount } from '@cypress/react'
 import { TestingPicasso } from '@toptal/picasso/test-utils'
 
@@ -37,6 +37,21 @@ describe('List', () => {
       )
 
       cy.get('body').happoScreenshot()
+    })
+
+    context('when put into reduced font-size container', () => {
+      // eslint-disable-next-line max-nested-callbacks
+      it('aligns bullets correctly', () => {
+        mount(
+          <TestingPicasso>
+            <Container style={{ fontSize: '0.825rem' }}>
+              <List>{generateListItems(5)}</List>
+            </Container>
+          </TestingPicasso>
+        )
+
+        cy.get('body').happoScreenshot()
+      })
     })
   })
 

--- a/packages/picasso/src/List/styles.ts
+++ b/packages/picasso/src/List/styles.ts
@@ -5,7 +5,8 @@ export default ({ palette }: Theme) =>
     root: {
       listStyle: 'none',
       padding: 0,
-      margin: 0
+      margin: 0,
+      fontSize: '1rem'
     },
     unordered: {
       color: palette.text.primary


### PR DESCRIPTION
### Description

Fixes ListItem bullets misalignment when List is rendered withing container with reduced font-size (e.g. picasso/Table)

### How to test

- Ensure unordered List items bullets are vertically aligned correctly 

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| <img width="229" alt="image" src="https://user-images.githubusercontent.com/903437/147462824-7f780332-93a2-4e45-b3fa-a6033a8d193e.png"> | <img width="264" alt="image" src="https://user-images.githubusercontent.com/903437/147462841-67b02fa2-9471-450e-9d25-c2f20aed4568.png"> |

### Review

- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure that tests pass by running `yarn test`
- [x] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
- [ ] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>
