### PR TITLE
test: add proper mock for global `window.matchMedia`

### DIFF
--- a/__tests__/matchMedia.js
+++ b/__tests__/matchMedia.js
@@ -1,0 +1,13 @@
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: jest.fn().mockImplementation(query => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: jest.fn(), // deprecated
+    removeListener: jest.fn(), // deprecated
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+    dispatchEvent: jest.fn()
+  }))
+})

--- a/packages/picasso/src/DatePicker/test.tsx
+++ b/packages/picasso/src/DatePicker/test.tsx
@@ -11,13 +11,19 @@ const testIds = {
   input: 'input'
 }
 
-jest.mock('@toptal/picasso/utils', () => ({
-  ...(jest.requireActual('@toptal/picasso/utils') as {}),
-  isPointerDevice: jest.fn(() => true)
-}))
-
 // eslint-disable-next-line max-lines-per-function
 describe('DatePicker', () => {
+  beforeEach(() => {
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: jest.fn().mockImplementation(() => ({
+        matches: true,
+        addListener: jest.fn(),
+        removeListener: jest.fn()
+      }))
+    })
+  })
+
   beforeAll(() => {
     jest.useFakeTimers()
   })

--- a/packages/picasso/src/DatePicker/test.tsx
+++ b/packages/picasso/src/DatePicker/test.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable max-lines-per-function */
 import React from 'react'
 
+import '../../../../__tests__/matchMedia'
 import { act, fireEvent, render } from '../test-utils'
 import DatePicker, { Props } from './DatePicker'
 import Tooltip from '../Tooltip'
@@ -13,17 +14,6 @@ const testIds = {
 
 // eslint-disable-next-line max-lines-per-function
 describe('DatePicker', () => {
-  beforeEach(() => {
-    Object.defineProperty(window, 'matchMedia', {
-      writable: true,
-      value: jest.fn().mockImplementation(() => ({
-        matches: true,
-        addListener: jest.fn(),
-        removeListener: jest.fn()
-      }))
-    })
-  })
-
   beforeAll(() => {
     jest.useFakeTimers()
   })

--- a/packages/picasso/src/FileListItem/test.tsx
+++ b/packages/picasso/src/FileListItem/test.tsx
@@ -4,11 +4,6 @@ import { render, fireEvent } from '@toptal/picasso/test-utils'
 
 import FileListItem, { Props } from './FileListItem'
 
-jest.mock('@toptal/picasso/utils', () => ({
-  ...(jest.requireActual('@toptal/picasso/utils') as {}),
-  isPointerDevice: jest.fn(() => true)
-}))
-
 const testIds = {
   progressBar: 'file-list-item-progressbar'
 }
@@ -17,6 +12,15 @@ const renderFileListItem = (props: OmitInternalProps<Props>) =>
   render(<FileListItem testIds={testIds} {...props} />)
 
 describe('FileListItem', () => {
+  beforeEach(() => {
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: jest.fn().mockImplementation(() => ({
+        matches: false
+      }))
+    })
+  })
+
   const file = {
     file: new File(['user-profile-picture.png'], 'user-profile-picture.png'),
     uploading: false,

--- a/packages/picasso/src/FileListItem/test.tsx
+++ b/packages/picasso/src/FileListItem/test.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { OmitInternalProps } from '@toptal/picasso-shared'
 import { render, fireEvent } from '@toptal/picasso/test-utils'
 
+import '../../../../__tests__/matchMedia'
 import FileListItem, { Props } from './FileListItem'
 
 const testIds = {
@@ -12,15 +13,6 @@ const renderFileListItem = (props: OmitInternalProps<Props>) =>
   render(<FileListItem testIds={testIds} {...props} />)
 
 describe('FileListItem', () => {
-  beforeEach(() => {
-    Object.defineProperty(window, 'matchMedia', {
-      writable: true,
-      value: jest.fn().mockImplementation(() => ({
-        matches: false
-      }))
-    })
-  })
-
   const file = {
     file: new File(['user-profile-picture.png'], 'user-profile-picture.png'),
     uploading: false,

--- a/packages/picasso/src/Tooltip/__snapshots__/test.tsx.snap
+++ b/packages/picasso/src/Tooltip/__snapshots__/test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Tooltip renders closed by default 1`] = `
+exports[`Tooltip with isPointerDevice being true renders closed by default 1`] = `
 <div>
   <div
     class="Picasso-root"
@@ -15,7 +15,7 @@ exports[`Tooltip renders closed by default 1`] = `
 </div>
 `;
 
-exports[`Tooltip renders initially opened 1`] = `
+exports[`Tooltip with isPointerDevice being true renders initially opened 1`] = `
 <div>
   <div
     class="Picasso-root"
@@ -56,7 +56,7 @@ exports[`Tooltip renders initially opened 1`] = `
 </div>
 `;
 
-exports[`Tooltip renders with portals disabled 1`] = `
+exports[`Tooltip with isPointerDevice being true renders with portals disabled 1`] = `
 <div>
   <div
     class="Picasso-root"

--- a/packages/picasso/src/Tooltip/test.tsx
+++ b/packages/picasso/src/Tooltip/test.tsx
@@ -33,7 +33,7 @@ describe('Tooltip', () => {
     beforeEach(() => {
       Object.defineProperty(window, 'matchMedia', {
         writable: true,
-        value: jest.fn().mockImplementation(() => ({
+        value: jest.fn(() => ({
           matches: true
         }))
       })
@@ -156,7 +156,7 @@ describe('Tooltip', () => {
     beforeEach(() => {
       Object.defineProperty(window, 'matchMedia', {
         writable: true,
-        value: jest.fn().mockImplementation(() => ({
+        value: jest.fn(() => ({
           matches: false
         }))
       })

--- a/packages/picasso/src/Tooltip/test.tsx
+++ b/packages/picasso/src/Tooltip/test.tsx
@@ -1,15 +1,9 @@
 import React, { forwardRef } from 'react'
 import { fireEvent, waitFor } from '@testing-library/react'
 import { OmitInternalProps } from '@toptal/picasso-shared'
-import { isPointerDevice } from '@toptal/picasso/utils'
 import { render } from '@toptal/picasso/test-utils'
 
 import Tooltip, { Props } from './Tooltip'
-
-jest.mock('@toptal/picasso/utils', () => ({
-  ...(jest.requireActual('@toptal/picasso/utils') as {}),
-  isPointerDevice: jest.fn(() => true)
-}))
 
 const TOOLTIP_SHORT_DELAY = 200
 const TOOLTIP_LONG_DELAY = 500
@@ -35,139 +29,148 @@ const renderTooltip = (props?: Partial<OmitInternalProps<Props>>) => {
 }
 
 describe('Tooltip', () => {
-  const mockedIsPointerDevice = isPointerDevice as jest.Mock
-
-  beforeEach(() => {
-    mockedIsPointerDevice.mockReturnValue(true)
-  })
-
-  afterEach(() => {
-    mockedIsPointerDevice.mockClear()
-  })
-
-  it('renders closed by default', () => {
-    const { container, queryByTestId } = renderTooltip()
-
-    expect(queryByTestId('tooltip-content')).not.toBeInTheDocument()
-    expect(container).toMatchSnapshot()
-  })
-
-  it('renders initially opened', () => {
-    const { container, queryByTestId } = renderTooltip({ open: true })
-
-    expect(queryByTestId('tooltip-content')).toBeInTheDocument()
-    expect(container).toMatchSnapshot()
-  })
-
-  it('renders with portals disabled', () => {
-    const { container, queryByTestId, unmount } = renderTooltip({
-      open: true,
-      disablePortal: true
+  describe('with isPointerDevice being true', () => {
+    beforeEach(() => {
+      Object.defineProperty(window, 'matchMedia', {
+        writable: true,
+        value: jest.fn().mockImplementation(() => ({
+          matches: true
+        }))
+      })
     })
+    it('renders closed by default', () => {
+      const { container, queryByTestId } = renderTooltip()
 
-    expect(queryByTestId('tooltip-content')).toBeInTheDocument()
-    expect(container).toMatchSnapshot()
-
-    unmount() // required to avoid updates from popper when portals are not used
-  })
-
-  it('opens and closes tooltip on focus', async () => {
-    const { getByTestId, queryByTestId, findByTestId } = renderTooltip()
-
-    fireEvent.focus(getByTestId('tooltip-trigger'))
-    await findByTestId('tooltip-content')
-
-    fireEvent.blur(getByTestId('tooltip-trigger'))
-    await waitFor(() => {
       expect(queryByTestId('tooltip-content')).not.toBeInTheDocument()
+      expect(container).toMatchSnapshot()
     })
-  })
 
-  it('opens and closes tooltip on touch screens', async () => {
-    mockedIsPointerDevice.mockReturnValue(false)
-    const { getByTestId, queryByTestId, findByTestId } = renderTooltip()
+    it('renders initially opened', () => {
+      const { container, queryByTestId } = renderTooltip({ open: true })
 
-    fireEvent.click(getByTestId('tooltip-trigger'))
-    await findByTestId('tooltip-content')
-
-    fireEvent.click(getByTestId('tooltip-trigger'))
-    await waitFor(() => {
-      expect(queryByTestId('tooltip-content')).not.toBeInTheDocument()
+      expect(queryByTestId('tooltip-content')).toBeInTheDocument()
+      expect(container).toMatchSnapshot()
     })
-  })
 
-  it('opens and closes tooltip on hover with a short delay', async () => {
-    const { getByTestId, queryByTestId } = renderTooltip({ delay: 'short' })
+    it('renders with portals disabled', () => {
+      const { container, queryByTestId, unmount } = renderTooltip({
+        open: true,
+        disablePortal: true
+      })
 
-    fireEvent.mouseEnter(getByTestId('tooltip-trigger'))
-    await waitFor(
-      () => {
+      expect(queryByTestId('tooltip-content')).toBeInTheDocument()
+      expect(container).toMatchSnapshot()
+
+      unmount() // required to avoid updates from popper when portals are not used
+    })
+
+    it('opens and closes tooltip on focus', async () => {
+      const { getByTestId, queryByTestId, findByTestId } = renderTooltip()
+
+      fireEvent.focus(getByTestId('tooltip-trigger'))
+      await findByTestId('tooltip-content')
+
+      fireEvent.blur(getByTestId('tooltip-trigger'))
+      await waitFor(() => {
         expect(queryByTestId('tooltip-content')).not.toBeInTheDocument()
-      },
-      { timeout: TOOLTIP_SHORT_DELAY / 2 }
-    )
-    await waitFor(
-      () => {
-        expect(queryByTestId('tooltip-content')).toBeInTheDocument()
-      },
-      { timeout: TOOLTIP_SHORT_DELAY }
-    )
-
-    fireEvent.mouseLeave(getByTestId('tooltip-trigger'))
-    await waitFor(() => {
-      expect(queryByTestId('tooltip-content')).not.toBeInTheDocument()
+      })
     })
-  })
 
-  it('opens and closes tooltip on hover with a long delay', async () => {
-    const { getByTestId, queryByTestId } = renderTooltip({ delay: 'long' })
+    it('opens and closes tooltip on hover with a short delay', async () => {
+      const { getByTestId, queryByTestId } = renderTooltip({ delay: 'short' })
 
-    fireEvent.mouseEnter(getByTestId('tooltip-trigger'))
-    await waitFor(
-      () => {
+      fireEvent.mouseEnter(getByTestId('tooltip-trigger'))
+      await waitFor(
+        () => {
+          expect(queryByTestId('tooltip-content')).not.toBeInTheDocument()
+        },
+        { timeout: TOOLTIP_SHORT_DELAY / 2 }
+      )
+      await waitFor(
+        () => {
+          expect(queryByTestId('tooltip-content')).toBeInTheDocument()
+        },
+        { timeout: TOOLTIP_SHORT_DELAY }
+      )
+
+      fireEvent.mouseLeave(getByTestId('tooltip-trigger'))
+      await waitFor(() => {
         expect(queryByTestId('tooltip-content')).not.toBeInTheDocument()
-      },
-      { timeout: TOOLTIP_LONG_DELAY / 2 }
-    )
-    await waitFor(
-      () => {
-        expect(queryByTestId('tooltip-content')).toBeInTheDocument()
-      },
-      { timeout: TOOLTIP_LONG_DELAY }
-    )
+      })
+    })
 
-    fireEvent.mouseLeave(getByTestId('tooltip-trigger'))
-    await waitFor(() => {
-      expect(queryByTestId('tooltip-content')).not.toBeInTheDocument()
+    it('opens and closes tooltip on hover with a long delay', async () => {
+      const { getByTestId, queryByTestId } = renderTooltip({ delay: 'long' })
+
+      fireEvent.mouseEnter(getByTestId('tooltip-trigger'))
+      await waitFor(
+        () => {
+          expect(queryByTestId('tooltip-content')).not.toBeInTheDocument()
+        },
+        { timeout: TOOLTIP_LONG_DELAY / 2 }
+      )
+      await waitFor(
+        () => {
+          expect(queryByTestId('tooltip-content')).toBeInTheDocument()
+        },
+        { timeout: TOOLTIP_LONG_DELAY }
+      )
+
+      fireEvent.mouseLeave(getByTestId('tooltip-trigger'))
+      await waitFor(() => {
+        expect(queryByTestId('tooltip-content')).not.toBeInTheDocument()
+      })
+    })
+
+    it('does not open tooltip with disabled listeners', async () => {
+      const { getByTestId, findByTestId } = renderTooltip({
+        disableListeners: true
+      })
+
+      fireEvent.focus(getByTestId('tooltip-trigger'))
+      fireEvent.click(getByTestId('tooltip-trigger'))
+      fireEvent.mouseEnter(getByTestId('tooltip-trigger'))
+
+      await expect(() => findByTestId('tooltip-content')).rejects.toThrow()
+    })
+
+    it('does not close tooltip when interactive content is used by the user', async () => {
+      const { getByTestId, queryByTestId, findByTestId } = renderTooltip({
+        interactive: true
+      })
+
+      fireEvent.focus(getByTestId('tooltip-trigger'))
+      await findByTestId('tooltip-content')
+
+      fireEvent.mouseEnter(getByTestId('tooltip-content'))
+      await findByTestId('tooltip-content')
+
+      fireEvent.mouseLeave(getByTestId('tooltip-content'))
+      await waitFor(() => {
+        expect(queryByTestId('tooltip-content')).not.toBeInTheDocument()
+      })
     })
   })
 
-  it('does not open tooltip with disabled listeners', async () => {
-    const { getByTestId, findByTestId } = renderTooltip({
-      disableListeners: true
+  describe('with isPointerDevice being false', () => {
+    beforeEach(() => {
+      Object.defineProperty(window, 'matchMedia', {
+        writable: true,
+        value: jest.fn().mockImplementation(() => ({
+          matches: false
+        }))
+      })
     })
+    it('opens and closes tooltip on touch screens', async () => {
+      const { getByTestId, queryByTestId, findByTestId } = renderTooltip()
 
-    fireEvent.focus(getByTestId('tooltip-trigger'))
-    fireEvent.click(getByTestId('tooltip-trigger'))
-    fireEvent.mouseEnter(getByTestId('tooltip-trigger'))
+      fireEvent.click(getByTestId('tooltip-trigger'))
+      await findByTestId('tooltip-content')
 
-    await expect(() => findByTestId('tooltip-content')).rejects.toThrow()
-  })
-
-  it('does not close tooltip when interactive content is used by the user', async () => {
-    const { getByTestId, queryByTestId, findByTestId } = renderTooltip({
-      interactive: true
-    })
-
-    fireEvent.focus(getByTestId('tooltip-trigger'))
-    await findByTestId('tooltip-content')
-
-    fireEvent.mouseEnter(getByTestId('tooltip-content'))
-    await findByTestId('tooltip-content')
-
-    fireEvent.mouseLeave(getByTestId('tooltip-content'))
-    await waitFor(() => {
-      expect(queryByTestId('tooltip-content')).not.toBeInTheDocument()
+      fireEvent.click(getByTestId('tooltip-trigger'))
+      await waitFor(() => {
+        expect(queryByTestId('tooltip-content')).not.toBeInTheDocument()
+      })
     })
   })
 })

--- a/packages/picasso/src/TypographyOverflow/test.tsx
+++ b/packages/picasso/src/TypographyOverflow/test.tsx
@@ -1,21 +1,14 @@
 import React from 'react'
 import { fireEvent, render, waitFor } from '@toptal/picasso/test-utils'
 
+import '../../../../__tests__/matchMedia'
 import TypographyOverflow from '.'
-jest.mock('../utils/is-overflown.ts', () => ({
+jest.mock('../utils/is-overflown', () => ({
   __esModule: true,
   default: jest.fn(() => true)
 }))
 
 describe('TypographyOverflow', () => {
-  beforeEach(() => {
-    Object.defineProperty(window, 'matchMedia', {
-      writable: true,
-      value: jest.fn().mockImplementation(() => ({
-        matches: false
-      }))
-    })
-  })
   describe('when overflow happened', () => {
     it('renders tooltip by default', async () => {
       const { getByTestId, queryByTestId } = render(

--- a/packages/picasso/src/TypographyOverflow/test.tsx
+++ b/packages/picasso/src/TypographyOverflow/test.tsx
@@ -2,14 +2,20 @@ import React from 'react'
 import { fireEvent, render, waitFor } from '@toptal/picasso/test-utils'
 
 import TypographyOverflow from '.'
-
-jest.mock('@toptal/picasso/utils', () => ({
-  ...(jest.requireActual('@toptal/picasso/utils') as {}),
-  isOverflown: jest.fn(() => true),
-  isPointerDevice: jest.fn(() => true)
+jest.mock('../utils/is-overflown.ts', () => ({
+  __esModule: true,
+  default: jest.fn(() => true)
 }))
 
 describe('TypographyOverflow', () => {
+  beforeEach(() => {
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: jest.fn().mockImplementation(() => ({
+        matches: false
+      }))
+    })
+  })
   describe('when overflow happened', () => {
     it('renders tooltip by default', async () => {
       const { getByTestId, queryByTestId } = render(


### PR DESCRIPTION
### Description

There is problem with current way how we mock functions from `@toptal/picasso/utils`, when we want to use another function from utils that actually does not have to be mocked.

I have found the proper way how to mock `window.matchMedia` in [Jest docs](https://jestjs.io/docs/manual-mocks#mocking-methods-which-are-not-implemented-in-jsdom). With the previous mock, I had difficulties making tests in RichTextEditor work.

### How to test

all unit tests should pass

### Review

- [ ] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [ ] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that tests pass by running `yarn test`
- [ ] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
- [ ] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>
