### PR TITLE
feat(ratingthumbs): add rating thumbs to picasso forms

### DIFF
--- a/.changeset/cyan-games-relax.md
+++ b/.changeset/cyan-games-relax.md
@@ -1,0 +1,9 @@
+---
+'@toptal/picasso-forms': minor
+---
+
+---
+
+### Form.Rating.Thumbs
+
+- Add missing Rating.Thumbs as Form.Rating.Thumbs

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "test:cypress:open": "yarn build:package && yarn test:setup cypress open-ct",
     "test:setup": "cross-env TZ=UTC NODE_ENV=test",
     "test:unit": "yarn test:setup jest",
+    "test:unit:debug": "yarn test:setup cross-env NODE_OPTIONS=--inspect-brk jest",
     "test:unit:ci": "yarn test:unit --maxWorkers=4 --ci",
     "test:unit:watch": "yarn test:unit --watch",
     "test:visual": "./bin/run-in-docker ./bin/test-visual",

--- a/packages/picasso-forms/src/Form/story/Default.example.tsx
+++ b/packages/picasso-forms/src/Form/story/Default.example.tsx
@@ -154,6 +154,11 @@ const Example = () => {
         label='How much do you love Picasso?'
         required
       />
+      <Form.Rating.Thumbs
+        name='thumbs'
+        label='Would you recommend picasso?'
+        required
+      />
       <Form.FileInput
         required
         name='avatar'

--- a/packages/picasso-forms/src/Form/story/TitleCase.example.tsx
+++ b/packages/picasso-forms/src/Form/story/TitleCase.example.tsx
@@ -136,6 +136,11 @@ const Example = () => {
         label='How much do you love Picasso?'
         required
       />
+      <Form.Rating.Thumbs
+        name='thumbs1'
+        label='Would you recommend picasso?'
+        required
+      />
       <Form.FileInput
         titleCase
         required

--- a/packages/picasso-forms/src/Rating/Rating.tsx
+++ b/packages/picasso-forms/src/Rating/Rating.tsx
@@ -1,7 +1,8 @@
 import React from 'react'
 import {
   Rating as PicassoRating,
-  RatingStarsProps as PicassoRatingStarsProps
+  RatingStarsProps as PicassoRatingStarsProps,
+  RatingThumbsProps as PicassoRatingThumbsProps
 } from '@toptal/picasso'
 
 import FieldWrapper, { FieldProps } from '../FieldWrapper'
@@ -15,8 +16,18 @@ const Stars = (props: RatingStarsProps) => (
   </FieldWrapper>
 )
 
+export type RatingThumbsProps = PicassoRatingThumbsProps &
+  FieldProps<PicassoRatingThumbsProps['value']>
+
+const Thumbs = (props: RatingThumbsProps) => (
+  <FieldWrapper<PicassoRatingThumbsProps> {...props}>
+    {inputProps => <PicassoRating.Thumbs {...inputProps} />}
+  </FieldWrapper>
+)
+
 export const Rating = {
-  Stars
+  Stars,
+  Thumbs
 }
 
 export default Rating

--- a/packages/picasso-forms/src/Rating/test.tsx
+++ b/packages/picasso-forms/src/Rating/test.tsx
@@ -1,0 +1,129 @@
+import React, { ComponentProps } from 'react'
+import { render, fireEvent } from '@toptal/picasso/test-utils'
+
+import Form from '../Form'
+
+let defaultOnSubmit: jest.Mock = jest.fn()
+
+enum TestId {
+  SUBMIT_BUTTON = 'submit-button',
+  POSITIVE_THUMB = 'positive-thumb',
+  NEGATIVE_THUMB = 'negative-thumb'
+}
+
+const renderThumbsForm = (
+  props: {
+    form?: Partial<ComponentProps<typeof Form>>
+    thumbs?: Partial<ComponentProps<typeof Form['Rating']['Thumbs']>>
+  } = {}
+) =>
+  render(
+    <Form onSubmit={defaultOnSubmit} {...props.form}>
+      <Form.Rating.Thumbs
+        name='thumbs'
+        testIds={{
+          positiveInput: TestId.POSITIVE_THUMB,
+          negativeInput: TestId.NEGATIVE_THUMB
+        }}
+        {...props.thumbs}
+      />
+
+      <button type='submit' data-testid={TestId.SUBMIT_BUTTON}>
+        Submit
+      </button>
+    </Form>
+  )
+
+describe('Rating', () => {
+  beforeEach(() => {
+    defaultOnSubmit = jest.fn()
+  })
+
+  describe('Thumbs', () => {
+    describe('when submitting while required', () => {
+      it("don't show a validation error for negative values", () => {
+        const { getByTestId, queryByText } = renderThumbsForm({
+          thumbs: { required: true }
+        })
+
+        fireEvent.click(getByTestId(TestId.NEGATIVE_THUMB))
+        fireEvent.click(getByTestId(TestId.SUBMIT_BUTTON))
+
+        expect(
+          queryByText('Please complete this field.')
+        ).not.toBeInTheDocument()
+
+        expect(defaultOnSubmit).toHaveBeenCalledWith(
+          { thumbs: false },
+          expect.anything(),
+          expect.anything()
+        )
+        expect(defaultOnSubmit).toHaveBeenCalledTimes(1)
+      })
+    })
+
+    describe('when submitting with custom validation', () => {
+      it('validate both required when having a custom validation with preference', () => {
+        const ERROR_MSG = 'Errata'
+        const { getByTestId, queryByText } = renderThumbsForm({
+          thumbs: { required: true, validate: () => ERROR_MSG }
+        })
+
+        fireEvent.click(getByTestId(TestId.SUBMIT_BUTTON))
+
+        expect(queryByText('Please complete this field.')).toBeInTheDocument()
+
+        expect(defaultOnSubmit).toHaveBeenCalledTimes(0)
+      })
+
+      it('validate both required and having a custom validation', () => {
+        const ERROR_MSG = 'Errata'
+        const { getByTestId, queryByText } = renderThumbsForm({
+          thumbs: { required: true, validate: () => ERROR_MSG }
+        })
+
+        fireEvent.click(getByTestId(TestId.NEGATIVE_THUMB))
+        fireEvent.click(getByTestId(TestId.SUBMIT_BUTTON))
+
+        expect(queryByText(ERROR_MSG)).toBeInTheDocument()
+
+        expect(defaultOnSubmit).toHaveBeenCalledTimes(0)
+      })
+
+      it('validate both required and having a custom validation, everythin ok', () => {
+        const { getByTestId, queryByText } = renderThumbsForm({
+          thumbs: { required: true, validate: () => undefined }
+        })
+
+        fireEvent.click(getByTestId(TestId.NEGATIVE_THUMB))
+        fireEvent.click(getByTestId(TestId.SUBMIT_BUTTON))
+
+        expect(
+          queryByText('Please complete this field.')
+        ).not.toBeInTheDocument()
+
+        expect(defaultOnSubmit).toHaveBeenCalledWith(
+          { thumbs: false },
+          expect.anything(),
+          expect.anything()
+        )
+        expect(defaultOnSubmit).toHaveBeenCalledTimes(1)
+      })
+    })
+
+    describe('when submitting with requiredPositive true', () => {
+      it("don't allow a negative value", () => {
+        const { getByTestId, queryByText } = renderThumbsForm({
+          thumbs: { requirePositive: true }
+        })
+
+        fireEvent.click(getByTestId(TestId.NEGATIVE_THUMB))
+        fireEvent.click(getByTestId(TestId.SUBMIT_BUTTON))
+
+        expect(queryByText('Please complete this field.')).toBeInTheDocument()
+
+        expect(defaultOnSubmit).toHaveBeenCalledTimes(0)
+      })
+    })
+  })
+})


### PR DESCRIPTION
[FX-2538](https://toptal-core.atlassian.net/browse/FX-2538)

### Description

Add the a component wrapper of `Rating.Thumbs` to `picasso-forms`, and some story examples as well

### How to test

- Go to the [storybook](https://picasso.toptal.net/fx-2538-add-rating-thumbs-to-picasso-forms/?path=/story/picasso-forms-form--form) and check out the code and functionality

### Screenshots

![image](https://user-images.githubusercontent.com/5845160/157166071-9893a805-dea2-483d-afd2-2e35d5c6ab0e.png)

### Review

- [ ] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [ ] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that tests pass by running `yarn test`
- [ ] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
- [ ] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>
