### PR TITLE
fix(Select): click on search icon focuses the input

### DIFF
--- a/cypress/component/Select.spec.tsx
+++ b/cypress/component/Select.spec.tsx
@@ -362,7 +362,7 @@ describe('Select', () => {
     getNativeOption(1).should('have.attr', 'aria-selected').and('match', /true/)
   })
 
-  it('sets background correctly to various select states', () => {
+  it.skip('sets background correctly to various select states', () => {
     mount(
       <TestingPicasso>
         <div style={{ background: palette.yellow.main }}>

--- a/cypress/component/Select.spec.tsx
+++ b/cypress/component/Select.spec.tsx
@@ -362,7 +362,7 @@ describe('Select', () => {
     getNativeOption(1).should('have.attr', 'aria-selected').and('match', /true/)
   })
 
-  it.skip('sets background correctly to various select states', () => {
+  it('sets background correctly to various select states', () => {
     mount(
       <TestingPicasso>
         <div style={{ background: palette.yellow.main }}>

--- a/cypress/component/Select.spec.tsx
+++ b/cypress/component/Select.spec.tsx
@@ -12,10 +12,6 @@ import { TestingPicasso } from '@toptal/picasso/test-utils'
 import { noop, palette } from '@toptal/picasso/utils'
 import { ValueType } from '@toptal/picasso/Select'
 
-const testIds = {
-  resetButton: 'reset-adornment'
-}
-
 const TestSelect = ({
   onChange = noop,
   value = undefined,
@@ -299,6 +295,8 @@ describe('Select', () => {
   })
 
   it('renders reset button', () => {
+    const testIds = { resetButton: 'reset-adornment' }
+
     mount(
       <TestingPicasso>
         <TestSelect enableReset value={OPTIONS[0].value} testIds={testIds} />
@@ -352,18 +350,6 @@ describe('Select', () => {
         <TestSelect icon={<Settings16 />} disabled />
       </TestingPicasso>
     )
-
-    cy.get('body').happoScreenshot()
-  })
-
-  it.skip('renders select with search', () => {
-    mount(
-      <TestingPicasso>
-        <TestSelect searchThreshold={-1} />
-      </TestingPicasso>
-    )
-
-    openSelect()
 
     cy.get('body').happoScreenshot()
   })
@@ -454,6 +440,53 @@ describe('Select', () => {
 
       cy.get('@searchInput').should('be.visible')
       cy.get('@searchInput').click().should('have.focus')
+    })
+  })
+
+  describe('with search input', () => {
+    it('focuses the input', () => {
+      mount(
+        <TestingPicasso>
+          <TestSelect
+            searchThreshold={-1}
+            testIds={{ searchInput: 'search-input' }}
+          />
+        </TestingPicasso>
+      )
+
+      const searchInput = '[data-testid="search-input"]'
+      const selectInput = '[data-testid="select"]'
+
+      cy.get('[data-testid="select"]')
+        .click()
+        .find('input')
+        .should('be.focused')
+
+      cy.get('body').happoScreenshot()
+
+      // focuses on the Search input by clicking on the input
+      cy.get(searchInput).click('center').find('input').should('be.focused')
+
+      // focuses on by click on the input wrapper
+      cy.get(selectInput)
+        .click()
+        .get(searchInput)
+        .click('bottom')
+        .find('input')
+        .should('be.focused')
+
+      // focuses on by click on the search icon
+      cy.get(selectInput)
+        .click()
+        .get(searchInput)
+        .closest('[role="menuitem"]')
+        .click(20, 20)
+        .find('input')
+        .should('be.focused')
+
+      // focuses on by typing
+      cy.get(selectInput).click().type('option')
+      cy.get(searchInput).find('input').should('be.focused')
     })
   })
 })

--- a/packages/picasso/src/NonNativeSelect/NonNativeSelect.tsx
+++ b/packages/picasso/src/NonNativeSelect/NonNativeSelect.tsx
@@ -27,6 +27,7 @@ import NonNativeSelectOptions from '../NonNativeSelectOptions'
 import { documentable, forwardRef, noop, useCombinedRefs } from '../utils'
 import styles from './styles'
 import NonNativeSelectLimitFooter from '../NonNativeSelectLimitFooter'
+import InputAdornment from '../InputAdornment'
 
 const useStyles = makeStyles<Theme>(styles)
 
@@ -120,12 +121,17 @@ export const NonNativeSelect = documentable(
           <OutlinedInput
             inputRef={searchInputRef}
             className={classes.searchOutlinedInput}
-            startAdornment={<Search16 className={classes.searchInputIcon} />}
+            startAdornment={
+              <InputAdornment position='start' disablePointerEvents>
+                <Search16 />
+              </InputAdornment>
+            }
             placeholder={searchPlaceholder}
             size={size}
             value={filterOptionsValue}
             testIds={testIds}
             aria-autocomplete='list'
+            data-testid={testIds?.searchInput}
             /* eslint-disable-next-line react/jsx-props-no-spreading */
             {...getSearchInputProps()}
           />

--- a/packages/picasso/src/NonNativeSelect/styles.ts
+++ b/packages/picasso/src/NonNativeSelect/styles.ts
@@ -44,9 +44,6 @@ export default ({ palette }: Theme) =>
     searchOutlinedInput: {
       width: '100%'
     },
-    searchInputIcon: {
-      marginRight: '0.5rem'
-    },
     nativeInput: {
       padding: 0
     },

--- a/packages/picasso/src/Select/types.ts
+++ b/packages/picasso/src/Select/types.ts
@@ -96,6 +96,7 @@ export interface SelectProps<
     noOptions?: string
     loader?: string
     limitFooter?: string
+    searchInput?: string
   }
 }
 


### PR DESCRIPTION
[FX-2668]

### Description

Follow up to [previous PR](https://github.com/toptal/picasso/pull/2690) that fixes the behavior of search input in Select.

### How to test

- Open select story with search behavior
- Click the select to open options
- Click the search icon in the search input
- Search input should be focused

### Review

- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure that tests pass by running `yarn test`
- [x] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-2668]: https://toptal-core.atlassian.net/browse/FX-2668?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ