### PR TITLE
fix(DatePicker): fix DatePicker disabled state

### DIFF
--- a/.changeset/sour-monkeys-design.md
+++ b/.changeset/sour-monkeys-design.md
@@ -1,0 +1,9 @@
+---
+'@toptal/picasso': patch
+---
+
+---
+
+### DatePicker
+
+- fixed a bug, that disabled DatePicker when clicked was showing a Calendar

--- a/packages/picasso/src/DatePicker/DatePicker.tsx
+++ b/packages/picasso/src/DatePicker/DatePicker.tsx
@@ -136,6 +136,7 @@ export const DatePicker = (props: Props) => {
     error,
     status,
     popperProps,
+    disabled,
     ...rest
   } = props
   const classes = useStyles()
@@ -344,6 +345,9 @@ export const DatePicker = (props: Props) => {
   }
 
   const handleFocusOrClick = () => {
+    if (disabled) {
+      return
+    }
     showCalendar()
     setIsInputFocused(true)
   }
@@ -368,6 +372,7 @@ export const DatePicker = (props: Props) => {
         <Input
           {...inputProps}
           status={error ? 'error' : status}
+          disabled={disabled}
           ref={inputRef}
           onKeyDown={handleInputKeydown}
           onClick={handleFocusOrClick}


### PR DESCRIPTION
[FX-X]

### Description

Fix disabled state of DatePicker, which at the moment of this PR still open calendar on input click even if disabled

### How to test

- FIXME: Add the steps describing how to verify your changes

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| Insert screenshots or screen recordings 

https://user-images.githubusercontent.com/65539882/161556155-9dd38b21-a401-4846-a653-c2ad98612723.mov

| Insert screenshots or screen recordings |

### Review

- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure that tests pass by running `yarn test`
- [x] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>
