### PR TITLE
fix: enable switching directly between lists

### DIFF
--- a/packages/picasso/src/RichTextEditor/hooks/useToolbarHandlers/useToolbarHandlers.tsx
+++ b/packages/picasso/src/RichTextEditor/hooks/useToolbarHandlers/useToolbarHandlers.tsx
@@ -51,7 +51,7 @@ const useToolbarHandlers = ({ editorRef, handleTextFormat, format }: Props) => {
   }
 
   const handleOrdered: ButtonHandlerType = () => {
-    const list = format.list === false ? 'ordered' : undefined
+    const list = format.list === 'ordered' ? undefined : 'ordered'
 
     sendFormatEvent({ list })
     handleTextFormat({
@@ -61,7 +61,7 @@ const useToolbarHandlers = ({ editorRef, handleTextFormat, format }: Props) => {
   }
 
   const handleUnordered: ButtonHandlerType = () => {
-    const list = format.list === false ? 'bullet' : undefined
+    const list = format.list === 'bullet' ? undefined : 'bullet'
 
     sendFormatEvent({ list })
     handleTextFormat({


### PR DESCRIPTION
[FX-2507]

### Description

When we have one type of list selected and want to change to another, it firstly unformats and on second click proper format is selected

**reproducing steps:**

1. write hello world
2. format it to unordered list
3. format it to ordered list

**expected:**
- we have one ordered list item with hello world

**current issue:**
- we have unformatted text hello world

### Review

- [ ] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [ ] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that tests pass by running `yarn test`
- [ ] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
- [ ] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-2507]: https://toptal-core.atlassian.net/browse/FX-2507?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ