### PR TITLE
chore(date-picker): fix an invalid displayed date after clicking in calendar when timezone is set

### DIFF
--- a/.changeset/metal-cherries-drive.md
+++ b/.changeset/metal-cherries-drive.md
@@ -1,0 +1,5 @@
+---
+'@toptal/picasso': patch
+---
+
+- chore(date-picker): fix an invalid displayed date after clicking in DatePicker when timezone is passed

--- a/packages/picasso/src/DatePicker/DatePicker.tsx
+++ b/packages/picasso/src/DatePicker/DatePicker.tsx
@@ -275,7 +275,7 @@ export const DatePicker = (props: Props) => {
 
     onChange(nextTimezoneValue)
     setInputValue(formatInputValue(nextValue))
-    setCalendarValue(nextTimezoneValue)
+    setCalendarValue(nextValue)
 
     if (hideOnSelect) {
       focus()

--- a/packages/picasso/src/DatePicker/test.tsx
+++ b/packages/picasso/src/DatePicker/test.tsx
@@ -12,6 +12,9 @@ const testIds = {
   input: 'input'
 }
 
+const FAR_EAST_TIMEZONE = 'Asia/Tokyo'
+const NEW_YORK_TIMEZONE = 'America/New_York'
+
 // eslint-disable-next-line max-lines-per-function
 describe('DatePicker', () => {
   beforeAll(() => {
@@ -427,17 +430,76 @@ describe('DatePicker', () => {
   })
 
   describe('Calendar', () => {
-    it('should display date in given timezone', () => {
-      const { getByPlaceholderText, getByTestId } = renderDatePicker({
-        ...defaultProps,
+    it.each([
+      {
+        date: '2020-06-25T00:00:00+09:00',
         timezone: FAR_EAST_TIMEZONE,
-        value: new Date(2020, 6, 24, 18)
-      })
+        expectedSelectedDate: '25'
+      },
+      {
+        date: '2020-06-24T23:59:59+09:00',
+        timezone: FAR_EAST_TIMEZONE,
+        expectedSelectedDate: '24'
+      },
+      {
+        date: '2020-06-25T00:00:00-05:00',
+        timezone: NEW_YORK_TIMEZONE,
+        expectedSelectedDate: '25'
+      }
+    ])(
+      'should display date in given timezone',
+      ({ date, timezone, expectedSelectedDate }) => {
+        const { getByPlaceholderText, getByTestId } = renderDatePicker({
+          ...defaultProps,
+          timezone,
+          value: new Date(date)
+        })
 
-      fireEvent.focus(getByPlaceholderText(defaultProps.placeholder))
+        fireEvent.focus(getByPlaceholderText(defaultProps.placeholder))
 
-      expect(getByTestId('day-button-selected')).toHaveTextContent('25')
-    })
+        expect(getByTestId('day-button-selected')).toHaveTextContent(
+          expectedSelectedDate
+        )
+      }
+    )
+
+    it.each([
+      {
+        date: '2020-06-25T00:00:00+09:00',
+        timezone: FAR_EAST_TIMEZONE
+      },
+      {
+        date: '2020-06-24T23:59:59+09:00',
+        timezone: FAR_EAST_TIMEZONE
+      },
+      {
+        date: '2020-06-25T00:00:00-05:00',
+        timezone: NEW_YORK_TIMEZONE
+      }
+    ])(
+      'should display date in given timezone after day click',
+      async ({ date, timezone }) => {
+        const {
+          getByPlaceholderText,
+          getByTestId,
+          getByText
+        } = renderDatePicker({
+          ...defaultProps,
+          timezone,
+          value: new Date(date)
+        })
+
+        fireEvent.focus(getByPlaceholderText(defaultProps.placeholder))
+
+        const day15 = getByText(/15/)
+
+        fireEvent.click(day15)
+
+        fireEvent.focus(getByPlaceholderText(defaultProps.placeholder))
+
+        expect(getByTestId('day-button-selected')).toHaveTextContent('15')
+      }
+    )
 
     describe('when `enableReset` option is passed', () => {
       it('should not close calendar on `reset` button click', async () => {
@@ -457,8 +519,6 @@ describe('DatePicker', () => {
       })
     })
   })
-
-  const FAR_EAST_TIMEZONE = 'Asia/Tokyo'
 
   const defaultProps = {
     onChange: () => {},


### PR DESCRIPTION
[SPT-2424]

### Description

**PLEASE, DO NOT MERGE THIS PR UNTIL I TEST IT IN STAFF-PORTAL!**

When timezone is passed, we call `onChange` with `nextTimezoneValue` first and then set the same `nextTimezoneValue` via `setCalendarValue`. But we should not use `setCalendarValue` here, instead we should use just raw `nextValue`, to follow the same behavior as in `useEffect` hook:
```
useLayoutEffect(() => {
    setCalendarValue(() => {
      if (!value) {
        return null
      }

      return timezoneConvert(value, timezone)
    })
  }, [value, timezone])
```
This bug causes behavior when after date selection, displayed selected date is `selected date - 1 day`

### How to test

Tests should cover this problem

### Review

- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure that tests pass by running `yarn test`
- [x] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[SPT-2424]: https://toptal-core.atlassian.net/browse/SPT-2424?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ