### PR TITLE
fix(TextEditor): update toolbar correctly on paste

### DIFF
--- a/packages/picasso-lab/package.json
+++ b/packages/picasso-lab/package.json
@@ -39,6 +39,7 @@
     "date-fns-tz": "^1.1.3",
     "quill": "^1.3.7",
     "quill-delta": "^4.2.0",
+    "quill-paste-smart": "^1.4.9",
     "react-dropzone": "^11.4.0",
     "react-router-dom": "^5.2.0",
     "simple-react-calendar": "^2.2.8"

--- a/packages/picasso-lab/src/QuillEditor/hooks/useQuillInstance/useQuillInstance.tsx
+++ b/packages/picasso-lab/src/QuillEditor/hooks/useQuillInstance/useQuillInstance.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react'
 import Quill, { QuillOptionsStatic } from 'quill'
+import 'quill-paste-smart'
 
 import {
   useTypographyClasses,
@@ -15,7 +16,13 @@ export type EditorOptionsType = {
 export const getModules = (): QuillOptionsStatic['modules'] => {
   return {
     clipboard: {
-      matchVisual: false
+      matchVisual: false,
+      allowed: {
+        tags: ['b', 'strong', 'i', 'p', 'br', 'ul', 'ol', 'li'],
+        attributes: []
+      },
+      keepSelection: true,
+      substituteBlockElements: true
     },
     keyboard: {
       // we need to specify default bindings

--- a/packages/picasso-lab/src/QuillEditor/hooks/useQuillInstance/useQuillInstance.tsx
+++ b/packages/picasso-lab/src/QuillEditor/hooks/useQuillInstance/useQuillInstance.tsx
@@ -18,7 +18,7 @@ export const getModules = (): QuillOptionsStatic['modules'] => {
     clipboard: {
       matchVisual: false,
       allowed: {
-        tags: ['b', 'strong', 'i', 'p', 'br', 'ul', 'ol', 'li'],
+        tags: ['b', 'strong', 'i', 'p', 'br', 'ul', 'ol', 'li', 'h3'],
         attributes: []
       },
       keepSelection: true,

--- a/packages/picasso-lab/src/QuillEditor/styles.ts
+++ b/packages/picasso-lab/src/QuillEditor/styles.ts
@@ -90,10 +90,21 @@ const editor = {
   }
 }
 
+const clipboard = {
+  '& .ql-clipboard': {
+    left: '-100000px',
+    height: '1px',
+    overflowY: 'hidden',
+    position: 'absolute',
+    top: '50%'
+  }
+}
+
 const quillSpecificStyles = (theme: Theme) => ({
   ...placeholder(theme),
   ...editor,
-  ...hidden
+  ...hidden,
+  ...clipboard
 })
 
 export default (theme: Theme) => {

--- a/packages/picasso-lab/src/QuillEditor/utils/getEditorChangeHandler/getEditorChangeHandler.tsx
+++ b/packages/picasso-lab/src/QuillEditor/utils/getEditorChangeHandler/getEditorChangeHandler.tsx
@@ -1,22 +1,28 @@
-import Quill from 'quill'
+import Quill, { RangeStatic, Sources } from 'quill'
+import Delta from 'quill-delta'
 
 import { FormatType } from '../../types'
+
+type SelectionChangeArgs = [RangeStatic, RangeStatic, Sources]
+type TextChangeArgx = [Delta, Delta, Sources]
 
 const getEditorChangeHandler = (
   quill: Quill,
   onSelectionChange: (format: FormatType) => void
 ) => {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const handler = (name: 'text-change' | 'selection-change', ...args: any) => {
+  const handler = (
+    name: 'text-change' | 'selection-change',
+    ...args: SelectionChangeArgs | TextChangeArgx
+  ) => {
     if (!quill) {
       return
     }
 
     if (name === 'selection-change') {
-      const [range, , source] = args
+      const [range, , source] = args as SelectionChangeArgs
 
       if (source === 'silent') {
-        const format = quill.getFormat(range) as FormatType
+        const format = quill.getFormat(range || undefined) as FormatType
 
         onSelectionChange(format)
       }

--- a/yarn.lock
+++ b/yarn.lock
@@ -10158,6 +10158,11 @@ domhandler@^4.0.0, domhandler@^4.2.0:
   dependencies:
     domelementtype "^2.2.0"
 
+dompurify@^2.0.10:
+  version "2.3.5"
+  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-2.3.5.tgz#c83ed5a3ae5ce23e52efe654ea052ffb358dd7e3"
+  integrity sha512-kD+f8qEaa42+mjdOpKeztu9Mfx5bv9gVLO6K9jRx4uGvh6Wv06Srn4jr1wPNY2OOUGGSKHNFN+A8MA3v0E0QAQ==
+
 domutils@1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/domutils/-/domutils-1.5.1.tgz#dcd8488a26f563d61079e48c9f7b7e32373682cf"
@@ -19635,6 +19640,13 @@ quill-delta@^4.0.1, quill-delta@^4.2.0:
     fast-diff "1.2.0"
     lodash.clonedeep "^4.5.0"
     lodash.isequal "^4.5.0"
+
+quill-paste-smart@^1.4.9:
+  version "1.4.9"
+  resolved "https://registry.yarnpkg.com/quill-paste-smart/-/quill-paste-smart-1.4.9.tgz#71c48a616e1fa6e317e64916158a83775cb054cc"
+  integrity sha512-AsHylP+birSoD2XTLo/7DxQOmABomq9woXkX6E0XAaJOoIi3TaC4kvWXG3FhtaJBnRuk93zR3zV3qGxSgmUmBA==
+  dependencies:
+    dompurify "^2.0.10"
 
 quill@^1.3.7:
   version "1.3.7"


### PR DESCRIPTION
[FX-2293]
[FX-2449]

### Description

fix the issue when pasting formatted text

### How to test

There were multiple issues with pasting
1. pasting anything threw an error
  - when passing undefined to `quill.getFormat()`, quill internally calls `quill.getSelection(true)`, so it first focuses editor and get latest selection
  
 2. after pasting wrapping `Container` lost focus, even we had a cursor inside the Editor.
 3. quill keeps styling of pasted text by default

- 2. and 3. issue was solved by adding library `quill-smart-paste`, that handles all these issues for us.

4. after pasting there was a styling issue in the editor.
- fixed by adding some styles to `ql-clipboard`. I have copied these styles from the default theme of the quill.


### Review

- [ ] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [ ] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that tests pass by running `yarn test`
- [ ] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
- [ ] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-2293]: https://toptal-core.atlassian.net/browse/FX-2293?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[FX-2449]: https://toptal-core.atlassian.net/browse/FX-2449?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ