### PR TITLE
chore(tooltip): add `followCursor` prop based on implementation from `@material-ui@5+`

### DIFF
--- a/.changeset/wild-vans-enjoy.md
+++ b/.changeset/wild-vans-enjoy.md
@@ -7,3 +7,4 @@
 ### Tooltip
 
 - add `followCursor` prop based on implementation from `@material-ui@5+`
+- fix of broken existing event listeners for `Tooltip`'s target when `disableListeners` is `true`

--- a/.changeset/wild-vans-enjoy.md
+++ b/.changeset/wild-vans-enjoy.md
@@ -1,0 +1,9 @@
+---
+'@toptal/picasso': minor
+---
+
+---
+
+### Tooltip
+
+- add `followCursor` prop based on implementation from `@material-ui@5+`

--- a/packages/picasso/src/Tooltip/Tooltip.tsx
+++ b/packages/picasso/src/Tooltip/Tooltip.tsx
@@ -116,7 +116,8 @@ export const Tooltip = forwardRef<unknown, Props>((props, ref) => {
     onOpen,
     onClose,
     onMouseOver: followCursorTooltipData?.handleMouseOver,
-    onMouseMove: followCursorTooltipData?.handleMouseMove
+    onMouseMove: followCursorTooltipData?.handleMouseMove,
+    onClick: followCursorTooltipData?.handleClick
   })
 
   const title = (

--- a/packages/picasso/src/Tooltip/Tooltip.tsx
+++ b/packages/picasso/src/Tooltip/Tooltip.tsx
@@ -104,17 +104,19 @@ export const Tooltip = forwardRef<unknown, Props>((props, ref) => {
 
   const delayDuration = getDelayDuration(delay, tooltipState.isTouchDevice)
 
+  const followCursorTooltipData = useTooltipFollowCursor({
+    followCursor,
+    tooltipState
+  })
+
   const { children, handleOpen, handleClose } = useTooltipHandlers({
     children: originalChildren as ReactElement<ChildrenProps>,
     tooltipState,
     disableListeners,
     onOpen,
-    onClose
-  })
-
-  const followCursorTooltipData = useTooltipFollowCursor({
-    followCursor,
-    tooltipState
+    onClose,
+    onMouseOver: followCursorTooltipData?.handleMouseOver,
+    onMouseMove: followCursorTooltipData?.handleMouseMove
   })
 
   const title = (
@@ -163,7 +165,6 @@ export const Tooltip = forwardRef<unknown, Props>((props, ref) => {
       interactive={interactive}
       onClose={handleClose}
       onOpen={handleOpen}
-      onMouseMove={followCursorTooltipData?.handleMouseMove}
       open={tooltipState.isOpen}
       placement={placement}
       title={title}

--- a/packages/picasso/src/Tooltip/story/FollowCursor.example.tsx
+++ b/packages/picasso/src/Tooltip/story/FollowCursor.example.tsx
@@ -1,0 +1,19 @@
+import React from 'react'
+import { Tooltip, Container } from '@toptal/picasso'
+
+const longContent = `Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.`
+
+const Example = () => (
+  <Container
+    flex
+    justifyContent='space-between'
+    padded='large'
+    style={{ height: '240px', width: '1000px', padding: '2rem 10rem' }}
+  >
+    <Tooltip content={longContent} followCursor placement='right'>
+      <Container>{longContent}</Container>
+    </Tooltip>
+  </Container>
+)
+
+export default Example

--- a/packages/picasso/src/Tooltip/story/index.jsx
+++ b/packages/picasso/src/Tooltip/story/index.jsx
@@ -44,6 +44,7 @@ page
   .addExample('Tooltip/story/Delay.example.tsx', 'Delay') // picasso-skip-visuals
   .addExample('Tooltip/story/Compact.example.tsx', 'Compact') // picasso-skip-visuals
   .addExample('Tooltip/story/MaxWidth.example.tsx', 'Max Width') // picasso-skip-visuals
+  .addExample('Tooltip/story/FollowCursor.example.tsx', 'Follow Cursor') // picasso-skip-visuals
   .addExample('Tooltip/story/Dropdown.example.tsx', {
     title: 'Inside of a Dropdown',
     effect: async (testPage, makeScreenshot) => {

--- a/packages/picasso/src/Tooltip/types.ts
+++ b/packages/picasso/src/Tooltip/types.ts
@@ -1,0 +1,9 @@
+import { ChangeEvent } from 'react'
+
+export type ChildrenProps = {
+  onClick?: (event: ChangeEvent<{}>) => void
+  onMouseEnter?: () => void
+  onMouseLeave?: () => void
+}
+
+export type ContainerValue = HTMLElement | (() => HTMLElement)

--- a/packages/picasso/src/Tooltip/types.ts
+++ b/packages/picasso/src/Tooltip/types.ts
@@ -1,9 +1,11 @@
-import { ChangeEvent } from 'react'
+import { ChangeEvent, MouseEvent } from 'react'
 
 export type ChildrenProps = {
   onClick?: (event: ChangeEvent<{}>) => void
-  onMouseEnter?: () => void
-  onMouseLeave?: () => void
+  onMouseEnter?: (event: MouseEvent<HTMLDivElement>) => void
+  onMouseOver?: (event: MouseEvent<HTMLDivElement>) => void
+  onMouseMove?: (event: MouseEvent<HTMLDivElement>) => void
+  onMouseLeave?: (event: MouseEvent<HTMLDivElement>) => void
 }
 
 export type ContainerValue = HTMLElement | (() => HTMLElement)

--- a/packages/picasso/src/Tooltip/types.ts
+++ b/packages/picasso/src/Tooltip/types.ts
@@ -2,7 +2,6 @@ import { ChangeEvent, MouseEvent } from 'react'
 
 export type ChildrenProps = {
   onClick?: (event: ChangeEvent<{}>) => void
-  onMouseEnter?: (event: MouseEvent<HTMLDivElement>) => void
   onMouseOver?: (event: MouseEvent<HTMLDivElement>) => void
   onMouseMove?: (event: MouseEvent<HTMLDivElement>) => void
   onMouseLeave?: (event: MouseEvent<HTMLDivElement>) => void

--- a/packages/picasso/src/Tooltip/types.ts
+++ b/packages/picasso/src/Tooltip/types.ts
@@ -1,10 +1,10 @@
-import { ChangeEvent, MouseEvent } from 'react'
+import { MouseEvent } from 'react'
 
 export type ChildrenProps = {
-  onClick?: (event: ChangeEvent<{}>) => void
-  onMouseOver?: (event: MouseEvent<HTMLDivElement>) => void
-  onMouseMove?: (event: MouseEvent<HTMLDivElement>) => void
-  onMouseLeave?: (event: MouseEvent<HTMLDivElement>) => void
+  onClick?: (event: MouseEvent<HTMLElement>) => void
+  onMouseOver?: (event: MouseEvent<HTMLElement>) => void
+  onMouseMove?: (event: MouseEvent<HTMLElement>) => void
+  onMouseLeave?: (event: MouseEvent<HTMLElement>) => void
 }
 
 export type ContainerValue = HTMLElement | (() => HTMLElement)

--- a/packages/picasso/src/Tooltip/useTooltipFollowCursor.ts
+++ b/packages/picasso/src/Tooltip/useTooltipFollowCursor.ts
@@ -57,8 +57,6 @@ export const useTooltipFollowCursor = ({
       return
     }
 
-    console.log('over')
-
     calculateTooltipPosition(event)
   }
 

--- a/packages/picasso/src/Tooltip/useTooltipFollowCursor.ts
+++ b/packages/picasso/src/Tooltip/useTooltipFollowCursor.ts
@@ -43,21 +43,33 @@ export const useTooltipFollowCursor = ({
     debounce(handleMouseStop, mouseMoveDebounceTimeout),
     [debounce, handleMouseStop]
   )
-  const handleMouseMove = (event: MouseEvent<HTMLDivElement>) => {
-    if (!followCursor) {
-      return
-    }
-
+  const calculateTooltipPosition = (event: MouseEvent<HTMLDivElement>) => {
     if (!mouseMoveStartPositionRef.current) {
       mouseMoveStartPositionRef.current = { x: event.clientX, y: event.clientY }
     }
 
     positionRef.current = { x: event.clientX, y: event.clientY }
+
     popperRef.current?.scheduleUpdate()
+  }
+  const handleMouseOver = (event: MouseEvent<HTMLDivElement>) => {
+    if (!followCursor) {
+      return
+    }
+
+    calculateTooltipPosition(event)
+  }
+
+  const handleMouseMove = (event: MouseEvent<HTMLDivElement>) => {
+    if (!followCursor) {
+      return
+    }
+
+    calculateTooltipPosition(event)
 
     const shouldCloseTooltip = isMouseMovedTooFar(
       positionRef.current,
-      mouseMoveStartPositionRef.current
+      mouseMoveStartPositionRef?.current ?? positionRef.current
     )
 
     // When the cursor is moved `mouseMoveCloseTooltipDistance` pixels and more in any direction, we close the tooltip
@@ -75,6 +87,7 @@ export const useTooltipFollowCursor = ({
 
   return {
     handleMouseMove,
+    handleMouseOver,
     followCursorPopperProps: {
       popperRef,
       modifiers: {

--- a/packages/picasso/src/Tooltip/useTooltipFollowCursor.ts
+++ b/packages/picasso/src/Tooltip/useTooltipFollowCursor.ts
@@ -34,16 +34,16 @@ export const useTooltipFollowCursor = ({
   const popperRef = useRef<PopperJs | null>(null)
 
   const handleMouseStop = useCallback(() => {
-    if (followCursor && targetHoveredRef.current) {
+    if (targetHoveredRef.current) {
       mouseMoveStartPositionRef.current = null
       openTooltip()
     }
-  }, [followCursor, targetHoveredRef])
+  }, [targetHoveredRef])
   const handleMouseStopDebounced = useCallback(
     debounce(handleMouseStop, mouseMoveDebounceTimeout),
     [debounce, handleMouseStop]
   )
-  const calculateTooltipPosition = (event: MouseEvent<HTMLDivElement>) => {
+  const calculateTooltipPosition = (event: MouseEvent<HTMLElement>) => {
     if (!mouseMoveStartPositionRef.current) {
       mouseMoveStartPositionRef.current = { x: event.clientX, y: event.clientY }
     }
@@ -52,19 +52,7 @@ export const useTooltipFollowCursor = ({
 
     popperRef.current?.scheduleUpdate()
   }
-  const handleMouseOver = (event: MouseEvent<HTMLDivElement>) => {
-    if (!followCursor) {
-      return
-    }
-
-    calculateTooltipPosition(event)
-  }
-
-  const handleMouseMove = (event: MouseEvent<HTMLDivElement>) => {
-    if (!followCursor) {
-      return
-    }
-
+  const handleMouseMove = (event: MouseEvent<HTMLElement>) => {
     calculateTooltipPosition(event)
 
     const shouldCloseTooltip = isMouseMovedTooFar(
@@ -87,7 +75,8 @@ export const useTooltipFollowCursor = ({
 
   return {
     handleMouseMove,
-    handleMouseOver,
+    handleMouseOver: calculateTooltipPosition,
+    handleClick: calculateTooltipPosition,
     followCursorPopperProps: {
       popperRef,
       modifiers: {

--- a/packages/picasso/src/Tooltip/useTooltipFollowCursor.ts
+++ b/packages/picasso/src/Tooltip/useTooltipFollowCursor.ts
@@ -57,6 +57,8 @@ export const useTooltipFollowCursor = ({
       return
     }
 
+    console.log('over')
+
     calculateTooltipPosition(event)
   }
 

--- a/packages/picasso/src/Tooltip/useTooltipHandlers.ts
+++ b/packages/picasso/src/Tooltip/useTooltipHandlers.ts
@@ -12,8 +12,9 @@ import { ChildrenProps } from './types'
 interface UseTooltipHandlersOptions {
   onOpen?: (event: ChangeEvent<{}>) => void
   onClose?: (event: ChangeEvent<{}>) => void
-  onMouseOver?: (event: MouseEvent<HTMLDivElement>) => void
-  onMouseMove?: (event: MouseEvent<HTMLDivElement>) => void
+  onMouseOver?: (event: MouseEvent<HTMLElement>) => void
+  onMouseMove?: (event: MouseEvent<HTMLElement>) => void
+  onClick?: (event: MouseEvent<HTMLElement>) => void
   children: ReactElement<ChildrenProps>
   tooltipState: TooltipState
   disableListeners?: boolean
@@ -24,6 +25,7 @@ export const useTooltipHandlers = ({
   onOpen,
   onMouseOver,
   onMouseMove,
+  onClick,
   tooltipState,
   disableListeners,
   children
@@ -58,32 +60,50 @@ export const useTooltipHandlers = ({
     onOpen?.(event)
     openTooltip()
   }
-  const handleClick = (event: ChangeEvent<{}>) => {
+  const handleClick = (event: MouseEvent<HTMLElement>) => {
+    children.props.onClick?.(event)
+
     if (disableListeners) {
       return
     }
 
-    children.props.onClick?.(event)
     if (isOpen) {
       setIgnoreOpening(true)
       handleClose(event)
     } else if (isTouchDevice) {
       handleOpen(event)
     }
+
+    onClick?.(event)
   }
-  const handleMouseOver = (event: MouseEvent<HTMLDivElement>) => {
+  const handleMouseOver = (event: MouseEvent<HTMLElement>) => {
+    children.props.onMouseOver?.(event)
+
+    if (disableListeners) {
+      return
+    }
+
     targetHoveredRef.current = true
     onMouseOver?.(event)
-    children.props.onMouseOver?.(event)
   }
-  const handleMouseMove = (event: MouseEvent<HTMLDivElement>) => {
-    onMouseMove?.(event)
+  const handleMouseMove = (event: MouseEvent<HTMLElement>) => {
     children.props.onMouseMove?.(event)
+
+    if (disableListeners) {
+      return
+    }
+
+    onMouseMove?.(event)
   }
-  const handleMouseLeave = (event: MouseEvent<HTMLDivElement>) => {
+  const handleMouseLeave = (event: MouseEvent<HTMLElement>) => {
+    children.props.onMouseLeave?.(event)
+
+    if (disableListeners) {
+      return
+    }
+
     targetHoveredRef.current = false
     setIgnoreOpening(false)
-    children.props.onMouseLeave?.(event)
   }
 
   return {

--- a/packages/picasso/src/Tooltip/useTooltipHandlers.ts
+++ b/packages/picasso/src/Tooltip/useTooltipHandlers.ts
@@ -1,4 +1,10 @@
-import { ChangeEvent, cloneElement, ReactElement, useState } from 'react'
+import {
+  ChangeEvent,
+  MouseEvent,
+  cloneElement,
+  ReactElement,
+  useState
+} from 'react'
 
 import { TooltipState } from './useTooltipState'
 import { ChildrenProps } from './types'
@@ -6,6 +12,8 @@ import { ChildrenProps } from './types'
 interface UseTooltipHandlersOptions {
   onOpen?: (event: ChangeEvent<{}>) => void
   onClose?: (event: ChangeEvent<{}>) => void
+  onMouseOver?: (event: MouseEvent<HTMLDivElement>) => void
+  onMouseMove?: (event: MouseEvent<HTMLDivElement>) => void
   children: ReactElement<ChildrenProps>
   tooltipState: TooltipState
   disableListeners?: boolean
@@ -14,6 +22,8 @@ interface UseTooltipHandlersOptions {
 export const useTooltipHandlers = ({
   onClose,
   onOpen,
+  onMouseOver,
+  onMouseMove,
   tooltipState,
   disableListeners,
   children
@@ -61,12 +71,22 @@ export const useTooltipHandlers = ({
       handleOpen(event)
     }
   }
-  const handleMouseEnter = () => {
+  const handleMouseEnter = (event: MouseEvent<HTMLDivElement>) => {
     targetHoveredRef.current = true
+    children.props.onMouseEnter?.(event)
   }
-  const handleMouseLeave = () => {
+  const handleMouseOver = (event: MouseEvent<HTMLDivElement>) => {
+    onMouseOver?.(event)
+    children.props.onMouseOver?.(event)
+  }
+  const handleMouseMove = (event: MouseEvent<HTMLDivElement>) => {
+    onMouseMove?.(event)
+    children.props.onMouseMove?.(event)
+  }
+  const handleMouseLeave = (event: MouseEvent<HTMLDivElement>) => {
     targetHoveredRef.current = false
     setIgnoreOpening(false)
+    children.props.onMouseLeave?.(event)
   }
 
   return {
@@ -75,6 +95,8 @@ export const useTooltipHandlers = ({
     children: cloneElement(children, {
       onClick: handleClick,
       onMouseEnter: handleMouseEnter,
+      onMouseOver: handleMouseOver,
+      onMouseMove: handleMouseMove,
       onMouseLeave: handleMouseLeave
     })
   }

--- a/packages/picasso/src/Tooltip/useTooltipHandlers.ts
+++ b/packages/picasso/src/Tooltip/useTooltipHandlers.ts
@@ -71,11 +71,8 @@ export const useTooltipHandlers = ({
       handleOpen(event)
     }
   }
-  const handleMouseEnter = (event: MouseEvent<HTMLDivElement>) => {
-    targetHoveredRef.current = true
-    children.props.onMouseEnter?.(event)
-  }
   const handleMouseOver = (event: MouseEvent<HTMLDivElement>) => {
+    targetHoveredRef.current = true
     onMouseOver?.(event)
     children.props.onMouseOver?.(event)
   }
@@ -94,7 +91,6 @@ export const useTooltipHandlers = ({
     handleClose,
     children: cloneElement(children, {
       onClick: handleClick,
-      onMouseEnter: handleMouseEnter,
       onMouseOver: handleMouseOver,
       onMouseMove: handleMouseMove,
       onMouseLeave: handleMouseLeave

--- a/packages/picasso/src/Tooltip/useTooltipHandlers.ts
+++ b/packages/picasso/src/Tooltip/useTooltipHandlers.ts
@@ -1,0 +1,81 @@
+import { ChangeEvent, cloneElement, ReactElement, useState } from 'react'
+
+import { TooltipState } from './useTooltipState'
+import { ChildrenProps } from './types'
+
+interface UseTooltipHandlersOptions {
+  onOpen?: (event: ChangeEvent<{}>) => void
+  onClose?: (event: ChangeEvent<{}>) => void
+  children: ReactElement<ChildrenProps>
+  tooltipState: TooltipState
+  disableListeners?: boolean
+}
+
+export const useTooltipHandlers = ({
+  onClose,
+  onOpen,
+  tooltipState,
+  disableListeners,
+  children
+}: UseTooltipHandlersOptions) => {
+  const {
+    isOpen,
+    isControlled,
+    isTouchDevice,
+    targetHoveredRef,
+    openTooltip,
+    closeTooltip
+  } = tooltipState
+  // After closing with click the tooltip should not be opened againg until the mouse leave event
+  const [ignoreOpening, setIgnoreOpening] = useState(false)
+
+  if (isControlled) {
+    return {
+      handleOpen: onOpen,
+      handleClose: onClose,
+      children
+    }
+  }
+  const handleClose = (event: ChangeEvent<{}>) => {
+    onClose?.(event)
+    closeTooltip()
+  }
+  const handleOpen = (event: ChangeEvent<{}>) => {
+    if (ignoreOpening) {
+      return
+    }
+
+    onOpen?.(event)
+    openTooltip()
+  }
+  const handleClick = (event: ChangeEvent<{}>) => {
+    if (disableListeners) {
+      return
+    }
+
+    children.props.onClick?.(event)
+    if (isOpen) {
+      setIgnoreOpening(true)
+      handleClose(event)
+    } else if (isTouchDevice) {
+      handleOpen(event)
+    }
+  }
+  const handleMouseEnter = () => {
+    targetHoveredRef.current = true
+  }
+  const handleMouseLeave = () => {
+    targetHoveredRef.current = false
+    setIgnoreOpening(false)
+  }
+
+  return {
+    handleOpen,
+    handleClose,
+    children: cloneElement(children, {
+      onClick: handleClick,
+      onMouseEnter: handleMouseEnter,
+      onMouseLeave: handleMouseLeave
+    })
+  }
+}

--- a/packages/picasso/src/Tooltip/useTooltipState.ts
+++ b/packages/picasso/src/Tooltip/useTooltipState.ts
@@ -1,0 +1,75 @@
+import { MutableRefObject, useRef, useState } from 'react'
+import { isPointerDevice } from '@toptal/picasso/utils'
+
+interface UseTooltipStateOptions {
+  externalOpen?: boolean
+  followCursor: boolean
+}
+
+export interface TooltipState {
+  isOpen: boolean
+  isControlled: boolean
+  isTouchDevice: boolean
+  targetHoveredRef: MutableRefObject<boolean>
+  openTooltip: () => void
+  closeTooltip: () => void
+}
+
+const getTooltipOpenState = ({
+  isOpen,
+  isOpenExternally,
+  isControlled,
+  isTouchDevice,
+  followCursor
+}: {
+  isOpen: boolean
+  isOpenExternally: boolean
+  isControlled: boolean
+  isTouchDevice: boolean
+  followCursor: boolean
+}): boolean => {
+  // We don't support `followCursor` prop when this prop is enabled on the touch device. Same as in `@material-ui@5`
+  if (isTouchDevice && followCursor) {
+    return false
+  }
+
+  if (isControlled) {
+    return isOpenExternally
+  }
+
+  return isOpen
+}
+
+export const useTooltipState = ({
+  externalOpen,
+  followCursor
+}: UseTooltipStateOptions): TooltipState => {
+  const isTouchDevice = !isPointerDevice()
+  const isTooltipControlled = typeof externalOpen !== 'undefined'
+  const [isOpen, setIsOpen] = useState(
+    isTooltipControlled ? externalOpen : false
+  )
+  const targetHoveredRef = useRef(false)
+
+  const openTooltip = () => {
+    setIsOpen(true)
+  }
+  const closeTooltip = () => {
+    setIsOpen(false)
+  }
+
+  return {
+    isOpen: getTooltipOpenState({
+      isOpen,
+      isOpenExternally: !!externalOpen,
+      isControlled: isTooltipControlled,
+      isTouchDevice,
+      followCursor
+    }),
+    isControlled: isTooltipControlled,
+    isTouchDevice,
+    targetHoveredRef,
+    openTooltip,
+    closeTooltip
+  }
+}


### PR DESCRIPTION
[SPT-2577]

### Description

Add `followCursor` prop based on implementation from `@material-ui@5+` but with improvements
https://github.com/mui/material-ui/issues/14270

Improvements:
- when the cursor is moved 50+ pixels in any direction, we close the tooltip during moving, because the tooltip becomes annoying during such long moving action. After moving the tooltip is shown again.
- when the cursor is moved less than 50 pixels, we do not close the tooltip

When this option is enabled, the tooltip is completely disabled for touch devices, same as in `material-ui@5`

### How to test

Open https://picasso.toptal.net/SPT-2577-tooltip-follow-cursor-prop/?path=/story/overlays-tooltip--tooltip, scroll to `Follow Cursor` example. Hover and move mouse over text. Test it carefully, especially logic when we move cursor outside of target element and logic with delays

### Review

- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure that tests pass by running `yarn test`
- [x] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[SPT-2577]: https://toptal-core.atlassian.net/browse/SPT-2577?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ