### PR TITLE
fix: return back old field wrapper

### DIFF
--- a/packages/picasso-forms/src/FieldWrapper/FieldWrapper.tsx
+++ b/packages/picasso-forms/src/FieldWrapper/FieldWrapper.tsx
@@ -1,0 +1,47 @@
+import React from 'react'
+
+import Field, {
+  Props as FieldProps,
+  ValueType,
+  IFormComponentProps
+} from '../Field'
+import FieldLabel from '../FieldLabel'
+
+export type Props<TWrappedComponentProps, TInputValue> = Omit<
+  FieldProps<TWrappedComponentProps, TInputValue>,
+  'label'
+> & { label?: string }
+
+const FieldWrapper = <
+  TWrappedComponentProps extends IFormComponentProps,
+  TInputValue extends ValueType = TWrappedComponentProps['value']
+>(
+  props: Props<TWrappedComponentProps, TInputValue>
+) => {
+  const { label, name, titleCase, children, ...rest } = props
+
+  return (
+    <Field<IFormComponentProps, TInputValue>
+      {...rest}
+      name={name}
+      label={
+        label ? (
+          <FieldLabel
+            name={props.name}
+            required={props.required}
+            label={label}
+            titleCase={titleCase}
+          />
+        ) : null
+      }
+    >
+      {children}
+    </Field>
+  )
+}
+
+FieldWrapper.defaultProps = {}
+
+FieldWrapper.displayName = 'FieldWrapper'
+
+export default FieldWrapper

--- a/packages/picasso-forms/src/FieldWrapper/index.ts
+++ b/packages/picasso-forms/src/FieldWrapper/index.ts
@@ -1,0 +1,2 @@
+export { default } from './FieldWrapper'
+export * from './FieldWrapper'

--- a/packages/picasso-forms/src/FieldWrapper/index.ts
+++ b/packages/picasso-forms/src/FieldWrapper/index.ts
@@ -1,2 +1,6 @@
 export { default } from './FieldWrapper'
 export * from './FieldWrapper'
+
+// this is done to keep backwards compatibility
+// when FieldWrapper was refactored and moved to Field component
+export { FieldProps } from '../Field'

--- a/packages/picasso-forms/src/FieldWrapper/story/index.jsx
+++ b/packages/picasso-forms/src/FieldWrapper/story/index.jsx
@@ -1,9 +1,9 @@
-import Field from '../Field'
+import FieldWrapper from '../FieldWrapper'
 import PicassoBook from '~/.storybook/components/PicassoBook'
 
 const componentDocs = PicassoBook.createComponentDocs(
-  Field,
-  'Form.Field',
+  FieldWrapper,
+  'FieldWrapper',
   undefined,
   {
     name: {

--- a/packages/picasso-forms/src/Form/story/index.jsx
+++ b/packages/picasso-forms/src/Form/story/index.jsx
@@ -1,5 +1,5 @@
 import Form from '../Form'
-import formFieldStory from '../../Field/story'
+import fieldWrapperStory from '../../FieldWrapper/story'
 import PicassoBook from '~/.storybook/components/PicassoBook'
 
 const page = PicassoBook.section('Picasso Forms').createPage('Form', 'Form')
@@ -127,7 +127,7 @@ Tip: It is possible to have autocomplete 'on' for the form, and 'off' for specif
       }
     }
   })
-  .addComponentDocs(formFieldStory.componentDocs)
+  .addComponentDocs(fieldWrapperStory.componentDocs)
 
 page
   .createChapter()

--- a/packages/picasso-forms/src/index.ts
+++ b/packages/picasso-forms/src/index.ts
@@ -42,6 +42,6 @@ export {
 
 // Picasso Forms exports
 export { default as Form } from './Form'
-export { default as FieldWrapper } from './Field'
+export { default as FieldWrapper } from './FieldWrapper'
 export type { FormConfigProps, RequiredVariant } from './FormConfig'
 // hygen code generator inserts export statements above this comment.

--- a/packages/picasso-forms/src/index.ts
+++ b/packages/picasso-forms/src/index.ts
@@ -23,7 +23,6 @@ export type {
   FieldRenderProps,
   FormRenderProps,
   FormSpyRenderProps,
-  FieldProps,
   FormProps,
   FieldInputProps
 } from 'react-final-form'
@@ -43,5 +42,6 @@ export {
 // Picasso Forms exports
 export { default as Form } from './Form'
 export { default as FieldWrapper } from './FieldWrapper'
+export { FieldProps } from './Field'
 export type { FormConfigProps, RequiredVariant } from './FormConfig'
 // hygen code generator inserts export statements above this comment.

--- a/packages/picasso-forms/src/index.ts
+++ b/packages/picasso-forms/src/index.ts
@@ -42,6 +42,6 @@ export {
 // Picasso Forms exports
 export { default as Form } from './Form'
 export { default as FieldWrapper } from './FieldWrapper'
-export { FieldProps } from './Field'
+export type { FieldProps } from './Field'
 export type { FormConfigProps, RequiredVariant } from './FormConfig'
 // hygen code generator inserts export statements above this comment.


### PR DESCRIPTION
### Description

Return back the old `FieldWrapper` component for external usage, due to other teams using it when it was removed.

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>
