### PR TITLE
chore: extract label from field wrapper

### DIFF
--- a/packages/picasso-forms/src/Autocomplete/Autocomplete.tsx
+++ b/packages/picasso-forms/src/Autocomplete/Autocomplete.tsx
@@ -5,12 +5,25 @@ import {
 } from '@toptal/picasso'
 
 import { FieldProps } from '../FieldWrapper'
+import FieldLabel from '../FieldLabel'
 import InputFieldWrapper from '../InputFieldWrapper'
 
 export type Props = AutocompleteProps & FieldProps<AutocompleteProps['value']>
 
 export const Autocomplete = (props: Props) => (
-  <InputFieldWrapper<AutocompleteProps> {...props}>
+  <InputFieldWrapper<AutocompleteProps>
+    {...props}
+    label={
+      props.label ? (
+        <FieldLabel
+          id={props.id}
+          required={props.required}
+          label={props.label}
+          titleCase={props.titleCase}
+        />
+      ) : null
+    }
+  >
     {(inputProps: AutocompleteProps) => {
       return <PicassoAutocomplete {...inputProps} />
     }}

--- a/packages/picasso-forms/src/ButtonCheckbox/ButtonCheckbox.tsx
+++ b/packages/picasso-forms/src/ButtonCheckbox/ButtonCheckbox.tsx
@@ -41,7 +41,6 @@ const ButtonCheckbox = ({ name, value, required, ...restProps }: Props) => {
   return (
     <FieldWrapper
       type='checkbox'
-      hideFieldLabel
       required={required}
       {...restProps}
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion

--- a/packages/picasso-forms/src/Checkbox/Checkbox.tsx
+++ b/packages/picasso-forms/src/Checkbox/Checkbox.tsx
@@ -51,7 +51,6 @@ export const Checkbox = ({
   return (
     <FieldWrapper
       type='checkbox'
-      hideFieldLabel
       required={required}
       {...restProps}
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion

--- a/packages/picasso-forms/src/CheckboxGroup/CheckboxGroup.tsx
+++ b/packages/picasso-forms/src/CheckboxGroup/CheckboxGroup.tsx
@@ -7,6 +7,7 @@ import {
 } from '@toptal/picasso'
 
 import FieldWrapper, { FieldProps } from '../FieldWrapper'
+import FieldLabel from '../FieldLabel'
 import CheckboxGroupContext from './CheckboxGroupContext'
 
 export type Props = CheckboxGroupProps & FieldProps<CheckboxProps['value']>
@@ -16,7 +17,21 @@ export const CheckboxGroup = (props: Props) => {
 
   return (
     <CheckboxGroupContext.Provider value={props.name}>
-      <FieldWrapper titleCase={titleCase} {...rest} type='checkbox'>
+      <FieldWrapper
+        titleCase={titleCase}
+        {...rest}
+        type='checkbox'
+        label={
+          props.label ? (
+            <FieldLabel
+              id={props.id}
+              required={props.required}
+              label={props.label}
+              titleCase={props.titleCase}
+            />
+          ) : null
+        }
+      >
         {() => (
           <PicassoCheckbox.Group {...rest}>{children}</PicassoCheckbox.Group>
         )}

--- a/packages/picasso-forms/src/DatePicker/DatePicker.tsx
+++ b/packages/picasso-forms/src/DatePicker/DatePicker.tsx
@@ -6,6 +6,7 @@ import {
 
 import { FieldProps } from '../FieldWrapper'
 import InputFieldWrapper from '../InputFieldWrapper'
+import FieldLabel from '../FieldLabel'
 
 export type FormDatePickerProps = Omit<DatePickerProps, 'onChange'> & {
   onChange?: DatePickerProps['onChange']
@@ -13,7 +14,17 @@ export type FormDatePickerProps = Omit<DatePickerProps, 'onChange'> & {
 export type Props = FormDatePickerProps & FieldProps<DatePickerProps['value']>
 
 export const DatePicker = (props: Props) => (
-  <InputFieldWrapper<FormDatePickerProps> {...props}>
+  <InputFieldWrapper<FormDatePickerProps>
+    {...props}
+    label={
+      <FieldLabel
+        id={props.id}
+        required={props.required}
+        label={props.label}
+        titleCase={props.titleCase}
+      />
+    }
+  >
     {(inputProps: DatePickerProps) => {
       return <PicassoDatePicker {...inputProps} />
     }}

--- a/packages/picasso-forms/src/Dropzone/Dropzone.tsx
+++ b/packages/picasso-forms/src/Dropzone/Dropzone.tsx
@@ -4,6 +4,7 @@ import { FileUpload } from '@toptal/picasso/FileInput'
 import { FieldInputProps as FinalFieldInputProps } from 'react-final-form'
 
 import FieldWrapper, { FieldProps } from '../FieldWrapper'
+import FieldLabel from '../FieldLabel'
 
 export type Props = DropzoneProps &
   FieldProps<DropzoneProps['value']> & {
@@ -54,6 +55,14 @@ const Dropzone = ({ dropzoneHint, ...props }: Props) => {
     <FieldWrapper<DropzoneProps, FileUpload[] | undefined>
       hideErrors
       {...props}
+      label={
+        <FieldLabel
+          id={props.id}
+          required={props.required}
+          label={props.label}
+          titleCase={props.titleCase}
+        />
+      }
     >
       {inputProps => (
         <PicassoDropzone

--- a/packages/picasso-forms/src/FieldLabel/FieldLabel.tsx
+++ b/packages/picasso-forms/src/FieldLabel/FieldLabel.tsx
@@ -1,0 +1,55 @@
+import React from 'react'
+import { Form as PicassoForm, RequiredDecoration } from '@toptal/picasso'
+
+import { useFormConfig, RequiredVariant } from '../FormConfig'
+
+export type Props = {
+  id?: string
+  label?: string
+  required?: boolean
+  titleCase?: boolean
+}
+
+const getRequiredDecoration = (
+  required?: boolean,
+  requiredVariant?: RequiredVariant
+): RequiredDecoration | undefined => {
+  const showAsterisk = required && requiredVariant === 'asterisk'
+
+  if (showAsterisk) {
+    return 'asterisk'
+  }
+
+  const showOptional =
+    !required && (!requiredVariant || requiredVariant === 'default')
+
+  if (showOptional) {
+    return 'optional'
+  }
+}
+
+const FieldLabel = (props: Props) => {
+  const { label, required, titleCase, id } = props
+
+  const formConfig = useFormConfig()
+  const requiredDecoration = getRequiredDecoration(
+    required,
+    formConfig.requiredVariant
+  )
+
+  return (
+    <PicassoForm.Label
+      requiredDecoration={requiredDecoration}
+      htmlFor={id}
+      titleCase={titleCase}
+    >
+      {label}
+    </PicassoForm.Label>
+  )
+}
+
+FieldLabel.defaultProps = {}
+
+FieldLabel.displayName = 'FieldLabel'
+
+export default FieldLabel

--- a/packages/picasso-forms/src/FieldLabel/FieldLabel.tsx
+++ b/packages/picasso-forms/src/FieldLabel/FieldLabel.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { Form as PicassoForm, RequiredDecoration } from '@toptal/picasso'
+import { TextLabelProps } from '@toptal/picasso-shared'
 
 import { useFormConfig, RequiredVariant } from '../FormConfig'
 
@@ -7,8 +8,7 @@ export type Props = {
   id?: string
   label?: string
   required?: boolean
-  titleCase?: boolean
-}
+} & TextLabelProps
 
 const getRequiredDecoration = (
   required?: boolean,

--- a/packages/picasso-forms/src/FieldLabel/__snapshots__/test.tsx.snap
+++ b/packages/picasso-forms/src/FieldLabel/__snapshots__/test.tsx.snap
@@ -1,0 +1,21 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`FieldLabel renders default field label 1`] = `
+<div>
+  <div
+    class="Picasso-root"
+  >
+    <label
+      class="PicassoFormLabel-root"
+      for="id"
+    >
+      <span
+        class="PicassoFormLabel-medium"
+      >
+        label
+         (optional)
+      </span>
+    </label>
+  </div>
+</div>
+`;

--- a/packages/picasso-forms/src/FieldLabel/index.ts
+++ b/packages/picasso-forms/src/FieldLabel/index.ts
@@ -1,0 +1,2 @@
+export { default } from './FieldLabel'
+export * from './FieldLabel'

--- a/packages/picasso-forms/src/FieldLabel/test.tsx
+++ b/packages/picasso-forms/src/FieldLabel/test.tsx
@@ -1,0 +1,52 @@
+import React from 'react'
+import { render } from '@toptal/picasso/test-utils'
+
+import Form from '../Form'
+import FieldLabel from './FieldLabel'
+
+describe('FieldLabel', () => {
+  it('renders default field label', () => {
+    const { container } = render(<FieldLabel id='id' label='label' />)
+
+    expect(container).toMatchSnapshot()
+  })
+
+  describe('optional required variant', () => {
+    it('renders label with optional mark', () => {
+      const { queryByText } = render(<FieldLabel id='id' label='label' />)
+
+      expect(queryByText('label (optional)')).toBeInTheDocument()
+    })
+
+    it('renders label without optional mark', () => {
+      const { queryByText } = render(
+        <FieldLabel id='id' label='label' required />
+      )
+
+      expect(queryByText('label (optional)')).not.toBeInTheDocument()
+      expect(queryByText('label')).toBeInTheDocument()
+    })
+  })
+
+  describe('asterisk required variant', () => {
+    it('renders label without asterisk', () => {
+      const { queryByText } = render(
+        <Form.ConfigProvider value={{ requiredVariant: 'asterisk' }}>
+          <FieldLabel id='id' label='label' />
+        </Form.ConfigProvider>
+      )
+
+      expect(queryByText('*')).not.toBeInTheDocument()
+    })
+
+    it('renders label with asterisk', () => {
+      const { queryByText } = render(
+        <Form.ConfigProvider value={{ requiredVariant: 'asterisk' }}>
+          <FieldLabel id='id' label='label' required />
+        </Form.ConfigProvider>
+      )
+
+      expect(queryByText('*')).toBeInTheDocument()
+    })
+  })
+})

--- a/packages/picasso-forms/src/FieldWrapper/FieldWrapper.tsx
+++ b/packages/picasso-forms/src/FieldWrapper/FieldWrapper.tsx
@@ -7,7 +7,6 @@ import {
 } from 'react-final-form'
 import {
   Form as PicassoForm,
-  RequiredDecoration,
   DateOrDateRangeType,
   OutlinedInputStatus
 } from '@toptal/picasso'
@@ -16,7 +15,7 @@ import { FileUpload } from '@toptal/picasso/FileInput'
 import { TextLabelProps } from '@toptal/picasso-shared'
 
 import { useFormContext } from '../Form/FormContext'
-import { useFormConfig, FormConfigProps, RequiredVariant } from '../FormConfig'
+import { useFormConfig, FormConfigProps } from '../FormConfig'
 import { validators } from '../utils'
 
 const { composeValidators, required: requiredValidator } = validators
@@ -52,10 +51,10 @@ export type Props<
   TextLabelProps & {
     name: string
     type?: string
-    hideFieldLabel?: boolean
-    hideLabelRequiredDecoration?: boolean
+    label?: React.ReactNode
     fieldType?: string
     status?: OutlinedInputStatus
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     children: (props: any) => React.ReactNode
     renderFieldRequirements?: (props: {
       value?: TInputValue
@@ -94,6 +93,7 @@ export const getInputError = <T extends ValueType>(
   return meta.submitError
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 const getValidators = (required: boolean, validate?: any) => {
   if (required && validate) {
     return composeValidators([requiredValidator, validate])
@@ -106,53 +106,6 @@ const getValidators = (required: boolean, validate?: any) => {
   return validate
 }
 
-const getProps = ({
-  hideFieldLabel,
-  label,
-  status
-}: {
-  hideFieldLabel?: boolean
-  label: string
-  status?: OutlinedInputStatus
-}) => {
-  if (hideFieldLabel) {
-    return {
-      label
-    }
-  }
-
-  if (status) {
-    return {
-      status
-    }
-  }
-
-  return {}
-}
-
-const getRequiredDecoration = (
-  hideLabelRequiredDecoration?: boolean,
-  required?: boolean,
-  requiredVariant?: RequiredVariant
-): RequiredDecoration | undefined => {
-  if (hideLabelRequiredDecoration) {
-    return
-  }
-
-  const showAsterisk = required && requiredVariant === 'asterisk'
-
-  if (showAsterisk) {
-    return 'asterisk'
-  }
-
-  const showOptional =
-    !required && (!requiredVariant || requiredVariant === 'default')
-
-  if (showOptional) {
-    return 'optional'
-  }
-}
-
 const FieldWrapper = <
   TWrappedComponentProps extends IFormComponentProps,
   TInputValue extends ValueType = TWrappedComponentProps['value']
@@ -161,8 +114,6 @@ const FieldWrapper = <
 ) => {
   const {
     type,
-    hideFieldLabel,
-    hideLabelRequiredDecoration,
     hint,
     label,
     required,
@@ -187,7 +138,6 @@ const FieldWrapper = <
     validate,
     validateFields,
     value,
-    titleCase,
     //
     ...rest
   } = props
@@ -232,7 +182,6 @@ const FieldWrapper = <
     id,
     ...rest,
     ...input,
-    ...getProps({ hideFieldLabel, label, status }),
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     onChange: (event: ChangeEvent<HTMLElement> | any) => {
       input.onChange(event)
@@ -257,12 +206,6 @@ const FieldWrapper = <
     }
   }
 
-  const requiredDecoration = getRequiredDecoration(
-    hideLabelRequiredDecoration,
-    required,
-    formConfig.requiredVariant
-  )
-
   return (
     <PicassoForm.Field
       error={error}
@@ -273,16 +216,7 @@ const FieldWrapper = <
         error: status === 'error'
       })}
     >
-      {!hideFieldLabel && label && (
-        <PicassoForm.Label
-          requiredDecoration={requiredDecoration}
-          htmlFor={id}
-          disabled={rest.disabled}
-          titleCase={titleCase}
-        >
-          {label}
-        </PicassoForm.Label>
-      )}
+      {label}
       {children(childProps)}
     </PicassoForm.Field>
   )

--- a/packages/picasso-forms/src/FileInput/FileInput.tsx
+++ b/packages/picasso-forms/src/FileInput/FileInput.tsx
@@ -4,6 +4,7 @@ import { FieldInputProps as FinalFieldInputProps } from 'react-final-form'
 import { FileUpload } from '@toptal/picasso/FileInput'
 
 import FieldWrapper, { FieldProps } from '../FieldWrapper'
+import FieldLabel from '../FieldLabel'
 
 type FinalFormOnChangeType = FinalFieldInputProps<
   FileInputProps['value']
@@ -43,7 +44,19 @@ export const FileInput = (props: Props) => {
   }
 
   return (
-    <FieldWrapper<FileInputProps, FileUpload[] | undefined> {...props}>
+    <FieldWrapper<FileInputProps, FileUpload[] | undefined>
+      {...props}
+      label={
+        props.label ? (
+          <FieldLabel
+            id={props.id}
+            required={props.required}
+            label={props.label}
+            titleCase={props.titleCase}
+          />
+        ) : null
+      }
+    >
       {inputProps => (
         <PicassoFileInput
           {...inputProps}

--- a/packages/picasso-forms/src/Input/Input.tsx
+++ b/packages/picasso-forms/src/Input/Input.tsx
@@ -2,6 +2,7 @@ import React, { useEffect } from 'react'
 import { Input as PicassoInput, InputProps } from '@toptal/picasso'
 
 import { FieldProps } from '../FieldWrapper'
+import FieldLabel from '../FieldLabel'
 import InputFieldWrapper from '../InputFieldWrapper'
 
 export type FormInputProps = Omit<InputProps, 'onResetClick'> & {
@@ -31,7 +32,19 @@ export const Input = React.forwardRef<HTMLInputElement, Props>((props, ref) => {
   }, [props.name])
 
   return (
-    <InputFieldWrapper<FormInputProps> {...props}>
+    <InputFieldWrapper<FormInputProps>
+      {...props}
+      label={
+        props.label ? (
+          <FieldLabel
+            id={props.id}
+            required={props.required}
+            label={props.label}
+            titleCase={props.titleCase}
+          />
+        ) : null
+      }
+    >
       {(inputProps: InputProps) => <PicassoInput {...inputProps} ref={ref} />}
     </InputFieldWrapper>
   )

--- a/packages/picasso-forms/src/NumberInput/NumberInput.tsx
+++ b/packages/picasso-forms/src/NumberInput/NumberInput.tsx
@@ -7,6 +7,7 @@ import { FieldValidator } from 'final-form'
 
 import { validators } from '../utils'
 import { FieldProps } from '../FieldWrapper'
+import FieldLabel from '../FieldLabel'
 import InputFieldWrapper from '../InputFieldWrapper'
 
 export type Props = NumberInputProps & FieldProps<NumberInputProps['value']>
@@ -31,6 +32,16 @@ export const NumberInput = (props: Props) => {
     <InputFieldWrapper<NumberInputProps>
       {...props}
       validate={composeValidators([validateNumberLimits, validate])}
+      label={
+        props.label ? (
+          <FieldLabel
+            id={props.id}
+            required={props.required}
+            label={props.label}
+            titleCase={props.titleCase}
+          />
+        ) : null
+      }
     >
       {(inputProps: NumberInputProps) => {
         return <PicassoNumberInput {...inputProps} />

--- a/packages/picasso-forms/src/PasswordInput/PasswordInput.tsx
+++ b/packages/picasso-forms/src/PasswordInput/PasswordInput.tsx
@@ -4,6 +4,7 @@ import { FieldValidator } from 'final-form'
 
 import { validators } from '../utils'
 import { FieldProps } from '../FieldWrapper'
+import FieldLabel from '../FieldLabel'
 import passwordValidators from './validators'
 import Form from '../Form'
 import InputFieldWrapper from '../InputFieldWrapper'
@@ -99,6 +100,16 @@ export const PasswordInput = ({
       validate={validationsObject}
       renderFieldRequirements={
         !hideRequirements ? renderFieldRequirements : undefined
+      }
+      label={
+        rest.label ? (
+          <FieldLabel
+            id={rest.id}
+            required={rest.required}
+            label={rest.label}
+            titleCase={rest.titleCase}
+          />
+        ) : null
       }
     >
       {(inputProps: PasswordInputProps) => {

--- a/packages/picasso-forms/src/RadioGroup/RadioGroup.tsx
+++ b/packages/picasso-forms/src/RadioGroup/RadioGroup.tsx
@@ -6,6 +6,7 @@ import {
 } from '@toptal/picasso'
 
 import FieldWrapper, { FieldProps } from '../FieldWrapper'
+import FieldLabel from '../FieldLabel'
 import RadioGroupContext from './RadioGroupContext'
 
 export type Props = RadioGroupProps & FieldProps<RadioProps['value']>
@@ -15,9 +16,24 @@ export const RadioGroup = (props: Props) => {
 
   return (
     <RadioGroupContext.Provider value={props.name}>
-      <FieldWrapper {...rest} type='radio'>
-        {inputProps => (
-          <PicassoRadio.Group {...inputProps}>{children}</PicassoRadio.Group>
+      <FieldWrapper
+        {...rest}
+        type='radio'
+        label={
+          props.label ? (
+            <FieldLabel
+              id={props.id}
+              required={props.required}
+              label={props.label}
+              titleCase={props.titleCase}
+            />
+          ) : null
+        }
+      >
+        {radioGroupProps => (
+          <PicassoRadio.Group {...radioGroupProps}>
+            {children}
+          </PicassoRadio.Group>
         )}
       </FieldWrapper>
     </RadioGroupContext.Provider>

--- a/packages/picasso-forms/src/Rating/Rating.tsx
+++ b/packages/picasso-forms/src/Rating/Rating.tsx
@@ -6,6 +6,7 @@ import {
 } from '@toptal/picasso'
 
 import FieldWrapper, { FieldProps } from '../FieldWrapper'
+import FieldLabel from '../FieldLabel'
 import { validators } from '../utils'
 
 export type RatingStarsProps = PicassoRatingStarsProps &
@@ -49,6 +50,16 @@ const Thumbs = ({
       validate={validateOverride}
       required={requirePositive}
       {...props}
+      label={
+        props.label ? (
+          <FieldLabel
+            id={props.id}
+            required={props.required}
+            label={props.label}
+            titleCase={props.titleCase}
+          />
+        ) : null
+      }
     >
       {inputProps => <PicassoRating.Thumbs {...inputProps} />}
     </FieldWrapper>

--- a/packages/picasso-forms/src/Select/Select.tsx
+++ b/packages/picasso-forms/src/Select/Select.tsx
@@ -8,6 +8,7 @@ import { generateRandomStringOrGetEmptyInTest } from '@toptal/picasso/utils'
 
 import { FieldProps } from '../FieldWrapper'
 import InputFieldWrapper from '../InputFieldWrapper'
+import FieldLabel from '../FieldLabel'
 
 export type Props<
   T extends SelectValueType,
@@ -26,6 +27,16 @@ export const Select = <T extends SelectValueType, M extends boolean = false>({
       {...rest}
       name={name}
       id={randomizedId}
+      label={
+        rest.label ? (
+          <FieldLabel
+            id={rest.id}
+            required={rest.required}
+            label={rest.label}
+            titleCase={rest.titleCase}
+          />
+        ) : null
+      }
     >
       {(selectProps: SelectProps) => {
         return (

--- a/packages/picasso-forms/src/Switch/Switch.tsx
+++ b/packages/picasso-forms/src/Switch/Switch.tsx
@@ -1,5 +1,9 @@
 import React from 'react'
-import { Switch as PicassoSwitch, SwitchProps } from '@toptal/picasso'
+import {
+  Switch as PicassoSwitch,
+  SwitchProps,
+  Form as PicassoForm
+} from '@toptal/picasso'
 
 import FieldWrapper, { FieldProps } from '../FieldWrapper'
 
@@ -9,7 +13,16 @@ export type FormSwitchProps = Omit<SwitchProps, 'onChange'> & {
 export type Props = FormSwitchProps & FieldProps<SwitchProps['value']>
 
 export const Switch = (props: Props) => (
-  <FieldWrapper<FormSwitchProps> hideLabelRequiredDecoration {...props}>
+  <FieldWrapper<FormSwitchProps>
+    {...props}
+    label={
+      props.label ? (
+        <PicassoForm.Label htmlFor={props.id} titleCase={props.titleCase}>
+          {props.label}
+        </PicassoForm.Label>
+      ) : null
+    }
+  >
     {(inputProps: SwitchProps) => {
       return <PicassoSwitch {...inputProps} />
     }}

--- a/packages/picasso-forms/src/TagSelector/TagSelector.tsx
+++ b/packages/picasso-forms/src/TagSelector/TagSelector.tsx
@@ -5,12 +5,25 @@ import {
 } from '@toptal/picasso'
 
 import { FieldProps } from '../FieldWrapper'
+import FieldLabel from '../FieldLabel'
 import InputFieldWrapper from '../InputFieldWrapper'
 
 export type Props = TagSelectorProps & FieldProps<TagSelectorProps['value']>
 
 export const TagSelector = (props: Props) => (
-  <InputFieldWrapper<TagSelectorProps> {...props}>
+  <InputFieldWrapper<TagSelectorProps>
+    {...props}
+    label={
+      props.label ? (
+        <FieldLabel
+          id={props.id}
+          required={props.required}
+          label={props.label}
+          titleCase={props.titleCase}
+        />
+      ) : null
+    }
+  >
     {(inputProps: TagSelectorProps) => {
       return <PicassoTagSelector {...inputProps} />
     }}

--- a/packages/picasso-forms/src/TimePicker/TimePicker.tsx
+++ b/packages/picasso-forms/src/TimePicker/TimePicker.tsx
@@ -6,6 +6,7 @@ import {
 
 import { FieldProps } from '../FieldWrapper'
 import InputFieldWrapper from '../InputFieldWrapper'
+import FieldLabel from '../FieldLabel'
 
 export type FormTimePickerProps = Omit<TimePickerProps, 'onChange'> & {
   onChange?: TimePickerProps['onChange']
@@ -13,7 +14,19 @@ export type FormTimePickerProps = Omit<TimePickerProps, 'onChange'> & {
 export type Props = FormTimePickerProps & FieldProps<TimePickerProps['value']>
 
 export const TimePicker = (props: Props) => (
-  <InputFieldWrapper<FormTimePickerProps> {...props}>
+  <InputFieldWrapper<FormTimePickerProps>
+    {...props}
+    label={
+      props.label ? (
+        <FieldLabel
+          id={props.id}
+          required={props.required}
+          label={props.label}
+          titleCase={props.titleCase}
+        />
+      ) : null
+    }
+  >
     {(inputProps: TimePickerProps) => {
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       const { enableReset, onResetClick, ...rest } = inputProps

--- a/packages/picasso/src/PageHead/PageHead.tsx
+++ b/packages/picasso/src/PageHead/PageHead.tsx
@@ -22,7 +22,10 @@ const useMainStyles = makeStyles(styles, {
   name: 'PicassoPageHeadMain'
 })
 
-const Title = ({ titleCase, children }: TextLabelProps) => {
+const Title = ({
+  titleCase,
+  children
+}: TextLabelProps & { children: ReactNode }) => {
   return (
     <Typography variant='heading' size='large' titleCase={titleCase}>
       {children}

--- a/packages/picasso/src/test-utils/TestingPicasso.tsx
+++ b/packages/picasso/src/test-utils/TestingPicasso.tsx
@@ -2,7 +2,11 @@ import React from 'react'
 import Picasso from '@toptal/picasso-provider'
 import { TextLabelProps } from '@toptal/picasso-shared'
 
-export const TestingPicasso = ({ children, titleCase }: TextLabelProps) => {
+export type Props = TextLabelProps & {
+  children: React.ReactNode
+}
+
+export const TestingPicasso = ({ children, titleCase }: Props) => {
   return (
     <Picasso
       loadFavicon={false}

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -22,7 +22,6 @@ export interface JssProps {
 
 export interface TextLabelProps {
   /** Defines if the text should be transformed to title case */
-  children?: React.ReactNode
   titleCase?: boolean
 }
 


### PR DESCRIPTION
### Description

Extract FieldLabel from FieldWrapper, remove multiple unnecessary props.

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>
