### PR TITLE
fix(RichTextEditor): reset toolbar format on blur

### DIFF
--- a/packages/picasso/src/QuillEditor/hooks/useDefaultValue/test.ts
+++ b/packages/picasso/src/QuillEditor/hooks/useDefaultValue/test.ts
@@ -37,7 +37,7 @@ describe('useDefaultValue', () => {
 
     expect(quill.clipboard.convert).toHaveBeenCalledWith(defaultValue)
     expect(quill.clipboard.convert).toHaveBeenCalledTimes(1)
-    expect(quill.setContents).toHaveBeenCalledWith(deltaMock, 'silent')
+    expect(quill.setContents).toHaveBeenCalledWith(deltaMock, 'api')
     expect(quill.setContents).toHaveBeenCalledTimes(1)
     rerender()
     expect(quill.clipboard.convert).toHaveBeenCalledTimes(1)

--- a/packages/picasso/src/QuillEditor/hooks/useDefaultValue/useDefaultValue.tsx
+++ b/packages/picasso/src/QuillEditor/hooks/useDefaultValue/useDefaultValue.tsx
@@ -20,7 +20,7 @@ const useDefaultValue = ({ defaultValue, quill }: Props) => {
       defaultValue
     )
 
-    quill.setContents(delta, 'silent')
+    quill.setContents(delta, 'api')
     hasBeenCalled.current = true
   }, [defaultValue, quill])
 }

--- a/packages/picasso/src/QuillEditor/hooks/useSubscribeToQuillEvents/test.ts
+++ b/packages/picasso/src/QuillEditor/hooks/useSubscribeToQuillEvents/test.ts
@@ -22,21 +22,26 @@ describe('useSubscribeToQuillEvents', () => {
       })
     )
 
-    expect(quill.on).toHaveBeenCalledTimes(4)
+    expect(quill.on).toHaveBeenCalledTimes(5)
     expect(quill.on).toHaveBeenCalledWith(
       'selection-change',
       expect.any(Function)
     )
     expect(quill.on).toHaveBeenCalledWith('text-change', expect.any(Function))
+    expect(quill.on).toHaveBeenCalledWith('editor-change', expect.any(Function))
     expect(quill.off).not.toHaveBeenCalled()
 
     unmount()
 
-    expect(quill.off).toHaveBeenCalledTimes(4)
+    expect(quill.off).toHaveBeenCalledTimes(5)
     expect(quill.off).toHaveBeenCalledWith(
       'selection-change',
       expect.any(Function)
     )
     expect(quill.off).toHaveBeenCalledWith('text-change', expect.any(Function))
+    expect(quill.off).toHaveBeenCalledWith(
+      'editor-change',
+      expect.any(Function)
+    )
   })
 })

--- a/packages/picasso/src/RichTextEditor/hooks/useOnFocus/test.ts
+++ b/packages/picasso/src/RichTextEditor/hooks/useOnFocus/test.ts
@@ -201,10 +201,13 @@ describe('useOnFocus', () => {
         handleBlur(mockEvent)
       })
 
-      expect(hookOptions.dispatch).toHaveBeenCalledTimes(1)
+      expect(hookOptions.dispatch).toHaveBeenCalledTimes(2)
       expect(hookOptions.dispatch).toHaveBeenCalledWith({
         payload: true,
         type: toolbarActionTypes.disabled
+      })
+      expect(hookOptions.dispatch).toHaveBeenCalledWith({
+        type: toolbarActionTypes.resetFormat
       })
       expect(hookOptions.onBlur).toHaveBeenCalledTimes(1)
       expect(hookOptions.onFocus).not.toHaveBeenCalled()

--- a/packages/picasso/src/RichTextEditor/hooks/useOnFocus/useOnFocus.tsx
+++ b/packages/picasso/src/RichTextEditor/hooks/useOnFocus/useOnFocus.tsx
@@ -59,9 +59,10 @@ const useOnFocus = ({
       ) {
         return
       }
-      console.log(focusElement)
 
       toolbarActions.setDisabled(dispatch)(true)
+
+      toolbarActions.resetFormat(dispatch)()
       onBlur()
     },
     [dispatch, onBlur, toolbarRef, editorRef, wrapperRef]

--- a/packages/picasso/src/RichTextEditor/store/toolbar/actionTypes.ts
+++ b/packages/picasso/src/RichTextEditor/store/toolbar/actionTypes.ts
@@ -3,7 +3,8 @@ const actionTypes = {
   header: 'TOOLBAR/SET_HEADER',
   italic: 'TOOLBAR/SET_ITALIC',
   list: 'TOOLBAR/SET_LIST',
-  disabled: 'TOOLBAR/SET_DISABLED'
+  disabled: 'TOOLBAR/SET_DISABLED',
+  resetFormat: 'TOOLBAR/RESET_FORMAT'
 } as const
 
 export default actionTypes

--- a/packages/picasso/src/RichTextEditor/store/toolbar/actions.ts
+++ b/packages/picasso/src/RichTextEditor/store/toolbar/actions.ts
@@ -6,7 +6,8 @@ import {
   SetHeaderActionType,
   SetItalicActionType,
   SetListActionType,
-  SetDisabled
+  SetDisabled,
+  ResetFormatType
 } from './types'
 
 const setBold = (dispatch: Dispatch<SetBoldActionType>) => (
@@ -28,12 +29,16 @@ const setList = (dispatch: Dispatch<SetListActionType>) => (
 const setDisabled = (dispatch: Dispatch<SetDisabled>) => (payload: boolean) =>
   dispatch({ type: actionTypes.disabled, payload })
 
+const resetFormat = (dispatch: Dispatch<ResetFormatType>) => () =>
+  dispatch({ type: actionTypes.resetFormat })
+
 const actions = {
   setBold,
   setItalic,
   setHeader,
   setList,
-  setDisabled
+  setDisabled,
+  resetFormat
 }
 
 export default actions

--- a/packages/picasso/src/RichTextEditor/store/toolbar/reducer.ts
+++ b/packages/picasso/src/RichTextEditor/store/toolbar/reducer.ts
@@ -31,6 +31,12 @@ const reducer: ToolbarReducerType = (state = initialState, action) => {
         disabled: action.payload
       }
 
+    case actionTypes.resetFormat:
+      return {
+        ...state,
+        format: initialState.format
+      }
+
     default:
       return state
   }

--- a/packages/picasso/src/RichTextEditor/store/toolbar/types.ts
+++ b/packages/picasso/src/RichTextEditor/store/toolbar/types.ts
@@ -42,12 +42,17 @@ export type SetDisabled = {
   payload: boolean
 }
 
+export type ResetFormatType = {
+  type: typeof actionTypes.resetFormat
+}
+
 export type ToolbarActionsType =
   | SetBoldActionType
   | SetItalicActionType
   | SetListActionType
   | SetHeaderActionType
   | SetDisabled
+  | ResetFormatType
 
 export type ToolbarReducerType = (
   state: ToolbarStateType | undefined,

--- a/packages/picasso/src/RichTextEditorToolbar/RichTextEditorToolbar.tsx
+++ b/packages/picasso/src/RichTextEditorToolbar/RichTextEditorToolbar.tsx
@@ -44,7 +44,7 @@ export const RichTextEditorToolbar = forwardRef<HTMLDivElement, Props>(
         <Container className={classes.group}>
           <Select
             onChange={onHeaderChange}
-            value={disabled ? '' : format.header}
+            value={format.header}
             options={[
               { value: '3', text: 'heading' },
               { value: '', text: 'normal' }
@@ -59,13 +59,13 @@ export const RichTextEditorToolbar = forwardRef<HTMLDivElement, Props>(
           <TextEditorButton
             icon={<Bold16 />}
             onClick={onBoldClick}
-            active={disabled ? false : format.bold}
+            active={format.bold}
             disabled={disabled}
           />
           <TextEditorButton
             icon={<Italic16 />}
             onClick={onItalicClick}
-            active={disabled ? false : format.italic}
+            active={format.italic}
             disabled={disabled}
           />
         </Container>
@@ -73,13 +73,13 @@ export const RichTextEditorToolbar = forwardRef<HTMLDivElement, Props>(
           <TextEditorButton
             icon={<ListUnordered16 />}
             onClick={onUnorderedClick}
-            active={disabled ? false : format.list === 'bullet'}
+            active={format.list === 'bullet'}
             disabled={disabled}
           />
           <TextEditorButton
             icon={<ListOrdered16 />}
             onClick={onOrderedClick}
-            active={disabled ? false : format.list === 'ordered'}
+            active={format.list === 'ordered'}
             disabled={disabled}
           />
         </Container>


### PR DESCRIPTION
[FX-2536]

### Description

Simply put, we need to reset the state of the toolbar on blur

**Reproducing steps:**
1. Write two lines of text to the editor
2. Format second line as header
3. Keep cursor in heading and click outside of the editor
4. The toolbar is disabled and in a default state
5. Click into first line without formatting

**Current:**
- For a moment we can see the previous format, so it makes the weird effect

**Expected:**
- On the last step in reproducing steps, we will not see the old value

![error showcase](https://user-images.githubusercontent.com/6830426/156359873-029b5e2a-339c-4f26-b338-f019b5b1ca0c.gif)


### Review

- [ ] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [ ] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that tests pass by running `yarn test`
- [ ] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
- [ ] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
6. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
7. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-2536]: https://toptal-core.atlassian.net/browse/FX-2536?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ