### PR TITLE
ci: add sshagent to picasso-master-publish-docs job

### DIFF
--- a/ci/jobs/picasso-master-publish-docs/Jenkinsfile
+++ b/ci/jobs/picasso-master-publish-docs/Jenkinsfile
@@ -50,20 +50,21 @@ pipeline {
           } else {
             imageCommitId = gitCommit()
           }
+          sshagent(credentials: ['e707ac4d-9c1a-43d1-a139-e3fd8c9ef412']) { //provbot (jenkins/provbot)
+            sh """
+              mkdir ${WORKSPACE}/deploy-docs
 
-          sh """
-            mkdir ${WORKSPACE}/deploy-docs
+              docker run --rm \
+              -v ${WORKSPACE}/deploy-docs:/app/deploy-docs \
+              -e DEPLOY_DOCS_PATH=/app/deploy-docs \
+              -e DEPLOY_DOCS_ARCHIVE=deploy-docs \
+              gcr.io/toptal-hub/${repoName}:${imageCommitId} \
+              ./bin/release-docs
 
-            docker run --rm \
-            -v ${WORKSPACE}/deploy-docs:/app/deploy-docs \
-            -e DEPLOY_DOCS_PATH=/app/deploy-docs \
-            -e DEPLOY_DOCS_ARCHIVE=deploy-docs \
-            gcr.io/toptal-hub/${repoName}:${imageCommitId} \
-            ./bin/release-docs
-
-            tar -zxvf ${WORKSPACE}/deploy-docs/deploy-docs.tar.gz -C ${WORKSPACE}/deploy-docs/
-            rm ${WORKSPACE}/deploy-docs/deploy-docs.tar.gz
-          """
+              tar -zxvf ${WORKSPACE}/deploy-docs/deploy-docs.tar.gz -C ${WORKSPACE}/deploy-docs/
+              rm ${WORKSPACE}/deploy-docs/deploy-docs.tar.gz
+            """
+          } //sshagent
         }//script
       }//steps
     }//stage


### PR DESCRIPTION


### Description

This is required for Jenkins to connect to the docs instance

### How to test

 - https://jenkins-build.toptal.net/job/picasso-docs/10947/console

### Review

 - [x] Get :+1: from code review
 - [x] Test manually

### Pre-merge checklist

 - [x] Feature branch is up-to-date with `master` (if not - rebase it)
 - [x] Squashed related commits together.

