### PR TITLE
chore(picasso): change key press focus logic for Select component

### DIFF
--- a/.changeset/small-seahorses-speak.md
+++ b/.changeset/small-seahorses-speak.md
@@ -1,5 +1,7 @@
 ---
-'@toptal/picasso': minor
+'@toptal/picasso': patch
 ---
 
-Typing one of the `@#$%()_+-=.,` symbols after clicking on Select component now triggers focus to its search input
+### Select
+
+- Typing special symbols after clicking on Select component now triggers focus to its search input

--- a/.changeset/small-seahorses-speak.md
+++ b/.changeset/small-seahorses-speak.md
@@ -1,0 +1,5 @@
+---
+'@toptal/picasso': minor
+---
+
+Typing one of the `@#$%()_+-=.,` symbols after clicking on Select component now triggers focus to its search input

--- a/packages/picasso/src/Select/hooks/use-select-props/use-select-keydown-handler/test.ts
+++ b/packages/picasso/src/Select/hooks/use-select-props/use-select-keydown-handler/test.ts
@@ -36,33 +36,66 @@ describe('useSelectKeydownHandle', () => {
     expect(props.selectProps.onKeyDown).toHaveBeenCalledWith(event)
   })
 
-  it('focuses input if typing text', () => {
-    const handleArrowsKeyDown = jest.fn()
-    const handleEnterOrSpaceKeyDown = jest.fn()
-    const handleEscapeKeyDown = jest.fn()
-    const props = {
-      ...getUseSelectPropsMock(),
-      handleArrowsKeyDown,
-      handleEnterOrSpaceKeyDown,
-      handleEscapeKeyDown
+  it.each([...'Aa0@#$%^()_+-=.,!?&*|'.split(''), 'Backspace'])(
+    'focuses input if pressing `%s` key',
+    character => {
+      const handleArrowsKeyDown = jest.fn()
+      const handleEnterOrSpaceKeyDown = jest.fn()
+      const handleEscapeKeyDown = jest.fn()
+      const props = {
+        ...getUseSelectPropsMock(),
+        handleArrowsKeyDown,
+        handleEnterOrSpaceKeyDown,
+        handleEscapeKeyDown
+      }
+
+      props.selectProps.onKeyDown = jest.fn()
+      props.selectState.showSearch = true
+
+      const { result } = renderHook(() => useSelectKeydownHandle(props))
+      const event = new KeyboardEvent('keydown', { key: character }) as any
+
+      event.preventDefault = jest.fn()
+
+      result.current(event)
+
+      expect(event.preventDefault).not.toHaveBeenCalled()
+      expect(focusRef).toHaveBeenCalledTimes(1)
+      expect(focusRef).toHaveBeenCalledWith(props.searchInputRef)
+      expect(props.selectProps.onKeyDown).toHaveBeenCalledTimes(1)
+      expect(props.selectProps.onKeyDown).toHaveBeenCalledWith(event)
     }
+  )
 
-    props.selectProps.onKeyDown = jest.fn()
-    props.selectState.showSearch = true
+  it.each(['Ctrl', 'Meta', 'Shift', 'CapsLock', 'Delete'])(
+    'does not focus input if pressing `%s` key',
+    character => {
+      const handleArrowsKeyDown = jest.fn()
+      const handleEnterOrSpaceKeyDown = jest.fn()
+      const handleEscapeKeyDown = jest.fn()
+      const props = {
+        ...getUseSelectPropsMock(),
+        handleArrowsKeyDown,
+        handleEnterOrSpaceKeyDown,
+        handleEscapeKeyDown
+      }
 
-    const { result } = renderHook(() => useSelectKeydownHandle(props))
-    const event = new KeyboardEvent('keydown', { key: 'A' }) as any
+      props.selectProps.onKeyDown = jest.fn()
+      props.selectState.showSearch = true
 
-    event.preventDefault = jest.fn()
+      const { result } = renderHook(() => useSelectKeydownHandle(props))
+      const event = new KeyboardEvent('keydown', { key: character }) as any
 
-    result.current(event)
+      event.preventDefault = jest.fn()
 
-    expect(event.preventDefault).not.toHaveBeenCalled()
-    expect(focusRef).toHaveBeenCalledTimes(1)
-    expect(focusRef).toHaveBeenCalledWith(props.searchInputRef)
-    expect(props.selectProps.onKeyDown).toHaveBeenCalledTimes(1)
-    expect(props.selectProps.onKeyDown).toHaveBeenCalledWith(event)
-  })
+      result.current(event)
+
+      expect(event.preventDefault).not.toHaveBeenCalled()
+      expect(focusRef).toHaveBeenCalledTimes(0)
+      expect(props.selectProps.onKeyDown).toHaveBeenCalledTimes(1)
+      expect(props.selectProps.onKeyDown).toHaveBeenCalledWith(event)
+    }
+  )
 
   it('focuses input on tab when open and search is shown', () => {
     const handleArrowsKeyDown = jest.fn()

--- a/packages/picasso/src/Select/hooks/use-select-props/use-select-keydown-handler/test.ts
+++ b/packages/picasso/src/Select/hooks/use-select-props/use-select-keydown-handler/test.ts
@@ -67,35 +67,42 @@ describe('useSelectKeydownHandle', () => {
     }
   )
 
-  it.each(['Ctrl', 'Meta', 'Shift', 'CapsLock', 'Delete'])(
-    'does not focus input if pressing `%s` key',
-    character => {
-      const handleArrowsKeyDown = jest.fn()
-      const handleEnterOrSpaceKeyDown = jest.fn()
-      const handleEscapeKeyDown = jest.fn()
-      const props = {
-        ...getUseSelectPropsMock(),
-        handleArrowsKeyDown,
-        handleEnterOrSpaceKeyDown,
-        handleEscapeKeyDown
-      }
-
-      props.selectProps.onKeyDown = jest.fn()
-      props.selectState.showSearch = true
-
-      const { result } = renderHook(() => useSelectKeydownHandle(props))
-      const event = new KeyboardEvent('keydown', { key: character }) as any
-
-      event.preventDefault = jest.fn()
-
-      result.current(event)
-
-      expect(event.preventDefault).not.toHaveBeenCalled()
-      expect(focusRef).toHaveBeenCalledTimes(0)
-      expect(props.selectProps.onKeyDown).toHaveBeenCalledTimes(1)
-      expect(props.selectProps.onKeyDown).toHaveBeenCalledWith(event)
+  it.each([
+    'Ctrl',
+    'Meta',
+    'Shift',
+    'CapsLock',
+    'Delete',
+    'PageUp',
+    'Home',
+    'F11',
+    ' '
+  ])('does not focus input if pressing `%s` key', character => {
+    const handleArrowsKeyDown = jest.fn()
+    const handleEnterOrSpaceKeyDown = jest.fn()
+    const handleEscapeKeyDown = jest.fn()
+    const props = {
+      ...getUseSelectPropsMock(),
+      handleArrowsKeyDown,
+      handleEnterOrSpaceKeyDown,
+      handleEscapeKeyDown
     }
-  )
+
+    props.selectProps.onKeyDown = jest.fn()
+    props.selectState.showSearch = true
+
+    const { result } = renderHook(() => useSelectKeydownHandle(props))
+    const event = new KeyboardEvent('keydown', { key: character }) as any
+
+    event.preventDefault = jest.fn()
+
+    result.current(event)
+
+    expect(event.preventDefault).not.toHaveBeenCalled()
+    expect(focusRef).toHaveBeenCalledTimes(0)
+    expect(props.selectProps.onKeyDown).toHaveBeenCalledTimes(1)
+    expect(props.selectProps.onKeyDown).toHaveBeenCalledWith(event)
+  })
 
   it('focuses input on tab when open and search is shown', () => {
     const handleArrowsKeyDown = jest.fn()

--- a/packages/picasso/src/Select/hooks/use-select-props/use-select-keydown-handler/use-select-keydown-handler.ts
+++ b/packages/picasso/src/Select/hooks/use-select-props/use-select-keydown-handler/use-select-keydown-handler.ts
@@ -33,24 +33,20 @@ const useSelectKeyDownHandler = <
         return
       }
 
-      const isValidInputValue =
-        Boolean(event.key.match(/^[A-z\d]$/)) || event.key === 'Backspace'
-
-      if (isValidInputValue) {
-        focusRef(searchInputRef)
-      }
-
       const key = normalizeArrowKey(event)
+      const isCharacterKey = key.length === 1
 
-      if (key === 'Tab' && isOpen && showSearch) {
-        event.preventDefault()
-        focusRef(searchInputRef)
-      } else if (key === 'ArrowUp' || key === 'ArrowDown') {
+      if (key === 'ArrowUp' || key === 'ArrowDown') {
         handleArrowsKeyDown(key, event)
       } else if (key === 'Enter' || key === ' ') {
         handleEnterOrSpaceKeyDown(event)
       } else if (key === 'Escape') {
         handleEscapeKeyDown(event)
+      } else if (key === 'Tab' && isOpen && showSearch) {
+        event.preventDefault()
+        focusRef(searchInputRef)
+      } else if (isCharacterKey || key === 'Backspace') {
+        focusRef(searchInputRef)
       }
 
       onKeyDown?.(event)


### PR DESCRIPTION
[SPT-2254]

Related issue
https://toptal-core.atlassian.net/browse/SPT-2254

This pr adds additional symbols to `useSelectKeyDownHandler` RegExp for Select component
That allows triggering focus to Select Input when typing `+`, `-` and other special symbols
PR is adding support for only a few special symbols

### How to test

1. Open https://picasso.toptal.net/SPT-2254-select-focus-regexp/?path=/story/forms-select--select
2. Click on Select component, when its popup opens, press one of the following characters `@#$%^()_+-=.,`. After pressing, search input should be focused
3. When its popup opens, press one of the following characters `!?&*|`. These characters should not trigger focus to search input

### Review

- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [n/a] Annotate all `props` in component with documentation
- [n/a] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure that tests pass by running `yarn test`
- [x] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[SPT-2254]: https://toptal-core.atlassian.net/browse/SPT-2254?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ