### PR TITLE
feat(Select): introduce disablePortal

### DIFF
--- a/.changeset/khaki-moons-change.md
+++ b/.changeset/khaki-moons-change.md
@@ -5,5 +5,4 @@
 ---
 ### Select
 
-- introduce new prop `disablePortal`. Needed in some edgecases,
-  for example when used in Drawer with search behaviour
+- introduce new prop `disablePortal` to allow using search input inside Drawer

--- a/.changeset/khaki-moons-change.md
+++ b/.changeset/khaki-moons-change.md
@@ -1,0 +1,9 @@
+---
+'@toptal/picasso': minor
+---
+
+---
+### Select
+
+- introduce new prop `disablePortal`. Needed in some edgecases,
+  for example when used in Drawer with search behaviour

--- a/cypress/component/Select.spec.tsx
+++ b/cypress/component/Select.spec.tsx
@@ -5,7 +5,8 @@ import {
   Form,
   Container,
   SelectProps,
-  Settings16
+  Settings16,
+  Drawer
 } from '@toptal/picasso'
 import { TestingPicasso } from '@toptal/picasso/test-utils'
 import { noop, palette } from '@toptal/picasso/utils'
@@ -25,6 +26,7 @@ const TestSelect = ({
   native = false,
   status,
   disabled = false,
+  disablePortal,
   loading = false,
   enableReset = false,
   searchThreshold,
@@ -45,6 +47,7 @@ const TestSelect = ({
     native={native}
     status={status}
     disabled={disabled}
+    disablePortal={disablePortal}
     loading={loading}
     enableReset={enableReset}
     menuWidth={menuWidth}
@@ -162,7 +165,8 @@ const pressEnter = () => {
 
 const getNativeSelect = () => cy.get('select')
 
-// eslint-disable-next-line max-lines-per-function
+/* eslint-disable max-lines-per-function */
+/* eslint-disable max-statements */
 describe('Select', () => {
   it('renders', () => {
     mount(
@@ -430,9 +434,26 @@ describe('Select', () => {
     getOption(4).should('have.attr', 'data-highlighted').and('match', /true/)
   })
 
-  // describe('when rendered in Drawer with search behaviour', () => {
-  //   it('is possible to focus the search input', () => {
+  describe('when rendered in Drawer with search behaviour', () => {
+    it('is possible to focus the search input by click', () => {
+      mount(
+        <TestingPicasso>
+          <Drawer open>
+            <Form>
+              <Form.Field>
+                <TestSelect searchThreshold={-1} disablePortal />
+              </Form.Field>
+            </Form>
+          </Drawer>
+        </TestingPicasso>
+      )
 
-  //   })
-  // })
+      openSelect()
+
+      cy.get('[role="tooltip"]').find('input').as('searchInput')
+
+      cy.get('@searchInput').should('be.visible')
+      cy.get('@searchInput').click().should('have.focus')
+    })
+  })
 })

--- a/cypress/component/Select.spec.tsx
+++ b/cypress/component/Select.spec.tsx
@@ -429,4 +429,10 @@ describe('Select', () => {
 
     getOption(4).should('have.attr', 'data-highlighted').and('match', /true/)
   })
+
+  // describe('when rendered in Drawer with search behaviour', () => {
+  //   it('is possible to focus the search input', () => {
+
+  //   })
+  // })
 })

--- a/packages/picasso/src/NonNativeSelect/NonNativeSelect.tsx
+++ b/packages/picasso/src/NonNativeSelect/NonNativeSelect.tsx
@@ -52,6 +52,7 @@ export const NonNativeSelect = documentable(
         renderOption = defaultRenderOption,
         placeholder,
         disabled,
+        disablePortal,
         error,
         status,
         multiple,
@@ -187,6 +188,7 @@ export const NonNativeSelect = documentable(
               open
               anchorEl={inputWrapperRef.current}
               container={popperContainer}
+              disablePortal={disablePortal}
             >
               {loading ? (
                 <NonNativeSelectLoader data-testid={testIds?.loader} />

--- a/packages/picasso/src/Select/story/SearchBehavior.example.tsx
+++ b/packages/picasso/src/Select/story/SearchBehavior.example.tsx
@@ -1,15 +1,7 @@
 import React, { useState, ChangeEvent } from 'react'
-import {
-  Select,
-  Form,
-  Container,
-  NumberInput,
-  Drawer,
-  Button
-} from '@toptal/picasso'
+import { Select, Form, Container, NumberInput } from '@toptal/picasso'
 
 const SelectSearchBehaviourExample = () => {
-  const [isOpen, setIsOpen] = useState(false)
   const [value, setValue] = useState<string>('')
   const [threshold, setThreshold] = useState(4)
 
@@ -29,34 +21,8 @@ const SelectSearchBehaviourExample = () => {
   }
 
   return (
-    <Container flex gap='small' direction='column'>
-      <Form.Field>
-        <Form.Label>Search for an option</Form.Label>
-        <Select
-          onChange={handleChange}
-          value={value}
-          options={OPTIONS}
-          placeholder='Choose an option...'
-          width='auto'
-          searchThreshold={threshold}
-          data-testid='select'
-        />
-      </Form.Field>
-
-      <Form.Field>
-        <Form.Label>Search threshold</Form.Label>
-        <NumberInput
-          value={threshold}
-          onChange={handleThresholdChange}
-          data-testid='input-threshold'
-        />
-      </Form.Field>
-      <Form.Field>
-        <Form.Label>Inside Drawer with disablePortal</Form.Label>
-        <Button onClick={() => setIsOpen(true)}>Open Drawer</Button>
-      </Form.Field>
-
-      <Drawer open={isOpen} onClose={() => setIsOpen(false)}>
+    <Container flex>
+      <Container right='small'>
         <Form.Field>
           <Form.Label>Search for an option</Form.Label>
           <Select
@@ -67,10 +33,19 @@ const SelectSearchBehaviourExample = () => {
             width='auto'
             searchThreshold={threshold}
             data-testid='select'
-            disablePortal
           />
         </Form.Field>
-      </Drawer>
+      </Container>
+      <Container>
+        <Form.Field>
+          <Form.Label>Search threshold</Form.Label>
+          <NumberInput
+            value={threshold}
+            onChange={handleThresholdChange}
+            data-testid='input-threshold'
+          />
+        </Form.Field>
+      </Container>
     </Container>
   )
 }

--- a/packages/picasso/src/Select/story/SearchBehavior.example.tsx
+++ b/packages/picasso/src/Select/story/SearchBehavior.example.tsx
@@ -1,7 +1,15 @@
 import React, { useState, ChangeEvent } from 'react'
-import { Select, Form, Container, NumberInput } from '@toptal/picasso'
+import {
+  Select,
+  Form,
+  Container,
+  NumberInput,
+  Drawer,
+  Button
+} from '@toptal/picasso'
 
 const SelectSearchBehaviourExample = () => {
+  const [isOpen, setIsOpen] = useState(false)
   const [value, setValue] = useState<string>('')
   const [threshold, setThreshold] = useState(4)
 
@@ -21,8 +29,34 @@ const SelectSearchBehaviourExample = () => {
   }
 
   return (
-    <Container flex>
-      <Container right='small'>
+    <Container flex gap='small' direction='column'>
+      <Form.Field>
+        <Form.Label>Search for an option</Form.Label>
+        <Select
+          onChange={handleChange}
+          value={value}
+          options={OPTIONS}
+          placeholder='Choose an option...'
+          width='auto'
+          searchThreshold={threshold}
+          data-testid='select'
+        />
+      </Form.Field>
+
+      <Form.Field>
+        <Form.Label>Search threshold</Form.Label>
+        <NumberInput
+          value={threshold}
+          onChange={handleThresholdChange}
+          data-testid='input-threshold'
+        />
+      </Form.Field>
+      <Form.Field>
+        <Form.Label>Inside Drawer with disablePortal</Form.Label>
+        <Button onClick={() => setIsOpen(true)}>Open Drawer</Button>
+      </Form.Field>
+
+      <Drawer open={isOpen} onClose={() => setIsOpen(false)}>
         <Form.Field>
           <Form.Label>Search for an option</Form.Label>
           <Select
@@ -33,19 +67,10 @@ const SelectSearchBehaviourExample = () => {
             width='auto'
             searchThreshold={threshold}
             data-testid='select'
+            disablePortal
           />
         </Form.Field>
-      </Container>
-      <Container>
-        <Form.Field>
-          <Form.Label>Search threshold</Form.Label>
-          <NumberInput
-            value={threshold}
-            onChange={handleThresholdChange}
-            data-testid='input-threshold'
-          />
-        </Form.Field>
-      </Container>
+      </Drawer>
     </Container>
   )
 }

--- a/packages/picasso/src/Select/story/index.jsx
+++ b/packages/picasso/src/Select/story/index.jsx
@@ -48,7 +48,7 @@ page
   .addExample('Select/story/SearchBehavior.example.tsx', {
     title: 'Search behavior',
     description: `Search is enabled when the number of options is greater or equal to \`searchThreshold\`.
-      ⚠️ When used in Drawer, we need to use \`disablePortal\` to search input work correctly.`
+      ⚠️ When used in Drawer, we need to use \`disablePortal\` to enable the mouse focus of the search input.`
   }) // picasso-skip-visuals
   .addExample('Select/story/Limit.example.tsx', {
     title: 'Limit',

--- a/packages/picasso/src/Select/story/index.jsx
+++ b/packages/picasso/src/Select/story/index.jsx
@@ -47,8 +47,8 @@ page
   .addExample('Select/story/Native.example.tsx', 'Native') // picasso-skip-visuals
   .addExample('Select/story/SearchBehavior.example.tsx', {
     title: 'Search behavior',
-    description:
-      'Search is enabled when the number of options is greater or equal to `searchThreshold`.'
+    description: `Search is enabled when the number of options is greater or equal to \`searchThreshold\`.
+      ⚠️ When used in Drawer, we need to use \`disablePortal\` to search input work correctly.`
   }) // picasso-skip-visuals
   .addExample('Select/story/Limit.example.tsx', {
     title: 'Limit',

--- a/packages/picasso/src/Select/types.ts
+++ b/packages/picasso/src/Select/types.ts
@@ -30,6 +30,8 @@ export interface SelectProps<
     > {
   /** If true, the 'Select' will be disabled */
   disabled?: boolean
+  /** To render select options in portal. Should be disabled in Modals */
+  disablePortal?: boolean
   /** @deprecated Indicate whether `Select` is in error state */
   error?: boolean
   /** Indicate whether `Select` is in `error` or `default` state */

--- a/packages/picasso/src/Select/types.ts
+++ b/packages/picasso/src/Select/types.ts
@@ -30,7 +30,7 @@ export interface SelectProps<
     > {
   /** If true, the 'Select' will be disabled */
   disabled?: boolean
-  /** To render select options in portal. Should be disabled in Modals */
+  /** Whether to render select options in portal. Should be disabled in Modals */
   disablePortal?: boolean
   /** @deprecated Indicate whether `Select` is in error state */
   error?: boolean


### PR DESCRIPTION
[FX-2668]

### Description

We got an edge case bug when we use Select with search behavior is used inside the Drawer. You can check the bug in [codesandbox](https://codesandbox.io/s/misty-sea-xg3ugm?file=/src/App.tsx:120-126)

To reproduce:
- try to search inside the drawer. By typing/clicking

I couldn't find any other solution than disabling the portal for Popper.

### How to test

- open storybook locally
- go to select stories
- check search behavior story
- try the new example inside the drawer
- search should be focusable and usable

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure that tests pass by running `yarn test`
- [x] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests

**Breaking change**

- codemod is created
- test alpha package of Picasso in StaffPortal

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-2668]: https://toptal-core.atlassian.net/browse/FX-2668?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ