### PR TITLE
fix: [SPC-1534] white background for bordered and with header bar section

### DIFF
--- a/.changeset/poor-needles-raise.md
+++ b/.changeset/poor-needles-raise.md
@@ -1,0 +1,5 @@
+---
+'@toptal/picasso-lab': patch
+---
+
+white background for bordered and with header bar section component variants

--- a/.changeset/poor-needles-raise.md
+++ b/.changeset/poor-needles-raise.md
@@ -2,4 +2,6 @@
 '@toptal/picasso-lab': patch
 ---
 
-white background for bordered and with header bar section component variants
+---
+### Section
+- white background for bordered and withHeaderBar variants

--- a/.changeset/poor-needles-raise.md
+++ b/.changeset/poor-needles-raise.md
@@ -4,4 +4,4 @@
 
 ---
 ### Section
-- white background for bordered and withHeaderBar variants
+- added white background for `bordered` and `withHeaderBar` variants

--- a/cypress/component/Section.spec.tsx
+++ b/cypress/component/Section.spec.tsx
@@ -82,7 +82,18 @@ const TestSection = ({
   return (
     <TestingPicasso>
       {/* The Container wrapper makes it easy to see the borders on the screenshot */}
-      <Container padded={rest.variant === 'bordered' ? 'large' : undefined}>
+      <Container
+        variant={
+          rest.variant === 'bordered' || rest.variant === 'withHeaderBar'
+            ? 'grey'
+            : undefined
+        }
+        padded={
+          rest.variant === 'bordered' || rest.variant === 'withHeaderBar'
+            ? 'large'
+            : undefined
+        }
+      >
         <Section
           title={title}
           subtitle={subtitle}

--- a/cypress/component/Section.spec.tsx
+++ b/cypress/component/Section.spec.tsx
@@ -135,7 +135,11 @@ describe('Section', () => {
 
     cy.get('body').happoScreenshot()
   })
+  it('renders with withHeaderBar variant', () => {
+    mount(<TestSection variant='withHeaderBar' />)
 
+    cy.get('body').happoScreenshot()
+  })
   describe('when collapsible', () => {
     it('renders initially collapsed', () => {
       mount(<TestSection collapsible />)

--- a/packages/picasso-lab/src/Section/Section.tsx
+++ b/packages/picasso-lab/src/Section/Section.tsx
@@ -133,6 +133,9 @@ export const Section = forwardRef<HTMLDivElement, Props>(function Section(
         classes.root,
         className
       )}
+      variant={
+        ['bordered', 'withHeaderBar'].includes(variant) ? 'white' : undefined
+      }
       style={style}
       {...rest}
     >

--- a/packages/picasso-lab/src/Section/styles.ts
+++ b/packages/picasso-lab/src/Section/styles.ts
@@ -38,8 +38,7 @@ export default ({ sizes, palette }: Theme) =>
       padding: '2rem',
       '& > :last-child': {
         paddingBottom: '0'
-      },
-      backgroundColor: palette.common.white
+      }
     },
     withHeaderBar: {
       padding: 0,
@@ -47,8 +46,7 @@ export default ({ sizes, palette }: Theme) =>
         padding: '1.5rem'
       },
       borderRadius: sizes.borderRadius.medium,
-      border: `solid ${sizes.borderWidth} ${palette.grey.light2}`,
-      backgroundColor: palette.common.white
+      border: `solid ${sizes.borderWidth} ${palette.grey.light2}`
     },
     defaultHeader,
     borderedHeader: defaultHeader,

--- a/packages/picasso-lab/src/Section/styles.ts
+++ b/packages/picasso-lab/src/Section/styles.ts
@@ -38,7 +38,8 @@ export default ({ sizes, palette }: Theme) =>
       padding: '2rem',
       '& > :last-child': {
         paddingBottom: '0'
-      }
+      },
+      backgroundColor: palette.common.white
     },
     withHeaderBar: {
       padding: 0,
@@ -46,7 +47,8 @@ export default ({ sizes, palette }: Theme) =>
         padding: '1.5rem'
       },
       borderRadius: sizes.borderRadius.medium,
-      border: `solid ${sizes.borderWidth} ${palette.grey.light2}`
+      border: `solid ${sizes.borderWidth} ${palette.grey.light2}`,
+      backgroundColor: palette.common.white
     },
     defaultHeader,
     borderedHeader: defaultHeader,


### PR DESCRIPTION
[SPC-1534]

### Description

Update Picasso Section component bordered and withHeaderBar variants to use white background for content and keep transparent for the default variant

### How to test

- Check the background for `bordered` and `withHeaderBar` section component is white

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| ![Captura de pantalla de 2022-01-18 13-19-40](https://user-images.githubusercontent.com/86490403/149936410-17f1d62e-7b17-463a-90a5-089eac93386c.png) | ![Captura de pantalla de 2022-01-18 13-18-56](https://user-images.githubusercontent.com/86490403/149936435-fd9439ce-ec06-47d5-b232-fb215687ce41.png) |

### Review

- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure that tests pass by running `yarn test`
- [x] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[SPC-1534]: https://toptal-core.atlassian.net/browse/SPC-1534?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ