### PR TITLE
fix: make autofill work for controlled input in Firefox

### DIFF
--- a/.changeset/olive-keys-protect.md
+++ b/.changeset/olive-keys-protect.md
@@ -1,0 +1,9 @@
+---
+'@toptal/picasso-forms': patch
+---
+
+---
+
+### Field
+
+- Make autofill work for controlled input in Firefox

--- a/.changeset/polite-apricots-drive.md
+++ b/.changeset/polite-apricots-drive.md
@@ -1,0 +1,5 @@
+---
+'@toptal/picasso-forms': patch
+---
+
+make autofill work for controlled input in Firefox

--- a/.changeset/polite-apricots-drive.md
+++ b/.changeset/polite-apricots-drive.md
@@ -1,5 +1,0 @@
----
-'@toptal/picasso-forms': patch
----
-
-make autofill work for controlled input in Firefox

--- a/packages/picasso-forms/package.json
+++ b/packages/picasso-forms/package.json
@@ -31,6 +31,7 @@
   },
   "dependencies": {
     "classnames": "^2.3.1",
+    "detect-browser": "^5.3.0",
     "final-form": "^4.20.2",
     "final-form-arrays": "^3.0.2",
     "react-final-form": "^6.5.1",

--- a/packages/picasso-forms/src/Field/Field.tsx
+++ b/packages/picasso-forms/src/Field/Field.tsx
@@ -146,6 +146,19 @@ const Field = <
     ...input,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     onChange: (event: ChangeEvent<HTMLElement> | any) => {
+      /**
+       * The fix for autofill in Firefox, it's taken from:
+       * https://github.com/facebook/react/issues/18986#issuecomment-636354428
+       * https://github.com/facebook/react/issues/15739
+       */
+      Object.defineProperty(event.target, 'defaultValue', {
+        configurable: true,
+        get() {
+          return ''
+        },
+        set() {}
+      })
+
       input.onChange(event)
 
       if (rest.onChange) {

--- a/packages/picasso-forms/src/Field/Field.tsx
+++ b/packages/picasso-forms/src/Field/Field.tsx
@@ -73,6 +73,8 @@ const getValidators = (required: boolean, validate?: any) => {
   return validate
 }
 
+const isFirefox = detect()?.name === 'firefox'
+
 const Field = <
   TWrappedComponentProps extends IFormComponentProps,
   TInputValue extends ValueType = TWrappedComponentProps['value']
@@ -147,7 +149,7 @@ const Field = <
     ...input,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     onChange: (event: ChangeEvent<HTMLElement> | any) => {
-      if (detect()?.name === 'firefox' && event?.target) {
+      if (isFirefox && event?.target) {
         /**
          * The fix for autofill in Firefox, it's taken from:
          * https://github.com/facebook/react/issues/18986#issuecomment-636354428

--- a/packages/picasso-forms/src/Field/Field.tsx
+++ b/packages/picasso-forms/src/Field/Field.tsx
@@ -12,6 +12,7 @@ import {
 import { Item } from '@toptal/picasso/Autocomplete'
 import { FileUpload } from '@toptal/picasso/FileInput'
 import { TextLabelProps } from '@toptal/picasso-shared'
+import { detect } from 'detect-browser'
 
 import { useFormConfig } from '../FormConfig'
 import { validators, useFieldValidation } from '../utils'
@@ -146,7 +147,7 @@ const Field = <
     ...input,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     onChange: (event: ChangeEvent<HTMLElement> | any) => {
-      if (event?.target) {
+      if (detect()?.name === 'firefox' && event?.target) {
         /**
          * The fix for autofill in Firefox, it's taken from:
          * https://github.com/facebook/react/issues/18986#issuecomment-636354428

--- a/packages/picasso-forms/src/Field/Field.tsx
+++ b/packages/picasso-forms/src/Field/Field.tsx
@@ -158,7 +158,7 @@ const Field = <
         Object.defineProperty(event.target, 'defaultValue', {
           configurable: true,
           get() {
-            return ''
+            return defaultValue ?? ''
           },
           set() {}
         })

--- a/packages/picasso-forms/src/Field/Field.tsx
+++ b/packages/picasso-forms/src/Field/Field.tsx
@@ -146,18 +146,20 @@ const Field = <
     ...input,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     onChange: (event: ChangeEvent<HTMLElement> | any) => {
-      /**
-       * The fix for autofill in Firefox, it's taken from:
-       * https://github.com/facebook/react/issues/18986#issuecomment-636354428
-       * https://github.com/facebook/react/issues/15739
-       */
-      Object.defineProperty(event.target, 'defaultValue', {
-        configurable: true,
-        get() {
-          return ''
-        },
-        set() {}
-      })
+      if (event?.target) {
+        /**
+         * The fix for autofill in Firefox, it's taken from:
+         * https://github.com/facebook/react/issues/18986#issuecomment-636354428
+         * https://github.com/facebook/react/issues/15739
+         */
+        Object.defineProperty(event.target, 'defaultValue', {
+          configurable: true,
+          get() {
+            return ''
+          },
+          set() {}
+        })
+      }
 
       input.onChange(event)
 


### PR DESCRIPTION
[SPT-2611]

### Description
There is an issue in React that breaks Firefox browser behavior for autofill/autocomplete in controlled inputs.
https://github.com/mui/material-ui/issues/16943
https://github.com/facebook/react/issues/15739
https://github.com/facebook/react/issues/18986

The solution is taken from one of the comment:
https://github.com/facebook/react/issues/18986#issuecomment-636354428

### How to test
- open Firefox
- go to https://codesandbox.io/s/withered-worker-0njelw (latest Picasso)
- add some values for plain and controlled Picasso input and submit the form
- check autofill for each input, you will notice that Picasso input will not have any autofill options
- <video src="https://user-images.githubusercontent.com/4816942/165672090-2bbb4cbf-79af-4506-b68f-bcc95402d71b.mp4" width="600" />
- go to https://picasso.toptal.net/SPT-2611-fix-autofill-for-firefox/?path=/story/picasso-forms-final-form--final-form
- `edit code`
- <details>
    <summary>Use this code to test it:</summary>

    ```typescript
    function App() {
      const onSubmit = async (values: any, form: any) => {
        form.submit();
        return new Promise((resolve) => setTimeout(resolve, 100));
      };

      return (
        <Picasso>
          <Container flex direction="column" alignItems="center" top="medium">
            <Form onSubmit={onSubmit}>
              <Container bottom="small">
                <input
                  type="text"
                  name="plainInput_PicassoWithFix"
                  autoComplete="on"
                />
              </Container>

              <Container bottom="small">
                <Form.Input
                  type="text"
                  name="controlledInput_PicassoWithFix"
                  autoComplete="on"
                />
              </Container>

              <Form.SubmitButton>submit</Form.SubmitButton>
            </Form>
          </Container>
        </Picasso>
      );
    }
    ```
- add some values for plain and controlled Picasso input and submit the form
- check autofill for each input
- autofill should work for both inputs

### Development checks
- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- n/a Annotate all `props` in component with documentation
- n/a Create `examples` for component
- n/a Ensure that deployed demo has expected results and good examples
- [x] Ensure that tests pass by running `yarn test`
- [x] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- n/a Covered with tests

**Breaking change**

- n/a codemod is created
- n/a test alpha package of Picasso in StaffPortal

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[SPT-2611]: https://toptal-core.atlassian.net/browse/SPT-2611?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ