### PR TITLE
fix(Select): pass proper `name` to `FieldLabel`

### DIFF
--- a/.changeset/warm-ducks-move.md
+++ b/.changeset/warm-ducks-move.md
@@ -1,0 +1,9 @@
+---
+'@toptal/picasso-forms': patch
+---
+
+---
+
+### Select
+
+- Pass proper 'name' to 'FieldLabel'

--- a/cypress/component/Calendar.spec.tsx
+++ b/cypress/component/Calendar.spec.tsx
@@ -11,6 +11,10 @@ const TestCalendar = (props: ComponentProps<typeof Calendar>) => (
 )
 
 describe('Calendar', () => {
+  beforeEach(() => {
+    cy.clock(new Date(2022, 4, 4).getTime())
+  })
+
   describe('when no custom renderers provided', () => {
     it('renders default', () => {
       mount(<TestCalendar onChange={noop} />)

--- a/packages/picasso-forms/src/Select/Select.tsx
+++ b/packages/picasso-forms/src/Select/Select.tsx
@@ -29,7 +29,7 @@ export const Select = <T extends SelectValueType, M extends boolean = false>(
       label={
         label ? (
           <FieldLabel
-            name={rest.name}
+            name={randomizedId}
             required={rest.required}
             label={label}
             titleCase={titleCase}


### PR DESCRIPTION
[SPT-2636]

### Description
This PR fixes the accessibility issue for `<Form.Select />`. Now we are able to open Select's options while clicking on the label.

### How to test
- go to https://picasso.toptal.net/SPT-2636-pass-proper-name-to-field-label/iframe.html?id=picasso-forms-form--form&viewMode=story
- go to `Default` story
- scroll to `Business type` select
- try to click on `Business type` label
- select's options will pop up

### Screenshots
**Before (missing `for` attribute)**
<img src="https://user-images.githubusercontent.com/4816942/166855689-13f6b4a9-09e8-4dd6-bb57-81a00cb91d83.png" width="400" />
<video src="https://user-images.githubusercontent.com/4816942/166855537-43f0dc91-8034-4ba4-9689-2c2bbc344e50.mp4" width="600" />

**After**
<img src="https://user-images.githubusercontent.com/4816942/166855662-2e488ccd-1c01-4493-a41c-2af873c5f4fc.png" width="400" />
<video src="https://user-images.githubusercontent.com/4816942/166855542-bf23be9d-51a2-47f6-b5e6-c8c7cf053054.mp4" width="600" />

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- n/a Annotate all `props` in component with documentation
- n/a Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure that tests pass by running `yarn test`
- [x] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- n/a Covered with tests

**Breaking change**

- n/a codemod is created and showcased in the changeset
- [x] test alpha package of Picasso in StaffPortal

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[SPT-2636]: https://toptal-core.atlassian.net/browse/SPT-2636?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ