### PR TITLE
refactor: replace useIsomorphicLayoutEffect with useEffect

### DIFF
--- a/.changeset/three-coins-yell.md
+++ b/.changeset/three-coins-yell.md
@@ -1,0 +1,7 @@
+---
+'@toptal/picasso': patch
+---
+
+---
+
+- replaced `useIsomorphicLayoutEffect` with `useEffect` where it was a better fit

--- a/packages/picasso-provider/src/Picasso/FontsLoader.tsx
+++ b/packages/picasso-provider/src/Picasso/FontsLoader.tsx
@@ -1,10 +1,10 @@
-import { useEffect } from 'react'
+import { useIsomorphicLayoutEffect } from '../hooks'
 
 const PROXIMA_NOVA_FONT = 'https://use.typekit.net/rlr4crj.css'
 
 // Feature check for rel='preload' as soon it's not supported by FF and IE
 // https://www.w3.org/TR/preload/#link-type-preload
-const DOMTokenListSupports = function (tokenList: DOMTokenList, token: string) {
+const DOMTokenListSupports = function(tokenList: DOMTokenList, token: string) {
   if (!tokenList || !tokenList.supports) {
     return
   }
@@ -46,7 +46,7 @@ const findFontsLoader = () => {
 }
 
 const FontsLoader = () => {
-  useEffect(() => {
+  useIsomorphicLayoutEffect(() => {
     const existingFontLoader = findFontsLoader()
 
     if (!existingFontLoader) {

--- a/packages/picasso-provider/src/Picasso/FontsLoader.tsx
+++ b/packages/picasso-provider/src/Picasso/FontsLoader.tsx
@@ -1,10 +1,10 @@
-import { useIsomorphicLayoutEffect } from '../hooks'
+import { useEffect } from 'react'
 
 const PROXIMA_NOVA_FONT = 'https://use.typekit.net/rlr4crj.css'
 
 // Feature check for rel='preload' as soon it's not supported by FF and IE
 // https://www.w3.org/TR/preload/#link-type-preload
-const DOMTokenListSupports = function(tokenList: DOMTokenList, token: string) {
+const DOMTokenListSupports = function (tokenList: DOMTokenList, token: string) {
   if (!tokenList || !tokenList.supports) {
     return
   }
@@ -46,7 +46,7 @@ const findFontsLoader = () => {
 }
 
 const FontsLoader = () => {
-  useIsomorphicLayoutEffect(() => {
+  useEffect(() => {
     const existingFontLoader = findFontsLoader()
 
     if (!existingFontLoader) {

--- a/packages/picasso/src/DatePicker/DatePicker.tsx
+++ b/packages/picasso/src/DatePicker/DatePicker.tsx
@@ -8,6 +8,7 @@ import React, {
   KeyboardEvent,
   ReactNode,
   useCallback,
+  useEffect,
   useMemo,
   useRef,
   useState
@@ -18,7 +19,7 @@ import Popper from '../Popper'
 import Container from '../Container'
 import Input, { InputProps } from '../Input'
 import InputAdornment from '../InputAdornment'
-import { noop, useIsomorphicLayoutEffect } from '../utils'
+import { noop } from '../utils'
 import Calendar, {
   DateOrDateRangeType,
   DateRangeType,
@@ -199,18 +200,18 @@ export const DatePicker = (props: Props) => {
   // Keep the input value in sync with date value update
   // Updating on incoming date value or timezone change
   // Should not update when input is focused to prevent overriding it's value
-  useIsomorphicLayoutEffect(() => {
+  useEffect(() => {
     updateInputValue({ preventUpdateOnFocus: true })
   }, [value, timezone])
 
   // Keep the input format in sync with its 'focus' state
   // Updating on input focus state change
-  useIsomorphicLayoutEffect(() => {
+  useEffect(() => {
     updateInputValue({ preventUpdateOnFocus: false })
   }, [isInputFocused])
 
   // Keep the calendar in sync with the input value
-  useIsomorphicLayoutEffect(() => {
+  useEffect(() => {
     setCalendarValue(() => {
       if (!value) {
         return null
@@ -354,9 +355,7 @@ export const DatePicker = (props: Props) => {
       <InputAdornment position='start' disablePointerEvents>
         {icon || <Calendar16 />}
       </InputAdornment>
-    ) : (
-      undefined
-    )
+    ) : undefined
 
   return (
     <>

--- a/packages/picasso/src/TreeView/useNodes.ts
+++ b/packages/picasso/src/TreeView/useNodes.ts
@@ -1,7 +1,6 @@
-import { createRef, useMemo, useRef, useState } from 'react'
+import { createRef, useEffect, useMemo, useRef, useState } from 'react'
 import { HierarchyPointNode } from 'd3-hierarchy'
 
-import { useIsomorphicLayoutEffect } from '../utils'
 import { DirectionsType, DynamicPointNode, TreeNodeInterface } from './types'
 
 const getDynamicNodes = (
@@ -124,7 +123,7 @@ export const useNodes = (
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [dynamicNodes, initialized, direction, verticalMargin, horizontalMargin])
 
-  useIsomorphicLayoutEffect(() => {
+  useEffect(() => {
     if (!dynamicNodes[0].ref.current || initialized) {
       return
     }

--- a/packages/picasso/src/utils/use-safe-state.ts
+++ b/packages/picasso/src/utils/use-safe-state.ts
@@ -1,12 +1,11 @@
-import { useRef, useState, useCallback } from 'react'
-import { useIsomorphicLayoutEffect } from '@toptal/picasso-shared'
+import { useRef, useState, useCallback, useEffect } from 'react'
 
 const useSafeState = <S>(initState: S | (() => S)) => {
   const [state, unsafeSetState] = useState<S>(initState)
 
   const isMounted = useRef(false)
 
-  useIsomorphicLayoutEffect(() => {
+  useEffect(() => {
     isMounted.current = true
 
     return () => {


### PR DESCRIPTION
[FX-2558]

### Description

Replace `useIsomorphicLayoutEffect` (previously `useLayoutEffect`) with `useEffect` where it makes sense. 
I understand that useLayoutEffect fits where there are some DOM measurement or/and updating the DOM.

### How to test

You can walk through the project and search for `useIsomorphicLayoutEffect` and check that every use-case has DOM related measurements and/or manipulations. But application should behave the same, for useEffect and useLayoutEffect acts almost the same way, only difference is that useLayoutEffect is run synchronously after DOM update but **before browser paint**.

### Review

- [ ] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [ ] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that tests pass by running `yarn test`
- [ ] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
- [ ] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-2558]: https://toptal-core.atlassian.net/browse/FX-2558?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ