### PR TITLE
chore: replace manual docs with auto for AnalyticsChart

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -3,7 +3,8 @@ const path = require('path')
 const { IgnoreNotFoundPlugin } = require('./plugins')
 
 // example1: /packages/picasso/src/Button/Button.tsx
-const PACKAGES_COMPONENT_DECLARATION_FILE_REGEXP = /packages\/.*\/src\/(.*)\/\1.tsx$/
+const PACKAGES_COMPONENT_DECLARATION_FILE_REGEXP =
+  /packages\/.*\/src\/(.*)\/\1.tsx$/
 
 const { env } = process
 const isDevelopment = env.NODE_ENV !== 'production' && env.NODE_ENV !== 'test'
@@ -41,7 +42,8 @@ module.exports = {
         }
 
         return true
-      }
+      },
+      shouldExtractLiteralValuesFromEnum: true
     }
   },
   webpackFinal: config => {

--- a/.storybook/utils/documentation-generator.ts
+++ b/.storybook/utils/documentation-generator.ts
@@ -99,7 +99,7 @@ class DocumentationGenerator {
 
     // Array type
     if (typeName.match(ARRAY_REGEX)) {
-      const objectType = typeName.substring(0, typeName.indexOf('[]'))
+      const objectType = typeName.substring(0, typeName.lastIndexOf('[]'))
       const objectDescription = this.generateObjectDescription(objectType)
 
       return {
@@ -149,7 +149,11 @@ class DocumentationGenerator {
         .slice(0, -1)
         .map(prop => {
           const name = prop.split(':')[0].trim()
-          const value = prop.slice(prop.indexOf(':') + 1)
+          const value = prop
+            .slice(prop.indexOf(':') + 1)
+            .trim()
+            .replace('|', '\\|')
+
           return `| ${name}: | ${escapeType(value)} |`
         })
         .join('\r\n')

--- a/packages/topkit-analytics-charts/src/AnalyticsChart/AnalyticsChart.tsx
+++ b/packages/topkit-analytics-charts/src/AnalyticsChart/AnalyticsChart.tsx
@@ -28,10 +28,24 @@ export type ReferenceLine = {
 }
 
 export type Props = BaseLineChartProps & {
+  /**
+   * A record of data points to be rendered as a line chart
+   * @type { id: string; values: Record<string, number|null>; }[]
+   */
   data: Point[]
+  /**
+   * A list of dates and to be highlighted
+   * @type { data: string[]; color: string; }[]
+   */
   highlights?: Highlight[]
+  /**
+   * A record of data points to be rendered as a dashed horizontal line
+   * @type { data: Record<string, number>; color: string; }[]
+   */
   referenceLines?: ReferenceLine[]
+  /** A function to custom format the X axis label */
   formatXAxisLabel?: (label: string) => string
+  /** A value that helps formatting the chart */
   granularity?: ChartGranularity
 }
 

--- a/packages/topkit-analytics-charts/src/AnalyticsChart/story/index.jsx
+++ b/packages/topkit-analytics-charts/src/AnalyticsChart/story/index.jsx
@@ -1,5 +1,4 @@
 import AnalyticsChart from '../AnalyticsChart'
-import { sharedLineChartDocs } from '../../../../picasso-charts/src/LineChart/story'
 import PicassoBook from '~/.storybook/components/PicassoBook'
 
 const page = PicassoBook.section('Picasso Charts').createPage(
@@ -9,48 +8,7 @@ const page = PicassoBook.section('Picasso Charts').createPage(
 
 page.createTabChapter('Props').addComponentDocs({
   component: AnalyticsChart,
-  name: 'AnalyticsChart',
-  additionalDocs: Object.assign({}, sharedLineChartDocs, {
-    data: {
-      name: 'data',
-      type: {
-        name: '[]',
-        description: '{ id: string, values: { [key: string]: number | null } }'
-      },
-      description: 'A record of data points to be rendered as a line chart',
-      required: true
-    },
-    highlights: {
-      name: 'highlights',
-      type: {
-        name: '[]',
-        description: '{ data: string[], color: string }'
-      },
-      description: 'A list of dates and to be highlighted'
-    },
-    referenceLines: {
-      name: 'referenceLines',
-      type: {
-        name: '[]',
-        description: `{ data: { [key: string]: number }, color: string }`
-      },
-      description:
-        'A record of data points to be rendered as a dashed horizontal line'
-    },
-    formatXAxisLabel: {
-      name: 'formatXAxisLabel',
-      type: {
-        name: 'function',
-        description: `(label: string) => string`
-      },
-      description: 'A function to custom format the X axis label'
-    },
-    granularity: {
-      name: 'granularity',
-      type: "'month' | 'week' | 'day' | 'hour'",
-      description: 'A value that helps formatting the chart'
-    }
-  })
+  name: 'AnalyticsChart'
 })
 
 page


### PR DESCRIPTION
### Description

There was a leftover detected:
<img width="1360" alt="Screenshot 2022-04-07 at 15 03 04" src="https://user-images.githubusercontent.com/2836281/162194302-f5958879-5144-41eb-95b4-42432b8c3c6b.png">

But it's possible to convert docs for `AnalyticsCharts` also to automatically-generated 👍  

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>
