### PR TITLE
style(Input): show success icon at the bottom of multiline input

### DIFF
--- a/.changeset/large-socks-give.md
+++ b/.changeset/large-socks-give.md
@@ -1,0 +1,7 @@
+---
+'@toptal/picasso': patch
+---
+
+### Input
+
+- improve success state of multiline input

--- a/.changeset/large-socks-give.md
+++ b/.changeset/large-socks-give.md
@@ -1,5 +1,5 @@
 ---
-'@toptal/picasso': patch
+'@toptal/picasso': minor
 ---
 
 ### Input

--- a/.changeset/large-socks-give.md
+++ b/.changeset/large-socks-give.md
@@ -4,4 +4,4 @@
 
 ### Input
 
-- improve success state of multiline input
+- show success icon at the bottom of multiline input

--- a/packages/picasso/src/Input/Input.tsx
+++ b/packages/picasso/src/Input/Input.tsx
@@ -21,6 +21,7 @@ import InputLimitAdornment, {
 import InputIconAdornment, {
   InputIconAdornmentProps
 } from '../InputIconAdornment'
+import InputMultilineAdornment from '../InputMultilineAdornment'
 
 export interface Props
   extends BaseProps,
@@ -104,6 +105,7 @@ type EndAdornmentProps = Pick<
   | 'multiline'
   | 'limit'
   | 'counter'
+  | 'status'
   | 'testIds'
 > & { charsLength?: number }
 
@@ -142,14 +144,17 @@ const EndAdornment = (props: EndAdornmentProps) => {
     multiline,
     charsLength,
     testIds,
-    counter
+    counter,
+    status
   } = props
 
   if (icon && iconPosition === 'end') {
     return <InputIconAdornment disabled={disabled} position='end' icon={icon} />
   }
 
-  if (charsLength && hasCounter({ counter, limit })) {
+  const showCounter = !!charsLength && hasCounter({ counter, limit })
+
+  if (!multiline && showCounter) {
     return (
       <InputLimitAdornment
         charsLength={charsLength}
@@ -158,6 +163,19 @@ const EndAdornment = (props: EndAdornmentProps) => {
         counter={counter!}
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         limit={limit!}
+        testIds={testIds}
+      />
+    )
+  }
+
+  if (multiline && (status === 'success' || showCounter)) {
+    return (
+      <InputMultilineAdornment
+        charsLength={charsLength}
+        multiline={multiline}
+        counter={counter}
+        limit={limit}
+        status={status}
         testIds={testIds}
       />
     )
@@ -290,6 +308,7 @@ export const Input = forwardRef<HTMLInputElement, Props>(function Input(
             charsLength={charsLength}
             multiline={multiline}
             counter={counter}
+            status={status}
             testIds={testIds}
           />
         )

--- a/packages/picasso/src/Input/Input.tsx
+++ b/packages/picasso/src/Input/Input.tsx
@@ -123,6 +123,14 @@ const hasEnteredCounter = ({ counter }: Pick<Props, 'counter'>) =>
 const hasCounter = ({ counter, limit }: Pick<Props, 'counter' | 'limit'>) =>
   hasRemainingCounter({ counter, limit }) || hasEnteredCounter({ counter })
 
+const hasMultilineAdornment = ({
+  multiline,
+  status,
+  counter,
+  limit
+}: Pick<Props, 'multiline' | 'status' | 'counter' | 'limit'>) =>
+  multiline && (status === 'success' || hasCounter({ counter, limit }))
+
 const StartAdornment = ({
   icon,
   iconPosition,
@@ -168,16 +176,20 @@ const EndAdornment = (props: EndAdornmentProps) => {
     )
   }
 
-  if (multiline && (status === 'success' || showCounter)) {
+  if (hasMultilineAdornment({ multiline, status, counter, limit })) {
     return (
-      <InputMultilineAdornment
-        charsLength={charsLength}
-        multiline={multiline}
-        counter={counter}
-        limit={limit}
-        status={status}
-        testIds={testIds}
-      />
+      <InputMultilineAdornment status={status} testIds={testIds}>
+        {showCounter && (
+          <InputLimitAdornment
+            charsLength={charsLength}
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            counter={counter!}
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            limit={limit!}
+            multiline={multiline}
+          />
+        )}
+      </InputMultilineAdornment>
     )
   }
 
@@ -262,8 +274,12 @@ export const Input = forwardRef<HTMLInputElement, Props>(function Input(
       classes={{
         root: cx(classes.root, {
           [classes.rootMultiline]: multiline,
-          [classes.rootMultilineLimiter]:
-            multiline && hasCounter({ counter, limit })
+          [classes.rootMultilineLimiter]: hasMultilineAdornment({
+            multiline,
+            status,
+            limit,
+            counter
+          })
         }),
         input: cx(classes.input, {
           [classes.inputMultilineResizable]: multiline && multilineResizable

--- a/packages/picasso/src/Input/__snapshots__/test.tsx.snap
+++ b/packages/picasso/src/Input/__snapshots__/test.tsx.snap
@@ -258,30 +258,38 @@ exports[`Input shows counter for regular input 1`] = `
 
 exports[`Input shows excess chars for multiline input with exceeded limit 1`] = `
 <div
-  class="MuiInputAdornment-root PicassoInputAdornment-root PicassoInputLimitAdornment-limiterMultiline MuiInputAdornment-disablePointerEvents MuiInputAdornment-positionEnd"
+  class="MuiInputAdornment-root PicassoInputAdornment-root makeStyles-multilineAdornment MuiInputAdornment-disablePointerEvents MuiInputAdornment-positionEnd"
   data-testid="limit-adornment-multiline-label"
 >
-  <span
-    class="PicassoInputLimitAdornment-limiterLabel PicassoInputLimitAdornment-limiterLabelError"
+  <div
+    class="MuiInputAdornment-root PicassoInputAdornment-root PicassoInputLimitAdornment-limiterMultiline MuiInputAdornment-disablePointerEvents MuiInputAdornment-positionEnd"
   >
-    1
-     
-    over the limit
-  </span>
+    <span
+      class="PicassoInputLimitAdornment-limiterLabel PicassoInputLimitAdornment-limiterLabelError"
+    >
+      1
+       
+      over the limit
+    </span>
+  </div>
 </div>
 `;
 
 exports[`Input shows remaining chars for for multiline input with limit 1`] = `
 <div
-  class="MuiInputAdornment-root PicassoInputAdornment-root PicassoInputLimitAdornment-limiterMultiline MuiInputAdornment-disablePointerEvents MuiInputAdornment-positionEnd"
+  class="MuiInputAdornment-root PicassoInputAdornment-root makeStyles-multilineAdornment MuiInputAdornment-disablePointerEvents MuiInputAdornment-positionEnd"
   data-testid="limit-adornment-multiline-label"
 >
-  <span
-    class="PicassoInputLimitAdornment-limiterLabel PicassoInputLimitAdornment-limiterLabelError"
+  <div
+    class="MuiInputAdornment-root PicassoInputAdornment-root PicassoInputLimitAdornment-limiterMultiline MuiInputAdornment-disablePointerEvents MuiInputAdornment-positionEnd"
   >
-    0
-     
-    characters left
-  </span>
+    <span
+      class="PicassoInputLimitAdornment-limiterLabel PicassoInputLimitAdornment-limiterLabelError"
+    >
+      0
+       
+      characters left
+    </span>
+  </div>
 </div>
 `;

--- a/packages/picasso/src/Input/__snapshots__/test.tsx.snap
+++ b/packages/picasso/src/Input/__snapshots__/test.tsx.snap
@@ -203,6 +203,9 @@ exports[`Input shows counter for multiline input 1`] = `
         class="MuiInputBase-input MuiOutlinedInput-input PicassoOutlinedInput-input PicassoOutlinedInput-inputMedium MuiInputBase-inputMultiline MuiOutlinedInput-inputMultiline PicassoOutlinedInput-inputMultiline MuiInputBase-inputAdornedStart MuiOutlinedInput-inputAdornedStart MuiInputBase-inputAdornedEnd MuiOutlinedInput-inputAdornedEnd"
         rows="4"
       />
+      <div
+        class="MuiInputAdornment-root PicassoInputAdornment-root makeStyles-multilineAdornment MuiInputAdornment-disablePointerEvents MuiInputAdornment-positionEnd"
+      />
       <fieldset
         aria-hidden="true"
         class="PrivateNotchedOutline-root MuiOutlinedInput-notchedOutline PicassoOutlinedInput-notchedOutline"

--- a/packages/picasso/src/Input/__snapshots__/test.tsx.snap
+++ b/packages/picasso/src/Input/__snapshots__/test.tsx.snap
@@ -204,7 +204,7 @@ exports[`Input shows counter for multiline input 1`] = `
         rows="4"
       />
       <div
-        class="MuiInputAdornment-root PicassoInputAdornment-root makeStyles-multilineAdornment MuiInputAdornment-disablePointerEvents MuiInputAdornment-positionEnd"
+        class="MuiInputAdornment-root PicassoInputAdornment-root PicassoInputMultilineAdornment-multilineAdornment MuiInputAdornment-disablePointerEvents MuiInputAdornment-positionEnd"
       />
       <fieldset
         aria-hidden="true"
@@ -261,7 +261,7 @@ exports[`Input shows counter for regular input 1`] = `
 
 exports[`Input shows excess chars for multiline input with exceeded limit 1`] = `
 <div
-  class="MuiInputAdornment-root PicassoInputAdornment-root makeStyles-multilineAdornment MuiInputAdornment-disablePointerEvents MuiInputAdornment-positionEnd"
+  class="MuiInputAdornment-root PicassoInputAdornment-root PicassoInputMultilineAdornment-multilineAdornment MuiInputAdornment-disablePointerEvents MuiInputAdornment-positionEnd"
   data-testid="limit-adornment-multiline-label"
 >
   <div
@@ -280,7 +280,7 @@ exports[`Input shows excess chars for multiline input with exceeded limit 1`] = 
 
 exports[`Input shows remaining chars for for multiline input with limit 1`] = `
 <div
-  class="MuiInputAdornment-root PicassoInputAdornment-root makeStyles-multilineAdornment MuiInputAdornment-disablePointerEvents MuiInputAdornment-positionEnd"
+  class="MuiInputAdornment-root PicassoInputAdornment-root PicassoInputMultilineAdornment-multilineAdornment MuiInputAdornment-disablePointerEvents MuiInputAdornment-positionEnd"
   data-testid="limit-adornment-multiline-label"
 >
   <div

--- a/packages/picasso/src/Input/story/Status.example.tsx
+++ b/packages/picasso/src/Input/story/Status.example.tsx
@@ -18,7 +18,7 @@ const Example = () => {
       </Form.Field>
       <Form.Field>
         <Form.Label>Success</Form.Label>
-        <Input value='Ukraine' multiline rows={4} status='success' limit={4} />
+        <Input value='Ukraine' multiline rows={4} status='success' />
       </Form.Field>
     </Form>
   )

--- a/packages/picasso/src/Input/story/Status.example.tsx
+++ b/packages/picasso/src/Input/story/Status.example.tsx
@@ -16,6 +16,10 @@ const Example = () => {
         <Form.Label>Success</Form.Label>
         <Input value='Ukraine' status='success' />
       </Form.Field>
+      <Form.Field>
+        <Form.Label>Success</Form.Label>
+        <Input value='Ukraine' multiline rows={4} status='success' limit={4} />
+      </Form.Field>
     </Form>
   )
 }

--- a/packages/picasso/src/Input/story/Status.example.tsx
+++ b/packages/picasso/src/Input/story/Status.example.tsx
@@ -17,7 +17,7 @@ const Example = () => {
         <Input value='Ukraine' status='success' />
       </Form.Field>
       <Form.Field>
-        <Form.Label>Success</Form.Label>
+        <Form.Label>Multiline Success</Form.Label>
         <Input value='Ukraine' multiline rows={4} status='success' />
       </Form.Field>
     </Form>

--- a/packages/picasso/src/InputLimitAdornment/styles.ts
+++ b/packages/picasso/src/InputLimitAdornment/styles.ts
@@ -11,13 +11,7 @@ export default ({ palette }: Theme) =>
       color: palette.red.main
     },
     limiterMultiline: {
-      position: 'absolute',
-      bottom: 0,
-      width: 'calc(100% - 1.25rem)',
-      height: '1.25rem',
-      justifyContent: 'flex-start',
-      margin: 0,
-      padding: '0.25rem 0',
-      borderTop: `1px solid ${palette.grey.lighter2}`
+      justifyContent: 'unset',
+      marginLeft: 'unset'
     }
   })

--- a/packages/picasso/src/InputMultilineAdornment/InputMultilineAdornment.tsx
+++ b/packages/picasso/src/InputMultilineAdornment/InputMultilineAdornment.tsx
@@ -14,7 +14,9 @@ export interface Props {
   }
 }
 
-const useStyles = makeStyles<Theme>(styles)
+const useStyles = makeStyles<Theme>(styles, {
+  name: 'PicassoInputMultilineAdornment'
+})
 
 const InputMultilineAdornment = (props: Props) => {
   const { children, status, testIds } = props
@@ -27,10 +29,8 @@ const InputMultilineAdornment = (props: Props) => {
       className={classes.multilineAdornment}
       disablePointerEvents
     >
-      <>
-        {children}
-        {status === 'success' && <InputValidIconAdornment />}
-      </>
+      {children}
+      {status === 'success' && <InputValidIconAdornment />}
     </InputAdornment>
   )
 }

--- a/packages/picasso/src/InputMultilineAdornment/InputMultilineAdornment.tsx
+++ b/packages/picasso/src/InputMultilineAdornment/InputMultilineAdornment.tsx
@@ -1,19 +1,13 @@
-import React from 'react'
+import React, { ReactNode } from 'react'
 import { makeStyles, Theme } from '@material-ui/core/styles'
 
 import styles from './styles'
 import InputAdornment from '../InputAdornment'
 import { Status } from '../OutlinedInput'
-import InputLimitAdornment from '../InputLimitAdornment'
-import { CheckMinor24 } from '../Icon'
-
-type CounterType = 'remaining' | 'entered'
+import InputValidIconAdornment from '../InputValidIconAdornment'
 
 export interface Props {
-  charsLength?: number
-  limit?: number
-  multiline?: boolean
-  counter?: CounterType
+  children: ReactNode
   status?: Status
   testIds?: {
     inputAdornment?: string
@@ -23,9 +17,8 @@ export interface Props {
 const useStyles = makeStyles<Theme>(styles)
 
 const InputMultilineAdornment = (props: Props) => {
-  const { charsLength, limit, multiline, counter, status, testIds } = props
+  const { children, status, testIds } = props
   const classes = useStyles()
-  const showCounter = !!charsLength && !!limit && !!counter
 
   return (
     <InputAdornment
@@ -34,19 +27,10 @@ const InputMultilineAdornment = (props: Props) => {
       className={classes.multilineAdornment}
       disablePointerEvents
     >
-      {status === 'success' && (
-        <span className={classes.multilineStatusCheckMark}>
-          <CheckMinor24 color='green' />
-        </span>
-      )}
-      {showCounter && (
-        <InputLimitAdornment
-          charsLength={charsLength}
-          counter={counter}
-          limit={limit}
-          multiline={multiline}
-        />
-      )}
+      <>
+        {children}
+        {status === 'success' && <InputValidIconAdornment />}
+      </>
     </InputAdornment>
   )
 }

--- a/packages/picasso/src/InputMultilineAdornment/InputMultilineAdornment.tsx
+++ b/packages/picasso/src/InputMultilineAdornment/InputMultilineAdornment.tsx
@@ -1,0 +1,54 @@
+import React from 'react'
+import { makeStyles, Theme } from '@material-ui/core/styles'
+
+import styles from './styles'
+import InputAdornment from '../InputAdornment'
+import { Status } from '../OutlinedInput'
+import InputLimitAdornment from '../InputLimitAdornment'
+import { CheckMinor24 } from '../Icon'
+
+type CounterType = 'remaining' | 'entered'
+
+export interface Props {
+  charsLength?: number
+  limit?: number
+  multiline?: boolean
+  counter?: CounterType
+  status?: Status
+  testIds?: {
+    inputAdornment?: string
+  }
+}
+
+const useStyles = makeStyles<Theme>(styles)
+
+const InputMultilineAdornment = (props: Props) => {
+  const { charsLength, limit, multiline, counter, status, testIds } = props
+  const classes = useStyles()
+  const showCounter = !!charsLength && !!limit && !!counter
+
+  return (
+    <InputAdornment
+      data-testid={testIds?.inputAdornment}
+      position='end'
+      className={classes.multilineAdornment}
+      disablePointerEvents
+    >
+      {status === 'success' && (
+        <span className={classes.multilineStatusCheckMark}>
+          <CheckMinor24 color='green' />
+        </span>
+      )}
+      {showCounter && (
+        <InputLimitAdornment
+          charsLength={charsLength}
+          counter={counter}
+          limit={limit}
+          multiline={multiline}
+        />
+      )}
+    </InputAdornment>
+  )
+}
+
+export default InputMultilineAdornment

--- a/packages/picasso/src/InputMultilineAdornment/index.ts
+++ b/packages/picasso/src/InputMultilineAdornment/index.ts
@@ -1,0 +1,6 @@
+import { OmitInternalProps } from '@toptal/picasso-shared'
+
+import { Props } from './InputMultilineAdornment'
+
+export { default } from './InputMultilineAdornment'
+export type InputMultilineAdornmentProps = OmitInternalProps<Props>

--- a/packages/picasso/src/InputMultilineAdornment/styles.ts
+++ b/packages/picasso/src/InputMultilineAdornment/styles.ts
@@ -7,7 +7,6 @@ export default ({ palette }: Theme) =>
       bottom: 0,
       width: 'calc(100% - 1.25rem)',
       height: '1.25rem',
-      flexDirection: 'row-reverse',
       justifyContent: 'space-between',
       margin: 0,
       padding: '0.25rem 0',

--- a/packages/picasso/src/InputMultilineAdornment/styles.ts
+++ b/packages/picasso/src/InputMultilineAdornment/styles.ts
@@ -1,0 +1,16 @@
+import { Theme, createStyles } from '@material-ui/core/styles'
+
+export default ({ palette }: Theme) =>
+  createStyles({
+    multilineAdornment: {
+      position: 'absolute',
+      bottom: 0,
+      width: 'calc(100% - 1.25rem)',
+      height: '1.25rem',
+      flexDirection: 'row-reverse',
+      justifyContent: 'space-between',
+      margin: 0,
+      padding: '0.25rem 0',
+      borderTop: `1px solid ${palette.grey.lighter2}`
+    }
+  })

--- a/packages/picasso/src/InputValidIconAdornment/InputValidIconAdornment.tsx
+++ b/packages/picasso/src/InputValidIconAdornment/InputValidIconAdornment.tsx
@@ -7,10 +7,10 @@ export interface Props {
   'data-testid'?: string
 }
 
-const ValidIconAdornment = ({ 'data-testid': dataTestId }: Props) => (
+const InputValidIconAdornment = ({ 'data-testid': dataTestId }: Props) => (
   <InputAdornment position='end'>
     <CheckMinor24 color='green' data-testid={dataTestId} />
   </InputAdornment>
 )
 
-export default ValidIconAdornment
+export default InputValidIconAdornment

--- a/packages/picasso/src/InputValidIconAdornment/InputValidIconAdornment.tsx
+++ b/packages/picasso/src/InputValidIconAdornment/InputValidIconAdornment.tsx
@@ -1,0 +1,16 @@
+import React from 'react'
+
+import { CheckMinor24 } from '../Icon'
+import InputAdornment from '../InputAdornment'
+
+export interface Props {
+  'data-testid'?: string
+}
+
+const ValidIconAdornment = ({ 'data-testid': dataTestId }: Props) => (
+  <InputAdornment position='end'>
+    <CheckMinor24 color='green' data-testid={dataTestId} />
+  </InputAdornment>
+)
+
+export default ValidIconAdornment

--- a/packages/picasso/src/InputValidIconAdornment/index.ts
+++ b/packages/picasso/src/InputValidIconAdornment/index.ts
@@ -1,0 +1,6 @@
+import { OmitInternalProps } from '@toptal/picasso-shared'
+
+import { Props } from './InputValidIconAdornment'
+
+export { default } from './InputValidIconAdornment'
+export type InputValidIconAdornmentProps = OmitInternalProps<Props>

--- a/packages/picasso/src/OutlinedInput/OutlinedInput.tsx
+++ b/packages/picasso/src/OutlinedInput/OutlinedInput.tsx
@@ -182,7 +182,7 @@ const OutlinedInput = forwardRef<HTMLElement, Props>(function OutlinedInput(
           testIds={testIds}
         />
       )}
-      {status === 'success' && (
+      {!multiline && status === 'success' && (
         <ValidIconAdornment data-testid={testIds?.validIcon} />
       )}
       {userDefinedEndAdornment}

--- a/packages/picasso/src/OutlinedInput/OutlinedInput.tsx
+++ b/packages/picasso/src/OutlinedInput/OutlinedInput.tsx
@@ -15,10 +15,11 @@ import { StandardProps, SizeType, Classes } from '@toptal/picasso-shared'
 
 import InputAdornment from '../InputAdornment'
 import ButtonCircular from '../ButtonCircular'
-import { CheckMinor24, CloseMinor16 } from '../Icon'
+import { CloseMinor16 } from '../Icon'
 import styles from './styles'
 import noop from '../utils/noop'
 import { usePropDeprecationWarning } from '../utils/use-deprecation-warnings'
+import InputValidIconAdornment from '../InputValidIconAdornment'
 
 type ValueType =
   | (string | number | boolean | object)[]
@@ -119,16 +120,6 @@ const ResetButton = ({
   </InputAdornment>
 )
 
-const ValidIconAdornment = ({
-  'data-testid': dataTestId
-}: {
-  'data-testid'?: string
-}) => (
-  <InputAdornment position='end'>
-    <CheckMinor24 color='green' data-testid={dataTestId} />
-  </InputAdornment>
-)
-
 const OutlinedInput = forwardRef<HTMLElement, Props>(function OutlinedInput(
   props,
   ref
@@ -183,7 +174,7 @@ const OutlinedInput = forwardRef<HTMLElement, Props>(function OutlinedInput(
         />
       )}
       {!multiline && status === 'success' && (
-        <ValidIconAdornment data-testid={testIds?.validIcon} />
+        <InputValidIconAdornment data-testid={testIds?.validIcon} />
       )}
       {userDefinedEndAdornment}
     </>


### PR DESCRIPTION
[TACO-1436]

### Description

This PR aims to improve the visuals of the success state of the multiline inputs.
We noticed that the current solution works great for single line inputs but not for multiline ones:

<img width="469" alt="image (1)" src="https://user-images.githubusercontent.com/4757057/168045247-43b13ccb-b4e0-4541-acfd-a6bd0febcf67.png">

<img width="306" alt="image" src="https://user-images.githubusercontent.com/4757057/168045267-1b0a1d9b-1632-4d66-a9ed-165812000049.png">

The inspiration for the new visual is based on a design file (https://www.figma.com/file/Lp9meoy0qlvH05GNUeQ2lW/Talent-Application-Form?node-id=201%3A9579):

![image](https://user-images.githubusercontent.com/4757057/168045470-e9cd14a0-81d0-4e1d-836d-f07155efe495.png)


### How to test

Check the Forms > Input > Status section of the storybook.

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| ![image](https://user-images.githubusercontent.com/4757057/168047033-99d1a026-4c34-4793-b54b-f5e5bfa7eeb3.png) | ![image](https://user-images.githubusercontent.com/4757057/168047300-f4838e4a-1514-43b3-a74d-3c8e39c4255f.png) |

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure that tests pass by running `yarn test`
- [x] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests

**Breaking change**

- n/a ~~codemod is created and showcased in the changeset~~
- n/a ~~test alpha package of Picasso in StaffPortal~~

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[TACO-1436]: https://toptal-core.atlassian.net/browse/TACO-1436?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ