### PR TITLE
chore: move docs publishing to GHA

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -43,7 +43,7 @@ jobs:
           GITHUB_TOKEN: ${{ env.TOPTAL_DEVBOT_TOKEN }}
           GCR_ACCOUNT_KEY: ${{ secrets.GCR_ACCOUNT_KEY }}
         with:
-          sha: ${{ github.sha }}
+          sha: ${{ github.event.pull_request.head.sha }}
           image_name: picasso-build-image
           environment: temploy
           docker_file: ./Dockerfile
@@ -146,7 +146,7 @@ jobs:
         env:
           JENKINS_JOB_NAME: picasso-pr-specs
           BRANCH: ${{ github.event.pull_request.head.ref }}
-          COMMIT_ID: ${{ github.sha }}
+          COMMIT_ID: ${{ github.event.pull_request.head.sha }}
         with:
           jenkins_url: https://jenkins-build.toptal.net/
           jenkins_user: toptal-jenkins

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -41,6 +41,7 @@ jobs:
       - uses: ./.github/actions/build-push-image
         env:
           GITHUB_TOKEN: ${{ env.TOPTAL_DEVBOT_TOKEN }}
+          GCR_ACCOUNT_KEY: ${{ secrets.GCR_ACCOUNT_KEY }}
         with:
           sha: ${{ github.sha }}
           image_name: picasso-build-image

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -39,6 +39,8 @@ jobs:
           path: ./.github/actions/
 
       - uses: ./.github/actions/build-push-image
+        env:
+          GITHUB_TOKEN: ${{ env.TOPTAL_DEVBOT_TOKEN }}
         with:
           sha: ${{ github.sha }}
           image_name: picasso-build-image

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -125,7 +125,7 @@ jobs:
         with:
           jenkins_url: https://jenkins-build.toptal.net/
           jenkins_user: toptal-jenkins
-          jenkins_token: ${{ env.TOPTAL_JENKINS_BUILD_TOKEN }}
+          jenkins_token: ${{ secrets.TOPTAL_JENKINS_BUILD_TOKEN }}
           proxy: ${{ env.HTTP_PROXY }}
           job_name: ${{ env.JENKINS_JOB_NAME }}
           job_params: |
@@ -150,7 +150,7 @@ jobs:
         with:
           jenkins_url: https://jenkins-build.toptal.net/
           jenkins_user: toptal-jenkins
-          jenkins_token: ${{ env.TOPTAL_JENKINS_BUILD_TOKEN }}
+          jenkins_token: ${{ secrets.TOPTAL_JENKINS_BUILD_TOKEN }}
           proxy: ${{ env.HTTP_PROXY }}
           job_name: ${{ env.JENKINS_JOB_NAME }}
           job_params: |

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -81,6 +81,8 @@ jobs:
       - uses: ./.github/actions/yarn-install
 
       - name: Danger
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: yarn davinci ci danger
 
       - name: Lint
@@ -121,7 +123,7 @@ jobs:
           BRANCH: ${{ github.event.pull_request.head.ref }}
           PR_ID: ${{ github.event.pull_request.id }}
         with:
-          jenkins_url: https://jenkins-deployment.toptal.net/
+          jenkins_url: https://jenkins.toptal.net/
           jenkins_user: ${{ env.TOPTAL_BOT_USERNAME }}
           jenkins_token: ${{ env.TOPTAL_BOT_JENKINS_DEPLOYMENT_TOKEN }}
           proxy: ${{ env.HTTP_PROXY }}
@@ -146,7 +148,7 @@ jobs:
           BRANCH: ${{ github.event.pull_request.head.ref }}
           COMMIT_ID: ${{ github.sha }}
         with:
-          jenkins_url: https://jenkins-deployment.toptal.net/
+          jenkins_url: https://jenkins.toptal.net/
           jenkins_user: ${{ env.TOPTAL_BOT_USERNAME }}
           jenkins_token: ${{ env.TOPTAL_BOT_JENKINS_DEPLOYMENT_TOKEN }}
           proxy: ${{ env.HTTP_PROXY }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -19,6 +19,7 @@ env:
 jobs:
   build-docker-image:
     if: ${{ github.event.pull_request.head.ref != 'changeset-release/master' }}
+    name: Build Picasso docker image
     runs-on: ubuntu-latest
     timeout-minutes: 45
     
@@ -50,6 +51,7 @@ jobs:
 
   tests:
     if: ${{ github.event.pull_request.head.ref != 'changeset-release/master' }}
+    name: PR Checks
     runs-on: ubuntu-latest
     timeout-minutes: 45
     env:
@@ -105,6 +107,7 @@ jobs:
 
   deploy-docs:
     if: ${{ github.event.pull_request.head.ref != 'changeset-release/master' }}
+    name: Deploy Picasso docs
     runs-on: ubuntu-latest
     needs: [ build-docker-image ]
 
@@ -135,8 +138,9 @@ jobs:
             }
           job_timeout: '3600'
 
-  trigger-old-visual-tests:
+  old-visual-tests:
     if: ${{ github.event.pull_request.head.ref != 'changeset-release/master' }}
+    name: Old Visual Tests
     runs-on: ubuntu-latest
     needs: [ build-docker-image ]
 

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -14,6 +14,36 @@ on:
       - ready_for_review # PR was converted from draft to open
 
 jobs:
+  build-docker-image:
+    if: ${{ github.event.pull_request.head.ref != 'changeset-release/master' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.6.0
+        with:
+          access_token: ${{ github.token }}
+
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Checkout davinci GHAs
+        uses: actions/checkout@v2
+        with:
+          repository: toptal/davinci-github-actions
+          token: ${{ env.GITHUB_TOKEN }}
+          path: ./.github/actions/
+
+      - uses: ./.github/actions/build-push-image
+        with:
+          sha: ${{ github.sha }}
+          image_name: picasso-build-image
+          environment: temploy
+          docker_file: ./Dockerfile
+
   tests:
     if: ${{ github.event.pull_request.head.ref != 'changeset-release/master' }}
     runs-on: ubuntu-latest
@@ -35,32 +65,17 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: Checkout davinci GHAs
+        uses: actions/checkout@v2
+        with:
+          repository: toptal/davinci-github-actions
+          token: ${{ env.GITHUB_TOKEN }}
+          path: ./.github/actions/
+      
       - name: Increase max_user_watches
         run: echo fs.inotify.max_user_watches=524288 | tee -a /etc/sysctl.conf && sysctl -p
 
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-
-      - uses: actions/cache@v1
-        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
-        with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
-
-      - name: Install Dependencies (from network)
-        if: steps.yarn-cache.outputs.cache-hit != 'true'
-        run: |
-          yarn policies set-version
-          yarn install --frozen-lockfile --ignore-optional
-
-      - name: Install Dependencies (from cache)
-        if: steps.yarn-cache.outputs.cache-hit == 'true'
-        run: |
-          yarn policies set-version
-          yarn install --frozen-lockfile --ignore-optional --offline
+      - uses: ./.github/actions/yarn-install
 
       - name: Danger
         run: yarn davinci ci danger
@@ -82,3 +97,72 @@ jobs:
         env:
           HAPPO_API_KEY: ${{ secrets.HAPPO_API_KEY }}
           HAPPO_API_SECRET: ${{ secrets.HAPPO_API_SECRET }}
+
+  deploy-docs:
+    if: ${{ github.event.pull_request.head.ref != 'changeset-release/master' }}
+    runs-on: ubuntu-latest
+    needs: [ build-docker-image ]
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    
+    steps:
+      - name: Checkout davinci GHAs
+        uses: actions/checkout@v2
+        with:
+          repository: toptal/davinci-github-actions
+          token: ${{ env.GITHUB_TOKEN }}
+          path: ./.github/actions/
+
+      - name: Trigger doc deployment job
+        uses: toptal/jenkins-job-trigger-action@1.0.0
+        env:
+          JENKINS_JOB_NAME: picasso-docs
+          BRANCH: ${{ github.event.pull_request.head.ref }}
+          PR_ID: ${{ github.event.pull_request.id }}
+        with:
+          jenkins_url: https://jenkins-deployment.toptal.net/
+          jenkins_user: ${{ env.TOPTAL_BOT_USERNAME }}
+          jenkins_token: ${{ env.TOPTAL_BOT_JENKINS_DEPLOYMENT_TOKEN }}
+          proxy: ${{ env.HTTP_PROXY }}
+          job_name: ${{ env.JENKINS_JOB_NAME }}
+          job_params: |
+            {
+              "BRANCH": "${{ env.BRANCH }}",
+              "PR_ID": "${{ env.PR_ID }}"
+            }
+          job_timeout: '3600'
+
+  trigger-old-visual-tests:
+    if: ${{ github.event.pull_request.head.ref != 'changeset-release/master' }}
+    runs-on: ubuntu-latest
+    needs: [ build-docker-image ]
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    
+    steps:
+      - name: Checkout davinci GHAs
+        uses: actions/checkout@v2
+        with:
+          repository: toptal/davinci-github-actions
+          token: ${{ env.GITHUB_TOKEN }}
+          path: ./.github/actions/
+
+      - name: Trigger doc deployment job
+        uses: toptal/jenkins-job-trigger-action@1.0.0
+        env:
+          JENKINS_JOB_NAME: picasso-pr-specs
+          BRANCH: ${{ github.event.pull_request.head.ref }}
+          COMMIT_ID: ${{ github.sha }}
+        with:
+          jenkins_url: https://jenkins-deployment.toptal.net/
+          jenkins_user: ${{ env.TOPTAL_BOT_USERNAME }}
+          jenkins_token: ${{ env.TOPTAL_BOT_JENKINS_DEPLOYMENT_TOKEN }}
+          proxy: ${{ env.HTTP_PROXY }}
+          job_name: ${{ env.JENKINS_JOB_NAME }}
+          job_params: |
+            {
+              "BRANCH": "${{ env.BRANCH }}",
+              "COMMIT_ID": "${{ env.COMMIT_ID }}"
+            }
+          job_timeout: '3600'
+    

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -44,7 +44,7 @@ jobs:
           GCR_ACCOUNT_KEY: ${{ secrets.GCR_ACCOUNT_KEY }}
         with:
           sha: ${{ github.event.pull_request.head.sha }}
-          image_name: picasso-build-image
+          image_name: picasso
           environment: temploy
           docker_file: ./Dockerfile
 

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -121,7 +121,7 @@ jobs:
         env:
           JENKINS_JOB_NAME: picasso-docs
           BRANCH: ${{ github.event.pull_request.head.ref }}
-          PR_ID: ${{ github.event.pull_request.id }}
+          PR_ID: ${{ github.event.pull_request.number }}
         with:
           jenkins_url: https://jenkins-build.toptal.net/
           jenkins_user: toptal-jenkins

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -136,13 +136,6 @@ jobs:
     needs: [ build-docker-image ]
 
     steps:
-      - name: Checkout davinci GHAs
-        uses: actions/checkout@v2
-        with:
-          repository: toptal/davinci-github-actions
-          token: ${{ env.TOPTAL_DEVBOT_TOKEN }}
-          path: ./.github/actions/
-
       - name: Trigger doc deployment job
         uses: toptal/jenkins-job-trigger-action@1.0.0
         env:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -123,7 +123,7 @@ jobs:
           BRANCH: ${{ github.event.pull_request.head.ref }}
           PR_ID: ${{ github.event.pull_request.id }}
         with:
-          jenkins_url: https://jenkins.toptal.net/
+          jenkins_url: https://jenkins-build.toptal.net/
           jenkins_user: ${{ env.TOPTAL_BOT_USERNAME }}
           jenkins_token: ${{ env.TOPTAL_BOT_JENKINS_DEPLOYMENT_TOKEN }}
           proxy: ${{ env.HTTP_PROXY }}
@@ -148,7 +148,7 @@ jobs:
           BRANCH: ${{ github.event.pull_request.head.ref }}
           COMMIT_ID: ${{ github.sha }}
         with:
-          jenkins_url: https://jenkins.toptal.net/
+          jenkins_url: https://jenkins-build.toptal.net/
           jenkins_user: ${{ env.TOPTAL_BOT_USERNAME }}
           jenkins_token: ${{ env.TOPTAL_BOT_JENKINS_DEPLOYMENT_TOKEN }}
           proxy: ${{ env.HTTP_PROXY }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -109,7 +109,6 @@ jobs:
       - name: Trigger doc deployment job
         uses: toptal/jenkins-job-trigger-action@1.0.0
         env:
-          JENKINS_JOB_NAME: picasso-docs
           BRANCH: ${{ github.event.pull_request.head.ref }}
           PR_ID: ${{ github.event.pull_request.number }}
         with:
@@ -117,7 +116,7 @@ jobs:
           jenkins_user: toptal-jenkins
           jenkins_token: ${{ secrets.TOPTAL_JENKINS_BUILD_TOKEN }}
           proxy: ${{ env.HTTP_PROXY }}
-          job_name: ${{ env.JENKINS_JOB_NAME }}
+          job_name: picasso-docs
           job_params: |
             {
               "BRANCH": "${{ env.BRANCH }}",
@@ -135,7 +134,6 @@ jobs:
       - name: Trigger doc deployment job
         uses: toptal/jenkins-job-trigger-action@1.0.0
         env:
-          JENKINS_JOB_NAME: picasso-pr-specs
           BRANCH: ${{ github.event.pull_request.head.ref }}
           COMMIT_ID: ${{ github.event.pull_request.head.sha }}
           PR_ID: ${{ github.event.pull_request.number }}
@@ -144,7 +142,7 @@ jobs:
           jenkins_user: toptal-jenkins
           jenkins_token: ${{ secrets.TOPTAL_JENKINS_BUILD_TOKEN }}
           proxy: ${{ env.HTTP_PROXY }}
-          job_name: ${{ env.JENKINS_JOB_NAME }}
+          job_name: picasso-pr-specs
           job_params: |
             {
               "BRANCH": "${{ env.BRANCH }}",

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -124,8 +124,8 @@ jobs:
           PR_ID: ${{ github.event.pull_request.id }}
         with:
           jenkins_url: https://jenkins-build.toptal.net/
-          jenkins_user: ${{ env.TOPTAL_BOT_USERNAME }}
-          jenkins_token: ${{ env.TOPTAL_BOT_JENKINS_DEPLOYMENT_TOKEN }}
+          jenkins_user: toptal-jenkins
+          jenkins_token: ${{ env.TOPTAL_JENKINS_BUILD_TOKEN }}
           proxy: ${{ env.HTTP_PROXY }}
           job_name: ${{ env.JENKINS_JOB_NAME }}
           job_params: |
@@ -149,8 +149,8 @@ jobs:
           COMMIT_ID: ${{ github.sha }}
         with:
           jenkins_url: https://jenkins-build.toptal.net/
-          jenkins_user: ${{ env.TOPTAL_BOT_USERNAME }}
-          jenkins_token: ${{ env.TOPTAL_BOT_JENKINS_DEPLOYMENT_TOKEN }}
+          jenkins_user: toptal-jenkins
+          jenkins_token: ${{ env.TOPTAL_JENKINS_BUILD_TOKEN }}
           proxy: ${{ env.HTTP_PROXY }}
           job_name: ${{ env.JENKINS_JOB_NAME }}
           job_params: |

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -112,13 +112,6 @@ jobs:
     needs: [ build-docker-image ]
 
     steps:
-      - name: Checkout davinci GHAs
-        uses: actions/checkout@v2
-        with:
-          repository: toptal/davinci-github-actions
-          token: ${{ env.TOPTAL_DEVBOT_TOKEN }}
-          path: ./.github/actions/
-
       - name: Trigger doc deployment job
         uses: toptal/jenkins-job-trigger-action@1.0.0
         env:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -13,14 +13,15 @@ on:
       - reopened # PR was closed and is now open again
       - ready_for_review # PR was converted from draft to open
 
+env:
+  TOPTAL_DEVBOT_TOKEN: ${{ secrets.TOPTAL_DEVBOT_TOKEN }}
+
 jobs:
   build-docker-image:
     if: ${{ github.event.pull_request.head.ref != 'changeset-release/master' }}
     runs-on: ubuntu-latest
     timeout-minutes: 45
-    env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
+    
     steps:
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.6.0
@@ -34,7 +35,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: toptal/davinci-github-actions
-          token: ${{ env.GITHUB_TOKEN }}
+          token: ${{ env.TOPTAL_DEVBOT_TOKEN }}
           path: ./.github/actions/
 
       - uses: ./.github/actions/build-push-image
@@ -50,7 +51,6 @@ jobs:
     timeout-minutes: 45
     env:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     container:
       image: cypress/included:9.5.0
@@ -69,7 +69,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: toptal/davinci-github-actions
-          token: ${{ env.GITHUB_TOKEN }}
+          token: ${{ env.TOPTAL_DEVBOT_TOKEN }}
           path: ./.github/actions/
       
       - name: Increase max_user_watches
@@ -102,15 +102,13 @@ jobs:
     if: ${{ github.event.pull_request.head.ref != 'changeset-release/master' }}
     runs-on: ubuntu-latest
     needs: [ build-docker-image ]
-    env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    
+
     steps:
       - name: Checkout davinci GHAs
         uses: actions/checkout@v2
         with:
           repository: toptal/davinci-github-actions
-          token: ${{ env.GITHUB_TOKEN }}
+          token: ${{ env.TOPTAL_DEVBOT_TOKEN }}
           path: ./.github/actions/
 
       - name: Trigger doc deployment job
@@ -136,15 +134,13 @@ jobs:
     if: ${{ github.event.pull_request.head.ref != 'changeset-release/master' }}
     runs-on: ubuntu-latest
     needs: [ build-docker-image ]
-    env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    
+
     steps:
       - name: Checkout davinci GHAs
         uses: actions/checkout@v2
         with:
           repository: toptal/davinci-github-actions
-          token: ${{ env.GITHUB_TOKEN }}
+          token: ${{ env.TOPTAL_DEVBOT_TOKEN }}
           path: ./.github/actions/
 
       - name: Trigger doc deployment job

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -151,6 +151,7 @@ jobs:
           JENKINS_JOB_NAME: picasso-pr-specs
           BRANCH: ${{ github.event.pull_request.head.ref }}
           COMMIT_ID: ${{ github.event.pull_request.head.sha }}
+          PR_ID: ${{ github.event.pull_request.number }}
         with:
           jenkins_url: https://jenkins-build.toptal.net/
           jenkins_user: toptal-jenkins
@@ -160,7 +161,8 @@ jobs:
           job_params: |
             {
               "BRANCH": "${{ env.BRANCH }}",
-              "COMMIT_ID": "${{ env.COMMIT_ID }}"
+              "COMMIT_ID": "${{ env.COMMIT_ID }}",
+              "PR_ID": "${{ env.PR_ID }}"
             }
           job_timeout: '3600'
     

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -13,6 +13,10 @@ on:
       - reopened # PR was closed and is now open again
       - ready_for_review # PR was converted from draft to open
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   TOPTAL_DEVBOT_TOKEN: ${{ secrets.TOPTAL_DEVBOT_TOKEN }}
 
@@ -24,11 +28,6 @@ jobs:
     timeout-minutes: 45
     
     steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.6.0
-        with:
-          access_token: ${{ github.token }}
-
       - name: Checkout
         uses: actions/checkout@v2
 
@@ -62,11 +61,6 @@ jobs:
       options: --privileged # thanks to this we can increase number of file watchers below
 
     steps:
-      - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@0.6.0
-        with:
-          access_token: ${{ github.token }}
-
       - name: Checkout
         uses: actions/checkout@v2
 

--- a/ci/jobs/picasso-master-publish-docs/Jenkinsfile
+++ b/ci/jobs/picasso-master-publish-docs/Jenkinsfile
@@ -57,7 +57,7 @@ pipeline {
             -v ${WORKSPACE}/deploy-docs:/app/deploy-docs \
             -e DEPLOY_DOCS_PATH=/app/deploy-docs \
             -e DEPLOY_DOCS_ARCHIVE=deploy-docs \
-            gcr.io/toptal-hub/${repoName}-build-image:${imageCommitId} \
+            gcr.io/toptal-hub/${repoName}:${imageCommitId} \
             ./bin/release-docs
 
             tar -zxvf ${WORKSPACE}/deploy-docs/deploy-docs.tar.gz -C ${WORKSPACE}/deploy-docs/

--- a/ci/jobs/picasso-master-publish-docs/Jenkinsfile
+++ b/ci/jobs/picasso-master-publish-docs/Jenkinsfile
@@ -57,7 +57,7 @@ pipeline {
             -v ${WORKSPACE}/deploy-docs:/app/deploy-docs \
             -e DEPLOY_DOCS_PATH=/app/deploy-docs \
             -e DEPLOY_DOCS_ARCHIVE=deploy-docs \
-            gcr.io/toptal-hub/${repoName}:${imageCommitId} \
+            gcr.io/toptal-hub/${repoName}-build-image:${imageCommitId} \
             ./bin/release-docs
 
             tar -zxvf ${WORKSPACE}/deploy-docs/deploy-docs.tar.gz -C ${WORKSPACE}/deploy-docs/

--- a/ci/jobs/picasso-pr-specs/Jenkinsfile
+++ b/ci/jobs/picasso-pr-specs/Jenkinsfile
@@ -66,7 +66,7 @@ pipeline {
 
             docker run --rm \
             -v ${DIR}/__diff_output__:/app/__diff_output__ \
-            gcr.io/toptal-hub/${repoName}:${COMMIT_ID} \
+            gcr.io/toptal-hub/${repoName}-build-image:${COMMIT_ID} \
             yarn run test:visual:ci
           """
         }

--- a/ci/jobs/picasso-pr-specs/Jenkinsfile
+++ b/ci/jobs/picasso-pr-specs/Jenkinsfile
@@ -4,9 +4,6 @@ ghHelper = new helpers.GithubNotifyHelper()
 helper = new helpers.Helpers()
 repoName = 'picasso'
 buildImageJobName = "${repoName}-build-image"
-def FAILURE_REASON
-def TOTAL_TESTS = 0
-def FAILED_TESTS = 0
 
 pipeline {
   agent { label 'docker' }
@@ -16,6 +13,11 @@ pipeline {
     timestamps()
     timeout(time: 45, unit: 'MINUTES')
     skipDefaultCheckout()
+  }
+
+  parameters {
+    string(name: 'BRANCH', defaultValue: 'master', description: 'Branch or tag to build')
+    string(name: 'COMMIT_ID', defaultValue: '', description: 'Commit hash from which docs should be created')
   }
 
   environment {
@@ -33,76 +35,25 @@ pipeline {
         }
       }
       steps {
-        info "== Checking out Git revision ${ghprbActualCommit}"
+        info "== Checking out Git revision ${COMMIT_ID}"
         gitCheckout(
-          branches: "${ghprbActualCommit}",
+          branches: "${COMMIT_ID}",
           credentials: [username: 'toptal-build', description: 'toptal-build-ssh-key'],
           url: 'git@github.com:toptal/picasso.git',
-          refspec: "+refs/heads/${ghprbTargetBranch}:refs/remotes/origin/${ghprbTargetBranch} +refs/pull/${ghprbPullId}/*:refs/remotes/origin/pr/${ghprbPullId}/*",
+          refspec: "+refs/heads/${BRANCH}:refs/remotes/origin/${BRANCH} +refs/pull/${ghprbPullId}/*:refs/remotes/origin/pr/${ghprbPullId}/*",
           additionalBehaviours: [
                   advancedCheckoutBehaviour: [timeout: 120],
                   advancedCloneBehaviour   : [depth: 0, noTags: true, reference: '', shallow: false, timeout: 340],
                   cleanBeforeCheckout      : false,
-                  calculateChangelog       : [compareRemote: 'origin', compareTarget: "${ghprbTargetBranch}"]
+                  calculateChangelog       : [compareRemote: 'origin', compareTarget: "${BRANCH}"]
           ]
         )
 
-        info "Git commit: ${gitCommit()}"
-        info "Git branch: ${gitBranch()}"
+        info "Git commit: ${COMMIT_ID}"
+        info "Git branch: ${BRANCH}"
         success 'Checkout finished'
       }
     }//stage
-
-    stage('Build image') {
-      when {
-        not {
-          expression {
-            ghprbSourceBranch == 'changeset-release/master'
-          }
-        }
-      }
-      steps {
-        script {
-          buildWithParameters(
-            jobName: buildImageJobName,
-            propagate: true,
-            wait: true,
-            parameters: [
-              BRANCH: ghprbSourceBranch,
-              VERSION: ghprbActualCommit,
-              IMAGE_NAME: repoName
-            ]
-          )
-        }
-      } //steps
-    } //stage
-
-    stage('Deploy documentation') {
-      when {
-        not {
-          expression {
-            ghprbSourceBranch == 'changeset-release/master'
-          }
-        }
-        expression {
-          ghprbMatchesComment(/deploy:documentation|all/)
-        }
-      }
-      steps {
-        info "== Deploying docs"
-        script {
-          buildWithParameters(
-            jobName: "picasso-docs",
-            propagate: false,
-            wait: false,
-            parameters: [
-              BRANCH: env.ghprbSourceBranch,
-              PR_ID: env.ghprbPullId
-            ]
-          )
-        }
-      }
-    }
 
     stage('Run visual tests') {
       when {
@@ -119,7 +70,7 @@ pipeline {
       steps {
         info 'Run visual tests...'
         script {
-          ghHelper.notifyPR('Visual Tests', 'PENDING', 'running', "${ghprbActualCommit}", "${BUILD_URL}", repoName)
+          ghHelper.notifyPR('Visual Tests', 'PENDING', 'running', "${COMMIT_ID}", "${BUILD_URL}", repoName)
 
           def DIR = pwd() // can't be replaced with ${PWD}, because it's pointing to the jenkins_root folder
           sh """
@@ -127,7 +78,7 @@ pipeline {
 
             docker run --rm \
             -v ${DIR}/__diff_output__:/app/__diff_output__ \
-            gcr.io/toptal-hub/${repoName}:${ghprbActualCommit} \
+            gcr.io/toptal-hub/${repoName}:${COMMIT_ID} \
             yarn run test:visual:ci
           """
         }
@@ -137,13 +88,13 @@ pipeline {
         success {
           success "Visual Tests"
           script {
-            ghHelper.notifyPR('Visual Tests', 'SUCCESS', 'Success', "${ghprbActualCommit}", "${BUILD_URL}/Visual_20Regression_20Tests/", repoName)
+            ghHelper.notifyPR('Visual Tests', 'SUCCESS', 'Success', "${COMMIT_ID}", "${BUILD_URL}/Visual_20Regression_20Tests/", repoName)
           }
         }
         failure {
           err "Visual Tests"
           script {
-            ghHelper.notifyPR('Visual Tests', 'ERROR', 'Job failed', "${ghprbActualCommit}","${BUILD_URL}/Visual_20Regression_20Tests/", repoName)
+            ghHelper.notifyPR('Visual Tests', 'ERROR', 'Job failed', "${COMMIT_ID}","${BUILD_URL}/Visual_20Regression_20Tests/", repoName)
           }
         }
       } //post

--- a/ci/jobs/picasso-pr-specs/Jenkinsfile
+++ b/ci/jobs/picasso-pr-specs/Jenkinsfile
@@ -17,6 +17,7 @@ pipeline {
   parameters {
     string(name: 'BRANCH', defaultValue: 'master', description: 'Branch or tag to build')
     string(name: 'COMMIT_ID', defaultValue: '', description: 'Commit hash from which docs should be created')
+    string(name: 'PR_ID', defaultValue: '', description: 'Pull request id')
   }
 
   environment {
@@ -32,7 +33,7 @@ pipeline {
           branches: "${COMMIT_ID}",
           credentials: [username: 'toptal-build', description: 'toptal-build-ssh-key'],
           url: 'git@github.com:toptal/picasso.git',
-          refspec: "+refs/heads/${BRANCH}:refs/remotes/origin/${BRANCH} +refs/pull/${ghprbPullId}/*:refs/remotes/origin/pr/${ghprbPullId}/*",
+          refspec: "+refs/heads/${BRANCH}:refs/remotes/origin/${BRANCH} +refs/pull/${PR_ID}/*:refs/remotes/origin/pr/${PR_ID}/*",
           additionalBehaviours: [
                   advancedCheckoutBehaviour: [timeout: 120],
                   advancedCloneBehaviour   : [depth: 0, noTags: true, reference: '', shallow: false, timeout: 340],
@@ -48,12 +49,6 @@ pipeline {
     }//stage
 
     stage('Run visual tests') {
-      when {
-        expression {
-          ghprbMatchesComment(/test:visual|visual|all/)
-        }
-      }
-
       steps {
         info 'Run visual tests...'
         script {

--- a/ci/jobs/picasso-pr-specs/Jenkinsfile
+++ b/ci/jobs/picasso-pr-specs/Jenkinsfile
@@ -27,13 +27,6 @@ pipeline {
   stages {
     // Perform this only for PRs
     stage('Git checkout PR') {
-      when {
-        not {
-          expression {
-            ghprbSourceBranch == 'changeset-release/master'
-          }
-        }
-      }
       steps {
         info "== Checking out Git revision ${COMMIT_ID}"
         gitCheckout(
@@ -57,11 +50,6 @@ pipeline {
 
     stage('Run visual tests') {
       when {
-        not {
-          expression {
-            ghprbSourceBranch == 'changeset-release/master'
-          }
-        }
         expression {
           ghprbMatchesComment(/test:visual|visual|all/)
         }

--- a/ci/jobs/picasso-pr-specs/Jenkinsfile
+++ b/ci/jobs/picasso-pr-specs/Jenkinsfile
@@ -3,7 +3,6 @@
 ghHelper = new helpers.GithubNotifyHelper()
 helper = new helpers.Helpers()
 repoName = 'picasso'
-buildImageJobName = "${repoName}-build-image"
 
 pipeline {
   agent { label 'docker' }
@@ -66,7 +65,7 @@ pipeline {
 
             docker run --rm \
             -v ${DIR}/__diff_output__:/app/__diff_output__ \
-            gcr.io/toptal-hub/${repoName}-build-image:${COMMIT_ID} \
+            gcr.io/toptal-hub/${repoName}:${COMMIT_ID} \
             yarn run test:visual:ci
           """
         }


### PR DESCRIPTION
### Description

Move docs publishing and triggering old visual tests to GH Actions. This would help us to make clean `Version Package` PR, that would not have GH checks in a pending state.

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>
