### PR TITLE
feat(FieldRequirements): add new component

### DIFF
--- a/.changeset/dirty-points-applaud.md
+++ b/.changeset/dirty-points-applaud.md
@@ -5,7 +5,7 @@
 ---
 ### FieldWrapper
 
-- add new prop to render field requirements if exist
+- add new prop to render passed field requirements
 
 ### PasswordInput
 

--- a/.changeset/dirty-points-applaud.md
+++ b/.changeset/dirty-points-applaud.md
@@ -1,0 +1,13 @@
+---
+'@toptal/picasso-forms': minor
+---
+
+---
+### FieldWrapper
+
+- add new prop to render field requirements if exist
+
+### PasswordInput
+
+- update the component to render field requirements
+

--- a/.changeset/silent-bananas-mate.md
+++ b/.changeset/silent-bananas-mate.md
@@ -1,0 +1,13 @@
+---
+'@toptal/picasso': minor
+---
+
+---
+### FieldRequirements
+
+- add new input component to list requirements
+
+### FormField
+
+- add new prop to pass field requirements as a ReactNode
+

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,26 @@
+# Those files need to be removed from here after this
+# version of prettier https://github.com/prettier/prettier/issues/7263 will
+# be supported in prettier-standard
+packages/picasso-charts/src/index.ts
+packages/picasso-charts/src/LineChart/index.ts
+packages/picasso-forms/src/CheckboxGroup/index.ts
+packages/picasso-forms/src/index.ts
+packages/picasso-forms/src/RadioGroup/index.ts
+packages/picasso/src/ApplicationUpdateNotification/index.ts
+packages/picasso/src/DatePicker/index.ts
+packages/picasso/src/FormLabel/index.ts
+packages/picasso/src/Grid/index.ts
+packages/picasso/src/index.ts
+packages/picasso/src/MonthSelect/index.ts
+packages/picasso/src/NativeSelectOptions/index.tsx
+packages/picasso/src/NativeSelectPlaceholder/index.tsx
+packages/picasso/src/Select/index.ts
+packages/picasso/src/TimePicker/index.ts
+packages/picasso/src/utils/Transitions/index.ts
+packages/picasso/src/YearSelect/index.ts
+packages/topkit-analytics-charts/src/AnalyticsChart/index.ts
+
+packages/picasso-codemod/src/v17.0.0/container-borders/__testfixtures__/expected.tsx
+packages/picasso-codemod/src/v17.0.0/container-borders/__testfixtures__/actual.tsx
+packages/picasso-codemod/src/v18.0.0/picasso-lab/__testfixtures__/basic.input.tsx
+packages/picasso-codemod/src/v18.0.0/picasso-lab/__testfixtures__/basic.output.tsx

--- a/cypress/component/FieldRequirements.spec.tsx
+++ b/cypress/component/FieldRequirements.spec.tsx
@@ -1,0 +1,55 @@
+import React from 'react'
+import { mount } from '@cypress/react'
+import {
+  FieldRequirement,
+  FieldRequirements,
+  FieldRequirementsProps
+} from '@toptal/picasso'
+import { TestingPicasso } from '@toptal/picasso/test-utils'
+
+const requirements: FieldRequirement[] = [
+  {
+    message: 'At least one number',
+    validator: (value: string) => /\d/.test(value),
+    'data-testid': 'requirement-1'
+  },
+  {
+    message: 'At least one uppercase character',
+    validator: (value: string) => /[A-Z]/.test(value),
+    'data-testid': 'requirement-2'
+  }
+]
+
+const FieldRequirementsExample = (props: Partial<FieldRequirementsProps>) => (
+  <FieldRequirements
+    open
+    requirements={requirements}
+    value='asd1'
+    testIds={{
+      description: 'field-requirements-description',
+      root: 'field-requirements-root',
+      gridContainer: 'field-requirements-grid-container'
+    }}
+    {...props}
+  />
+)
+
+describe('FieldRequirements', () => {
+  it('renders requirements with bullets and checks for default', () => {
+    mount(
+      <TestingPicasso>
+        <FieldRequirementsExample />
+      </TestingPicasso>
+    )
+    cy.get('body').happoScreenshot()
+  })
+
+  it('renders requirements with close icons and checks for error', () => {
+    mount(
+      <TestingPicasso>
+        <FieldRequirementsExample error />
+      </TestingPicasso>
+    )
+    cy.get('body').happoScreenshot()
+  })
+})

--- a/cypress/component/FieldRequirements.spec.tsx
+++ b/cypress/component/FieldRequirements.spec.tsx
@@ -7,7 +7,7 @@ import {
 } from '@toptal/picasso'
 import { TestingPicasso } from '@toptal/picasso/test-utils'
 
-const requirements: FieldRequirement[] = [
+const requirements: FieldRequirement<string>[] = [
   {
     message: '1 number',
     validator: (value: string) => /\d/.test(value),
@@ -21,7 +21,7 @@ const requirements: FieldRequirement[] = [
 ]
 
 const FieldRequirementsExample = (props: Partial<FieldRequirementsProps>) => (
-  <FieldRequirements
+  <FieldRequirements<string>
     open
     requirements={requirements}
     value='asd1'
@@ -38,7 +38,7 @@ describe('FieldRequirements', () => {
   it('renders requirements with bullets and checks for default', () => {
     mount(
       <TestingPicasso>
-        <FieldRequirementsExample />
+        <FieldRequirementsExample value='dene' />
       </TestingPicasso>
     )
     cy.get('body').happoScreenshot()

--- a/cypress/component/FieldRequirements.spec.tsx
+++ b/cypress/component/FieldRequirements.spec.tsx
@@ -9,12 +9,12 @@ import { TestingPicasso } from '@toptal/picasso/test-utils'
 
 const requirements: FieldRequirement[] = [
   {
-    message: 'At least one number',
+    message: '1 number',
     validator: (value: string) => /\d/.test(value),
     'data-testid': 'requirement-1'
   },
   {
-    message: 'At least one uppercase character',
+    message: '1 uppercase character',
     validator: (value: string) => /[A-Z]/.test(value),
     'data-testid': 'requirement-2'
   }

--- a/cypress/component/FieldRequirements.spec.tsx
+++ b/cypress/component/FieldRequirements.spec.tsx
@@ -20,11 +20,13 @@ const requirements: FieldRequirement<string>[] = [
   }
 ]
 
-const FieldRequirementsExample = (props: Partial<FieldRequirementsProps>) => (
+const FieldRequirementsExample = (
+  props: Partial<FieldRequirementsProps<string>>
+) => (
   <FieldRequirements<string>
+    value='asd1'
     open
     requirements={requirements}
-    value='asd1'
     testIds={{
       description: 'field-requirements-description',
       root: 'field-requirements-root',

--- a/cypress/component/FieldRequirements.spec.tsx
+++ b/cypress/component/FieldRequirements.spec.tsx
@@ -11,12 +11,22 @@ const requirements: FieldRequirement<string>[] = [
   {
     message: '1 number',
     validator: (value: string) => /\d/.test(value),
-    'data-testid': 'requirement-1'
+    testIds: {
+      root: 'requirement-1',
+      defaultIcon: 'requirement-1-default-icon',
+      successIcon: 'requirement-1-success-icon',
+      errorIcon: 'requirement-1-error-icon'
+    }
   },
   {
     message: '1 uppercase character',
     validator: (value: string) => /[A-Z]/.test(value),
-    'data-testid': 'requirement-2'
+    testIds: {
+      root: 'requirement-2',
+      defaultIcon: 'requirement-2-default-icon',
+      successIcon: 'requirement-2-success-icon',
+      errorIcon: 'requirement-2-error-icon'
+    }
   }
 ]
 

--- a/packages/picasso-forms/src/FieldWrapper/FieldWrapper.tsx
+++ b/packages/picasso-forms/src/FieldWrapper/FieldWrapper.tsx
@@ -51,6 +51,10 @@ export type Props<
     hideLabelRequiredDecoration?: boolean
     fieldType?: string
     children: (props: any) => React.ReactNode
+    renderFieldRequirements?: (props: {
+      value?: ValueType
+      error?: boolean
+    }) => React.ReactNode
   }
 
 type FieldMeta<T> = FieldMetaState<T> & {
@@ -155,6 +159,7 @@ const FieldWrapper = <
     enableReset,
     onResetClick,
     'data-testid': dataTestId,
+    renderFieldRequirements,
     // FieldProps - https://final-form.org/docs/react-final-form/types/FieldProps
     afterSubmit,
     allowNull,
@@ -267,7 +272,15 @@ const FieldWrapper = <
   )
 
   return (
-    <PicassoForm.Field error={error} hint={hint} data-testid={dataTestId}>
+    <PicassoForm.Field
+      error={error}
+      hint={hint}
+      data-testid={dataTestId}
+      fieldRequirements={renderFieldRequirements?.({
+        value: input.value,
+        error: error
+      })}
+    >
       {!hideFieldLabel && label && (
         <PicassoForm.Label
           requiredDecoration={requiredDecoration}

--- a/packages/picasso-forms/src/FieldWrapper/FieldWrapper.tsx
+++ b/packages/picasso-forms/src/FieldWrapper/FieldWrapper.tsx
@@ -52,7 +52,7 @@ export type Props<
     fieldType?: string
     children: (props: any) => React.ReactNode
     renderFieldRequirements?: (props: {
-      value?: ValueType
+      value?: TInputValue
       error?: boolean
     }) => React.ReactNode
   }

--- a/packages/picasso-forms/src/Form/Form.tsx
+++ b/packages/picasso-forms/src/Form/Form.tsx
@@ -4,7 +4,11 @@ import {
   FormProps as FinalFormProps
 } from 'react-final-form'
 import { FormApi, SubmissionErrors, getIn, setIn, AnyObject } from 'final-form'
-import { Form as PicassoForm, Container } from '@toptal/picasso'
+import {
+  Form as PicassoForm,
+  Container,
+  FieldRequirements
+} from '@toptal/picasso'
 import { useNotifications } from '@toptal/picasso/utils'
 
 import Autocomplete from '../Autocomplete'
@@ -33,6 +37,7 @@ import {
   FormContextProps,
   createFormContext
 } from './FormContext'
+import PasswordInput from '../PasswordInput'
 
 export type Props<T = AnyObject> = FinalFormProps<T> & {
   disableScrollOnError?: boolean
@@ -184,5 +189,7 @@ Form.ConfigProvider = FormConfigContext.Provider
 Form.Switch = Switch
 Form.Rating = Rating
 Form.Dropzone = Dropzone
+Form.PasswordInput = PasswordInput
+Form.FieldRequirements = FieldRequirements
 
 export default Form

--- a/packages/picasso-forms/src/Form/story/FieldRequirements.example.tsx
+++ b/packages/picasso-forms/src/Form/story/FieldRequirements.example.tsx
@@ -1,0 +1,43 @@
+import React from 'react'
+import { Container } from '@toptal/picasso'
+import { Form } from '@toptal/picasso-forms'
+
+type FormType = {
+  password: string
+  confirmPassword: string
+}
+
+const Example = () => {
+  const handleSubmit = ({ password, confirmPassword }: FormType) => {
+    window.alert(`Password: ${password}, Confirm Password: ${confirmPassword}`)
+  }
+
+  return (
+    <Form<FormType>
+      autoComplete='off'
+      onSubmit={handleSubmit}
+      initialValues={{
+        password: '',
+        confirmPassword: ''
+      }}
+    >
+      <Form.PasswordInput label='Password' name='password' required />
+      <Form.PasswordInput
+        label='Confirm password'
+        name='confirmPassword'
+        hideRequirements
+        required
+        validate={(confirmPassword, allValues) => {
+          if ((allValues as FormType).password !== confirmPassword) {
+            return 'Passwords do not match'
+          }
+        }}
+      />
+      <Container top='small'>
+        <Form.SubmitButton>Submit</Form.SubmitButton>
+      </Container>
+    </Form>
+  )
+}
+
+export default Example

--- a/packages/picasso-forms/src/Form/story/index.jsx
+++ b/packages/picasso-forms/src/Form/story/index.jsx
@@ -218,3 +218,7 @@ however, you may need custom validators for more complex types of fields.
     title: 'No scrolling case',
     description: "Showcase Form's behavior on form submission error."
   }) // picasso-skip-visuals
+  .addExample('Form/story/FieldRequirements.example.tsx', {
+    title: 'Field requirements',
+    description: 'Showcase how to display field requirements.'
+  }) // picasso-skip-visuals

--- a/packages/picasso-forms/src/PasswordInput/PasswordInput.tsx
+++ b/packages/picasso-forms/src/PasswordInput/PasswordInput.tsx
@@ -15,6 +15,8 @@ export type Props = PasswordInputProps &
 
 const { composeValidators } = validators
 
+const TIMEOUT = 500
+
 export const PasswordInput = ({
   validate,
   hideRequirements,
@@ -51,7 +53,7 @@ export const PasswordInput = ({
       open={showContent}
       error={error}
       description='Please make sure that your password contains:'
-      timeout={500}
+      timeout={TIMEOUT}
       requirements={[
         {
           message: 'At least 8 characters',
@@ -95,7 +97,10 @@ export const PasswordInput = ({
         const handleBlur = (event: FocusEvent<HTMLInputElement>) => {
           inputProps.onBlur?.(event)
 
-          setShowContent(false)
+          // Hide the requirements after a short delay
+          setTimeout(() => {
+            setShowContent(false)
+          }, TIMEOUT)
         }
 
         return (

--- a/packages/picasso-forms/src/PasswordInput/PasswordInput.tsx
+++ b/packages/picasso-forms/src/PasswordInput/PasswordInput.tsx
@@ -1,18 +1,110 @@
-import React from 'react'
+import React, { useState, FocusEvent, ReactNode } from 'react'
 import {
   PasswordInput as PicassoPasswordInput,
   PasswordInputProps
 } from '@toptal/picasso'
+import { FieldValidator } from 'final-form'
 
+import { validators } from '../utils'
 import FieldWrapper, { FieldProps } from '../FieldWrapper'
+import passwordValidators from './validators'
+import Form from '../Form'
 
-export type Props = PasswordInputProps & FieldProps<PasswordInputProps['value']>
+export type Props = PasswordInputProps &
+  FieldProps<PasswordInputProps['value']> & { hideRequirements?: boolean }
 
-export const PasswordInput = (props: Props) => {
+const { composeValidators } = validators
+
+export const PasswordInput = ({
+  validate,
+  hideRequirements,
+  ...rest
+}: Props) => {
+  const [showContent, setShowContent] = useState(false)
+
+  const validatePassword: FieldValidator<PasswordInputProps['value']> = (
+    value?: string
+  ) => {
+    if (!value || hideRequirements) {
+      return undefined
+    }
+
+    const validationResult =
+      passwordValidators.atLeastEightCharacters(value) &&
+      passwordValidators.atLeastOneNumber(value) &&
+      passwordValidators.atLeastOneUpperCaseCharacter(value) &&
+      passwordValidators.atLeastOneLowerCaseCharacter(value) &&
+      passwordValidators.atLeastOneSpecialCharacter(value)
+
+    return validationResult ? undefined : 'Invalid password'
+  }
+
+  const renderFieldRequirements: ({
+    value,
+    error
+  }: {
+    value?: any
+    error?: boolean
+  }) => ReactNode = ({ value, error }) => (
+    <Form.FieldRequirements
+      value={value}
+      open={showContent}
+      error={error}
+      description='Please make sure that your password contains:'
+      timeout={500}
+      requirements={[
+        {
+          message: 'At least 8 characters',
+          validator: passwordValidators.atLeastEightCharacters
+        },
+        {
+          message: '1 number',
+          validator: passwordValidators.atLeastOneNumber
+        },
+        {
+          message: '1 uppercase character',
+          validator: passwordValidators.atLeastOneUpperCaseCharacter
+        },
+        {
+          message: '1 special character',
+          validator: passwordValidators.atLeastOneSpecialCharacter
+        },
+        {
+          message: '1 lowercase character',
+          validator: passwordValidators.atLeastOneLowerCaseCharacter
+        }
+      ]}
+    />
+  )
+
   return (
-    <FieldWrapper<PasswordInputProps> {...props}>
+    <FieldWrapper<PasswordInputProps>
+      {...rest}
+      validate={composeValidators([validatePassword, validate])}
+      renderFieldRequirements={
+        !hideRequirements ? renderFieldRequirements : undefined
+      }
+    >
       {(inputProps: PasswordInputProps) => {
-        return <PicassoPasswordInput {...inputProps} />
+        const handleFocus = (event: FocusEvent<HTMLInputElement>) => {
+          inputProps.onFocus?.(event)
+
+          setShowContent(true)
+        }
+
+        const handleBlur = (event: FocusEvent<HTMLInputElement>) => {
+          inputProps.onBlur?.(event)
+
+          setShowContent(false)
+        }
+
+        return (
+          <PicassoPasswordInput
+            {...inputProps}
+            onFocus={handleFocus}
+            onBlur={handleBlur}
+          />
+        )
       }}
     </FieldWrapper>
   )

--- a/packages/picasso-forms/src/PasswordInput/PasswordInput.tsx
+++ b/packages/picasso-forms/src/PasswordInput/PasswordInput.tsx
@@ -1,8 +1,7 @@
 import React, { useState, FocusEvent, ReactNode } from 'react'
 import {
   PasswordInput as PicassoPasswordInput,
-  PasswordInputProps,
-  FieldRequirementValueType
+  PasswordInputProps
 } from '@toptal/picasso'
 import { FieldValidator } from 'final-form'
 
@@ -50,11 +49,11 @@ export const PasswordInput = ({
     value,
     error
   }: {
-    value?: FieldRequirementValueType
+    value?: string
     error?: boolean
   }) => ReactNode = ({ value, error }) => (
     <Form.FieldRequirements<string>
-      value={(value ?? '') as string}
+      value={value}
       open={showContent}
       error={error}
       description='Please make sure that your password contains:'

--- a/packages/picasso-forms/src/PasswordInput/test.ts
+++ b/packages/picasso-forms/src/PasswordInput/test.ts
@@ -1,0 +1,45 @@
+import passwordValidators from './validators'
+
+const {
+  atLeastEightCharacters,
+  atLeastOneUpperCaseCharacter,
+  atLeastOneLowerCaseCharacter,
+  atLeastOneNumber,
+  atLeastOneSpecialCharacter
+} = passwordValidators
+
+describe('PasswordInput field requirements', () => {
+  describe('atLeastEightCharacters', () => {
+    it('test string to have at least eight characters', () => {
+      expect(atLeastEightCharacters('1234567')).toBe(false)
+      expect(atLeastEightCharacters('12345678')).toBe(true)
+    })
+  })
+
+  describe('atLeastOneUpperCaseCharacter', () => {
+    it('test string to have at least one uppercase character', () => {
+      expect(atLeastOneUpperCaseCharacter('asdfgh')).toBe(false)
+      expect(atLeastOneUpperCaseCharacter('asDfgh')).toBe(true)
+    })
+  })
+
+  describe('atLeastOneLowerCaseCharacter', () => {
+    it('test string to have at least one lowercase character', () => {
+      expect(atLeastOneLowerCaseCharacter('ASDFGH')).toBe(false)
+      expect(atLeastOneLowerCaseCharacter('ASdFGH')).toBe(true)
+    })
+  })
+
+  describe('atLeastOneNumber', () => {
+    it('test string to have at least one number', () => {
+      expect(atLeastOneNumber('asdfgh')).toBe(false)
+      expect(atLeastOneNumber('asdfgh1')).toBe(true)
+    })
+  })
+  describe('atLeastOneSpecialCharacter', () => {
+    it('test string to have at least one special character', () => {
+      expect(atLeastOneSpecialCharacter('asdfgh')).toBe(false)
+      expect(atLeastOneSpecialCharacter('asd*fgh')).toBe(true)
+    })
+  })
+})

--- a/packages/picasso-forms/src/PasswordInput/validators.ts
+++ b/packages/picasso-forms/src/PasswordInput/validators.ts
@@ -1,0 +1,28 @@
+const atLeastEightCharacters = (value: string) => {
+  return value.length >= 8
+}
+
+const atLeastOneUpperCaseCharacter = (value: string) => {
+  return /[A-Z]/.test(value)
+}
+
+const atLeastOneLowerCaseCharacter = (value: string) => {
+  return /[a-z]/.test(value)
+}
+
+const atLeastOneNumber = (value: string) => {
+  return /[0-9]/.test(value)
+}
+
+const atLeastOneSpecialCharacter = (value: string) => {
+  // eslint-disable-next-line no-useless-escape
+  return /[!@#$%^&*()_+\-=\[\]{};':"\\|,.<>\/?]/.test(value)
+}
+
+export default {
+  atLeastEightCharacters,
+  atLeastOneUpperCaseCharacter,
+  atLeastOneLowerCaseCharacter,
+  atLeastOneNumber,
+  atLeastOneSpecialCharacter
+}

--- a/packages/picasso/src/FieldRequirements/FieldRequirementItem.tsx
+++ b/packages/picasso/src/FieldRequirements/FieldRequirementItem.tsx
@@ -6,13 +6,13 @@ import Typography from '../Typography'
 import Grid from '../Grid'
 import styles from './styles'
 import { CheckMinor16, CloseMinor16 } from '../Icon'
-import { ColorType } from '../../../shared/src'
 
 const useStyles = makeStyles<Theme>(styles, {
   name: 'FieldRequirementItem'
 })
 
 export type FieldRequirementItemStatus = 'default' | 'success' | 'error'
+type ColorType = 'dark-grey' | 'inherit' | 'red'
 
 const colorMap: Record<FieldRequirementItemStatus, ColorType> = {
   default: 'dark-grey',
@@ -41,14 +41,17 @@ const FieldRequirementItem = ({
     >
       {status === 'success' ? (
         <CheckMinor16
-          color='inherit'
+          color={colorMap[status]}
           data-testid={`${dataTestId}-valid-icon`}
         />
       ) : status === 'error' ? (
-        <CloseMinor16 color='red' data-testid={`${dataTestId}-error-icon`} />
+        <CloseMinor16
+          color={colorMap[status]}
+          data-testid={`${dataTestId}-error-icon`}
+        />
       ) : (
         <Bullet16
-          color='dark-grey'
+          color={colorMap[status]}
           data-testid={`${dataTestId}-default-icon`}
         />
       )}

--- a/packages/picasso/src/FieldRequirements/FieldRequirementItem.tsx
+++ b/packages/picasso/src/FieldRequirements/FieldRequirementItem.tsx
@@ -20,6 +20,12 @@ const colorMap: Record<FieldRequirementItemStatus, ColorType> = {
   error: 'red'
 }
 
+const IconsMap = {
+  default: Bullet16,
+  success: CheckMinor16,
+  error: CloseMinor16
+}
+
 interface Props
   extends PropsWithChildren<{
     'data-testid'?: string
@@ -33,28 +39,18 @@ const FieldRequirementItem = ({
 }: Props) => {
   const classes = useStyles()
 
+  const IconComponent = IconsMap[status]
+
   return (
     <Grid.Item
       small={6}
       className={classes.fieldRequirementItem}
       data-testid={dataTestId}
     >
-      {status === 'success' ? (
-        <CheckMinor16
-          color={colorMap[status]}
-          data-testid={`${dataTestId}-valid-icon`}
-        />
-      ) : status === 'error' ? (
-        <CloseMinor16
-          color={colorMap[status]}
-          data-testid={`${dataTestId}-error-icon`}
-        />
-      ) : (
-        <Bullet16
-          color={colorMap[status]}
-          data-testid={`${dataTestId}-default-icon`}
-        />
-      )}
+      <IconComponent
+        color={colorMap[status]}
+        data-testid={`${dataTestId}-${status}-icon`}
+      />
       <Typography
         color={colorMap[status]}
         className={classes.fieldRequirementItemMessage}

--- a/packages/picasso/src/FieldRequirements/FieldRequirementItem.tsx
+++ b/packages/picasso/src/FieldRequirements/FieldRequirementItem.tsx
@@ -1,11 +1,10 @@
 import React, { PropsWithChildren } from 'react'
 import { makeStyles, Theme } from '@material-ui/core/styles'
 
-import Bullet16 from '../Icon/Bullet16'
 import Typography from '../Typography'
 import Grid from '../Grid'
 import styles from './styles'
-import { CheckMinor16, CloseMinor16 } from '../Icon'
+import { Bullet16, CheckMinor16, CloseMinor16 } from '../Icon'
 
 const useStyles = makeStyles<Theme>(styles, {
   name: 'FieldRequirementItem'
@@ -26,31 +25,28 @@ const IconsMap = {
   error: CloseMinor16
 }
 
-interface Props
-  extends PropsWithChildren<{
-    'data-testid'?: string
-  }> {
+interface Props extends PropsWithChildren<{}> {
   status: FieldRequirementItemStatus
+  testIds?: {
+    root?: string
+    successIcon?: string
+    errorIcon?: string
+    defaultIcon?: string
+  }
 }
-const FieldRequirementItem = ({
-  children,
-  status,
-  'data-testid': dataTestId
-}: Props) => {
+const FieldRequirementItem = ({ children, status, testIds }: Props) => {
   const classes = useStyles()
 
   const IconComponent = IconsMap[status]
+  const iconTestId = getIconTestId(status, testIds)
 
   return (
     <Grid.Item
       small={6}
       className={classes.fieldRequirementItem}
-      data-testid={dataTestId}
+      data-testid={testIds?.root}
     >
-      <IconComponent
-        color={colorMap[status]}
-        data-testid={`${dataTestId}-${status}-icon`}
-      />
+      <IconComponent color={colorMap[status]} data-testid={iconTestId} />
       <Typography
         color={colorMap[status]}
         className={classes.fieldRequirementItemMessage}
@@ -63,3 +59,22 @@ const FieldRequirementItem = ({
 }
 
 export default FieldRequirementItem
+
+const getIconTestId = (
+  status: FieldRequirementItemStatus,
+  testIds?: {
+    root?: string
+    successIcon?: string
+    errorIcon?: string
+    defaultIcon?: string
+  }
+) => {
+  if (status === 'error') {
+    return testIds?.errorIcon
+  }
+  if (status === 'success') {
+    return testIds?.successIcon
+  }
+
+  return testIds?.defaultIcon
+}

--- a/packages/picasso/src/FieldRequirements/FieldRequirementItem.tsx
+++ b/packages/picasso/src/FieldRequirements/FieldRequirementItem.tsx
@@ -6,22 +6,29 @@ import Typography from '../Typography'
 import Grid from '../Grid'
 import styles from './styles'
 import { CheckMinor16, CloseMinor16 } from '../Icon'
+import { ColorType } from '../../../shared/src'
 
 const useStyles = makeStyles<Theme>(styles, {
   name: 'FieldRequirementItem'
 })
 
+export type FieldRequirementItemStatus = 'default' | 'success' | 'error'
+
+const colorMap: Record<FieldRequirementItemStatus, ColorType> = {
+  default: 'dark-grey',
+  success: 'inherit',
+  error: 'red'
+}
+
 interface Props
   extends PropsWithChildren<{
     'data-testid'?: string
   }> {
-  valid: boolean
-  error?: boolean
+  status: FieldRequirementItemStatus
 }
 const FieldRequirementItem = ({
   children,
-  valid,
-  error,
+  status,
   'data-testid': dataTestId
 }: Props) => {
   const classes = useStyles()
@@ -32,12 +39,12 @@ const FieldRequirementItem = ({
       className={classes.fieldRequirementItem}
       data-testid={dataTestId}
     >
-      {valid ? (
+      {status === 'success' ? (
         <CheckMinor16
           color='inherit'
           data-testid={`${dataTestId}-valid-icon`}
         />
-      ) : error ? (
+      ) : status === 'error' ? (
         <CloseMinor16 color='red' data-testid={`${dataTestId}-error-icon`} />
       ) : (
         <Bullet16
@@ -46,7 +53,7 @@ const FieldRequirementItem = ({
         />
       )}
       <Typography
-        color={valid ? 'inherit' : error ? 'red' : 'dark-grey'}
+        color={colorMap[status]}
         className={classes.fieldRequirementItemMessage}
         size='xxsmall'
       >

--- a/packages/picasso/src/FieldRequirements/FieldRequirementItem.tsx
+++ b/packages/picasso/src/FieldRequirements/FieldRequirementItem.tsx
@@ -1,0 +1,59 @@
+import React, { PropsWithChildren } from 'react'
+import { makeStyles, Theme } from '@material-ui/core/styles'
+
+import Bullet16 from '../Icon/Bullet16'
+import Typography from '../Typography'
+import Grid from '../Grid'
+import styles from './styles'
+import { CheckMinor16, CloseMinor16 } from '../Icon'
+
+const useStyles = makeStyles<Theme>(styles, {
+  name: 'FieldRequirementItem'
+})
+
+interface Props
+  extends PropsWithChildren<{
+    'data-testid'?: string
+  }> {
+  valid: boolean
+  error?: boolean
+}
+const FieldRequirementItem = ({
+  children,
+  valid,
+  error,
+  'data-testid': dataTestId
+}: Props) => {
+  const classes = useStyles()
+
+  return (
+    <Grid.Item
+      small={6}
+      className={classes.fieldRequirementItem}
+      data-testid={dataTestId}
+    >
+      {valid ? (
+        <CheckMinor16
+          color='inherit'
+          data-testid={`${dataTestId}-valid-icon`}
+        />
+      ) : error ? (
+        <CloseMinor16 color='red' data-testid={`${dataTestId}-error-icon`} />
+      ) : (
+        <Bullet16
+          color='dark-grey'
+          data-testid={`${dataTestId}-default-icon`}
+        />
+      )}
+      <Typography
+        color={valid ? 'inherit' : error ? 'red' : 'dark-grey'}
+        className={classes.fieldRequirementItemMessage}
+        size='xxsmall'
+      >
+        {children}
+      </Typography>
+    </Grid.Item>
+  )
+}
+
+export default FieldRequirementItem

--- a/packages/picasso/src/FieldRequirements/FieldRequirements.tsx
+++ b/packages/picasso/src/FieldRequirements/FieldRequirements.tsx
@@ -87,7 +87,7 @@ export const FieldRequirements = function <
             <FieldRequirementItem
               key={requirement.message}
               status={status}
-              data-testid={requirement['data-testid']}
+              testIds={requirement.testIds}
             >
               {requirement.message}
             </FieldRequirementItem>

--- a/packages/picasso/src/FieldRequirements/FieldRequirements.tsx
+++ b/packages/picasso/src/FieldRequirements/FieldRequirements.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef } from 'react'
+import React from 'react'
 import { makeStyles, Theme } from '@material-ui/core/styles'
 import { Collapse } from '@material-ui/core'
 import { BaseProps } from '@toptal/picasso-shared'
@@ -8,14 +8,15 @@ import FieldRequirementItem, {
   FieldRequirementItemStatus
 } from './FieldRequirementItem'
 import Typography from '../Typography'
-import { FieldRequirement } from './types'
+import { FieldRequirement, ValueType } from './types'
 import Grid from '../Grid'
 
-export interface Props extends BaseProps {
+export interface Props<TInputValue extends ValueType = ValueType>
+  extends BaseProps {
   /** A string that defines the title of the requirement list */
   description?: string
   /** Value of the related input. It will be used to validate the requirements */
-  value: any
+  value: TInputValue
   /** Open/Close the requirements section. Opening it with focus is the default behavior */
   open: boolean
   /** Indicate whether `PasswordInput` is in error state */
@@ -23,7 +24,7 @@ export interface Props extends BaseProps {
   /** Duration for the collapse animation */
   timeout?: number
   /** Array of object to specify requirements. They will be executed */
-  requirements: FieldRequirement[]
+  requirements: FieldRequirement<TInputValue>[]
   testIds?: {
     root?: string
     description?: string
@@ -31,77 +32,75 @@ export interface Props extends BaseProps {
   }
 }
 
+const ANIMATION_TIMEOUT = 500
+
 const useStyles = makeStyles<Theme>(styles)
 
-export const FieldRequirements = forwardRef<HTMLDivElement, Props>(
-  function FieldRequirements(
-    {
-      value,
-      description,
-      open,
-      error,
-      timeout,
-      requirements,
-      className,
-      style,
-      testIds
-    }: Props,
-    ref
-  ) {
-    const classes = useStyles()
+export const FieldRequirements = function <
+  TInputValue extends ValueType = ValueType
+>({
+  value,
+  description,
+  open,
+  error,
+  timeout,
+  requirements,
+  className,
+  style,
+  testIds
+}: Props<TInputValue>) {
+  const classes = useStyles()
 
-    return (
-      <Collapse
-        ref={ref}
-        style={style}
-        className={className}
-        in={open}
-        timeout={timeout}
-        data-testid={testIds?.root}
-      >
-        {description && (
-          <Typography
-            data-testid={testIds?.description}
-            variant='body'
-            size='xxsmall'
-            className={classes.description}
-          >
-            {description}
-          </Typography>
-        )}
-        <Grid
-          className={classes.root}
-          spacing={0}
-          data-testid={testIds?.gridContainer}
+  return (
+    <Collapse
+      style={style}
+      className={className}
+      in={open}
+      timeout={timeout}
+      data-testid={testIds?.root}
+    >
+      {description && (
+        <Typography
+          data-testid={testIds?.description}
+          variant='body'
+          size='xxsmall'
+          className={classes.description}
         >
-          {requirements.map(requirement => {
-            let status: FieldRequirementItemStatus = 'default'
+          {description}
+        </Typography>
+      )}
+      <Grid
+        className={classes.root}
+        spacing={0}
+        data-testid={testIds?.gridContainer}
+      >
+        {requirements.map(requirement => {
+          let status: FieldRequirementItemStatus = 'default'
 
-            if (requirement.validator(value)) {
-              status = 'success'
-            } else if (error) {
-              status = 'error'
-            }
+          if (requirement.validator(value)) {
+            status = 'success'
+          } else if (error) {
+            status = 'error'
+          }
 
-            return (
-              <FieldRequirementItem
-                key={requirement.message}
-                status={status}
-                data-testid={requirement['data-testid']}
-              >
-                {requirement.message}
-              </FieldRequirementItem>
-            )
-          })}
-        </Grid>
-      </Collapse>
-    )
-  }
-)
+          return (
+            <FieldRequirementItem
+              key={requirement.message}
+              status={status}
+              data-testid={requirement['data-testid']}
+            >
+              {requirement.message}
+            </FieldRequirementItem>
+          )
+        })}
+      </Grid>
+    </Collapse>
+  )
+}
 
 FieldRequirements.defaultProps = {
   open: false,
-  timeout: 500
+  timeout: ANIMATION_TIMEOUT
 }
 
 FieldRequirements.displayName = 'FieldRequirements'

--- a/packages/picasso/src/FieldRequirements/FieldRequirements.tsx
+++ b/packages/picasso/src/FieldRequirements/FieldRequirements.tsx
@@ -1,0 +1,98 @@
+import React, { forwardRef } from 'react'
+import { makeStyles, Theme } from '@material-ui/core/styles'
+import { Collapse } from '@material-ui/core'
+import { BaseProps } from '@toptal/picasso-shared'
+
+import styles from './styles'
+import FieldRequirementItem from './FieldRequirementItem'
+import Typography from '../Typography'
+import { FieldRequirement } from './types'
+import Grid from '../Grid'
+
+export interface Props extends BaseProps {
+  /** A string that defines the title of the requirement list */
+  description?: string
+  /** Value of the related input. It will be used to validate the requirements */
+  value: any
+  /** Open/Close the requirements section. Opening it with focus is the default behavior */
+  open: boolean
+  /** Indicate whether `PasswordInput` is in error state */
+  error?: boolean
+  /** Duration for the collapse animation */
+  timeout?: number
+  /** Array of object to specify requirements. They will be executed */
+  requirements: FieldRequirement[]
+  testIds?: {
+    root?: string
+    description?: string
+    gridContainer?: string
+  }
+}
+
+const useStyles = makeStyles<Theme>(styles)
+
+export const FieldRequirements = forwardRef<HTMLDivElement, Props>(
+  function FieldRequirements(
+    {
+      value,
+      description,
+      open,
+      error,
+      timeout,
+      requirements,
+      className,
+      style,
+      testIds
+    }: Props,
+    ref
+  ) {
+    const classes = useStyles()
+
+    return (
+      <Collapse
+        ref={ref}
+        style={style}
+        className={className}
+        in={open}
+        timeout={timeout}
+        data-testid={testIds?.root}
+      >
+        {description && (
+          <Typography
+            data-testid={testIds?.description}
+            variant='body'
+            size='xxsmall'
+            className={classes.description}
+          >
+            {description}
+          </Typography>
+        )}
+        <Grid
+          className={classes.root}
+          spacing={0}
+          data-testid={testIds?.gridContainer}
+        >
+          {requirements.map(requirement => (
+            <FieldRequirementItem
+              key={requirement.message}
+              valid={requirement.validator(value)}
+              error={error}
+              data-testid={requirement['data-testid']}
+            >
+              {requirement.message}
+            </FieldRequirementItem>
+          ))}
+        </Grid>
+      </Collapse>
+    )
+  }
+)
+
+FieldRequirements.defaultProps = {
+  open: false,
+  timeout: 500
+}
+
+FieldRequirements.displayName = 'FieldRequirements'
+
+export default FieldRequirements

--- a/packages/picasso/src/FieldRequirements/FieldRequirements.tsx
+++ b/packages/picasso/src/FieldRequirements/FieldRequirements.tsx
@@ -8,15 +8,14 @@ import FieldRequirementItem, {
   FieldRequirementItemStatus
 } from './FieldRequirementItem'
 import Typography from '../Typography'
-import { FieldRequirement, ValueType } from './types'
+import { FieldRequirement } from './types'
 import Grid from '../Grid'
 
-export interface Props<TInputValue extends ValueType = ValueType>
-  extends BaseProps {
+export interface Props<TValueType> extends BaseProps {
   /** A string that defines the title of the requirement list */
   description?: string
   /** Value of the related input. It will be used to validate the requirements */
-  value: TInputValue
+  value?: TValueType
   /** Open/Close the requirements section. Opening it with focus is the default behavior */
   open: boolean
   /** Indicate whether `PasswordInput` is in error state */
@@ -24,7 +23,7 @@ export interface Props<TInputValue extends ValueType = ValueType>
   /** Duration for the collapse animation */
   timeout?: number
   /** Array of object to specify requirements. They will be executed */
-  requirements: FieldRequirement<TInputValue>[]
+  requirements: FieldRequirement<TValueType>[]
   testIds?: {
     root?: string
     description?: string
@@ -36,9 +35,7 @@ const ANIMATION_TIMEOUT = 500
 
 const useStyles = makeStyles<Theme>(styles)
 
-export const FieldRequirements = function <
-  TInputValue extends ValueType = ValueType
->({
+export const FieldRequirements = function<TValueType>({
   value,
   description,
   open,
@@ -48,7 +45,7 @@ export const FieldRequirements = function <
   className,
   style,
   testIds
-}: Props<TInputValue>) {
+}: Props<TValueType>) {
   const classes = useStyles()
 
   return (
@@ -77,7 +74,8 @@ export const FieldRequirements = function <
         {requirements.map(requirement => {
           let status: FieldRequirementItemStatus = 'default'
 
-          if (requirement.validator(value)) {
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+          if (requirement.validator(value!)) {
             status = 'success'
           } else if (error) {
             status = 'error'
@@ -100,7 +98,8 @@ export const FieldRequirements = function <
 
 FieldRequirements.defaultProps = {
   open: false,
-  timeout: ANIMATION_TIMEOUT
+  timeout: ANIMATION_TIMEOUT,
+  value: ''
 }
 
 FieldRequirements.displayName = 'FieldRequirements'

--- a/packages/picasso/src/FieldRequirements/FieldRequirements.tsx
+++ b/packages/picasso/src/FieldRequirements/FieldRequirements.tsx
@@ -4,7 +4,9 @@ import { Collapse } from '@material-ui/core'
 import { BaseProps } from '@toptal/picasso-shared'
 
 import styles from './styles'
-import FieldRequirementItem from './FieldRequirementItem'
+import FieldRequirementItem, {
+  FieldRequirementItemStatus
+} from './FieldRequirementItem'
 import Typography from '../Typography'
 import { FieldRequirement } from './types'
 import Grid from '../Grid'
@@ -72,16 +74,25 @@ export const FieldRequirements = forwardRef<HTMLDivElement, Props>(
           spacing={0}
           data-testid={testIds?.gridContainer}
         >
-          {requirements.map(requirement => (
-            <FieldRequirementItem
-              key={requirement.message}
-              valid={requirement.validator(value)}
-              error={error}
-              data-testid={requirement['data-testid']}
-            >
-              {requirement.message}
-            </FieldRequirementItem>
-          ))}
+          {requirements.map(requirement => {
+            let status: FieldRequirementItemStatus = 'default'
+
+            if (requirement.validator(value)) {
+              status = 'success'
+            } else if (error) {
+              status = 'error'
+            }
+
+            return (
+              <FieldRequirementItem
+                key={requirement.message}
+                status={status}
+                data-testid={requirement['data-testid']}
+              >
+                {requirement.message}
+              </FieldRequirementItem>
+            )
+          })}
         </Grid>
       </Collapse>
     )

--- a/packages/picasso/src/FieldRequirements/index.ts
+++ b/packages/picasso/src/FieldRequirements/index.ts
@@ -1,10 +1,9 @@
 import { OmitInternalProps } from '@toptal/picasso-shared'
 
 import { Props } from './FieldRequirements'
-import { ValueType } from './types'
 
 export { default } from './FieldRequirements'
 export * from './types'
-export type FieldRequirementsProps<
-  TInputType extends ValueType = ValueType
-> = OmitInternalProps<Props<TInputType>>
+export type FieldRequirementsProps<TValueType> = OmitInternalProps<
+  Props<TValueType>
+>

--- a/packages/picasso/src/FieldRequirements/index.ts
+++ b/packages/picasso/src/FieldRequirements/index.ts
@@ -1,7 +1,10 @@
 import { OmitInternalProps } from '@toptal/picasso-shared'
 
 import { Props } from './FieldRequirements'
+import { ValueType } from './types'
 
 export { default } from './FieldRequirements'
 export * from './types'
-export type FieldRequirementsProps = OmitInternalProps<Props>
+export type FieldRequirementsProps<
+  TInputType extends ValueType = ValueType
+> = OmitInternalProps<Props<TInputType>>

--- a/packages/picasso/src/FieldRequirements/index.ts
+++ b/packages/picasso/src/FieldRequirements/index.ts
@@ -1,0 +1,7 @@
+import { OmitInternalProps } from '@toptal/picasso-shared'
+
+import { Props } from './FieldRequirements'
+
+export { default } from './FieldRequirements'
+export * from './types'
+export type FieldRequirementsProps = OmitInternalProps<Props>

--- a/packages/picasso/src/FieldRequirements/story/Default.example.tsx
+++ b/packages/picasso/src/FieldRequirements/story/Default.example.tsx
@@ -9,7 +9,7 @@ const requirements: FieldRequirement[] = [
   },
   {
     message: 'Max 10 characters',
-    validator: value => value.length < 10
+    validator: value => value.length <= 10
   },
   { message: 'No space character', validator: value => !/\s/.test(value) }
 ]

--- a/packages/picasso/src/FieldRequirements/story/Default.example.tsx
+++ b/packages/picasso/src/FieldRequirements/story/Default.example.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react'
 import { Container, Input, FieldRequirements } from '@toptal/picasso'
 import type { FieldRequirement } from '@toptal/picasso'
 
-const requirements: FieldRequirement[] = [
+const requirements: FieldRequirement<string>[] = [
   {
     message: 'Min 5 characters',
     validator: value => value.length >= 5

--- a/packages/picasso/src/FieldRequirements/story/Default.example.tsx
+++ b/packages/picasso/src/FieldRequirements/story/Default.example.tsx
@@ -1,0 +1,40 @@
+import React, { useState } from 'react'
+import { Container, Input, FieldRequirements } from '@toptal/picasso'
+import type { FieldRequirement } from '@toptal/picasso'
+
+const requirements: FieldRequirement[] = [
+  {
+    message: 'Min 5 characters',
+    validator: value => value.length >= 5
+  },
+  {
+    message: 'Max 10 characters',
+    validator: value => value.length < 10
+  },
+  { message: 'No space character', validator: value => !/\s/.test(value) }
+]
+
+const Example = () => {
+  const [value, setValue] = useState('')
+  const [open, setOpen] = useState(false)
+
+  return (
+    <Container>
+      <Input
+        value={value}
+        onChange={event => setValue(event.target.value)}
+        onFocus={() => setOpen(true)}
+        onBlur={() => setOpen(false)}
+      />
+      <FieldRequirements
+        style={{ maxWidth: 300 }}
+        description='Please provide a value that fulfills the requirements'
+        open={open}
+        requirements={requirements}
+        value={value}
+      />
+    </Container>
+  )
+}
+
+export default Example

--- a/packages/picasso/src/FieldRequirements/story/Error.example.tsx
+++ b/packages/picasso/src/FieldRequirements/story/Error.example.tsx
@@ -1,0 +1,42 @@
+import React, { useState } from 'react'
+import { Container, Input, FieldRequirements } from '@toptal/picasso'
+import type { FieldRequirement } from '@toptal/picasso'
+
+const requirements: FieldRequirement[] = [
+  {
+    message: 'Min 5 characters',
+    validator: value => value.length >= 5
+  },
+  {
+    message: 'Max 10 characters',
+    validator: value => value.length < 10
+  },
+  { message: 'No space character', validator: value => !/\s/.test(value) }
+]
+
+const Example = () => {
+  const [value, setValue] = useState('')
+  const [open, setOpen] = useState(false)
+
+  return (
+    <Container>
+      <Input
+        error
+        value={value}
+        onChange={event => setValue(event.target.value)}
+        onFocus={() => setOpen(true)}
+        onBlur={() => setOpen(false)}
+      />
+      <FieldRequirements
+        error
+        style={{ maxWidth: 300 }}
+        description='Please provide a value that fulfills the requirements'
+        open={open}
+        requirements={requirements}
+        value={value}
+      />
+    </Container>
+  )
+}
+
+export default Example

--- a/packages/picasso/src/FieldRequirements/story/Error.example.tsx
+++ b/packages/picasso/src/FieldRequirements/story/Error.example.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react'
 import { Container, Input, FieldRequirements } from '@toptal/picasso'
 import type { FieldRequirement } from '@toptal/picasso'
 
-const requirements: FieldRequirement[] = [
+const requirements: FieldRequirement<string>[] = [
   {
     message: 'Min 5 characters',
     validator: value => value.length >= 5

--- a/packages/picasso/src/FieldRequirements/story/Error.example.tsx
+++ b/packages/picasso/src/FieldRequirements/story/Error.example.tsx
@@ -1,6 +1,10 @@
 import React, { useState } from 'react'
-import { Container, Input, FieldRequirements } from '@toptal/picasso'
-import type { FieldRequirement } from '@toptal/picasso'
+import {
+  Container,
+  Input,
+  FieldRequirements,
+  FieldRequirement
+} from '@toptal/picasso'
 
 const requirements: FieldRequirement<string>[] = [
   {
@@ -9,7 +13,7 @@ const requirements: FieldRequirement<string>[] = [
   },
   {
     message: 'Max 10 characters',
-    validator: value => value.length < 10
+    validator: value => value.length <= 10
   },
   { message: 'No space character', validator: value => !/\s/.test(value) }
 ]

--- a/packages/picasso/src/FieldRequirements/story/index.jsx
+++ b/packages/picasso/src/FieldRequirements/story/index.jsx
@@ -1,0 +1,16 @@
+import { FieldRequirements } from '../FieldRequirements'
+import PicassoBook from '~/.storybook/components/PicassoBook'
+
+const page = PicassoBook.section('Components').createPage(
+  'FieldRequirements',
+  'Component to list field requirements to be valid'
+)
+
+page
+  .createTabChapter('Props')
+  .addComponentDocs({ component: FieldRequirements, name: 'FieldRequirements' })
+
+page
+  .createChapter()
+  .addExample('FieldRequirements/story/Default.example.tsx', 'Default') // picasso-skip-visuals
+  .addExample('FieldRequirements/story/Error.example.tsx', 'Error') // picasso-skip-visuals

--- a/packages/picasso/src/FieldRequirements/styles.ts
+++ b/packages/picasso/src/FieldRequirements/styles.ts
@@ -1,0 +1,20 @@
+import { createStyles, Theme } from '@material-ui/core/styles'
+
+export default ({ palette, spacing, sizes: { input } }: Theme) =>
+  createStyles({
+    root: {
+      display: 'flex',
+      width: input.width
+    },
+    description: {
+      marginTop: '0.4rem'
+    },
+    fieldRequirementItem: {
+      display: 'flex',
+      alignItems: 'center',
+      color: palette.grey.main2
+    },
+    fieldRequirementItemMessage: {
+      marginLeft: spacing(1)
+    }
+  })

--- a/packages/picasso/src/FieldRequirements/test.tsx
+++ b/packages/picasso/src/FieldRequirements/test.tsx
@@ -53,19 +53,19 @@ describe('FieldRequirements', () => {
       <FieldRequirements open value='asd1' requirements={requirements} />
     )
 
-    const requirement1ValidIcon = getByTestId('requirement-1-valid-icon')
+    const requirement1SuccessIcon = getByTestId('requirement-1-success-icon')
 
     expect(requirement1DefaultIcon).not.toBeVisible()
-    expect(requirement1ValidIcon).toBeVisible()
+    expect(requirement1SuccessIcon).toBeVisible()
 
     rerender(
       <FieldRequirements open value='asd1A' requirements={requirements} />
     )
 
-    const requirement2ValidIcon = getByTestId('requirement-2-valid-icon')
+    const requirement2SuccessIcon = getByTestId('requirement-2-success-icon')
 
     expect(requirement2DefaultIcon).not.toBeVisible()
-    expect(requirement2ValidIcon).toBeVisible()
+    expect(requirement2SuccessIcon).toBeVisible()
   })
 
   it('renders error state', () => {
@@ -94,18 +94,18 @@ describe('FieldRequirements', () => {
       <FieldRequirements open value='asd1' requirements={requirements} />
     )
 
-    const requirement1ValidIcon = getByTestId('requirement-1-valid-icon')
+    const requirement1SuccessIcon = getByTestId('requirement-1-success-icon')
 
     expect(requirement1ErrorIcon).not.toBeVisible()
-    expect(requirement1ValidIcon).toBeVisible()
+    expect(requirement1SuccessIcon).toBeVisible()
 
     rerender(
       <FieldRequirements open value='asd1A' requirements={requirements} />
     )
 
-    const requirement2ValidIcon = getByTestId('requirement-2-valid-icon')
+    const requirement2SuccessIcon = getByTestId('requirement-2-success-icon')
 
     expect(requirement2ErrorIcon).not.toBeVisible()
-    expect(requirement2ValidIcon).toBeVisible()
+    expect(requirement2SuccessIcon).toBeVisible()
   })
 })

--- a/packages/picasso/src/FieldRequirements/test.tsx
+++ b/packages/picasso/src/FieldRequirements/test.tsx
@@ -5,7 +5,7 @@ import { OmitInternalProps } from '@toptal/picasso-shared'
 import FieldRequirements, { Props } from './FieldRequirements'
 import { FieldRequirement, ValueType } from './types'
 
-const renderFieldRequirements = function <TInputValue extends ValueType>(
+const renderFieldRequirements = function<TInputValue extends ValueType>(
   children: ReactNode,
   props: OmitInternalProps<Props<TInputValue>>
 ) {
@@ -45,11 +45,11 @@ describe('FieldRequirements', () => {
       value: 'asd',
       testIds: {
         root: 'root',
-        gridContainer: 'gridContainer'
+        gridContainer: 'grid-container'
       }
     })
 
-    const gridContainer = getByTestId('gridContainer')
+    const gridContainer = getByTestId('grid-container')
 
     expect(gridContainer).toBeInTheDocument()
 
@@ -86,11 +86,11 @@ describe('FieldRequirements', () => {
       value: 'asd',
       testIds: {
         root: 'root',
-        gridContainer: 'gridContainer'
+        gridContainer: 'grid-container'
       }
     })
 
-    const gridContainer = getByTestId('gridContainer')
+    const gridContainer = getByTestId('grid-container')
 
     expect(gridContainer).toBeInTheDocument()
 

--- a/packages/picasso/src/FieldRequirements/test.tsx
+++ b/packages/picasso/src/FieldRequirements/test.tsx
@@ -3,16 +3,18 @@ import { render } from '@toptal/picasso/test-utils'
 import { OmitInternalProps } from '@toptal/picasso-shared'
 
 import FieldRequirements, { Props } from './FieldRequirements'
-import { FieldRequirement } from './types'
+import { FieldRequirement, ValueType } from './types'
 
-const renderFieldRequirements = (
+const renderFieldRequirements = function <TInputValue extends ValueType>(
   children: ReactNode,
-  props: OmitInternalProps<Props>
-) => {
-  return render(<FieldRequirements {...props}>{children}</FieldRequirements>)
+  props: OmitInternalProps<Props<TInputValue>>
+) {
+  return render(
+    <FieldRequirements<TInputValue> {...props}>{children}</FieldRequirements>
+  )
 }
 
-const requirements: FieldRequirement[] = [
+const requirements: FieldRequirement<string>[] = [
   {
     message: 'At least one number',
     validator: (value: string) => /\d/.test(value),

--- a/packages/picasso/src/FieldRequirements/test.tsx
+++ b/packages/picasso/src/FieldRequirements/test.tsx
@@ -1,0 +1,109 @@
+import React, { ReactNode } from 'react'
+import { render } from '@toptal/picasso/test-utils'
+import { OmitInternalProps } from '@toptal/picasso-shared'
+
+import FieldRequirements, { Props } from './FieldRequirements'
+import { FieldRequirement } from './types'
+
+const renderFieldRequirements = (
+  children: ReactNode,
+  props: OmitInternalProps<Props>
+) => {
+  return render(<FieldRequirements {...props}>{children}</FieldRequirements>)
+}
+
+const requirements: FieldRequirement[] = [
+  {
+    message: 'At least one number',
+    validator: (value: string) => /\d/.test(value),
+    'data-testid': 'requirement-1'
+  },
+  {
+    message: 'At least one uppercase character',
+    validator: (value: string) => /[A-Z]/.test(value),
+    'data-testid': 'requirement-2'
+  }
+]
+
+describe('FieldRequirements', () => {
+  it('default render', () => {
+    const { getByTestId, rerender } = renderFieldRequirements(null, {
+      requirements,
+      open: true,
+      value: 'asd',
+      testIds: {
+        root: 'root',
+        gridContainer: 'gridContainer'
+      }
+    })
+
+    const gridContainer = getByTestId('gridContainer')
+
+    expect(gridContainer).toBeInTheDocument()
+
+    const requirement1DefaultIcon = getByTestId('requirement-1-default-icon')
+    const requirement2DefaultIcon = getByTestId('requirement-2-default-icon')
+
+    expect(requirement1DefaultIcon).toBeVisible()
+    expect(requirement2DefaultIcon).toBeVisible()
+
+    rerender(
+      <FieldRequirements open value='asd1' requirements={requirements} />
+    )
+
+    const requirement1ValidIcon = getByTestId('requirement-1-valid-icon')
+
+    expect(requirement1DefaultIcon).not.toBeVisible()
+    expect(requirement1ValidIcon).toBeVisible()
+
+    rerender(
+      <FieldRequirements open value='asd1A' requirements={requirements} />
+    )
+
+    const requirement2ValidIcon = getByTestId('requirement-2-valid-icon')
+
+    expect(requirement2DefaultIcon).not.toBeVisible()
+    expect(requirement2ValidIcon).toBeVisible()
+  })
+
+  it('renders error state', () => {
+    const { getByTestId, rerender } = renderFieldRequirements(null, {
+      requirements,
+      open: true,
+      error: true,
+      value: 'asd',
+      testIds: {
+        root: 'root',
+        gridContainer: 'gridContainer'
+      }
+    })
+
+    const gridContainer = getByTestId('gridContainer')
+
+    expect(gridContainer).toBeInTheDocument()
+
+    const requirement1ErrorIcon = getByTestId('requirement-1-error-icon')
+    const requirement2ErrorIcon = getByTestId('requirement-2-error-icon')
+
+    expect(requirement1ErrorIcon).toBeVisible()
+    expect(requirement2ErrorIcon).toBeVisible()
+
+    rerender(
+      <FieldRequirements open value='asd1' requirements={requirements} />
+    )
+
+    const requirement1ValidIcon = getByTestId('requirement-1-valid-icon')
+
+    expect(requirement1ErrorIcon).not.toBeVisible()
+    expect(requirement1ValidIcon).toBeVisible()
+
+    rerender(
+      <FieldRequirements open value='asd1A' requirements={requirements} />
+    )
+
+    const requirement2ValidIcon = getByTestId('requirement-2-valid-icon')
+
+    expect(requirement2ErrorIcon).not.toBeVisible()
+    expect(requirement2ValidIcon).toBeVisible()
+  })
+})

--- a/packages/picasso/src/FieldRequirements/test.tsx
+++ b/packages/picasso/src/FieldRequirements/test.tsx
@@ -18,12 +18,22 @@ const requirements: FieldRequirement<string>[] = [
   {
     message: 'At least one number',
     validator: (value: string) => /\d/.test(value),
-    'data-testid': 'requirement-1'
+    testIds: {
+      root: 'requirement-1',
+      defaultIcon: 'requirement-1-default-icon',
+      successIcon: 'requirement-1-success-icon',
+      errorIcon: 'requirement-1-error-icon'
+    }
   },
   {
     message: 'At least one uppercase character',
     validator: (value: string) => /[A-Z]/.test(value),
-    'data-testid': 'requirement-2'
+    testIds: {
+      root: 'requirement-2',
+      defaultIcon: 'requirement-2-default-icon',
+      successIcon: 'requirement-2-success-icon',
+      errorIcon: 'requirement-2-error-icon'
+    }
   }
 ]
 

--- a/packages/picasso/src/FieldRequirements/test.tsx
+++ b/packages/picasso/src/FieldRequirements/test.tsx
@@ -3,9 +3,9 @@ import { render } from '@toptal/picasso/test-utils'
 import { OmitInternalProps } from '@toptal/picasso-shared'
 
 import FieldRequirements, { Props } from './FieldRequirements'
-import { FieldRequirement, ValueType } from './types'
+import { FieldRequirement } from './types'
 
-const renderFieldRequirements = function<TInputValue extends ValueType>(
+const renderFieldRequirements = function<TInputValue>(
   children: ReactNode,
   props: OmitInternalProps<Props<TInputValue>>
 ) {

--- a/packages/picasso/src/FieldRequirements/types.ts
+++ b/packages/picasso/src/FieldRequirements/types.ts
@@ -1,5 +1,22 @@
-export interface FieldRequirement {
+import { Item } from '../Autocomplete'
+import { DateOrDateRangeType } from '../Calendar'
+import { FileUpload } from '../FileInput'
+
+// copied from FieldWrapper to be consistent
+export type ValueType =
+  | string
+  | string[]
+  | number
+  | boolean
+  | null
+  | undefined
+  | FileUpload[]
+  | DateOrDateRangeType
+  | Item
+  | Item[]
+
+export interface FieldRequirement<TInputType extends ValueType = ValueType> {
   message: string
-  validator: (value: any) => boolean
+  validator: (value: TInputType) => boolean
   'data-testid'?: string
 }

--- a/packages/picasso/src/FieldRequirements/types.ts
+++ b/packages/picasso/src/FieldRequirements/types.ts
@@ -1,23 +1,6 @@
-import { Item } from '../Autocomplete'
-import { DateOrDateRangeType } from '../Calendar'
-import { FileUpload } from '../FileInput'
-
-// copied from FieldWrapper to be consistent
-export type ValueType =
-  | string
-  | string[]
-  | number
-  | boolean
-  | null
-  | undefined
-  | FileUpload[]
-  | DateOrDateRangeType
-  | Item
-  | Item[]
-
-export interface FieldRequirement<TInputType extends ValueType = ValueType> {
+export interface FieldRequirement<TValueType> {
   message: string
-  validator: (value: TInputType) => boolean
+  validator: (value: TValueType) => boolean
   testIds?: {
     root?: string
     successIcon?: string

--- a/packages/picasso/src/FieldRequirements/types.ts
+++ b/packages/picasso/src/FieldRequirements/types.ts
@@ -1,0 +1,5 @@
+export interface FieldRequirement {
+  message: string
+  validator: (value: any) => boolean
+  'data-testid'?: string
+}

--- a/packages/picasso/src/FieldRequirements/types.ts
+++ b/packages/picasso/src/FieldRequirements/types.ts
@@ -18,5 +18,10 @@ export type ValueType =
 export interface FieldRequirement<TInputType extends ValueType = ValueType> {
   message: string
   validator: (value: TInputType) => boolean
-  'data-testid'?: string
+  testIds?: {
+    root?: string
+    successIcon?: string
+    errorIcon?: string
+    defaultIcon?: string
+  }
 }

--- a/packages/picasso/src/FormField/FormField.tsx
+++ b/packages/picasso/src/FormField/FormField.tsx
@@ -14,6 +14,8 @@ export interface Props extends BaseProps, HTMLAttributes<HTMLDivElement> {
   error?: string
   /** The content of the Form.Field */
   children: ReactNode
+  /** Field requirements for this specific field */
+  fieldRequirements?: ReactNode
 }
 
 const useStyles = makeStyles<Theme>(styles, { name: 'PicassoFormField' })
@@ -22,7 +24,15 @@ export const FormField = forwardRef<HTMLDivElement, Props>(function FormField(
   props,
   ref
 ) {
-  const { className, style, hint, children, error, ...rest } = props
+  const {
+    className,
+    style,
+    hint,
+    children,
+    error,
+    fieldRequirements,
+    ...rest
+  } = props
 
   const classes = useStyles()
 
@@ -37,6 +47,7 @@ export const FormField = forwardRef<HTMLDivElement, Props>(function FormField(
       {children}
       {error && <FormError className={classes.error}>{error}</FormError>}
       {hint && <FormHint className={classes.hint}>{hint}</FormHint>}
+      {fieldRequirements}
     </div>
   )
 })

--- a/packages/picasso/src/PasswordInput/PasswordInput.tsx
+++ b/packages/picasso/src/PasswordInput/PasswordInput.tsx
@@ -66,7 +66,7 @@ export const PasswordInput = forwardRef<HTMLInputElement, Props>(
         <Button.Circular
           className={classes.toggle}
           variant='flat'
-          icon={showPassword ? <SvgEyeHidden16 /> : <SvgEye16 />}
+          icon={showPassword ? <SvgEye16 /> : <SvgEyeHidden16 />}
           onClick={handleToggleVisibilityClick}
           data-testid={rest.testIds?.toggle}
           disabled={disabled}

--- a/packages/picasso/src/index.ts
+++ b/packages/picasso/src/index.ts
@@ -194,8 +194,7 @@ export type { PasswordInputProps } from './PasswordInput'
 export { default as FieldRequirements } from './FieldRequirements'
 export type {
   FieldRequirementsProps,
-  FieldRequirement,
-  ValueType as FieldRequirementValueType
+  FieldRequirement
 } from './FieldRequirements'
 
 // hygen code generator inserts export statements above this comment.

--- a/packages/picasso/src/index.ts
+++ b/packages/picasso/src/index.ts
@@ -192,7 +192,11 @@ export type { RatingThumbsProps } from './RatingThumbs'
 export { default as PasswordInput } from './PasswordInput'
 export type { PasswordInputProps } from './PasswordInput'
 export { default as FieldRequirements } from './FieldRequirements'
-export type { FieldRequirementsProps, FieldRequirement } from './FieldRequirements'
+export type {
+  FieldRequirementsProps,
+  FieldRequirement,
+  ValueType as FieldRequirementValueType
+} from './FieldRequirements'
 
 // hygen code generator inserts export statements above this comment.
 export * from './Icon'

--- a/packages/picasso/src/index.ts
+++ b/packages/picasso/src/index.ts
@@ -191,6 +191,8 @@ export type { RichTextProps, ASTType } from './RichText'
 export type { RatingThumbsProps } from './RatingThumbs'
 export { default as PasswordInput } from './PasswordInput'
 export type { PasswordInputProps } from './PasswordInput'
+export { default as FieldRequirements } from './FieldRequirements'
+export type { FieldRequirementsProps, FieldRequirement } from './FieldRequirements'
 
 // hygen code generator inserts export statements above this comment.
 export * from './Icon'


### PR DESCRIPTION
[FX-2525]

### Description

- FieldRequirements: added a new component
- forms/PasswordInput: now supporting FieldRequirements as default but it can be hidden with `hideRequirements` (ex: confirm password field)
- I had to touch `FormField` and `FieldWrapper` so please share your considerations for the future

### How to test

- PasswordInput: https://picasso.toptal.net/fx-2525-add-strength-validations-section-to-passwordinput/?path=/story/forms-passwordinput--passwordinput
- FieldRequirements: https://picasso.toptal.net/fx-2525-add-strength-validations-section-to-passwordinput/?path=/story/components-fieldrequirements--fieldrequirements
- Form version(bottom of the page): https://picasso.toptal.net/fx-2525-add-strength-validations-section-to-passwordinput/?path=/story/picasso-forms-form--form

### Screenshots

<img width="505" alt="Screen Shot 2022-03-01 at 10 26 32" src="https://user-images.githubusercontent.com/7733167/156124045-ac08bd75-9044-4611-8b1c-aafd19305350.png">
<img width="505" alt="Screen Shot 2022-03-01 at 10 26 46" src="https://user-images.githubusercontent.com/7733167/156124051-c4742b90-f7e6-4bc9-b644-35a95b986bf4.png">
<img width="505" alt="Screen Shot 2022-03-01 at 10 27 02" src="https://user-images.githubusercontent.com/7733167/156124053-270d5351-d54c-43d4-95fc-1f66c00a681e.png">

### Review

- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure that tests pass by running `yarn test`
- [x] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
- [ ] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-2525]: https://toptal-core.atlassian.net/browse/FX-2525?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ