### PR TITLE
feat(DatePicker): add popperProps that allow data-* attrs for the Popper

### DIFF
--- a/.changeset/popular-beans-turn.md
+++ b/.changeset/popular-beans-turn.md
@@ -1,0 +1,8 @@
+---
+'@toptal/picasso': minor
+---
+
+---
+### DatePicker
+
+- add `popperProps` prop to let consumers control data-* attrs of the Popper

--- a/packages/picasso/src/DatePicker/DatePicker.tsx
+++ b/packages/picasso/src/DatePicker/DatePicker.tsx
@@ -101,6 +101,10 @@ export interface Props
   timezone?: string
   /** Custom parser for `DatePicker`'s input value to process custom input value, like, human-readable dates */
   parseInputValue?: DatePickerInputCustomValueParser
+  /** Additional data-* attrs for the inner Popper */
+  popperProps?: {
+    [key: `data-${string}`]: unknown
+  }
   testIds?: InputProps['testIds'] & {
     calendar?: string
     input?: string
@@ -131,6 +135,7 @@ export const DatePicker = (props: Props) => {
     testIds,
     error,
     status,
+    popperProps,
     ...rest
   } = props
   const classes = useStyles()
@@ -388,6 +393,7 @@ export const DatePicker = (props: Props) => {
           container={popperContainer}
           popperOptions={DEFAULT_POPPER_OPTIONS}
           ref={popperRef}
+          {...popperProps}
         >
           <Calendar
             activeMonth={activeMonth}


### PR DESCRIPTION
[TOP-2072]
[FX-2565]

### Description

We at TopTeam use [data-private attribute to control visibility of some parts of UI for LogRocket](https://docs.logrocket.com/docs/privacy#exclude-data-in-videos). On of the things we need to hide this way is a DatePicker-powered input on member termination modal. Though currently if we render `<DatePicker data-private />` it's only going to be applied to the `<input` within date picker, while calendar popup still stays visible.

This PR adds proper support of `data-private` prop to DatePicker component, so that both input and calendar popup are hidden when you do render `<DatePicker data-private />`

### Review

- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [x] Ensure that tests pass by running `yarn test`
- [x] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions. 

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[TOP-2072]: https://toptal-core.atlassian.net/browse/TOP-2072?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[FX-2565]: https://toptal-core.atlassian.net/browse/FX-2565?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ