### PR TITLE
fix(ImageAvatar): prevent image blur on downscaled image

### DIFF
--- a/.changeset/prevent-avatar-image-blur.md
+++ b/.changeset/prevent-avatar-image-blur.md
@@ -1,0 +1,8 @@
+---
+'@toptal/picasso': patch
+---
+
+---
+### Avatar
+
+- Applied `image-rendering` css property for `<AvatarImage />`, preventing blur on downscaled images

--- a/packages/picasso/src/Avatar/ImageAvatar/styles.ts
+++ b/packages/picasso/src/Avatar/ImageAvatar/styles.ts
@@ -9,7 +9,9 @@ export default () =>
       height: '100%',
       position: 'absolute',
       left: 0,
-      top: 0
+      top: 0,
+      /* Required to prevent image blur on downscale */
+      imageRendering: '-webkit-optimize-contrast'
     },
     logoContainer: {
       display: 'flex',


### PR DESCRIPTION
[SPB-3288]

### Description

A little ~~tweak~~ hack that prevents downscaled image to be blurred

### How to test

Try to use this image as image source for Avatar in storybook.
The difference in clear on `medium` Avatar size for 100% page scale in Chrome. Also on `small` size for 125% scale.
To see the difference toggle
`image-rendering: -webkit-optimize-contrast`


![portrait-upsplash (226x226)](https://user-images.githubusercontent.com/17253416/165481990-58f6b95b-08c3-4075-b4b8-7fbcf12e821e.jpg)
```https://user-images.githubusercontent.com/17253416/165481990-58f6b95b-08c3-4075-b4b8-7fbcf12e821e.jpg```


### Screenshots

![image](https://user-images.githubusercontent.com/17253416/165485167-9c8c9570-874c-4a92-8d07-ab0fec2462ed.png)

### Review

- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- `N/A` Annotate all `props` in component with documentation
- `N/A` Create `examples` for component
- `N/A` Ensure that deployed demo has expected results and good examples
- [x] Ensure that tests pass by running `yarn test`
- [x] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
- `N/A` Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[SPB-3288]: https://toptal-core.atlassian.net/browse/SPB-3288?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ