### PR TITLE
chore: fix dependabot by removing secrets

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,15 +1,4 @@
 version: 2
-registries:
-  docker-registry-gcr-io:
-    type: docker-registry
-    url: https://gcr.io
-    username: _json_key
-    password: "${{secrets.DOCKER_REGISTRY_GCR_IO_PASSWORD}}"
-  npm-registry-registry-npmjs-org:
-    type: npm-registry
-    url: https://registry.npmjs.org
-    token: "${{secrets.NPM_REGISTRY_REGISTRY_NPMJS_ORG_TOKEN}}"
-
 updates:
 - package-ecosystem: npm
   directory: "/"
@@ -18,25 +7,7 @@ updates:
     time: "07:00"
   pull-request-branch-name:
     separator: "-"
-  open-pull-requests-limit: 3
+  open-pull-requests-limit: 4
   labels:
-  - no-jira
+    - no-jira
   versioning-strategy: increase
-  registries:
-  - npm-registry-registry-npmjs-org
-- package-ecosystem: docker
-  directory: "/"
-  schedule:
-    interval: daily
-    time: "07:00"
-  pull-request-branch-name:
-    separator: "-"
-  open-pull-requests-limit: 3
-  labels:
-  - no-jira
-  ignore:
-  - dependency-name: node
-    versions:
-    - 16.pre.alpine
-  registries:
-  - docker-registry-gcr-io


### PR DESCRIPTION
### Description

Fix dependabot, by removing secrets. They are not needed, due to the fact, that Picasso is open-source

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>
