### PR TITLE
chore: added deprecation warning to

### DIFF
--- a/.changeset/tricky-ties-grab.md
+++ b/.changeset/tricky-ties-grab.md
@@ -1,0 +1,9 @@
+---
+'@toptal/picasso': patch
+---
+
+---
+
+### FormLabel, FormControlLabel, Checkbox
+
+- added deprecation warning to `requiredDecoration` prop

--- a/packages/picasso-forms/src/FieldLabel/FieldLabel.tsx
+++ b/packages/picasso-forms/src/FieldLabel/FieldLabel.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { Form as PicassoForm, RequiredDecoration } from '@toptal/picasso'
 import { TextLabelProps } from '@toptal/picasso-shared'
+import { usePropDeprecationWarning } from '@toptal/picasso/utils/use-deprecation-warnings'
 
 import { useFormConfig, RequiredVariant } from '../FormConfig'
 
@@ -36,6 +37,13 @@ const FieldLabel = (props: Props) => {
     required,
     formConfig.requiredVariant
   )
+
+  usePropDeprecationWarning({
+    props,
+    name: 'requiredDecoration',
+    componentName: 'FieldLabel',
+    description: "There will be 'optional' boolean property instead"
+  })
 
   return (
     <PicassoForm.Label

--- a/packages/picasso/src/Checkbox/Checkbox.tsx
+++ b/packages/picasso/src/Checkbox/Checkbox.tsx
@@ -13,6 +13,7 @@ import CheckboxGroup from '../CheckboxGroup'
 import Container from '../Container'
 import FormControlLabel from '../FormControlLabel'
 import styles from './styles'
+import { usePropDeprecationWarning } from '../utils/use-deprecation-warnings'
 
 const useStyles = makeStyles<Theme>(styles, { name: 'PicassoCheckbox' })
 
@@ -57,6 +58,13 @@ export const Checkbox = forwardRef<HTMLButtonElement | HTMLLabelElement, Props>(
       titleCase,
       ...rest
     } = props
+
+    usePropDeprecationWarning({
+      props,
+      name: 'requiredDecoration',
+      componentName: 'Checkbox',
+      description: "There will be 'optional' boolean property instead"
+    })
 
     const classes = useStyles()
     const rootClasses = {

--- a/packages/picasso/src/FormControlLabel/FormControlLabel.tsx
+++ b/packages/picasso/src/FormControlLabel/FormControlLabel.tsx
@@ -12,9 +12,11 @@ import cx from 'classnames'
 import { RequiredDecoration } from '../FormLabel'
 import styles from './styles'
 import Form from '../Form'
+import { usePropDeprecationWarning } from '../utils/use-deprecation-warnings'
 
-export type FormControlLabelAttributesType = LabelHTMLAttributes<HTMLLabelElement> &
-  Pick<FormControlLabelProps, 'onChange'>
+export type FormControlLabelAttributesType =
+  LabelHTMLAttributes<HTMLLabelElement> &
+    Pick<FormControlLabelProps, 'onChange'>
 
 export interface Props
   extends StandardProps,
@@ -51,6 +53,13 @@ const FormControlLabel = forwardRef<HTMLLabelElement, Props>(
     } = props
 
     const classes = useStyles(props)
+
+    usePropDeprecationWarning({
+      props,
+      name: 'requiredDecoration',
+      componentName: 'FormControlLabel',
+      description: "There will be 'optional' boolean property instead"
+    })
 
     return (
       <label

--- a/packages/picasso/src/FormLabel/FormLabel.tsx
+++ b/packages/picasso/src/FormLabel/FormLabel.tsx
@@ -10,6 +10,7 @@ import {
 
 import styles from './styles'
 import toTitleCase from '../utils/to-title-case'
+import { usePropDeprecationWarning } from '../utils/use-deprecation-warnings'
 
 type ComponentType = 'label' | 'span'
 export type RequiredDecoration = 'asterisk' | 'optional'
@@ -58,6 +59,13 @@ export const FormLabel = forwardRef<HTMLLabelElement, Props>(function FormLabel(
 
   const isInline = inline || Component === 'span'
   const titleCase = useTitleCase(propsTitleCase)
+
+  usePropDeprecationWarning({
+    props,
+    name: 'requiredDecoration',
+    componentName: 'FormLabel',
+    description: "There will be 'optional' boolean property instead"
+  })
 
   return (
     <Component


### PR DESCRIPTION
[FX-2614]

### Description

Added deprecation warning for `requiredDecoration` in components FormLabel, FormControlLabel, Checkbox

### How to test

Open and check if the warning appears on Form components and Check

### Review

- [ ] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [ ] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that tests pass by running `yarn test`
- [ ] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
- [ ] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-2614]: https://toptal-core.atlassian.net/browse/FX-2614?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ