### PR TITLE
fix: remove `onSearchChange` prop deprecation leftover

### DIFF
--- a/.changeset/bright-phones-think.md
+++ b/.changeset/bright-phones-think.md
@@ -1,0 +1,9 @@
+---
+'@toptal/picasso': patch
+---
+
+---
+
+### Select
+
+- remove `onSearchChange` deprecation leftover

--- a/.changeset/bright-phones-think.md
+++ b/.changeset/bright-phones-think.md
@@ -6,4 +6,4 @@
 
 ### Select
 
-- remove `onSearchChange` deprecation leftover
+- remove `onSearchChange` deprecated prop

--- a/packages/picasso/src/Select/Select.tsx
+++ b/packages/picasso/src/Select/Select.tsx
@@ -37,14 +37,6 @@ export const Select = <T extends ValueType, M extends boolean = false>({
 }: SelectProps<T, M>) => {
   usePropDeprecationWarning({
     props,
-    name: 'onSearchChange',
-    componentName: 'Select',
-    description:
-      'Use the Autocomplete component if you require dynamic options.'
-  })
-
-  usePropDeprecationWarning({
-    props,
     name: 'error',
     componentName: 'Select',
     description:

--- a/packages/picasso/src/Select/hooks/use-select-props/mocks.ts
+++ b/packages/picasso/src/Select/hooks/use-select-props/mocks.ts
@@ -22,7 +22,6 @@ export const getUseSelectPropsMock = (): UseSelectProps => {
       error: false,
       loading: false,
       onChange: jest.fn(),
-      onSearchChange: jest.fn(),
       options: [],
       renderOption: jest.fn(),
       getDisplayValue: jest.fn(),

--- a/packages/picasso/src/Select/hooks/use-select-props/use-search-change-handler/test.ts
+++ b/packages/picasso/src/Select/hooks/use-select-props/use-search-change-handler/test.ts
@@ -12,8 +12,6 @@ describe('useSearchChangeHandler', () => {
 
     result.current(event)
 
-    expect(props.selectProps.onSearchChange).toHaveBeenCalledTimes(1)
-    expect(props.selectProps.onSearchChange).toHaveBeenCalledWith('foo')
     expect(props.selectState.setFilterOptionsValue).toHaveBeenCalledTimes(1)
     expect(props.selectState.setFilterOptionsValue).toHaveBeenCalledWith('foo')
   })

--- a/packages/picasso/src/Select/hooks/use-select-props/use-search-change-handler/use-search-change-handler.ts
+++ b/packages/picasso/src/Select/hooks/use-select-props/use-search-change-handler/use-search-change-handler.ts
@@ -6,15 +6,13 @@ const useSearchChangeHandler = <
   T extends ValueType,
   M extends boolean = false
 >({
-  selectState: { setFilterOptionsValue },
-  selectProps: { onSearchChange }
+  selectState: { setFilterOptionsValue }
 }: UseSelectProps<T, M>) =>
   useCallback(
     (event: ChangeEvent<HTMLInputElement>) => {
-      onSearchChange?.(event.target.value)
       setFilterOptionsValue(event.target.value)
     },
-    [onSearchChange, setFilterOptionsValue]
+    [setFilterOptionsValue]
   )
 
 export default useSearchChangeHandler

--- a/packages/picasso/src/Select/hooks/use-select-props/use-search-change-handler/use-search-change-handler.ts
+++ b/packages/picasso/src/Select/hooks/use-select-props/use-search-change-handler/use-search-change-handler.ts
@@ -1,18 +1,12 @@
-import { useCallback, ChangeEvent } from 'react'
+import { ChangeEvent } from 'react'
 
 import { ValueType, UseSelectProps } from '../../../types'
 
-const useSearchChangeHandler = <
-  T extends ValueType,
-  M extends boolean = false
->({
-  selectState: { setFilterOptionsValue }
-}: UseSelectProps<T, M>) =>
-  useCallback(
-    (event: ChangeEvent<HTMLInputElement>) => {
-      setFilterOptionsValue(event.target.value)
-    },
-    [setFilterOptionsValue]
-  )
+const useSearchChangeHandler =
+  <T extends ValueType, M extends boolean = false>({
+    selectState: { setFilterOptionsValue }
+  }: UseSelectProps<T, M>) =>
+  (event: ChangeEvent<HTMLInputElement>) =>
+    setFilterOptionsValue(event.target.value)
 
 export default useSearchChangeHandler

--- a/packages/picasso/src/Select/test.tsx
+++ b/packages/picasso/src/Select/test.tsx
@@ -2,7 +2,6 @@ import React from 'react'
 import { render, PicassoConfig } from '@toptal/picasso/test-utils'
 import { OmitInternalProps } from '@toptal/picasso-shared'
 
-import { usePropDeprecationWarning } from '../utils/use-deprecation-warnings'
 import Select from './Select'
 import { SelectProps } from './types'
 
@@ -16,26 +15,12 @@ jest.mock('../NativeSelect', () => ({
   default: () => <div data-testid='native-select' />
 }))
 
-jest.mock('../utils/use-deprecation-warnings', () => ({
-  __esModule: true,
-  usePropDeprecationWarning: jest.fn()
-}))
-
-const mockedUsePropDeprecationWarning =
-  usePropDeprecationWarning as jest.MockedFunction<
-    typeof usePropDeprecationWarning
-  >
-
 const renderSelect = (
   props: OmitInternalProps<SelectProps>,
   picassoConfig?: PicassoConfig
 ) => render(<Select {...props} />, undefined, picassoConfig)
 
 describe('Select', () => {
-  beforeEach(() => {
-    mockedUsePropDeprecationWarning.mockClear()
-  })
-
   it('renders native', () => {
     const { getByTestId } = renderSelect({ options: [], native: true })
 

--- a/packages/picasso/src/Select/test.tsx
+++ b/packages/picasso/src/Select/test.tsx
@@ -21,9 +21,10 @@ jest.mock('../utils/use-deprecation-warnings', () => ({
   usePropDeprecationWarning: jest.fn()
 }))
 
-const mockedUsePropDeprecationWarning = usePropDeprecationWarning as jest.MockedFunction<
-  typeof usePropDeprecationWarning
->
+const mockedUsePropDeprecationWarning =
+  usePropDeprecationWarning as jest.MockedFunction<
+    typeof usePropDeprecationWarning
+  >
 
 const renderSelect = (
   props: OmitInternalProps<SelectProps>,
@@ -45,19 +46,5 @@ describe('Select', () => {
     const { getByTestId } = renderSelect({ options: [] })
 
     expect(getByTestId('non-native-select')).toBeInTheDocument()
-  })
-
-  it('warns about deprecated props', () => {
-    const props = { options: [] }
-
-    renderSelect(props)
-
-    expect(mockedUsePropDeprecationWarning).toHaveBeenCalledWith({
-      props: expect.objectContaining(props),
-      name: 'onSearchChange',
-      componentName: 'Select',
-      description:
-        'Use the Autocomplete component if you require dynamic options.'
-    })
   })
 })

--- a/packages/picasso/src/Select/types.ts
+++ b/packages/picasso/src/Select/types.ts
@@ -57,8 +57,6 @@ export interface SelectProps<
       value: V
     }>
   ) => void
-  /** @deprecated Callback invoked when search value changes */
-  onSearchChange?: (value: string) => void
   /** Label to show when no options were found */
   noOptionsText?: string
   /** List of options or option groups to be rendered as `Select` */


### PR DESCRIPTION
[FX-2644]

### Description

A prop deprecation leftover is being removed here. We should mostly see deleted code.

### How to test

- Select component still works as expected, for both Native and NonNative

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| Insert screenshots or screen recordings | Insert screenshots or screen recordings |

### Review

- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure that tests pass by running `yarn test`
- [x] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-2644]: https://toptal-core.atlassian.net/browse/FX-2644?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ