### PR TITLE
Add FieldWrapper+Autocomplete demo

### DIFF
--- a/packages/picasso-forms/src/Form/story/FieldWrapper.example.tsx
+++ b/packages/picasso-forms/src/Form/story/FieldWrapper.example.tsx
@@ -1,0 +1,25 @@
+import React from 'react'
+import { Container, Autocomplete } from '@toptal/picasso'
+import { Form, FieldWrapper } from '@toptal/picasso-forms'
+
+const required = (value?: any) => {
+  if (!value) {
+    return 'required'
+  }
+
+  return undefined
+}
+
+const FieldWrapperExample = () => (
+  <Form onSubmit={values => window.alert(values)}>
+    <FieldWrapper name='userAge' validate={required}>
+      {(inputProps: any) => <Autocomplete {...inputProps} />}
+    </FieldWrapper>
+
+    <Container top='small'>
+      <Form.SubmitButton>Submit</Form.SubmitButton>
+    </Container>
+  </Form>
+)
+
+export default FieldWrapperExample

--- a/packages/picasso-forms/src/Form/story/index.jsx
+++ b/packages/picasso-forms/src/Form/story/index.jsx
@@ -149,6 +149,14 @@ types supported by picasso-forms.
     'picasso-form'
   )
   .addExample(
+    'Form/story/FieldWrapper.example.tsx',
+    {
+      title: 'FieldWrapper',
+      description: ''
+    },
+    'picasso-form'
+  ) // picasso-skip-visuals
+  .addExample(
     'Form/story/CustomValidator.example.tsx',
     {
       title: 'Custom validator',


### PR DESCRIPTION
`<FieldWrapper` does not inject proper status/error props for it's children to turn on its actual erroneous appearance. In the demo this PR adds you can see error message is shown under Autocomplete, but Autocomplete has no red outline. 

<img width="450" alt="image" src="https://user-images.githubusercontent.com/903437/163707115-0efe8396-be34-4f6a-ab47-ebcf5adee515.png">

While expected appearance for a field with an error is to have that red outline:

<img width="450" alt="image" src="https://user-images.githubusercontent.com/903437/163706660-fe932868-cafd-4a3d-88ca-819dc37d42f7.png">

### Review

- [ ] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [ ] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that tests pass by running `yarn test`
- [ ] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
- [ ] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>
