### PR TITLE
test: add test for removing all formats

### DIFF
--- a/cypress/component/RichTextEditor.spec.tsx
+++ b/cypress/component/RichTextEditor.spec.tsx
@@ -39,13 +39,13 @@ const renderEditor = (props: RichTextEditorProps) => (
 const buttonShouldBeActive = (
   button: Cypress.Chainable<JQuery<HTMLButtonElement>>
 ) => {
-  button.should('have.css', 'background-color').and('eq', 'rgb(69, 80, 101)')
+  button.should('have.attr', 'class').and('include', 'activeButton')
 }
 
 const buttonShouldNotBeActive = (
   button: Cypress.Chainable<JQuery<HTMLButtonElement>>
 ) => {
-  button.should('have.css', 'background-color').and('eq', 'rgba(0, 0, 0, 0)')
+  button.should('have.attr', 'class').and('not.include', 'activeButton')
 }
 
 describe('RichTextEditor', () => {
@@ -73,8 +73,12 @@ describe('RichTextEditor', () => {
     // test bold
     cy.get('@editor').type('{ctrl}b')
     buttonShouldBeActive(cy.get('@boldButton'))
-    cy.get('@editor').type(content.bold).type('{enter}')
-    cy.contains(content.bold).should('have.css', 'font-weight').and('eq', '600')
+    cy.get('@editor')
+      .type(content.bold)
+      .type('{enter}')
+    cy.contains(content.bold)
+      .parent()
+      .should('include.html', 'strong')
 
     // test bold italic
     cy.get('@editor').type('{ctrl}i')
@@ -83,12 +87,10 @@ describe('RichTextEditor', () => {
 
     cy.get('@editor').type(content.bold_italic)
     cy.contains(content.bold_italic)
-      .as('boldItalicText')
-      .should('have.css', 'font-weight')
-      .and('eq', '600')
-    cy.get('@boldItalicText')
-      .should('have.css', 'font-style')
-      .and('eq', 'italic')
+      .parent()
+      .should('include.html', 'em')
+      .parent()
+      .should('include.html', 'strong')
 
     // test italic
     cy.get('@editor').type('{ctrl}b')
@@ -97,8 +99,8 @@ describe('RichTextEditor', () => {
     buttonShouldBeActive(cy.get('@italicButton'))
 
     cy.contains(content.italic)
-      .should('have.css', 'font-style')
-      .and('eq', 'italic')
+      .parent()
+      .should('include.html', 'em')
   })
 
   it('formats text correctly when changed in toolbar', () => {
@@ -124,7 +126,9 @@ describe('RichTextEditor', () => {
 
     cy.get('@editor').realClick()
     cy.get('@headerSelect').realClick()
-    cy.get('span').contains('heading').realClick()
+    cy.get('span')
+      .contains('heading')
+      .realClick()
     cy.get('@editor').realType('Heading text{enter}')
 
     cy.get('@editor').realType('normal text{enter}')
@@ -165,13 +169,17 @@ describe('RichTextEditor', () => {
       // add heading to editor
       cy.get('@editor').realClick()
       cy.get('@headerSelect').realClick()
-      cy.get('span').contains('heading').realClick()
+      cy.get('span')
+        .contains('heading')
+        .realClick()
       cy.get('@editor').type('Heading example{enter}')
 
       // remove all
       cy.get('@editor').type('{selectall}{del}')
       cy.get('.ql-blank').should('exist')
-      cy.get('@headerSelect').find('input').should('have.value', 'normal')
+      cy.get('@headerSelect')
+        .find('input')
+        .should('have.value', 'normal')
     })
 
     it('removes lists', () => {
@@ -195,9 +203,6 @@ describe('RichTextEditor', () => {
       // remove all
       cy.get('@editor').type('{selectall}{del}')
 
-      // move mouse from ol button
-      cy.get('@editor').realHover()
-
       cy.get('.ql-blank').should('exist')
       buttonShouldNotBeActive(cy.get('@olButton'))
       buttonShouldNotBeActive(cy.get('@boldButton'))
@@ -216,11 +221,15 @@ describe('RichTextEditor', () => {
       // add heading to editor
       cy.get('@editor').realClick()
       cy.get('@headerSelect').realClick()
-      cy.get('span').contains('heading').realClick()
+      cy.get('span')
+        .contains('heading')
+        .realClick()
       cy.get('@editor').type('Heading example{enter}')
 
       // on new line we have unformatted text
-      cy.get('@headerSelect').find('input').should('have.value', 'normal')
+      cy.get('@headerSelect')
+        .find('input')
+        .should('have.value', 'normal')
     })
     it('removes list', () => {
       // render editor
@@ -234,7 +243,6 @@ describe('RichTextEditor', () => {
       // add ul
       cy.get('@editor').realClick()
       cy.get('@ulButton').realClick()
-      cy.get('@editor').realHover()
       // first enter triggers new line with list item, another enter removes the format
       cy.get('@editor').type('list item{enter}{enter}')
       buttonShouldNotBeActive(cy.get('@ulButton'))
@@ -242,7 +250,6 @@ describe('RichTextEditor', () => {
       // add ol
       cy.get('@editor').realClick()
       cy.get('@olButton').realClick()
-      cy.get('@editor').realHover()
       // first enter triggers new line with list item, another enter removes the format
       cy.get('@editor').type('list item{enter}{enter}')
       buttonShouldNotBeActive(cy.get('@olButton'))
@@ -258,7 +265,6 @@ describe('RichTextEditor', () => {
       // add bold to editor
       cy.get('@editor').realClick()
       cy.get('@boldButton').realClick()
-      cy.get('@editor').realHover()
       cy.get('@editor').type('Button example{enter}')
 
       // on new line we have bold format preserved


### PR DESCRIPTION
[FX-2541]

### Description

Test to cover this already [solved bug](https://toptal-core.atlassian.net/browse/FX-2505)

It adds formatted text than CTRL + A; DEL. Everything should be removed even formats.

During writing the first test I figured that we introduced back already solved bug, so I fixed it and handled it too.

When we are using block format and enter new empty line, format should disappear. But for inline formats we should preserve it.

**Reproducing steps:**

**First scenario:**
1. Enter some heading
2. Press enter

**expected:** `normal` text **should be** selected in the Toolbar

**Second scenario:**

1. Enter any list item
2. Press enter (new list item should appear)
3. Press enter (new list item should be removed)

**expected:** list **should not be** active the Toolbar

**Third scenario:**

1. Enter bold text
2. Press enter

**expected:** Bold **should be** active in the Toolbar


 

### Review

- [ ] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [ ] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that tests pass by running `yarn test`
- [ ] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
- [ ] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
5. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
4. Acceptance criteria is not reached.
6. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
4. You have an opinionated comment regarding the code that requires a discussion.
5. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
5. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-2541]: https://toptal-core.atlassian.net/browse/FX-2541?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ