### PR TITLE
style: remove focus outline when disabled

### DIFF
--- a/packages/picasso/src/RichTextEditor/RichTextEditor.tsx
+++ b/packages/picasso/src/RichTextEditor/RichTextEditor.tsx
@@ -104,7 +104,7 @@ export const RichTextEditor = forwardRef<HTMLDivElement, Props>(
           classes.editorWrapper,
           {
             [classes.disabled]: disabled,
-            [classes.isFocused]: isEditorFocused
+            [classes.focused]: isEditorFocused
           },
           className
         )}

--- a/packages/picasso/src/RichTextEditor/styles.ts
+++ b/packages/picasso/src/RichTextEditor/styles.ts
@@ -15,11 +15,14 @@ export default ({ palette, sizes }: Theme) =>
     disabled: {
       background: palette.grey.lighter,
       borderRadius: '0.25em',
-      border: `1px solid ${palette.grey.lighter2}`
+      border: `1px solid ${palette.grey.lighter2}`,
+      pointerEvents: 'none'
     },
 
     isFocused: {
-      borderColor: palette.blue.main,
-      ...outline(palette.primary.main)
+      '&:hover:not($disabled)': {
+        borderColor: palette.blue.main,
+        ...outline(palette.primary.main)
+      }
     }
   })

--- a/packages/picasso/src/RichTextEditor/styles.ts
+++ b/packages/picasso/src/RichTextEditor/styles.ts
@@ -7,22 +7,20 @@ export default ({ palette, sizes }: Theme) =>
       borderRadius: sizes.borderRadius.small,
       border: `1px solid ${palette.grey.light2}`,
       padding: '0.5em',
-      '&:hover:not($disabled):not($isFocused)': {
+
+      '&:hover:not($disabled)': {
         borderColor: palette.grey.main2
       }
     },
 
     disabled: {
+      pointerEvents: 'none',
       background: palette.grey.lighter,
-      borderRadius: '0.25em',
-      border: `1px solid ${palette.grey.lighter2}`,
-      pointerEvents: 'none'
+      border: `1px solid ${palette.grey.lighter2}`
     },
 
-    isFocused: {
-      '&:hover:not($disabled)': {
-        borderColor: palette.blue.main,
-        ...outline(palette.primary.main)
-      }
+    focused: {
+      borderColor: palette.grey.main2,
+      ...outline(palette.primary.main)
     }
   })


### PR DESCRIPTION
[FX-2504]

### Description

When I click on disabled editor it gets focus outline, but it should not

### How to test

1. click on disabled RichTextEditor
2. focus outline should not appear

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| ![image](https://user-images.githubusercontent.com/6830426/154667147-1b93924f-05a3-47ab-bf54-43de9d8e23ac.png) | ![image](https://user-images.githubusercontent.com/6830426/154667183-6bd685a3-f4c3-4bdb-88b1-8a46751c0b92.png) |

### Review

- [ ] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [ ] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that tests pass by running `yarn test`
- [ ] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
- [ ] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-2504]: https://toptal-core.atlassian.net/browse/FX-2504?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ