### PR TITLE
chore(picasso): fixes DatePicker Input `reset` button and Input overlapping

### DIFF
--- a/.changeset/curvy-dolls-pump.md
+++ b/.changeset/curvy-dolls-pump.md
@@ -1,0 +1,8 @@
+---
+'@toptal/picasso-lab': patch
+---
+
+## DatePicker
+
+Fixed broken Reset icon of DatePicker's Input
+Fixed case when DatePicker's popper can overlap DatePicker's input

--- a/packages/picasso-lab/src/DatePicker/DatePicker.tsx
+++ b/packages/picasso-lab/src/DatePicker/DatePicker.tsx
@@ -30,7 +30,8 @@ import Calendar, {
 } from '../Calendar'
 import {
   DEFAULT_DATE_PICKER_DISPLAY_DATE_FORMAT,
-  DEFAULT_DATE_PICKER_EDIT_DATE_FORMAT
+  DEFAULT_DATE_PICKER_EDIT_DATE_FORMAT,
+  DEFAULT_POPPER_OPTIONS
 } from './constants'
 import styles from './styles'
 import { DatePickerValue, DatePickerInputCustomValueParser } from './types'
@@ -110,6 +111,7 @@ export const DatePicker = (props: Props) => {
     editDateFormat = DEFAULT_DATE_PICKER_EDIT_DATE_FORMAT,
     onBlur = noop,
     onChange,
+    onResetClick,
     value,
     width,
     icon,
@@ -324,6 +326,13 @@ export const DatePicker = (props: Props) => {
     setIsInputFocused(true)
   }
 
+  const handleResetClick = (
+    event: React.MouseEvent<HTMLButtonElement & HTMLAnchorElement>
+  ) => {
+    setInputValue('')
+    onResetClick?.(event)
+  }
+
   const startAdornment =
     size !== 'small' ? (
       <InputAdornment position='start' disablePointerEvents>
@@ -341,6 +350,7 @@ export const DatePicker = (props: Props) => {
           onClick={handleFocusOrClick}
           onFocus={handleFocusOrClick}
           onBlur={handleBlur}
+          onResetClick={handleResetClick}
           value={inputValue}
           onChange={handleInputChange}
           size={size}
@@ -358,6 +368,7 @@ export const DatePicker = (props: Props) => {
           autoWidth={false}
           enableCompactMode
           container={popperContainer}
+          popperOptions={DEFAULT_POPPER_OPTIONS}
           ref={popperRef}
         >
           <Calendar

--- a/packages/picasso-lab/src/DatePicker/constants.ts
+++ b/packages/picasso-lab/src/DatePicker/constants.ts
@@ -1,2 +1,9 @@
 export const DEFAULT_DATE_PICKER_EDIT_DATE_FORMAT = 'MM-dd-yyyy'
 export const DEFAULT_DATE_PICKER_DISPLAY_DATE_FORMAT = 'MMM d, yyyy'
+export const DEFAULT_POPPER_OPTIONS = {
+  modifiers: {
+    preventOverflow: {
+      enabled: false
+    }
+  }
+}

--- a/packages/picasso-lab/src/DatePicker/story/WithResetButton.example.tsx
+++ b/packages/picasso-lab/src/DatePicker/story/WithResetButton.example.tsx
@@ -1,0 +1,21 @@
+import React, { useState } from 'react'
+import { DatePicker, DatePickerValue } from '@toptal/picasso-lab'
+
+const WithResetButton = () => {
+  const [datepickerValue, setDatepickerValue] = useState<DatePickerValue>()
+
+  return (
+    <div style={{ height: '50vh' }}>
+      <DatePicker
+        value={datepickerValue}
+        enableReset
+        onResetClick={() => setDatepickerValue(null)}
+        onChange={date => {
+          setDatepickerValue(date as Date)
+        }}
+      />
+    </div>
+  )
+}
+
+export default WithResetButton

--- a/packages/picasso-lab/src/DatePicker/story/index.jsx
+++ b/packages/picasso-lab/src/DatePicker/story/index.jsx
@@ -29,6 +29,10 @@ page
     description: 'Do not hide calendar on date select'
   }) // picasso-skip-visuals
   .addExample(
+    'DatePicker/story/WithResetButton.example.tsx',
+    'With reset button'
+  ) // picasso-skip-visuals
+  .addExample(
     'DatePicker/story/WithInitialValue.example.tsx',
     'With initial value specified'
   ) // picasso-skip-visuals


### PR DESCRIPTION
[SPT-2269]

### Description

Fixed broken Reset icon of DatePicker's Input
Fixed case when DatePicker's popper can overlap DatePicker's input

### How to test

- First issue: Open https://picasso.toptal.net/SPT-2269-date-picker-improvements/?path=/story/picasso-lab-datepicker--datepicker, scroll down to the `With reset button
` section, select the date via manual input or calendar and click `reset` icon at the right of DatePicker's Input. Input value should be reset as well as selected date in the calendar.
- Second issue: When the viewport height is quite small and DatePicker's popup is opened, if we scroll the page this popup sticks to the top or bottom of the pages that causing overlapping of the DatePicker's Input by DatePicker's popup. It can be reproducible here https://picasso.toptal.net/?path=/story/picasso-lab-datepicker--datepicker
So to test it open https://picasso.toptal.net/SPT-2269-date-picker-improvements/?path=/story/picasso-lab-datepicker--datepicker and check that now when the viewport height is small, DatePicker's popup does not stick to the top or bottom edge of the viewport

### Review

- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure that tests pass by running `yarn test`
- [x] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[SPT-2269]: https://toptal-core.atlassian.net/browse/SPT-2269?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ