### PR TITLE
docs(decision): jest snapshot update as breaking changes

### DIFF
--- a/docs/decisions/01-jest-snapshots-breaking-change.md
+++ b/docs/decisions/01-jest-snapshots-breaking-change.md
@@ -1,0 +1,16 @@
+## Problem
+
+We release a new version of Picasso with changed jest snapshots, however, Picasso users don't need to take any actions to support those changes except updating snapshots. Do we want to treat this as breaking change?
+
+## Proposal
+
+Not to treat such changes as a breaking change.
+
+## Alternatives
+
+Treat such changes as breaking change.
+
+## Decision
+
+We do not treat change in jest snapshots as breaking change.
+Almost all changes in Picasso update jest snapshots, that's why we decided to not treat such changes as breaking changes.

--- a/docs/decisions/01-jest-snapshots-breaking-change.md
+++ b/docs/decisions/01-jest-snapshots-breaking-change.md
@@ -1,6 +1,6 @@
 ## Problem
 
-We release a new version of Picasso with changed jest snapshots, however, Picasso users don't need to take any actions to support those changes except updating snapshots. Do we want to treat this as breaking change?
+We release a new version of Picasso with changed jest snapshots, however, Picasso users don't need to take any actions to support those changes except updating snapshots. Do we want to treat this as a breaking change?
 
 ## Proposal
 
@@ -12,5 +12,5 @@ Treat such changes as breaking change.
 
 ## Decision
 
-We do not treat change in jest snapshots as breaking change.
+We do not treat change in jest snapshots as a breaking change.
 Almost all changes in Picasso update jest snapshots, that's why we decided to not treat such changes as breaking changes.


### PR DESCRIPTION
### Description

Add a decision about jest snapshots to treat as non-breaking changes

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>
