### PR TITLE
fix(Notification): do not show left ellipses if not needed

### DIFF
--- a/.changeset/large-cobras-jam.md
+++ b/.changeset/large-cobras-jam.md
@@ -1,0 +1,8 @@
+---
+'@toptal/picasso': patch
+---
+
+---
+### Pagination
+
+- Left ellipses were appearing even when not necessary

--- a/packages/picasso/src/Pagination/utils/has-ellipsises/has-ellipsises.ts
+++ b/packages/picasso/src/Pagination/utils/has-ellipsises/has-ellipsises.ts
@@ -10,9 +10,10 @@ const hasEllipses = ({
   siblingCount
 }: Args): [boolean, boolean] => {
   const rightmostSibling = activePage + siblingCount
+
   const leftmostSibling = activePage - siblingCount
 
-  return [leftmostSibling > 1, rightmostSibling < totalPages - 1]
+  return [leftmostSibling > 2, rightmostSibling < totalPages - 1]
 }
 
 export default hasEllipses

--- a/packages/picasso/src/Pagination/utils/has-ellipsises/test.ts
+++ b/packages/picasso/src/Pagination/utils/has-ellipsises/test.ts
@@ -13,5 +13,21 @@ describe('hasEllipses', () => {
     expect(
       hasEllipses({ activePage: 2, totalPages: 3, siblingCount: 1 })
     ).toEqual([false, false])
+
+    expect(
+      hasEllipses({ activePage: 4, totalPages: 4, siblingCount: 2 })
+    ).toEqual([false, false])
+
+    expect(
+      hasEllipses({ activePage: 1, totalPages: 4, siblingCount: 2 })
+    ).toEqual([false, false])
+
+    expect(
+      hasEllipses({ activePage: 4, totalPages: 7, siblingCount: 2 })
+    ).toEqual([false, false])
+
+    expect(
+      hasEllipses({ activePage: 4, totalPages: 10, siblingCount: 2 })
+    ).toEqual([false, true])
   })
 })

--- a/packages/picasso/src/Pagination/utils/has-ellipsises/test.ts
+++ b/packages/picasso/src/Pagination/utils/has-ellipsises/test.ts
@@ -1,33 +1,43 @@
 import hasEllipses from './has-ellipsises'
 
 describe('hasEllipses', () => {
-  it('works correctly', () => {
+  it('has only ellipses on right side when we are on first page', () => {
     expect(
       hasEllipses({ activePage: 1, totalPages: 5, siblingCount: 1 })
     ).toEqual([false, true])
+  })
 
+  it('has only ellipses on both sides when we are in middle', () => {
     expect(
       hasEllipses({ activePage: 24, totalPages: 52, siblingCount: 2 })
     ).toEqual([true, true])
+  })
 
+  it('has NO ellipses when we have only one sibling', () => {
     expect(
       hasEllipses({ activePage: 2, totalPages: 3, siblingCount: 1 })
     ).toEqual([false, false])
+  })
 
+  it('has NO ellipses when ellipses would appear between two consecutive numbers', () => {
+    // We want to avoid 1 .. 2 3 4
     expect(
       hasEllipses({ activePage: 4, totalPages: 4, siblingCount: 2 })
     ).toEqual([false, false])
 
+    // We want to avoid 1 2 3 .. 4
     expect(
       hasEllipses({ activePage: 1, totalPages: 4, siblingCount: 2 })
     ).toEqual([false, false])
 
+    // We want to avoid 1 .. 2 3 4 5 6 .. 7
     expect(
       hasEllipses({ activePage: 4, totalPages: 7, siblingCount: 2 })
     ).toEqual([false, false])
 
+    // We want to avoid 1 .. 2 3 4 5 6 .. 8
     expect(
-      hasEllipses({ activePage: 4, totalPages: 10, siblingCount: 2 })
+      hasEllipses({ activePage: 4, totalPages: 8, siblingCount: 2 })
     ).toEqual([false, true])
   })
 })

--- a/packages/picasso/src/Pagination/utils/has-ellipsises/test.ts
+++ b/packages/picasso/src/Pagination/utils/has-ellipsises/test.ts
@@ -39,5 +39,10 @@ describe('hasEllipses', () => {
     expect(
       hasEllipses({ activePage: 4, totalPages: 8, siblingCount: 2 })
     ).toEqual([false, true])
+
+    // We want to check 1 .. 3 4 5 6 7 .. 9
+    expect(
+      hasEllipses({ activePage: 5, totalPages: 9, siblingCount: 2 })
+    ).toEqual([true, true])
   })
 })


### PR DESCRIPTION
[FX-NNNN]

### Description

@alexvcasillas [pointed out](https://toptal-core.slack.com/archives/CERF5NHT3/p1650451875451999), that we don't calculate correctly left ellipses.

I have added multiple test cases to cover edge cases.

### How to test

- CI is green
- play with Pagination in storybook

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| ![image](https://user-images.githubusercontent.com/6830426/164430544-aaf65323-b553-4586-a684-e13d5e7c61e9.png) | ![image](https://user-images.githubusercontent.com/6830426/164430463-aac23d32-2ea0-4d25-be9a-51b6f0cf0fbb.png) |

### Review

- [ ] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [ ] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure that tests pass by running `yarn test`
- [ ] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
- [ ] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>
