### PR TITLE
fix: storybook links

### DIFF
--- a/.storybook/components/PicassoBook/Chapter.tsx
+++ b/.storybook/components/PicassoBook/Chapter.tsx
@@ -159,12 +159,15 @@ class Chapter extends Base {
       )
     }
 
-    const sectionLinkId = normalize(sectionId)
+    const childSection = (this.options as any).title
+    const sectionLinkId = childSection
+      ? normalize(`${childSection}-${sectionId}`)
+      : normalize(sectionId)
     const permanentLink = generateUrl({
       host: getHost(),
       kind: this.page.section,
       type: this.page.title,
-      section: sectionId
+      section: sectionLinkId
     })
 
     const render = () => (

--- a/.storybook/components/PicassoBook/Chapter.tsx
+++ b/.storybook/components/PicassoBook/Chapter.tsx
@@ -160,14 +160,14 @@ class Chapter extends Base {
     }
 
     const childSection = (this.options as any).title
-    const sectionLinkId = childSection
+    const anchor = childSection
       ? normalize(`${childSection}-${sectionId}`)
       : normalize(sectionId)
     const permanentLink = generateUrl({
       host: getHost(),
       kind: this.page.section,
       type: this.page.title,
-      section: sectionLinkId
+      section: anchor
     })
 
     const render = () => (
@@ -175,7 +175,7 @@ class Chapter extends Base {
         <div
           className='chapter-container'
           style={{ display: TEST_ENV === 'visual' ? 'inline-block' : 'block' }}
-          id={sectionLinkId}
+          id={anchor}
         >
           <CodeExample
             src={source}

--- a/src/utils/url-generator.ts
+++ b/src/utils/url-generator.ts
@@ -26,7 +26,7 @@ export const generateUrl = ({ host, kind, type, section }: UrlOptions) => {
     return url
   }
 
-  return `${url}#${normalize(section)}`
+  return `${url}#${section}`
 }
 
 export const generateIframeUrl = ({ host, kind, type }: UrlOptions) => {


### PR DESCRIPTION
### Description

- If storybook component has child component section, and that section's example has same id as parent component's example id, they collide.

For example:
- `Alert` has child component `Alert.Inline`
- Both have examples with id `Default`
- If we copy `Alert.Inline`'s example link with id `Default`, and copy it in new tab, it would jump to `Alert`'s example instead

### How to test

1. Visit any [Picasso component with child component section](https://picasso.toptal.net/correct-links-in-storybook/?path=/story/components-alert--alert)
2. Copy [link of child component section](https://picasso.toptal.net/correct-links-in-storybook/?path=/story/components-alert--alert#alert-inline-default)
3. Paste it in new tab and it would jump to that example

### Screenshots

before:

https://user-images.githubusercontent.com/72510037/166431200-ce6054c3-89c0-4c87-ac2a-f0ff9dac1930.mp4

after:

https://user-images.githubusercontent.com/72510037/166431221-a8e842b5-4f39-48ad-a20a-33df8475d3f6.mp4

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure that tests pass by running `yarn test`
- [x] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests

**Breaking change**

- [x] codemod is created and showcased in the changeset
- [x] test alpha package of Picasso in StaffPortal

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
4. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
5. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>
