### PR TITLE
fix(MenuItem): use anchor as a link for menu item component

### DIFF
--- a/.changeset/young-sloths-train.md
+++ b/.changeset/young-sloths-train.md
@@ -3,5 +3,6 @@
 ---
 
 ---
+### Menu.Item
 
-- fixed undeline styling when used as a Link by replacing passed Link as `as` prop with HTML anchor.
+- fixed [undeline styling](https://toptal-core.slack.com/archives/CCC3GP6CC/p1642067846008000) when used as a Link by replacing passed Link as `as` prop with HTML anchor.

--- a/.changeset/young-sloths-train.md
+++ b/.changeset/young-sloths-train.md
@@ -5,4 +5,4 @@
 ---
 ### Menu.Item
 
-- fixed [undeline styling](https://toptal-core.slack.com/archives/CCC3GP6CC/p1642067846008000) when used as a Link by replacing passed Link as `as` prop with HTML anchor.
+- fixed [underline styling](https://toptal-core.slack.com/archives/CCC3GP6CC/p1642067846008000) when used as a Link by replacing passed Link as `as` prop with HTML anchor.

--- a/.changeset/young-sloths-train.md
+++ b/.changeset/young-sloths-train.md
@@ -1,0 +1,7 @@
+---
+'@toptal/picasso': patch
+---
+
+---
+
+- fixed undeline styling when used as a Link by replacing passed Link as `as` prop with HTML anchor.

--- a/packages/picasso/src/MenuItem/MenuItem.tsx
+++ b/packages/picasso/src/MenuItem/MenuItem.tsx
@@ -24,6 +24,7 @@ import Container from '../Container'
 import { ChevronMinor16, CheckMinor16 } from '../Icon'
 import Paper from '../Paper'
 import Popper from '../Popper'
+import Link from '../Link'
 import { ClickAwayListener, toTitleCase } from '../utils'
 import { useMenuItem } from './hooks'
 import styles from './styles'
@@ -109,7 +110,7 @@ export const MenuItem: OverridableComponent<Props> = forwardRef<
       <MUIMenuItem
         {...rest}
         ref={ref}
-        component={as}
+        component={as === Link && rest.href ? 'a' : as}
         classes={{
           root: cx({
             [classes[`gutters${size && capitalize(size)}`]]: size

--- a/packages/picasso/src/MenuItem/MenuItem.tsx
+++ b/packages/picasso/src/MenuItem/MenuItem.tsx
@@ -104,13 +104,16 @@ export const MenuItem: OverridableComponent<Props> = forwardRef<
     onClick,
     onMouseEnter
   })
+  const isLink = as === Link && rest.href
 
   return (
     <>
       <MUIMenuItem
         {...rest}
         ref={ref}
-        component={as === Link && rest.href ? 'a' : as}
+        // replace Picasso Link with Anchor to not applying Picasso
+        // Link component styles, this is the only difference between them now
+        component={isLink ? 'a' : as}
         classes={{
           root: cx({
             [classes[`gutters${size && capitalize(size)}`]]: size

--- a/yarn.lock
+++ b/yarn.lock
@@ -4917,17 +4917,6 @@
     micromatch "^4.0.4"
     requireindex "^1.2.0"
 
-"@toptal/picasso-provider@^0.4.0":
-  version "0.4.1"
-  resolved "https://registry.yarnpkg.com/@toptal/picasso-provider/-/picasso-provider-0.4.1.tgz#9c6603c35fe7c38c7211ce91750d33365f9a5325"
-  integrity sha512-oXxkA2GMSZ80D7PXS+yEh8CDkEUZFryK44AKLn4sOqjquZ8mTHlcUeC4y5RwYz0Nzd+1YOBITpbkPr6TuEGV6w==
-  dependencies:
-    "@material-ui/core" "4.11.0"
-    "@material-ui/utils" "4.10.2"
-    classnames "^2.3.1"
-    notistack "1.0.5"
-    react-helmet "6.1.0"
-
 "@types/anymatch@*":
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/@types/anymatch/-/anymatch-1.3.1.tgz#336badc1beecb9dacc38bea2cf32adf627a8421a"


### PR DESCRIPTION
### Description

`MenuItem` has some weird behavior when using `Link` as `as`. Here is more info - https://toptal-core.slack.com/archives/CCC3GP6CC/p1642067846008000

<img width="568" alt="Screenshot 2022-01-13 at 18 30 37" src="https://user-images.githubusercontent.com/2836281/149369939-9a7d1f62-16bf-49f1-8586-6ddeb00fedcf.png">

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>
