### PR TITLE
fix: add sticky header

### DIFF
--- a/.changeset/afraid-poets-begin.md
+++ b/.changeset/afraid-poets-begin.md
@@ -1,0 +1,5 @@
+---
+'@toptal/picasso': patch
+---
+
+Update PageTopBar from fixed to sticky position

--- a/.changeset/afraid-poets-begin.md
+++ b/.changeset/afraid-poets-begin.md
@@ -2,4 +2,9 @@
 '@toptal/picasso': patch
 ---
 
-Update PageTopBar from fixed to sticky position
+---
+
+### PageTopBar
+
+- update PageTopBar component from fixed to sticky position
+- move `style` prop from the `header` to the parent element

--- a/.changeset/afraid-poets-begin.md
+++ b/.changeset/afraid-poets-begin.md
@@ -1,5 +1,5 @@
 ---
-'@toptal/picasso': patch
+'@toptal/picasso': major
 ---
 
 ---
@@ -8,3 +8,4 @@
 
 - update PageTopBar component from fixed to sticky position
 - move `style` prop from the `header` to the parent element
+- `header` can be directly styled by using `className` prop

--- a/packages/picasso/src/PageTopBar/PageTopBar.tsx
+++ b/packages/picasso/src/PageTopBar/PageTopBar.tsx
@@ -23,6 +23,8 @@ import styles from './styles'
 type VariantType = 'dark' | 'light'
 
 export interface Props extends BaseProps, HTMLAttributes<HTMLElement> {
+  /** Style applied to header element */
+  className?: string
   /** Title which is displayed along the `Logo` */
   title?: string
   /** Link component to wrap `Logo`  */

--- a/packages/picasso/src/PageTopBar/PageTopBar.tsx
+++ b/packages/picasso/src/PageTopBar/PageTopBar.tsx
@@ -106,12 +106,11 @@ export const PageTopBar = forwardRef<HTMLElement, Props>(function PageTopBar(
   )
 
   return (
-    <div className={classes.wrapper}>
+    <div className={classes.wrapper} style={style}>
       <header
         {...rest}
         ref={ref}
         className={cx('mui-fixed', classes.root, classes[variant], className)}
-        style={style}
       >
         <div className={innerClassName}>
           <div className={classes.left}>

--- a/packages/picasso/src/PageTopBar/styles.ts
+++ b/packages/picasso/src/PageTopBar/styles.ts
@@ -5,8 +5,7 @@ export const headerHeight = { default: '3.5rem', smallAndMedium: '3rem' }
 export default ({ palette, layout, zIndex, screens }: Theme) =>
   createStyles({
     root: {
-      fontSize: '1rem',
-      width: '100%'
+      fontSize: '1rem'
     },
     light: {
       backgroundColor: palette.common.white,

--- a/packages/picasso/src/PageTopBar/styles.ts
+++ b/packages/picasso/src/PageTopBar/styles.ts
@@ -30,12 +30,13 @@ export default ({ palette, layout, zIndex, screens }: Theme) =>
     },
     wrapper: {
       zIndex: zIndex.appBar,
-      position: 'sticky',
       top: 0,
       left: 0,
       right: 0,
       height: headerHeight.default,
+      position: 'sticky',
       [screens('small', 'medium')]: {
+        position: 'fixed',
         height: headerHeight.smallAndMedium
       }
     },

--- a/packages/picasso/src/PageTopBar/styles.ts
+++ b/packages/picasso/src/PageTopBar/styles.ts
@@ -6,12 +6,7 @@ export default ({ palette, layout, zIndex, screens }: Theme) =>
   createStyles({
     root: {
       fontSize: '1rem',
-      width: '100%',
-      position: 'fixed',
-      top: 0,
-      left: 0,
-      right: 0,
-      zIndex: zIndex.appBar
+      width: '100%'
     },
     light: {
       backgroundColor: palette.common.white,
@@ -34,6 +29,11 @@ export default ({ palette, layout, zIndex, screens }: Theme) =>
       }
     },
     wrapper: {
+      zIndex: zIndex.appBar,
+      position: 'sticky',
+      top: 0,
+      left: 0,
+      right: 0,
       height: headerHeight.default,
       [screens('small', 'medium')]: {
         height: headerHeight.smallAndMedium


### PR DESCRIPTION
[SPC-1621]

### Description

Transform from fixed `Page.TopBar` to a sticky one. 
On mobile header was shrink and we were not able to have a horizontal scroll, same as page content and transforming to a sticky header solves this issue.

### How to test

- FIXME: Add the steps describing how to verify your changes

### Screenshots

Before:


https://user-images.githubusercontent.com/20658410/152378994-60328035-1e60-425f-a06d-4bde88adc701.mov


After:


https://user-images.githubusercontent.com/20658410/152379026-2bca3ce1-654d-4631-be4c-454bece86f47.mov




### Review

- [ ] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [ ] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that tests pass by running `yarn test`
- [ ] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
- [ ] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[SPC-1621]: https://toptal-core.atlassian.net/browse/SPC-1621?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ