### PR TITLE
chore: codemod for removing asterisks

### DIFF
--- a/.changeset/blue-suits-perform.md
+++ b/.changeset/blue-suits-perform.md
@@ -1,0 +1,9 @@
+---
+'@toptal/picasso-codemod': minor
+---
+
+---
+
+### remove-asterisks
+
+- codemod for removing asterisks from forms

--- a/packages/picasso-codemod/README.md
+++ b/packages/picasso-codemod/README.md
@@ -41,6 +41,37 @@ Codemods do not guarantee the code format preservation. Therefore be sure to run
 
 ## Included Scripts
 
+### v22.0.0
+
+#### `remove-asterisks`
+
+This codemod aims to help you with transition to forms without asterisks. 
+It transforms `requiredDecoration` prop to `optional` boolean property. 
+Also removes `requiredVariant` from FormConfig context.
+
+```diff
+-<Form.Label requiredDecoration='asterisk'>Label</Form.Label>
++<Form.Label>Label</Form.Label>
+
+-<Form.Label requiredDecoration='optional'>Label</Form.Label>
++<Form.Label optional>Label</Form.Label>
+
+-<Form.ConfigProvider value={{ requiredVariant: 'asterisk' }}>
++<Form.ConfigProvider value={{}}>
+```
+
+You may want to refactor `Form.ConfigProvider` a little bit after runnning the codemod,
+for there may be some empty objects left.
+
+<details>
+<summary>Command</summary>
+
+```sh
+npx @toptal/picasso-codemod v22.0.0/remove-asterisks
+```
+
+</details>
+
 ### v20.0.0
 
 #### `replace-error`

--- a/packages/picasso-codemod/src/v22.0.0/remove-asterisks/__testfixtures__/basic.input.tsx
+++ b/packages/picasso-codemod/src/v22.0.0/remove-asterisks/__testfixtures__/basic.input.tsx
@@ -1,0 +1,39 @@
+import { Form, FormLabel } from '@toptal/picasso'
+import { Form as PicassoForm } from '@toptal/picasso-forms'
+// @ts-nocheck
+import React from 'react'
+
+const FORM_CONFIG_PROPS = {
+  requiredVariant: 'asterisk',
+  foo: 'abr'
+}
+
+const requiredVariant = 'test'
+const required = true
+const label = 'Label'
+
+export default () => (
+  <>
+    <PicassoForm.ConfigProvider value={{ requiredVariant: 'asterisk' }}>
+      <Form.Label requiredDecoration='asterisk'>Referral slug</Form.Label>
+    </PicassoForm.ConfigProvider>
+
+    <Form.Label requiredDecoration='asterisk'>Referral slug</Form.Label>
+    <Form.Label requiredDecoration='optional'>Referral slug</Form.Label>
+    <Form.Label requiredDecoration={required ? 'asterisk' : 'optional'}>
+      {label}
+    </Form.Label>
+    <Form.Label requiredDecoration={required ? 'asterisk' : 'default'}>
+      {label}
+    </Form.Label>
+    <Form.Label requiredDecoration={required ? undefined : 'optional'}>
+      {label}
+    </Form.Label>
+    <Form.Label requiredDecoration={requiredVariant ? 'optional' : undefined}>
+      {label}
+    </Form.Label>
+    <FormLabel requiredDecoration={!required ? undefined : 'optional'}>
+      Expiration Date
+    </FormLabel>
+  </>
+)

--- a/packages/picasso-codemod/src/v22.0.0/remove-asterisks/__testfixtures__/basic.output.tsx
+++ b/packages/picasso-codemod/src/v22.0.0/remove-asterisks/__testfixtures__/basic.output.tsx
@@ -1,0 +1,28 @@
+import { Form, FormLabel } from '@toptal/picasso'
+import { Form as PicassoForm } from '@toptal/picasso-forms'
+// @ts-nocheck
+import React from 'react'
+
+const FORM_CONFIG_PROPS = {
+  foo: 'abr'
+}
+
+const requiredVariant = 'test'
+const required = true
+const label = 'Label'
+
+export default () => (
+  <>
+    <PicassoForm.ConfigProvider value={{}}>
+      <Form.Label>Referral slug</Form.Label>
+    </PicassoForm.ConfigProvider>
+
+    <Form.Label>Referral slug</Form.Label>
+    <Form.Label optional>Referral slug</Form.Label>
+    <Form.Label optional={!required}>{label}</Form.Label>
+    <Form.Label>{label}</Form.Label>
+    <Form.Label optional={!required}>{label}</Form.Label>
+    <Form.Label optional={requiredVariant}>{label}</Form.Label>
+    <FormLabel optional={required}>Expiration Date</FormLabel>
+  </>
+)

--- a/packages/picasso-codemod/src/v22.0.0/remove-asterisks/__tests__/test.ts
+++ b/packages/picasso-codemod/src/v22.0.0/remove-asterisks/__tests__/test.ts
@@ -1,0 +1,3 @@
+import { defineTest } from 'jscodeshift/src/testUtils'
+
+defineTest(__dirname, 'remove-asterisks', {}, 'basic', { parser: 'tsx' })

--- a/packages/picasso-codemod/src/v22.0.0/remove-asterisks/index.ts
+++ b/packages/picasso-codemod/src/v22.0.0/remove-asterisks/index.ts
@@ -1,0 +1,1 @@
+export { default } from './remove-asterisks'

--- a/packages/picasso-codemod/src/v22.0.0/remove-asterisks/remove-asterisks.ts
+++ b/packages/picasso-codemod/src/v22.0.0/remove-asterisks/remove-asterisks.ts
@@ -1,0 +1,122 @@
+import {
+  ASTNode,
+  ConditionalExpression,
+  JSCodeshift,
+  StringLiteral,
+  Transform,
+  JSXExpressionContainer
+} from 'jscodeshift'
+
+interface ActionInterface {
+  type: 'replaceWith' | 'remove'
+  param?: ASTNode
+}
+
+const getStringValue = (node: ASTNode): string => {
+  if (node.type !== 'StringLiteral') {
+    return ''
+  }
+
+  return node.value
+}
+
+const getActionFromLiteral = (
+  attribute: StringLiteral,
+  j: JSCodeshift
+): ActionInterface => {
+  if (attribute.value === 'optional') {
+    return {
+      type: 'replaceWith',
+      param: j.jsxAttribute(j.jsxIdentifier('optional'))
+    }
+  }
+
+  return {
+    type: 'remove'
+  }
+}
+
+const getActionFromExpression = (
+  attribute: JSXExpressionContainer,
+  j: JSCodeshift
+): ActionInterface => {
+  const { alternate, consequent, test } =
+    attribute.expression as ConditionalExpression
+
+  const consequentString = getStringValue(consequent)
+  const alternateString = getStringValue(alternate)
+
+  if (consequentString !== 'optional' && alternateString !== 'optional') {
+    return {
+      type: 'remove'
+    }
+  }
+
+  const isOptionalConsequent = consequentString === 'optional'
+
+  const replacementParam = j.jsxAttribute(
+    j.jsxIdentifier('optional'),
+    j.jsxExpressionContainer(
+      isOptionalConsequent
+        ? test
+        : test.type === 'UnaryExpression'
+        ? test.argument
+        : j.unaryExpression('!', test)
+    )
+  )
+
+  return {
+    type: 'replaceWith',
+    param: replacementParam
+  }
+}
+
+const transform: Transform = (file, api) => {
+  const j = api.jscodeshift
+  const root = j(file.source)
+
+  // remove `requiredVariant` from FormConfigContext
+  // usages: https://github.com/search?q=org%3Atoptal+RequiredVariant+-repo%3Atoptal%2Fpicasso&type=code
+  root
+    .find(j.Identifier, { name: 'requiredVariant' })
+    .filter(({ parentPath }) => parentPath.value.type === 'ObjectProperty')
+    .forEach(({ parentPath }) => j(parentPath).remove())
+
+  // replace `requiredDecoration` with `optional` on FormLabel
+  // usages: https://github.com/search?q=org%3Atoptal+requiredDecoration+-repo%3Atoptal%2Fpicasso&type=code
+  root
+    .find(j.JSXAttribute, {
+      name: {
+        type: 'JSXIdentifier',
+        name: 'requiredDecoration'
+      }
+    })
+    .forEach(attribute => {
+      const value = attribute.value.value
+
+      // if attribute is empty, don't do anything
+      if (!value) {
+        return
+      }
+
+      const type = value!.type
+      let action
+
+      if (type === 'StringLiteral') {
+        action = getActionFromLiteral(value, j)
+      } else if (
+        type === 'JSXExpressionContainer' &&
+        value.expression.type === 'ConditionalExpression'
+      ) {
+        action = getActionFromExpression(value, j)
+      }
+
+      if (action) {
+        j(attribute)[action.type](action.param)
+      }
+    })
+
+  return root.toSource({ quote: 'single' })
+}
+
+export default transform


### PR DESCRIPTION
[FX-2175]

### Description

Codemod for removing asterisks (`requiredDecoration` prop and `requiredVariant` FormConfig context value)

### How to test

CI should be green

### Review

- [ ] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [ ] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that tests pass by running `yarn test`
- [ ] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
- [ ] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-2175]: https://toptal-core.atlassian.net/browse/FX-2175?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ