### PR TITLE
fix: switch between block elements

### DIFF
--- a/packages/picasso/src/QuillEditor/hooks/useDefaultValue/useDefaultValue.tsx
+++ b/packages/picasso/src/QuillEditor/hooks/useDefaultValue/useDefaultValue.tsx
@@ -20,7 +20,7 @@ const useDefaultValue = ({ defaultValue, quill }: Props) => {
       defaultValue
     )
 
-    quill.setContents(delta, 'api')
+    quill.setContents(delta, 'silent')
     hasBeenCalled.current = true
   }, [defaultValue, quill])
 }

--- a/packages/picasso/src/QuillEditor/utils/getEditorChangeHandler/getEditorChangeHandler.tsx
+++ b/packages/picasso/src/QuillEditor/utils/getEditorChangeHandler/getEditorChangeHandler.tsx
@@ -4,7 +4,7 @@ import Delta from 'quill-delta'
 import { FormatType } from '../../types'
 
 type SelectionChangeArgs = [RangeStatic, RangeStatic, Sources]
-type TextChangeArgx = [Delta, Delta, Sources]
+type TextChangeArgs = [Delta, Delta, Sources]
 
 const getEditorChangeHandler = (
   quill: Quill,
@@ -12,10 +12,10 @@ const getEditorChangeHandler = (
 ) => {
   const handler = (
     name: 'text-change' | 'selection-change',
-    ...args: SelectionChangeArgs | TextChangeArgx
+    ...args: SelectionChangeArgs | TextChangeArgs
   ) => {
     if (name === 'text-change') {
-      const [, , source] = args as TextChangeArgx
+      const [, , source] = args as TextChangeArgs
       // this event is triggered when format of block element is changed
       // for example from p > h3 | h3 > ol
       const isFromApi = source === 'api'

--- a/packages/picasso/src/QuillEditor/utils/getEditorChangeHandler/getEditorChangeHandler.tsx
+++ b/packages/picasso/src/QuillEditor/utils/getEditorChangeHandler/getEditorChangeHandler.tsx
@@ -14,8 +14,18 @@ const getEditorChangeHandler = (
     name: 'text-change' | 'selection-change',
     ...args: SelectionChangeArgs | TextChangeArgx
   ) => {
-    if (!quill) {
-      return
+    if (name === 'text-change') {
+      const [, , source] = args as TextChangeArgx
+      // this event is triggered when format of block element is changed
+      // for example from p > h3 | h3 > ol
+      const isFromApi = source === 'api'
+
+      if (!isFromApi) {
+        return
+      }
+      const format = quill.getFormat() as FormatType
+
+      onSelectionChange(format)
     }
 
     if (name === 'selection-change') {

--- a/packages/picasso/src/QuillEditor/utils/getEditorChangeHandler/test.ts
+++ b/packages/picasso/src/QuillEditor/utils/getEditorChangeHandler/test.ts
@@ -1,0 +1,75 @@
+import { act } from '@toptal/picasso/test-utils'
+import Quill, { RangeStatic } from 'quill'
+
+import getEditorChangeHandler from './getEditorChangeHandler'
+
+const rangeMock = { index: 0, length: 0 } as RangeStatic
+
+describe('getEditorChangeHandler', () => {
+  describe('text-change event', () => {
+    describe('when source is not api', () => {
+      it('does nothing', () => {
+        const quill = ({
+          getFormat: jest.fn(() => ({}))
+        } as unknown) as Quill
+        const onSelectionChange = jest.fn()
+
+        const handler = getEditorChangeHandler(quill, onSelectionChange)
+
+        act(() => handler('text-change', rangeMock, rangeMock, 'user'))
+        act(() => handler('text-change', rangeMock, rangeMock, 'silent'))
+
+        expect(quill.getFormat).not.toHaveBeenCalled()
+        expect(onSelectionChange).not.toHaveBeenCalled()
+      })
+    })
+    describe('when source is api', () => {
+      it('calls the callback with quill format', () => {
+        const quill = ({
+          getFormat: jest.fn(() => ({}))
+        } as unknown) as Quill
+        const onSelectionChange = jest.fn()
+
+        const handler = getEditorChangeHandler(quill, onSelectionChange)
+
+        act(() => handler('text-change', rangeMock, rangeMock, 'api'))
+
+        expect(quill.getFormat).toHaveBeenCalled()
+        expect(onSelectionChange).toHaveBeenCalledWith({})
+      })
+    })
+  })
+  describe('selection-change event', () => {
+    describe('when source is not silent', () => {
+      it('does nothing', () => {
+        const quill = ({
+          getFormat: jest.fn(() => ({}))
+        } as unknown) as Quill
+        const onSelectionChange = jest.fn()
+
+        const handler = getEditorChangeHandler(quill, onSelectionChange)
+
+        act(() => handler('selection-change', rangeMock, rangeMock, 'api'))
+        act(() => handler('selection-change', rangeMock, rangeMock, 'user'))
+
+        expect(quill.getFormat).not.toHaveBeenCalled()
+        expect(onSelectionChange).not.toHaveBeenCalled()
+      })
+    })
+    describe('when source is silent', () => {
+      it('calls the callback with quill format', () => {
+        const quill = ({
+          getFormat: jest.fn(() => ({}))
+        } as unknown) as Quill
+        const onSelectionChange = jest.fn()
+
+        const handler = getEditorChangeHandler(quill, onSelectionChange)
+
+        act(() => handler('selection-change', rangeMock, rangeMock, 'silent'))
+
+        expect(quill.getFormat).toHaveBeenCalled()
+        expect(onSelectionChange).toHaveBeenCalledWith({})
+      })
+    })
+  })
+})


### PR DESCRIPTION
[FX-2506]

### Description

When switching between the header and list format, the state is not updated properly, both formats are selected until we write something.

**reproducing steps:**

1. switch text format from normal to heading in select
2. click the list button (ordered/unordered)

**expected:**
- only the list button is highlighted and normal is selected in text format selectbox

**current:**
- list button is highlighted and the heading is selected in text format selectbox 

### Review

- [ ] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [ ] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that tests pass by running `yarn test`
- [ ] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
- [ ] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-2506]: https://toptal-core.atlassian.net/browse/FX-2506?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ