### PR TITLE
style(RichTextEditor): add hover and focus styles

### DIFF
--- a/packages/picasso/src/QuillEditor/styles.ts
+++ b/packages/picasso/src/QuillEditor/styles.ts
@@ -1,5 +1,4 @@
 import { createStyles, Theme } from '@material-ui/core/styles'
-import { sizes } from '@toptal/picasso-provider'
 import { rem } from '@toptal/picasso-shared'
 
 const margins = {
@@ -108,8 +107,6 @@ const quillSpecificStyles = (theme: Theme) => ({
 })
 
 export default (theme: Theme) => {
-  const { palette } = theme
-
   return createStyles({
     root: {
       height: '12.5em',
@@ -119,60 +116,6 @@ export default (theme: Theme) => {
       ...listStyles,
       ...margins,
       ...quillSpecificStyles(theme)
-    },
-
-    editorWrapper: {
-      borderRadius: sizes.borderRadius.small,
-      border: `1px solid ${palette.grey.light2}`,
-      padding: '0.5em'
-    },
-
-    qlToolbar: {
-      display: 'flex',
-      borderBottom: `1px solid ${palette.grey.light2}`,
-      paddingBottom: '0.5em'
-    },
-
-    qlFormats: {
-      display: 'flex',
-      alignItems: 'center',
-      position: 'relative',
-
-      '&:not(:last-child)::after': {
-        content: '""',
-        height: '1em',
-        width: '1px',
-        position: 'relative',
-        marginLeft: '0.5em',
-        marginRight: '0.5em',
-        backgroundColor: palette.grey.lighter2
-      }
-    },
-
-    textStylesSelect: {
-      width: '7.125em'
-    },
-
-    button: {
-      borderRadius: sizes.borderRadius.small,
-
-      '&+&': {
-        marginLeft: '0.5em'
-      }
-    },
-
-    activeButton: {
-      backgroundColor: palette.grey.dark,
-
-      '&:not(:hover) svg': {
-        fill: palette.common.white
-      }
-    },
-
-    disabled: {
-      background: palette.grey.lighter,
-      borderRadius: '0.25em',
-      border: `1px solid ${palette.grey.lighter2}`
     }
   })
 }

--- a/packages/picasso/src/RichTextEditor/RichTextEditor.tsx
+++ b/packages/picasso/src/RichTextEditor/RichTextEditor.tsx
@@ -103,7 +103,8 @@ export const RichTextEditor = forwardRef<HTMLDivElement, Props>(
         className={cx(
           classes.editorWrapper,
           {
-            [classes.disabled]: disabled
+            [classes.disabled]: disabled,
+            [classes.isFocused]: isEditorFocused
           },
           className
         )}

--- a/packages/picasso/src/RichTextEditor/styles.ts
+++ b/packages/picasso/src/RichTextEditor/styles.ts
@@ -1,3 +1,4 @@
+import { outline } from '@toptal/picasso-shared'
 import { createStyles, Theme } from '@material-ui/core/styles'
 
 export default ({ palette, sizes }: Theme) =>
@@ -5,12 +6,20 @@ export default ({ palette, sizes }: Theme) =>
     editorWrapper: {
       borderRadius: sizes.borderRadius.small,
       border: `1px solid ${palette.grey.light2}`,
-      padding: '0.5em'
+      padding: '0.5em',
+      '&:hover:not($disabled):not($isFocused)': {
+        borderColor: palette.grey.main2
+      }
     },
 
     disabled: {
       background: palette.grey.lighter,
       borderRadius: '0.25em',
       border: `1px solid ${palette.grey.lighter2}`
+    },
+
+    isFocused: {
+      borderColor: palette.blue.main,
+      ...outline(palette.primary.main)
     }
   })


### PR DESCRIPTION
[FX-2450]

### Description

RichTextEditor is still form input, so we need to follow styles as normal Input has. Here we add black border on hover and blue outline with blue border on focus. Copied from OutlineButton styles.

### How to test

- Check [storybook](https://picasso.toptal.net/FX-2450-outline/?path=/story/components-richtexteditor--richtexteditor), hover and focus states should be the same as for normal input. (We don't have these styles in design for TextEditor)

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| ![image](https://user-images.githubusercontent.com/6830426/153834369-4c920519-9d0f-45c5-97b0-477033078b01.png) | ![image](https://user-images.githubusercontent.com/6830426/153834093-651ee129-88b2-47de-9247-e9f15df67549.png) |

### Review

- [ ] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [ ] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that tests pass by running `yarn test`
- [ ] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
- [ ] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-2450]: https://toptal-core.atlassian.net/browse/FX-2450?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ