### PR TITLE
feat(RichTextEditor): return empty string when no content

### DIFF
--- a/packages/picasso/src/QuillEditor/utils/getTextChangeHandler/getTextChangeHandler.tsx
+++ b/packages/picasso/src/QuillEditor/utils/getTextChangeHandler/getTextChangeHandler.tsx
@@ -14,6 +14,14 @@ const getTextChangeHandler = (
       return
     }
 
+    const isEmpty = quill.getLength() === 1
+
+    if (isEmpty) {
+      handleTextChange('')
+
+      return
+    }
+
     const [cleanValue] = [quill.root.innerHTML]
       .map(removeCursorSpan)
       .map(removeClasses)

--- a/packages/picasso/src/QuillEditor/utils/getTextChangeHandler/test.ts
+++ b/packages/picasso/src/QuillEditor/utils/getTextChangeHandler/test.ts
@@ -25,7 +25,8 @@ describe('getTextChangeHandler', () => {
     const quill = ({
       root: {
         innerHTML: '<p class="foo">bar</p>'
-      }
+      },
+      getLength: jest.fn(() => 4)
     } as unknown) as Quill
     const handleTextChange = jest.fn()
     const handler = getTextChangeHandler(quill, handleTextChange)
@@ -34,5 +35,23 @@ describe('getTextChangeHandler', () => {
 
     expect(handleTextChange).toHaveBeenCalledWith('<p>bar</p>')
     expect(handleTextChange).toHaveBeenCalledTimes(1)
+  })
+
+  describe('when content is removed', () => {
+    it('returns empty string', () => {
+      const quill = ({
+        root: {
+          innerHTML: '<p><br></p>'
+        },
+        getLength: jest.fn(() => 1)
+      } as unknown) as Quill
+      const handleTextChange = jest.fn()
+      const handler = getTextChangeHandler(quill, handleTextChange)
+
+      act(() => handler(mockDelta, mockDelta, 'user'))
+
+      expect(handleTextChange).toHaveBeenCalledWith('')
+      expect(handleTextChange).toHaveBeenCalledTimes(1)
+    })
   })
 })


### PR DESCRIPTION
[FX-2549]

### Description

When we remove content from the editor, we should provide empty value, so `required` validation could work properly (done in different task)

**Reproducing steps:**

1. write any text in the editor
2. remove all the text

**expected:**

- value is `''`

**current:**

- value is `<p><br></p>`

### How to test

- Checkout storybook and try to follow reproducing steps.

### Review

- [ ] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [ ] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that tests pass by running `yarn test`
- [ ] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
- [ ] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
3. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
4. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-2549]: https://toptal-core.atlassian.net/browse/FX-2549?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ