### PR TITLE
chore(picasso): add support for returning undefined value from `getKey` selector of Autocomplete

### DIFF
--- a/.changeset/breezy-waves-fold.md
+++ b/.changeset/breezy-waves-fold.md
@@ -1,0 +1,7 @@
+---
+'@toptal/picasso': minor
+---
+
+### Autocomplete
+
+- add support for returning undefined value from `getKey` selector for Autocomplete

--- a/packages/picasso/src/Autocomplete/Autocomplete.tsx
+++ b/packages/picasso/src/Autocomplete/Autocomplete.tsx
@@ -93,7 +93,7 @@ export interface Props
   /** Callback responsible for rendering the option given the option and its index in the list of options */
   renderOption?: (option: Item, index: number) => ReactNode
   /** Provide unique key for each option */
-  getKey?: (item: Item) => string
+  getKey?: (item: Item) => string | undefined
   /** Specifies whether the autofill enabled or not, disabled by default */
   enableAutofill?: boolean
   /** Whether to render reset icon when there is a value in the input */
@@ -206,21 +206,29 @@ export const Autocomplete = forwardRef<HTMLInputElement, Props>(
         data-testid={testIds?.scrollMenu}
         selectedIndex={highlightedIndex}
       >
-        {options?.map((option, index) => (
-          <Menu.Item
-            data-test-id={`${testIds?.menuItem}-${index}`}
-            size='medium'
-            key={getKey(option)}
-            {...getItemProps(index, option)}
-            titleCase={false}
-            description={option.description}
-            className={classes.option}
-          >
-            {renderOption
-              ? renderOption(option, index)
-              : getDisplayValue(option)}
-          </Menu.Item>
-        ))}
+        {options?.map((option, index) => {
+          const key = getKey(option)
+
+          if (!key) {
+            return null
+          }
+
+          return (
+            <Menu.Item
+              data-test-id={`${testIds?.menuItem}-${index}`}
+              size='medium'
+              key={key}
+              {...getItemProps(index, option)}
+              titleCase={false}
+              description={option.description}
+              className={classes.option}
+            >
+              {renderOption
+                ? renderOption(option, index)
+                : getDisplayValue(option)}
+            </Menu.Item>
+          )
+        })}
         {shouldShowOtherOption && (
           <OtherOptionMenuItem
             data-testid={testIds?.otherOption}

--- a/packages/picasso/src/Autocomplete/__snapshots__/test.tsx.snap
+++ b/packages/picasso/src/Autocomplete/__snapshots__/test.tsx.snap
@@ -561,3 +561,62 @@ exports[`Autocomplete static behavior uses a custom popper container 1`] = `
   value=""
 />
 `;
+
+exports[`Autocomplete static behavior when cannot found custom option key does not renders custom option 1`] = `
+<ul
+  class="MuiList-root PicassoMenu-root PicassoScrollMenu-menu"
+  data-testid="scroll-menu"
+  role="menu"
+  tabindex="-1"
+>
+  <div
+    class="PicassoScrollMenu-scrollView"
+    tabindex="0"
+  >
+    <li
+      aria-disabled="false"
+      aria-selected="true"
+      class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root PicassoMenuItem-guttersMedium PicassoMenuItem-root PicassoMenuItem-light PicassoAutocomplete-option Mui-selected PicassoMenuItem-selected MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button Mui-selected"
+      data-test-id="menu-item-0"
+      role="option"
+      tabindex="-1"
+    >
+      <div
+        class="PicassoContainer-flex PicassoContainer-column PicassoMenuItem-content"
+      >
+        <div
+          class="PicassoContainer-centerAlignItems PicassoContainer-flex"
+        >
+          <div
+            data-testid="custom-option"
+          >
+            BY
+          </div>
+        </div>
+      </div>
+    </li>
+    <li
+      aria-disabled="false"
+      aria-selected="false"
+      class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root PicassoMenuItem-guttersMedium PicassoMenuItem-root PicassoMenuItem-light PicassoAutocomplete-option MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+      data-test-id="menu-item-3"
+      role="option"
+      tabindex="-1"
+    >
+      <div
+        class="PicassoContainer-flex PicassoContainer-column PicassoMenuItem-content"
+      >
+        <div
+          class="PicassoContainer-centerAlignItems PicassoContainer-flex"
+        >
+          <div
+            data-testid="custom-option"
+          >
+            LU
+          </div>
+        </div>
+      </div>
+    </li>
+  </div>
+</ul>
+`;

--- a/packages/picasso/src/Autocomplete/story/CustomOptionRenderer.example.tsx
+++ b/packages/picasso/src/Autocomplete/story/CustomOptionRenderer.example.tsx
@@ -9,24 +9,27 @@ const renderOtherOption = (value: string) => (
   </Typography>
 )
 
-interface Country extends Item {
-  country: string
-  capital: string
-  code: string
-}
+type Country =
+  | (Item & {
+      country: string
+      capital: string
+      code?: string
+    })
+  | null
 
 const EMPTY_INPUT_VALUE = ''
 
 const allOptions: Country[] = [
   { country: 'Belarus', capital: 'Minsk', code: 'BE' },
-  { country: 'Croatia', capital: 'Zagreb', code: 'HR' },
+  null,
+  { country: 'Croatia', capital: 'Zagreb' },
   { country: 'Lithuania', capital: 'Vilnius', code: 'LU' },
   { country: 'Slovakia', capital: 'Bratislava', code: 'SK' },
   { country: 'Ukraine', capital: 'Kyiv', code: 'UA' }
 ]
 
 const getDisplayValue = (item: Item | null) =>
-  (item && (item as Country).country) || ''
+  (item && (item as Country)?.country) ?? ''
 
 const filterOptions = (str: string) =>
   str !== ''
@@ -43,22 +46,24 @@ const CustomOptionRenderer = () => {
         showOtherOption
         value={value}
         placeholder='Start typing country...'
-        options={options}
-        getKey={(item: Item) => (item as Country).code}
-        renderOption={(option: Partial<Country>, index) => (
-          <Container>
-            <Typography size='medium' weight='semibold'>
-              {option.country}
-            </Typography>
-            <Typography size='inherit' style={{ fontSize: '12px' }}>
-              {option.capital} ({index})
-            </Typography>
-          </Container>
-        )}
+        options={options as Item[]}
+        getKey={item => (item as Country)?.code}
+        renderOption={(option: Partial<Country>, index) =>
+          option && (
+            <Container>
+              <Typography size='medium' weight='semibold'>
+                {option.country}
+              </Typography>
+              <Typography size='inherit' style={{ fontSize: '12px' }}>
+                {option.capital} ({index})
+              </Typography>
+            </Container>
+          )
+        }
         renderOtherOption={renderOtherOption}
         onSelect={(option: Partial<Country>) => {
           window.console.log('onSelect returns item object:', option)
-          window.console.log('selected capital:', option.capital)
+          window.console.log('selected capital:', option?.capital)
 
           const itemValue = getDisplayValue(option)
 

--- a/packages/picasso/src/Autocomplete/test.tsx
+++ b/packages/picasso/src/Autocomplete/test.tsx
@@ -2,6 +2,7 @@
 /* eslint-disable max-lines-per-function */
 import React from 'react'
 import { render, fireEvent, PicassoConfig } from '@toptal/picasso/test-utils'
+import { Item } from '@toptal/picasso/Autocomplete/types'
 import { OmitInternalProps } from '@toptal/picasso-shared'
 import { generateRandomString } from '@toptal/picasso-provider'
 import * as titleCaseModule from 'ap-style-title-case'
@@ -262,6 +263,40 @@ describe('Autocomplete', () => {
 
       expect(renderOption).toHaveBeenCalledTimes(10)
       expect(getDisplayValue).not.toHaveBeenCalled()
+    })
+
+    describe('when cannot found custom option key', () => {
+      const partiallyInvalidTestOptions = [
+        { text: 'Belarus', value: 'BY' },
+        null,
+        { text: 'Croatia' },
+        { text: 'Lithuania', value: 'LU' }
+      ]
+
+      it('does not render custom option', () => {
+        const getDisplayValue = jest.fn()
+        const renderOption = jest.fn(item => (
+          <div data-testid='custom-option'>{item.value}</div>
+        ))
+        const getKey = jest.fn(option => option?.value)
+
+        const { getByTestId, getAllByTestId } = renderAutocomplete({
+          options: partiallyInvalidTestOptions as Item[],
+          value: '',
+          renderOption,
+          getDisplayValue,
+          getKey
+        })
+
+        const input = getByTestId('autocomplete')
+
+        fireEvent.click(input)
+
+        expect(renderOption).toHaveBeenCalledTimes(4)
+        expect(getAllByTestId('custom-option')).toHaveLength(2)
+        expect(getDisplayValue).not.toHaveBeenCalled()
+        expect(getByTestId(testIds.scrollMenu)).toMatchSnapshot()
+      })
     })
 
     it('should not transform options text to title case when Picasso titleCase property is true', () => {

--- a/packages/picasso/src/TagSelector/TagSelector.tsx
+++ b/packages/picasso/src/TagSelector/TagSelector.tsx
@@ -68,7 +68,7 @@ export interface Props
   /** Specifies whether the autofill enabled or not, disabled by default */
   enableAutofill?: boolean
   /** Provide unique key for each option */
-  getKey?: (item: Item) => string
+  getKey?: (item: Item) => string | undefined
   /** Callback responsible for rendering the option given the option and its index in the list of options */
   renderOption?: (option: Item, index: number) => ReactNode
   /** Callback responsible for rendering the label given the option and Label props */
@@ -143,7 +143,7 @@ export const TagSelector = forwardRef<HTMLInputElement, Props>(
       onOtherOptionSelect(value)
     }
 
-    const getKey = (item: Item): string => {
+    const getKey = (item: Item): string | undefined => {
       if (customGetKey) {
         return customGetKey(item)
       }


### PR DESCRIPTION
[SPT-2294]

### Description

Please do not merge this PR until i test it in Staff-Portal

#### Motivation
In staff portal as part of this task https://toptal-core.atlassian.net/browse/SPT-2294 we have to update all FE code for updated `node` type that becomes nullable in related BE PR (https://github.com/toptal/platform/pull/54372).

We have many places such as:
```
const getTagId = (tagEdge: Item) =>
  (tagEdge as TaskTagEdgeFragment).node.id

<Autocomplete getKey={getTagId} />
```

Where `(tagEdge as TaskTagEdgeFragment).node` is nullable value, so now to correctly pass this selector to Autocomplete component we have to do the following:
```
const getTagId = (tagEdge: Item) =>
  (tagEdge as TaskTagEdgeFragment).node?.id ?? ''

<Autocomplete getKey={getTagId} />
```
This potentially may cause some unexpected behavior.

To prevent it, support for returning undefined value from `getKey` selector was added to Autocomplete
Now if we return `undefined` value from `getKey` selector, such option wont be rendered at all, so we can keep the following code on our side:
```
const getTagId = (tagEdge: Item) =>
  (tagEdge as TaskTagEdgeFragment).node?.id

<Autocomplete getKey={getTagId} />
```

### How to test

1. Open https://picasso.toptal.net/SPT-2294-autocomplete-allow-undefined-return-from-get-key/?path=/story/forms-autocomplete--autocomplete
2. Scroll down to the `Custom options rendering` example
3. Open autocomplete popup.
4. It should have only 4 option items

### Review

- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure that tests pass by running `yarn test`
- [x] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[SPT-2294]: https://toptal-core.atlassian.net/browse/SPT-2294?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ