### PR TITLE
[FX-2434] Add styles for disable state

### DIFF
--- a/.changeset/pretty-swans-wait.md
+++ b/.changeset/pretty-swans-wait.md
@@ -1,0 +1,9 @@
+---
+'@toptal/picasso-lab': minor
+---
+
+- Add disabled styling to text editor.
+
+> Note: According to the [design](https://share.goabstract.com/2de8e3f4-5704-4139-8a68-9e9519ed09f8?mode=design&sha=4f1f6493dfac89015cc6c71ea348807e931fe3bc)
+> resize icon should be a different color. As it's too complicated to implement
+> we agreed to ignore it and leave it as a native color.

--- a/packages/picasso-lab/src/TextEditor/TextEditor.tsx
+++ b/packages/picasso-lab/src/TextEditor/TextEditor.tsx
@@ -75,11 +75,14 @@ export const TextEditor = forwardRef<HTMLDivElement, Props>(function TextEditor(
   })
 
   return (
-    <Container className={classes.editorWrapper}>
+    <Container
+      className={cx(classes.editorWrapper, { [classes.disabled]: disabled })}
+    >
       <TextEditorToolbar
         id={id}
         state={toolbarState}
         handlers={toolbarHandlers}
+        disabled={disabled}
       />
       <Typography
         as='div'

--- a/packages/picasso-lab/src/TextEditor/TextEditorButton.tsx
+++ b/packages/picasso-lab/src/TextEditor/TextEditorButton.tsx
@@ -10,6 +10,7 @@ type Props = BaseProps & {
   icon: ReactElement
   onClick: ButtonHandlerType
   active?: boolean
+  disabled?: boolean
 }
 
 const useStyles = makeStyles<Theme>(styles, {
@@ -18,7 +19,7 @@ const useStyles = makeStyles<Theme>(styles, {
 })
 
 const TextEditorButton = (props: Props) => {
-  const { icon, onClick, active, className, style, ...rest } = props
+  const { icon, onClick, active, className, style, disabled, ...rest } = props
   const classes = useStyles()
 
   return (
@@ -34,6 +35,7 @@ const TextEditorButton = (props: Props) => {
         },
         className
       )}
+      disabled={disabled}
       {...rest}
     />
   )

--- a/packages/picasso-lab/src/TextEditor/TextEditorToolbar.tsx
+++ b/packages/picasso-lab/src/TextEditor/TextEditorToolbar.tsx
@@ -16,6 +16,7 @@ type Props = {
   id: string
   state: ToolbarStateType
   handlers: ToolbarHandlers
+  disabled?: boolean
 }
 
 const useStyles = makeStyles<Theme>(styles, {
@@ -24,7 +25,7 @@ const useStyles = makeStyles<Theme>(styles, {
 })
 
 export const TextEditorToolbar = (props: Props) => {
-  const { id, state, handlers } = props
+  const { id, state, handlers, disabled } = props
 
   const classes = useStyles()
 
@@ -41,6 +42,7 @@ export const TextEditorToolbar = (props: Props) => {
           size='small'
           menuWidth='123px'
           className={classes.textStylesSelect}
+          disabled={disabled}
         />
       </Container>
       <Container className={classes.qlFormats}>
@@ -48,11 +50,13 @@ export const TextEditorToolbar = (props: Props) => {
           icon={<Bold16 />}
           onClick={handlers.handleBold}
           active={state.bold}
+          disabled={disabled}
         />
         <TextEditorButton
           icon={<Italic16 />}
           onClick={handlers.handleItalic}
           active={state.italic}
+          disabled={disabled}
         />
       </Container>
       <Container className={classes.qlFormats}>
@@ -60,11 +64,13 @@ export const TextEditorToolbar = (props: Props) => {
           icon={<ListUnordered16 />}
           onClick={handlers.handleUnordered}
           active={state.list === 'bullet'}
+          disabled={disabled}
         />
         <TextEditorButton
           icon={<ListOrdered16 />}
           onClick={handlers.handleOrdered}
           active={state.list === 'ordered'}
+          disabled={disabled}
         />
       </Container>
     </Container>

--- a/packages/picasso-lab/src/TextEditor/styles.ts
+++ b/packages/picasso-lab/src/TextEditor/styles.ts
@@ -156,6 +156,12 @@ export default (theme: Theme) => {
       '&:not(:hover) svg': {
         fill: palette.common.white
       }
+    },
+
+    disabled: {
+      background: palette.grey.lighter,
+      borderRadius: '0.25em',
+      border: `1px solid ${palette.grey.lighter2}`
     }
   })
 }


### PR DESCRIPTION
[FX-2434]

[Abstract](https://share.goabstract.com/2de8e3f4-5704-4139-8a68-9e9519ed09f8?mode=design&sha=4f1f6493dfac89015cc6c71ea348807e931fe3bc)

### Description

- Add disabled styling.

> Note: According to the [design](https://share.goabstract.com/2de8e3f4-5704-4139-8a68-9e9519ed09f8?mode=design&sha=4f1f6493dfac89015cc6c71ea348807e931fe3bc), resize icon should be a different color. As it's too complicated to implement we agreed to ignore it and leave it as a native color.

### How to test

- Visit [TextEditor Picasso component](https://picasso.toptal.net/fx-2434-texteditor-add-styles-for-disable-state/?path=/story/picasso-lab-texteditor--texteditor) and check `Disabled` example, it should be according to the design.

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| ![Screenshot from 2022-01-19 14-48-00](https://user-images.githubusercontent.com/72510037/150115522-f23ee9a9-1039-4b91-ad3a-1c44da807777.png) | ![Screenshot from 2022-01-19 14-47-47](https://user-images.githubusercontent.com/72510037/150115556-cd7c9eb8-50cf-4d3e-85b8-89df412d9adf.png) |

### Review

- [ ] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [ ] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that tests pass by running `yarn test`
- [ ] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
- [ ] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-2434]: https://toptal-core.atlassian.net/browse/FX-2434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ