### PR TITLE
fix: removed BarCharts warnings

### DIFF
--- a/.changeset/rare-chefs-remain.md
+++ b/.changeset/rare-chefs-remain.md
@@ -1,0 +1,9 @@
+---
+'@toptal/picasso-charts': patch
+---
+
+---
+
+### BarChart
+
+- extend `width` and `height` props to accept strings (e.g. '100%')

--- a/packages/picasso-charts/src/BarChart/test.tsx
+++ b/packages/picasso-charts/src/BarChart/test.tsx
@@ -12,13 +12,15 @@ const TEST_DATA = [
 
 const renderBarChart = (showBarLabel?: boolean) => {
   return render(
-    <BarChart
-      data={TEST_DATA}
-      getBarColor={() => palette.blue.main}
-      getBarLabelColor={() => palette.grey.dark}
-      width={720}
-      showBarLabel={showBarLabel}
-    />
+    <div style={{ width: 720 }}>
+      <BarChart
+        data={TEST_DATA}
+        getBarColor={() => palette.blue.main}
+        getBarLabelColor={() => palette.grey.dark}
+        width={'100%'}
+        showBarLabel={showBarLabel}
+      />
+    </div>
   )
 }
 
@@ -62,19 +64,15 @@ describe('BarChart', () => {
     )
   })
 
-  it('shows label of each bar with `showBarLabel` prop being set to `true` by default', async () => {
+  it('shows label of each bar with `showBarLabel` prop being set to `true` by default', () => {
     const { queryByText } = renderBarChart()
 
-    await waitFor(() => {
-      expect(queryByText('118')).toBeInTheDocument()
-    })
+    waitFor(() => expect(queryByText('118')).toBeInTheDocument())
   })
 
-  it('hides label of each bar via passed `showBarLabel` prop being set to `false', async () => {
+  it('hides label of each bar via passed `showBarLabel` prop being set to `false', () => {
     const { queryByText } = renderBarChart(false)
 
-    await waitFor(() => {
-      expect(queryByText('118')).not.toBeInTheDocument()
-    })
+    waitFor(() => expect(queryByText('118')).not.toBeInTheDocument())
   })
 })

--- a/packages/picasso-charts/src/types.ts
+++ b/packages/picasso-charts/src/types.ts
@@ -23,9 +23,9 @@ export type PositionTranslate = {
 
 export interface BaseChartProps extends BaseProps {
   /** Height of chart */
-  height?: number
+  height?: number | string
   /** Width of chart */
-  width?: number
+  width?: number | string
   /** Toggle tooltip on hover */
   tooltip?: boolean
   /** Requires `tooltip` to be `true` */


### PR DESCRIPTION
[FX-2598]

### Description

`BarChart` uses [ResponsiveContainer from recharts](https://recharts.org/en-US/api/ResponsiveContainer) which throws warning console.log when static numbers are used - which is exactly our case, we do not allow strings as width or height (e.g. "100%").
One solution (that I used) is to extend width/height props to allow strings as well. Another would be to remove the ResponsiveContainer. 

### How to test

running `yarn test:unit packages/picasso-charts/src/BarChart` locally should not throw any warning

### Review

- [ ] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [ ] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that tests pass by running `yarn test`
- [ ] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
- [ ] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-2598]: https://toptal-core.atlassian.net/browse/FX-2598?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ