### PR TITLE
feat(Link): changed color for visited links

### DIFF
--- a/.changeset/angry-eels-doubt.md
+++ b/.changeset/angry-eels-doubt.md
@@ -1,0 +1,8 @@
+---
+'@toptal/picasso': minor
+---
+
+---
+### Link
+
+- Aligned color for visited state with BASE. Changed to `#6727cf`

--- a/cypress/component/Colors.spec.tsx
+++ b/cypress/component/Colors.spec.tsx
@@ -1,0 +1,16 @@
+import React from 'react'
+import { mount } from '@cypress/react'
+import { TestingPicasso } from '@toptal/picasso/test-utils'
+import Colors from '@toptal/picasso/utils/Colors/story/Default.example'
+
+describe('Colors palette', () => {
+  it('renders palette', () => {
+    mount(
+      <TestingPicasso>
+        <Colors />
+      </TestingPicasso>
+    )
+
+    cy.get('body').happoScreenshot()
+  })
+})

--- a/cypress/component/Link.spec.tsx
+++ b/cypress/component/Link.spec.tsx
@@ -10,7 +10,7 @@ import {
 import { mount } from '@cypress/react'
 import { TestingPicasso } from '@toptal/picasso/test-utils'
 
-const DARKER_BLUE = 'rgb(103, 39, 207)'
+const PURPLE_MAIN = 'rgb(103, 39, 207)'
 const GREY = 'rgb(196, 198, 202)'
 
 const TestUserBadgeLink = () => {
@@ -210,7 +210,7 @@ describe('Link', () => {
       cy.get('[data-testid="blue-link"]').should(
         'have.css',
         'color',
-        DARKER_BLUE
+        PURPLE_MAIN
       )
 
       cy.get('[data-testid="white-link"]').should('have.css', 'color', GREY)

--- a/cypress/component/Link.spec.tsx
+++ b/cypress/component/Link.spec.tsx
@@ -10,7 +10,7 @@ import {
 import { mount } from '@cypress/react'
 import { TestingPicasso } from '@toptal/picasso/test-utils'
 
-const DARKER_BLUE = 'rgb(15, 37, 110)'
+const DARKER_BLUE = 'rgb(103, 39, 207)'
 const GREY = 'rgb(196, 198, 202)'
 
 const TestUserBadgeLink = () => {

--- a/packages/picasso-provider/src/Picasso/config/palette.ts
+++ b/packages/picasso-provider/src/Picasso/config/palette.ts
@@ -18,6 +18,7 @@ declare module '@material-ui/core/styles/createPalette' {
     green: SimplePaletteColorOptions
     yellow: SimplePaletteColorOptions
     red: SimplePaletteColorOptions
+    purple: SimplePaletteColorOptions
   }
 }
 
@@ -57,6 +58,9 @@ export const colors = {
     main: '#00cc83',
     dark: '#03b080',
     darker: '#05947c'
+  },
+  purple: {
+    main: '#6727cf'
   },
   common: {
     black: '#000',

--- a/packages/picasso/src/Link/styles.ts
+++ b/packages/picasso/src/Link/styles.ts
@@ -43,7 +43,7 @@ export default ({ typography, palette }: Theme) =>
     visited: {},
     blue: {
       '&:visited, &$visited': {
-        color: palette.blue.darker
+        color: '#6727cf'
       }
     },
     white: {

--- a/packages/picasso/src/Link/styles.ts
+++ b/packages/picasso/src/Link/styles.ts
@@ -43,7 +43,7 @@ export default ({ typography, palette }: Theme) =>
     visited: {},
     blue: {
       '&:visited, &$visited': {
-        color: '#6727cf'
+        color: palette.purple.main
       }
     },
     white: {

--- a/packages/picasso/src/utils/Colors/index.ts
+++ b/packages/picasso/src/utils/Colors/index.ts
@@ -1,0 +1,1 @@
+export { default } from './story/Default.example'

--- a/packages/picasso/src/utils/Colors/story/index.jsx
+++ b/packages/picasso/src/utils/Colors/story/index.jsx
@@ -11,4 +11,4 @@ const page = PicassoBook.section('Utils').createPage(
 page
   .createChapter()
   .addExample('utils/Colors/story/HowToUse.example.tsx', 'How to use') // picasso-skip-visuals
-  .addExample('utils/Colors/story/Default.example.tsx', 'Colors')
+  .addExample('utils/Colors/story/Default.example.tsx', 'Colors') // picasso-skip-visuals


### PR DESCRIPTION
[FX-2539]

### Description

Aligned color for visited state with [BASE](https://www.figma.com/file/q2nvjiyO2CLqBv4DeJnU3i/Product-Library-Documentation?node-id=218%3A4060). Changed to `#6727cf`

### How to test

- open [Link component in storybook](https://picasso.toptal.net/fx-2539-typography-change-color-for-visited-links/?path=/story/components-link--link) and click on a default link

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| ![image](https://user-images.githubusercontent.com/22159416/156577982-1e07223b-971d-4094-9813-40fd594c51fc.png) | ![image](https://user-images.githubusercontent.com/22159416/156578055-7da44be9-d466-4eab-b72e-14a59e9f2dad.png) |

### Review

- [ ] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [ ] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that tests pass by running `yarn test`
- [ ] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
- [ ] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-2539]: https://toptal-core.atlassian.net/browse/FX-2539?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ