### PR TITLE
fix(Badge): use mui  prop

### DIFF
--- a/.changeset/sixty-doors-type.md
+++ b/.changeset/sixty-doors-type.md
@@ -1,0 +1,11 @@
+---
+'@toptal/picasso': patch
+---
+
+---
+### Badge
+
+- Use MUI `max` property instead of our custom.
+  When we sended `string` (+9999) to MUIBadge,
+  it worked as we expected, but when we passed `number` (150),
+  it was always trimmed by default mui `max` +99

--- a/packages/picasso/src/Badge/Badge.tsx
+++ b/packages/picasso/src/Badge/Badge.tsx
@@ -34,16 +34,6 @@ const thresholds: Record<SizeType, number> = {
   large: 99
 }
 
-const formatNumber = (
-  content: number,
-  size: SizeType,
-  max: number | undefined
-): string => {
-  const trimThreshold = max ?? thresholds[size]
-
-  return content > trimThreshold ? `${trimThreshold}+` : String(content)
-}
-
 export const Badge = forwardRef<HTMLDivElement, Props>(function Badge(
   {
     children,
@@ -60,14 +50,13 @@ export const Badge = forwardRef<HTMLDivElement, Props>(function Badge(
 
   const hasChildren = Children.count(children) > 0
 
-  const badgeContent = formatNumber(content, size, max)
-
   return (
     <MuiBadge
       ref={ref}
       style={style}
       data-testid={testId}
-      badgeContent={badgeContent}
+      badgeContent={content}
+      max={max || thresholds[size]}
       classes={{
         badge: cx(classes.root, classes[variant], classes[size], {
           [classes.static]: !hasChildren

--- a/packages/picasso/src/Badge/test.tsx
+++ b/packages/picasso/src/Badge/test.tsx
@@ -71,9 +71,25 @@ describe('Badge', () => {
     expect(screen.getByTestId('badge-root')).toBeInTheDocument()
   })
 
-  it('should trim number with custom max value', () => {
-    const { getByText } = renderBadge({ content: 9999, max: 55, size: 'large' })
+  describe('when max is set', () => {
+    it('should trim number with custom max value', () => {
+      const { getByText } = renderBadge({
+        content: 9999,
+        max: 999,
+        size: 'large'
+      })
 
-    expect(getByText('55+')).toBeVisible()
+      expect(getByText('999+')).toBeVisible()
+    })
+
+    it('should not trim when content is lower than max value', () => {
+      const { getByText } = renderBadge({
+        content: 150,
+        max: 999,
+        size: 'large'
+      })
+
+      expect(getByText('150')).toBeVisible()
+    })
   })
 })


### PR DESCRIPTION
[FX-2659]

### Description

In our [Slack core channel](https://toptal-core.slack.com/archives/CERF5NHT3/p1650444203438359) user reported a bug in our Badge component.

The problem was, that MUIBadge also has `max` and it is set by default to `99`.
- when we passed `string` to MUIBadge, for example `'+999'`, it was treated as a string and not trimmed.
- when we passed `number` to MUIBadge, it was always trimmed to `+99`

I have added a new test case to cover this bug.

### How to test

- CI is green

### Review

- [ ] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [ ] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that tests pass by running `yarn test`
- [ ] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
- [ ] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-2659]: https://toptal-core.atlassian.net/browse/FX-2659?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ