### PR TITLE
fix(RichTextEditor): keep the correct state of toolbar

### DIFF
--- a/packages/picasso/src/QuillEditor/utils/getEditorChangeHandler/getEditorChangeHandler.tsx
+++ b/packages/picasso/src/QuillEditor/utils/getEditorChangeHandler/getEditorChangeHandler.tsx
@@ -6,6 +6,27 @@ import { FormatType } from '../../types'
 type SelectionChangeArgs = [RangeStatic, RangeStatic, Sources]
 type TextChangeArgs = [Delta, Delta, Sources]
 
+// When we write heading and enter new line, we have normal text format.
+// We need to send this information to the state
+const handleNewLineAfterHeader = ({
+  quill,
+  onSelectionChange,
+  latestDelta
+}: {
+  quill: Quill
+  onSelectionChange: (format: FormatType) => void
+  latestDelta: Delta
+}) => {
+  const isHeaderFormatRemoved =
+    latestDelta.ops[latestDelta.ops.length - 1]?.attributes?.header === null
+
+  if (isHeaderFormatRemoved) {
+    const format = quill.getFormat() as FormatType
+
+    onSelectionChange({ ...format, header: undefined })
+  }
+}
+
 const getEditorChangeHandler = (
   quill: Quill,
   onSelectionChange: (format: FormatType) => void
@@ -15,26 +36,19 @@ const getEditorChangeHandler = (
     ...args: SelectionChangeArgs | TextChangeArgs
   ) => {
     if (name === 'text-change') {
-      const [, , source] = args as TextChangeArgs
-      // this event is triggered when format of block element is changed
-      // for example from p > h3 | h3 > ol
+      const [latestDelta, , source] = args as TextChangeArgs
+
       const isFromApi = source === 'api'
+      const isFromUser = source === 'user'
 
-      if (!isFromApi) {
-        return
+      if (isFromApi) {
+        // this event is triggered when format of block element is changed
+        // for example from p > h3 | h3 > ol
+        onSelectionChange(quill.getFormat() as FormatType)
       }
-      const format = quill.getFormat() as FormatType
 
-      onSelectionChange(format)
-    }
-
-    if (name === 'selection-change') {
-      const [range, , source] = args as SelectionChangeArgs
-
-      if (source === 'silent') {
-        const format = quill.getFormat(range || undefined) as FormatType
-
-        onSelectionChange(format)
+      if (isFromUser) {
+        handleNewLineAfterHeader({ latestDelta, quill, onSelectionChange })
       }
     }
   }

--- a/packages/picasso/src/RichTextEditor/RichTextEditor.tsx
+++ b/packages/picasso/src/RichTextEditor/RichTextEditor.tsx
@@ -69,6 +69,11 @@ export interface Props extends BaseProps {
   testIds?: {
     wrapper?: string
     editor?: string
+    headerSelect?: string
+    boldButton?: string
+    italicButton?: string
+    unorderedListButton?: string
+    orderedListButton?: string
   }
 }
 
@@ -178,6 +183,13 @@ export const RichTextEditor = forwardRef<HTMLDivElement, Props>(
           onUnorderedClick={handleUnordered}
           onOrderedClick={handleOrdered}
           onHeaderChange={handleHeader}
+          testIds={{
+            headerSelect: testIds?.headerSelect,
+            boldButton: testIds?.boldButton,
+            italicButton: testIds?.italicButton,
+            unorderedListButton: testIds?.unorderedListButton,
+            orderedListButton: testIds?.orderedListButton
+          }}
         />
         <QuillEditor
           ref={editorRef}

--- a/packages/picasso/src/RichTextEditor/hooks/useToolbarHandlers/useToolbarHandlers.tsx
+++ b/packages/picasso/src/RichTextEditor/hooks/useToolbarHandlers/useToolbarHandlers.tsx
@@ -73,7 +73,9 @@ const useToolbarHandlers = ({ editorRef, handleTextFormat, format }: Props) => {
   const handleHeader: SelectOnChangeHandler = event => {
     const header = convertHeaderToEditorValue(event.target.value)
 
-    sendFormatEvent({ header })
+    sendFormatEvent(
+      header ? { header, bold: false, italic: false } : { header }
+    )
     handleTextFormat({
       formatName: 'header',
       value: header

--- a/packages/picasso/src/RichTextEditorToolbar/RichTextEditorToolbar.tsx
+++ b/packages/picasso/src/RichTextEditorToolbar/RichTextEditorToolbar.tsx
@@ -13,6 +13,13 @@ type Props = {
   disabled: boolean
   id: string
   format: FormatType
+  testIds?: {
+    headerSelect?: string
+    boldButton?: string
+    italicButton?: string
+    unorderedListButton?: string
+    orderedListButton?: string
+  }
   onBoldClick: ButtonHandlerType
   onItalicClick: ButtonHandlerType
   onHeaderChange: SelectOnChangeHandler
@@ -34,10 +41,12 @@ export const RichTextEditorToolbar = forwardRef<HTMLDivElement, Props>(
       onItalicClick,
       onHeaderChange,
       onUnorderedClick,
-      onOrderedClick
+      onOrderedClick,
+      testIds
     } = props
 
     const classes = useStyles(props)
+    const isHeadingFormat = format.header === '3'
 
     return (
       <Container id={`${id}toolbar`} ref={ref} className={classes.toolbar}>
@@ -53,20 +62,23 @@ export const RichTextEditorToolbar = forwardRef<HTMLDivElement, Props>(
             menuWidth='123px'
             className={classes.select}
             disabled={disabled}
+            data-testid={testIds?.headerSelect}
           />
         </Container>
         <Container className={classes.group}>
           <TextEditorButton
             icon={<Bold16 />}
             onClick={onBoldClick}
-            active={format.bold}
-            disabled={disabled}
+            active={isHeadingFormat ? false : format.bold}
+            disabled={isHeadingFormat || disabled}
+            data-testid={testIds?.boldButton}
           />
           <TextEditorButton
             icon={<Italic16 />}
             onClick={onItalicClick}
-            active={format.italic}
-            disabled={disabled}
+            active={isHeadingFormat ? false : format.italic}
+            disabled={isHeadingFormat || disabled}
+            data-testid={testIds?.italicButton}
           />
         </Container>
         <Container className={classes.group}>
@@ -75,12 +87,14 @@ export const RichTextEditorToolbar = forwardRef<HTMLDivElement, Props>(
             onClick={onUnorderedClick}
             active={format.list === 'bullet'}
             disabled={disabled}
+            data-testid={testIds?.unorderedListButton}
           />
           <TextEditorButton
             icon={<ListOrdered16 />}
             onClick={onOrderedClick}
             active={format.list === 'ordered'}
             disabled={disabled}
+            data-testid={testIds?.orderedListButton}
           />
         </Container>
       </Container>

--- a/packages/picasso/src/index.ts
+++ b/packages/picasso/src/index.ts
@@ -83,8 +83,8 @@ export type { PromptModalProps } from './PromptModal'
 export { default as Radio } from './Radio'
 export type { RadioProps } from './Radio'
 export type { RadioGroupProps } from './RadioGroup'
-export { default as RichTextEditor } from '../../picasso/src/RichTextEditor'
-export type { RichTextEditorProps, RichTextEditorChangeHandler } from '../../picasso/src/RichTextEditor'
+export { default as RichTextEditor } from './RichTextEditor'
+export type { RichTextEditorProps, RichTextEditorChangeHandler } from './RichTextEditor'
 export { default as Select } from './Select'
 export type {
   SelectProps,


### PR DESCRIPTION
[FX-2293]

### Description

https://user-images.githubusercontent.com/6830426/156837288-0c70c588-5b32-4115-9762-f996cc4219fa.mp4

The problem is, when entering a new line, there is a `silent selection-change` event, which we were listening to update the state of the toolbar. This doesn't work correctly, because when we ask quill for currently applied formats, it always says it is empty. Which is correct for the header, but not for formats of inline text.

We need both these scenarios to work:

**Scenario 1 - heading**
1. Write `Hello world`
2. Apply heading format
3. Press Enter

**expected** - The value of the select box in the toolbar is `normal`

**Scenario 2 - inline text formats**
1. Click the bold button
2. Write `Hello world`
3. Press Enter

**expected** - The bold button in the toolbar is active

### How to test

- Try both scenarios in the storybook


### Review

- [ ] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [ ] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that tests pass by running `yarn test`
- [ ] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
- [ ] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
5. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
5. Acceptance criteria is not reached.
6. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
6. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>
