### PR TITLE
chore: remove ci infra team as coowners of workflow files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,7 +8,3 @@
 
 # These owners will be the default owners for everything in the repo.
 * @toptal/frontend-experience-eng
-
-# CI Infrastructure team
-ci/jobs/ @toptal/ci-infrastructure-eng @toptal/frontend-experience-eng
-.github/workflows/ @toptal/ci-infrastructure-eng @toptal/frontend-experience-eng


### PR DESCRIPTION
[CI-988]

Description
[CI-988] Remove CI infra team as co-owners of workflow files.

How to test
Everything should work as before.

[CI-988]: https://toptal-core.atlassian.net/browse/CI-988?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CI-988]: https://toptal-core.atlassian.net/browse/CI-988?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ