### PR TITLE
test(RichTextEditor): inline formats are disabled when heading is active

### DIFF
--- a/cypress/component/RichTextEditor.spec.tsx
+++ b/cypress/component/RichTextEditor.spec.tsx
@@ -321,4 +321,25 @@ describe('RichTextEditor', () => {
         .and('not.include', 'focused')
     })
   })
+
+  describe('toolbar', () => {
+    it('disables bold and italic when header format is active', () => {
+      mount(renderEditor(defaultProps))
+      setAliases()
+
+      cy.get('@editor').realClick()
+
+      setSelectValue(cy.get('@headerSelect'), 'heading')
+      cy.get('@boldButton').should('have.attr', 'disabled')
+      cy.get('@italicButton').should('have.attr', 'disabled')
+      cy.get('@ulButton').should('not.have.attr', 'disabled')
+      cy.get('@olButton').should('not.have.attr', 'disabled')
+
+      setSelectValue(cy.get('@headerSelect'), 'normal')
+      cy.get('@boldButton').should('not.have.attr', 'disabled')
+      cy.get('@italicButton').should('not.have.attr', 'disabled')
+      cy.get('@ulButton').should('not.have.attr', 'disabled')
+      cy.get('@olButton').should('not.have.attr', 'disabled')
+    })
+  })
 })

--- a/cypress/component/RichTextEditor.spec.tsx
+++ b/cypress/component/RichTextEditor.spec.tsx
@@ -1,6 +1,8 @@
 /* eslint-disable promise/catch-or-return */
 /* eslint-disable promise/always-return */
 /* eslint-disable max-statements */
+/* eslint-disable max-nested-callbacks */
+/* eslint-disable max-lines-per-function */
 import React from 'react'
 import { mount } from '@cypress/react'
 import { RichTextEditor, RichTextEditorProps, Container } from '@toptal/picasso'
@@ -340,6 +342,24 @@ describe('RichTextEditor', () => {
       cy.get('@italicButton').should('not.have.attr', 'disabled')
       cy.get('@ulButton').should('not.have.attr', 'disabled')
       cy.get('@olButton').should('not.have.attr', 'disabled')
+    })
+
+    it.only('does not open selectbox on click when toolbar is disabled', () => {
+      mount(renderEditor(defaultProps))
+      setAliases()
+
+      cy.on('fail', error => {
+        expect(error.message).to.include('prevents user mouse interaction')
+      })
+
+      cy.get('@headerSelect')
+        .find('input')
+        .should('have.attr', 'disabled')
+      cy.get('@headerSelect').click({ timeout: 100 })
+      // the click should not open select but just simply trigger focus on whole editor
+      cy.get('@headerSelect')
+        .find('input')
+        .should('not.have.attr', 'disabled')
     })
   })
 })


### PR DESCRIPTION
[FX-2541]

### Description

Test that bold and italic buttons are disabled when the heading format is active.

### Review

- [ ] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [ ] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that tests pass by running `yarn test`
- [ ] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
- [ ] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-2541]: https://toptal-core.atlassian.net/browse/FX-2541?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ