### PR TITLE
chore: rename FieldWrapper to Field

### DIFF
--- a/packages/picasso-forms/src/Autocomplete/Autocomplete.tsx
+++ b/packages/picasso-forms/src/Autocomplete/Autocomplete.tsx
@@ -4,9 +4,9 @@ import {
   AutocompleteProps
 } from '@toptal/picasso'
 
-import { FieldProps } from '../FieldWrapper'
+import { FieldProps } from '../Field'
 import FieldLabel from '../FieldLabel'
-import InputFieldWrapper from '../InputFieldWrapper'
+import InputField from '../InputField'
 
 export type Props = AutocompleteProps & FieldProps<AutocompleteProps['value']>
 
@@ -14,7 +14,7 @@ export const Autocomplete = (props: Props) => {
   const { label, titleCase, ...rest } = props
 
   return (
-    <InputFieldWrapper<AutocompleteProps>
+    <InputField<AutocompleteProps>
       {...rest}
       label={
         label ? (
@@ -30,7 +30,7 @@ export const Autocomplete = (props: Props) => {
       {(inputProps: AutocompleteProps) => {
         return <PicassoAutocomplete {...inputProps} />
       }}
-    </InputFieldWrapper>
+    </InputField>
   )
 }
 

--- a/packages/picasso-forms/src/ButtonCheckbox/ButtonCheckbox.tsx
+++ b/packages/picasso-forms/src/ButtonCheckbox/ButtonCheckbox.tsx
@@ -5,7 +5,7 @@ import {
   FieldRenderProps as FinalFormFieldProps
 } from 'react-final-form'
 
-import FieldWrapper, { FieldProps } from '../FieldWrapper'
+import PicassoField, { FieldProps } from '../Field'
 import { CheckboxGroupContext } from '../CheckboxGroup'
 
 type CheckboxValue =
@@ -39,7 +39,7 @@ const ButtonCheckbox = ({ name, value, required, ...restProps }: Props) => {
   }
 
   return (
-    <FieldWrapper
+    <PicassoField
       type='checkbox'
       required={required}
       {...restProps}
@@ -47,7 +47,7 @@ const ButtonCheckbox = ({ name, value, required, ...restProps }: Props) => {
       name={name!}
     >
       {(input: ButtonCheckboxProps) => <Button.Checkbox {...input} />}
-    </FieldWrapper>
+    </PicassoField>
   )
 }
 

--- a/packages/picasso-forms/src/Checkbox/Checkbox.tsx
+++ b/packages/picasso-forms/src/Checkbox/Checkbox.tsx
@@ -5,7 +5,7 @@ import {
   FieldRenderProps as FinalFormFieldProps
 } from 'react-final-form'
 
-import FieldWrapper, { FieldProps } from '../FieldWrapper'
+import PicassoField, { FieldProps } from '../Field'
 import { CheckboxGroupContext } from '../CheckboxGroup'
 import { useFormConfig } from '../FormConfig'
 
@@ -50,7 +50,7 @@ export const Checkbox = ({
   const requiredDecoration = showAsterisk ? 'asterisk' : undefined
 
   return (
-    <FieldWrapper
+    <PicassoField
       type='checkbox'
       required={required}
       {...restProps}
@@ -65,7 +65,7 @@ export const Checkbox = ({
           requiredDecoration={requiredDecoration}
         />
       )}
-    </FieldWrapper>
+    </PicassoField>
   )
 }
 

--- a/packages/picasso-forms/src/CheckboxGroup/CheckboxGroup.tsx
+++ b/packages/picasso-forms/src/CheckboxGroup/CheckboxGroup.tsx
@@ -6,7 +6,7 @@ import {
   CheckboxGroupProps
 } from '@toptal/picasso'
 
-import FieldWrapper, { FieldProps } from '../FieldWrapper'
+import PicassoField, { FieldProps } from '../Field'
 import FieldLabel from '../FieldLabel'
 import CheckboxGroupContext from './CheckboxGroupContext'
 
@@ -17,7 +17,7 @@ export const CheckboxGroup = (props: Props) => {
 
   return (
     <CheckboxGroupContext.Provider value={props.name}>
-      <FieldWrapper
+      <PicassoField
         {...rest}
         type='checkbox'
         label={
@@ -34,7 +34,7 @@ export const CheckboxGroup = (props: Props) => {
         {() => (
           <PicassoCheckbox.Group {...rest}>{children}</PicassoCheckbox.Group>
         )}
-      </FieldWrapper>
+      </PicassoField>
     </CheckboxGroupContext.Provider>
   )
 }

--- a/packages/picasso-forms/src/DatePicker/DatePicker.tsx
+++ b/packages/picasso-forms/src/DatePicker/DatePicker.tsx
@@ -4,8 +4,8 @@ import {
   DatePickerProps
 } from '@toptal/picasso'
 
-import { FieldProps } from '../FieldWrapper'
-import InputFieldWrapper from '../InputFieldWrapper'
+import { FieldProps } from '../Field'
+import InputField from '../InputField'
 import FieldLabel from '../FieldLabel'
 
 export type FormDatePickerProps = Omit<DatePickerProps, 'onChange'> & {
@@ -17,7 +17,7 @@ export const DatePicker = (props: Props) => {
   const { label, titleCase, ...rest } = props
 
   return (
-    <InputFieldWrapper<FormDatePickerProps>
+    <InputField<FormDatePickerProps>
       {...rest}
       label={
         <FieldLabel
@@ -31,7 +31,7 @@ export const DatePicker = (props: Props) => {
       {(inputProps: DatePickerProps) => {
         return <PicassoDatePicker {...inputProps} />
       }}
-    </InputFieldWrapper>
+    </InputField>
   )
 }
 

--- a/packages/picasso-forms/src/Dropzone/Dropzone.tsx
+++ b/packages/picasso-forms/src/Dropzone/Dropzone.tsx
@@ -3,7 +3,7 @@ import { Dropzone as PicassoDropzone, DropzoneProps } from '@toptal/picasso'
 import { FileUpload } from '@toptal/picasso/FileInput'
 import { FieldInputProps as FinalFieldInputProps } from 'react-final-form'
 
-import FieldWrapper, { FieldProps } from '../FieldWrapper'
+import PicassoField, { FieldProps } from '../Field'
 import FieldLabel from '../FieldLabel'
 
 export type Props = DropzoneProps &
@@ -52,7 +52,7 @@ const Dropzone = ({ dropzoneHint, ...props }: Props) => {
   }
 
   return (
-    <FieldWrapper<DropzoneProps, FileUpload[] | undefined>
+    <PicassoField<DropzoneProps, FileUpload[] | undefined>
       hideErrors
       {...props}
       label={
@@ -84,7 +84,7 @@ const Dropzone = ({ dropzoneHint, ...props }: Props) => {
           }}
         />
       )}
-    </FieldWrapper>
+    </PicassoField>
   )
 }
 

--- a/packages/picasso-forms/src/Field/Field.tsx
+++ b/packages/picasso-forms/src/Field/Field.tsx
@@ -72,7 +72,7 @@ const getValidators = (required: boolean, validate?: any) => {
   return validate
 }
 
-const FieldWrapper = <
+const Field = <
   TWrappedComponentProps extends IFormComponentProps,
   TInputValue extends ValueType = TWrappedComponentProps['value']
 >(
@@ -184,8 +184,8 @@ const FieldWrapper = <
   )
 }
 
-FieldWrapper.defaultProps = {}
+Field.defaultProps = {}
 
-FieldWrapper.displayName = 'FieldWrapper'
+Field.displayName = 'Field'
 
-export default FieldWrapper
+export default Field

--- a/packages/picasso-forms/src/Field/index.ts
+++ b/packages/picasso-forms/src/Field/index.ts
@@ -1,0 +1,2 @@
+export { default } from './Field'
+export * from './Field'

--- a/packages/picasso-forms/src/Field/story/index.jsx
+++ b/packages/picasso-forms/src/Field/story/index.jsx
@@ -1,8 +1,8 @@
-import FieldWrapper from '../FieldWrapper'
+import Field from '../Field'
 import PicassoBook from '~/.storybook/components/PicassoBook'
 
 const componentDocs = PicassoBook.createComponentDocs(
-  FieldWrapper,
+  Field,
   'Form.Field',
   undefined,
   {

--- a/packages/picasso-forms/src/FieldWrapper/index.ts
+++ b/packages/picasso-forms/src/FieldWrapper/index.ts
@@ -1,2 +1,0 @@
-export { default } from './FieldWrapper'
-export * from './FieldWrapper'

--- a/packages/picasso-forms/src/FileInput/FileInput.tsx
+++ b/packages/picasso-forms/src/FileInput/FileInput.tsx
@@ -3,7 +3,7 @@ import { FileInput as PicassoFileInput, FileInputProps } from '@toptal/picasso'
 import { FieldInputProps as FinalFieldInputProps } from 'react-final-form'
 import { FileUpload } from '@toptal/picasso/FileInput'
 
-import FieldWrapper, { FieldProps } from '../FieldWrapper'
+import PicassoField, { FieldProps } from '../Field'
 import FieldLabel from '../FieldLabel'
 
 type FinalFormOnChangeType = FinalFieldInputProps<
@@ -44,7 +44,7 @@ export const FileInput = (props: Props) => {
   }
 
   return (
-    <FieldWrapper<FileInputProps, FileUpload[] | undefined>
+    <PicassoField<FileInputProps, FileUpload[] | undefined>
       {...props}
       label={
         props.label ? (
@@ -68,7 +68,7 @@ export const FileInput = (props: Props) => {
           }}
         />
       )}
-    </FieldWrapper>
+    </PicassoField>
   )
 }
 

--- a/packages/picasso-forms/src/Form/story/index.jsx
+++ b/packages/picasso-forms/src/Form/story/index.jsx
@@ -1,5 +1,5 @@
 import Form from '../Form'
-import formFieldStory from '../../FieldWrapper/story'
+import formFieldStory from '../../Field/story'
 import PicassoBook from '~/.storybook/components/PicassoBook'
 
 const page = PicassoBook.section('Picasso Forms').createPage('Form', 'Form')

--- a/packages/picasso-forms/src/Input/Input.tsx
+++ b/packages/picasso-forms/src/Input/Input.tsx
@@ -1,9 +1,9 @@
 import React, { useEffect } from 'react'
 import { Input as PicassoInput, InputProps } from '@toptal/picasso'
 
-import { FieldProps } from '../FieldWrapper'
+import { FieldProps } from '../Field'
 import FieldLabel from '../FieldLabel'
-import InputFieldWrapper from '../InputFieldWrapper'
+import InputField from '../InputField'
 
 export type FormInputProps = Omit<InputProps, 'onResetClick'> & {
   /** Callback invoked when reset button was clicked */
@@ -34,7 +34,7 @@ export const Input = React.forwardRef<HTMLInputElement, Props>((props, ref) => {
   const { label, titleCase, ...rest } = props
 
   return (
-    <InputFieldWrapper<FormInputProps>
+    <InputField<FormInputProps>
       {...rest}
       label={
         label ? (
@@ -48,7 +48,7 @@ export const Input = React.forwardRef<HTMLInputElement, Props>((props, ref) => {
       }
     >
       {(inputProps: InputProps) => <PicassoInput {...inputProps} ref={ref} />}
-    </InputFieldWrapper>
+    </InputField>
   )
 })
 

--- a/packages/picasso-forms/src/InputField/InputField.tsx
+++ b/packages/picasso-forms/src/InputField/InputField.tsx
@@ -2,11 +2,11 @@ import React from 'react'
 import { OutlinedInputStatus } from '@toptal/picasso'
 import { FieldMetaState, useField } from 'react-final-form'
 
-import FieldWrapper, {
-  Props as FieldWrapperProps,
+import Field, {
+  Props as FieldProps,
   ValueType,
   IFormComponentProps
-} from '../FieldWrapper'
+} from '../Field'
 import { FormConfigProps, useFormConfig } from '../FormConfig'
 import useFormInputReset from '../utils/use-form-input-reset'
 
@@ -37,11 +37,11 @@ export const getInputStatus = <T extends ValueType>(
   return formConfig.showValidState ? 'success' : 'default'
 }
 
-const InputFieldWrapper = <
+const InputField = <
   TWrappedComponentProps extends IFormComponentProps,
   TInputValue extends ValueType = TWrappedComponentProps['value']
 >(
-  props: FieldWrapperProps<TWrappedComponentProps, TInputValue>
+  props: FieldProps<TWrappedComponentProps, TInputValue>
 ) => {
   const { name, children, enableReset, onResetClick, ...rest } = props
 
@@ -56,7 +56,7 @@ const InputFieldWrapper = <
   })
 
   return (
-    <FieldWrapper<IFormComponentProps, TInputValue>
+    <Field<IFormComponentProps, TInputValue>
       status={status}
       name={name}
       onResetClick={onFormInputResetClick}
@@ -64,12 +64,12 @@ const InputFieldWrapper = <
       {...rest}
     >
       {children}
-    </FieldWrapper>
+    </Field>
   )
 }
 
-InputFieldWrapper.defaultProps = {}
+InputField.defaultProps = {}
 
-InputFieldWrapper.displayName = 'InputFieldWrapper'
+InputField.displayName = 'InputField'
 
-export default InputFieldWrapper
+export default InputField

--- a/packages/picasso-forms/src/InputField/index.ts
+++ b/packages/picasso-forms/src/InputField/index.ts
@@ -1,0 +1,1 @@
+export { default } from './InputField'

--- a/packages/picasso-forms/src/InputField/test.ts
+++ b/packages/picasso-forms/src/InputField/test.ts
@@ -1,6 +1,6 @@
 import { FieldMetaState } from 'react-final-form'
 
-import { getInputStatus } from './InputFieldWrapper'
+import { getInputStatus } from './InputField'
 
 describe('getInputStatus', () => {
   describe('when field has an error', () => {

--- a/packages/picasso-forms/src/InputFieldWrapper/index.ts
+++ b/packages/picasso-forms/src/InputFieldWrapper/index.ts
@@ -1,1 +1,0 @@
-export { default } from './InputFieldWrapper'

--- a/packages/picasso-forms/src/NumberInput/NumberInput.tsx
+++ b/packages/picasso-forms/src/NumberInput/NumberInput.tsx
@@ -6,9 +6,9 @@ import {
 import { FieldValidator } from 'final-form'
 
 import { validators } from '../utils'
-import { FieldProps } from '../FieldWrapper'
+import { FieldProps } from '../Field'
 import FieldLabel from '../FieldLabel'
-import InputFieldWrapper from '../InputFieldWrapper'
+import InputField from '../InputField'
 
 export type Props = NumberInputProps & FieldProps<NumberInputProps['value']>
 
@@ -20,7 +20,9 @@ const { composeValidators } = validators
 export const NumberInput = (props: Props) => {
   const { min = MIN, max = MAX, validate, label, titleCase, ...rest } = props
 
-  const validateNumberLimits: FieldValidator<NumberInputProps['value']> = value => {
+  const validateNumberLimits: FieldValidator<
+    NumberInputProps['value']
+  > = value => {
     if (Number(value) > max) {
       return `Must be less than or equal to ${max}.`
     }
@@ -30,7 +32,7 @@ export const NumberInput = (props: Props) => {
   }
 
   return (
-    <InputFieldWrapper<NumberInputProps>
+    <InputField<NumberInputProps>
       {...rest}
       validate={composeValidators([validateNumberLimits, validate])}
       label={
@@ -47,7 +49,7 @@ export const NumberInput = (props: Props) => {
       {(inputProps: NumberInputProps) => {
         return <PicassoNumberInput {...inputProps} />
       }}
-    </InputFieldWrapper>
+    </InputField>
   )
 }
 

--- a/packages/picasso-forms/src/PasswordInput/PasswordInput.tsx
+++ b/packages/picasso-forms/src/PasswordInput/PasswordInput.tsx
@@ -3,11 +3,11 @@ import { PasswordInputProps } from '@toptal/picasso'
 import { FieldValidator } from 'final-form'
 
 import { validators } from '../utils'
-import { FieldProps } from '../FieldWrapper'
+import { FieldProps } from '../Field'
 import FieldLabel from '../FieldLabel'
 import passwordValidators from './validators'
 import Form from '../Form'
-import InputFieldWrapper from '../InputFieldWrapper'
+import InputField from '../InputField'
 import FieldRenderer from './FieldRenderer'
 
 export type Props = PasswordInputProps &
@@ -95,7 +95,7 @@ export const PasswordInput = ({
   }, [])
 
   return (
-    <InputFieldWrapper<PasswordInputProps>
+    <InputField<PasswordInputProps>
       {...rest}
       validate={validationsObject}
       renderFieldRequirements={
@@ -121,7 +121,7 @@ export const PasswordInput = ({
           />
         )
       }}
-    </InputFieldWrapper>
+    </InputField>
   )
 }
 

--- a/packages/picasso-forms/src/RadioGroup/RadioGroup.tsx
+++ b/packages/picasso-forms/src/RadioGroup/RadioGroup.tsx
@@ -5,7 +5,7 @@ import {
   RadioGroupProps
 } from '@toptal/picasso'
 
-import FieldWrapper, { FieldProps } from '../FieldWrapper'
+import PicassoField, { FieldProps } from '../Field'
 import FieldLabel from '../FieldLabel'
 import RadioGroupContext from './RadioGroupContext'
 
@@ -16,7 +16,7 @@ export const RadioGroup = (props: Props) => {
 
   return (
     <RadioGroupContext.Provider value={props.name}>
-      <FieldWrapper
+      <PicassoField
         {...rest}
         type='radio'
         label={
@@ -35,7 +35,7 @@ export const RadioGroup = (props: Props) => {
             {children}
           </PicassoRadio.Group>
         )}
-      </FieldWrapper>
+      </PicassoField>
     </RadioGroupContext.Provider>
   )
 }

--- a/packages/picasso-forms/src/Rating/Rating.tsx
+++ b/packages/picasso-forms/src/Rating/Rating.tsx
@@ -5,7 +5,7 @@ import {
   RatingThumbsProps as PicassoRatingThumbsProps
 } from '@toptal/picasso'
 
-import FieldWrapper, { FieldProps } from '../FieldWrapper'
+import PicassoField, { FieldProps } from '../Field'
 import FieldLabel from '../FieldLabel'
 import { validators } from '../utils'
 
@@ -16,7 +16,7 @@ const Stars = (props: RatingStarsProps) => {
   const { label, titleCase, ...rest } = props
 
   return (
-    <FieldWrapper<PicassoRatingStarsProps>
+    <PicassoField<PicassoRatingStarsProps>
       {...rest}
       type='number'
       label={
@@ -31,7 +31,7 @@ const Stars = (props: RatingStarsProps) => {
       }
     >
       {inputProps => <PicassoRating.Stars {...inputProps} />}
-    </FieldWrapper>
+    </PicassoField>
   )
 }
 
@@ -52,14 +52,8 @@ const thumbsRequired = (value: boolean | undefined) =>
   value == null ? validators.required(null) : undefined
 
 const Thumbs = (props: RatingThumbsProps) => {
-  const {
-    required,
-    validate,
-    requirePositive,
-    label,
-    titleCase,
-    ...rest
-  } = props
+  const { required, validate, requirePositive, label, titleCase, ...rest } =
+    props
 
   const validateOverride = validators.composeValidators([
     required && !requirePositive ? thumbsRequired : undefined,
@@ -67,7 +61,7 @@ const Thumbs = (props: RatingThumbsProps) => {
   ])
 
   return (
-    <FieldWrapper<PicassoRatingThumbsProps>
+    <PicassoField<PicassoRatingThumbsProps>
       validate={validateOverride}
       required={requirePositive}
       {...rest}
@@ -83,7 +77,7 @@ const Thumbs = (props: RatingThumbsProps) => {
       }
     >
       {inputProps => <PicassoRating.Thumbs {...inputProps} />}
-    </FieldWrapper>
+    </PicassoField>
   )
 }
 

--- a/packages/picasso-forms/src/Select/Select.tsx
+++ b/packages/picasso-forms/src/Select/Select.tsx
@@ -6,8 +6,8 @@ import {
 } from '@toptal/picasso'
 import { generateRandomStringOrGetEmptyInTest } from '@toptal/picasso/utils'
 
-import { FieldProps } from '../FieldWrapper'
-import InputFieldWrapper from '../InputFieldWrapper'
+import { FieldProps } from '../Field'
+import InputField from '../InputField'
 import FieldLabel from '../FieldLabel'
 
 export type Props<
@@ -22,7 +22,7 @@ export const Select = <T extends SelectValueType, M extends boolean = false>(
   const randomizedId = id ? generateRandomStringOrGetEmptyInTest(id) : undefined
 
   return (
-    <InputFieldWrapper<SelectProps<any, any>>
+    <InputField<SelectProps<any, any>>
       {...rest}
       name={name}
       id={randomizedId}
@@ -47,7 +47,7 @@ export const Select = <T extends SelectValueType, M extends boolean = false>(
           />
         )
       }}
-    </InputFieldWrapper>
+    </InputField>
   )
 }
 

--- a/packages/picasso-forms/src/Switch/Switch.tsx
+++ b/packages/picasso-forms/src/Switch/Switch.tsx
@@ -5,7 +5,7 @@ import {
   Form as PicassoForm
 } from '@toptal/picasso'
 
-import FieldWrapper, { FieldProps } from '../FieldWrapper'
+import PicassoField, { FieldProps } from '../Field'
 
 export type FormSwitchProps = Omit<SwitchProps, 'onChange'> & {
   onChange?: SwitchProps['onChange']
@@ -13,7 +13,7 @@ export type FormSwitchProps = Omit<SwitchProps, 'onChange'> & {
 export type Props = FormSwitchProps & FieldProps<SwitchProps['value']>
 
 export const Switch = (props: Props) => (
-  <FieldWrapper<FormSwitchProps>
+  <PicassoField<FormSwitchProps>
     {...props}
     label={
       props.label ? (
@@ -26,7 +26,7 @@ export const Switch = (props: Props) => (
     {(inputProps: SwitchProps) => {
       return <PicassoSwitch {...inputProps} />
     }}
-  </FieldWrapper>
+  </PicassoField>
 )
 
 Switch.defaultProps = {}

--- a/packages/picasso-forms/src/TagSelector/TagSelector.tsx
+++ b/packages/picasso-forms/src/TagSelector/TagSelector.tsx
@@ -4,9 +4,9 @@ import {
   TagSelectorProps
 } from '@toptal/picasso'
 
-import { FieldProps } from '../FieldWrapper'
+import { FieldProps } from '../Field'
 import FieldLabel from '../FieldLabel'
-import InputFieldWrapper from '../InputFieldWrapper'
+import InputField from '../InputField'
 
 export type Props = TagSelectorProps & FieldProps<TagSelectorProps['value']>
 
@@ -14,7 +14,7 @@ export const TagSelector = (props: Props) => {
   const { label, titleCase, ...rest } = props
 
   return (
-    <InputFieldWrapper<TagSelectorProps>
+    <InputField<TagSelectorProps>
       {...rest}
       label={
         label ? (
@@ -30,7 +30,7 @@ export const TagSelector = (props: Props) => {
       {(inputProps: TagSelectorProps) => {
         return <PicassoTagSelector {...inputProps} />
       }}
-    </InputFieldWrapper>
+    </InputField>
   )
 }
 

--- a/packages/picasso-forms/src/TimePicker/TimePicker.tsx
+++ b/packages/picasso-forms/src/TimePicker/TimePicker.tsx
@@ -4,8 +4,8 @@ import {
   TimePickerProps
 } from '@toptal/picasso'
 
-import { FieldProps } from '../FieldWrapper'
-import InputFieldWrapper from '../InputFieldWrapper'
+import { FieldProps } from '../Field'
+import InputField from '../InputField'
 import FieldLabel from '../FieldLabel'
 
 export type FormTimePickerProps = Omit<TimePickerProps, 'onChange'> & {
@@ -17,7 +17,7 @@ export const TimePicker = (props: Props) => {
   const { label, titleCase, ...rest } = props
 
   return (
-    <InputFieldWrapper<FormTimePickerProps>
+    <InputField<FormTimePickerProps>
       {...rest}
       label={
         label ? (
@@ -36,7 +36,7 @@ export const TimePicker = (props: Props) => {
 
         return <PicassoTimePicker {...rest} />
       }}
-    </InputFieldWrapper>
+    </InputField>
   )
 }
 

--- a/packages/picasso-forms/src/index.ts
+++ b/packages/picasso-forms/src/index.ts
@@ -42,6 +42,6 @@ export {
 
 // Picasso Forms exports
 export { default as Form } from './Form'
-export { default as FieldWrapper } from './FieldWrapper'
+export { default as FieldWrapper } from './Field'
 export type { FormConfigProps, RequiredVariant } from './FormConfig'
 // hygen code generator inserts export statements above this comment.

--- a/packages/picasso-forms/src/utils/use-field-validation/use-field-validation.ts
+++ b/packages/picasso-forms/src/utils/use-field-validation/use-field-validation.ts
@@ -2,7 +2,7 @@ import { useEffect } from 'react'
 import { FieldValidator } from 'final-form'
 import { FieldMetaState } from 'react-final-form'
 
-import { ValueType } from '../../FieldWrapper'
+import { ValueType } from '../../Field'
 import { useFormContext } from '../../Form/FormContext'
 
 export type Props<T extends ValueType> = {


### PR DESCRIPTION
### Description

Rename `FieldWrapper` to `Field`, so later we can introduce `FieldWrapper` as a combination of `Field` + `FieldLabel`.

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>
