### PR TITLE
fix: zero content case for Badge

### DIFF
--- a/.changeset/shiny-spiders-complain.md
+++ b/.changeset/shiny-spiders-complain.md
@@ -1,0 +1,9 @@
+---
+"@toptal/picasso": major
+---
+
+---
+
+### Badge
+
+- badge is not hidden when the content is zero

--- a/packages/picasso/src/Badge/Badge.tsx
+++ b/packages/picasso/src/Badge/Badge.tsx
@@ -59,6 +59,7 @@ export const Badge = forwardRef<HTMLDivElement, Props>(function Badge(
       badgeContent={content}
       max={max || thresholds[size]}
       className={className}
+      showZero
       classes={{
         badge: cx(classes.root, classes[variant], classes[size], {
           [classes.static]: !hasChildren

--- a/packages/picasso/src/Badge/test.tsx
+++ b/packages/picasso/src/Badge/test.tsx
@@ -91,5 +91,13 @@ describe('Badge', () => {
 
       expect(getByText('150')).toBeVisible()
     })
+
+    it('should show the badge if the content is 0', () => {
+      const { getByText } = renderBadge({
+        content: 0
+      })
+
+      expect(getByText('0')).toBeVisible()
+    })
   })
 })


### PR DESCRIPTION
[FX-2777](https://toptal-core.atlassian.net/browse/FX-2777)

### Description

Badge is hidden when content is `0`. In order to fix this behavior, the `showZero` property was added to the reused `<MuiBadge/>`.

### How to test

- Navigate to `Badge` Story book and display the badge with `content={0}`, it **should be** displayed (https://picasso.toptal.net/SPT-NULL-fix-zero-badges-case/?path=/story/components-badge--badge)

### Screenshots

<img width="531" alt="Screenshot 2022-05-16 at 13 25 40" src="https://user-images.githubusercontent.com/1390758/168525114-d2fe5bd6-2002-42ce-b681-532c63d1121d.png">

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure that tests pass by running `yarn test`
- [x] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests

**Breaking change**

- [x] codemod is created and showcased in the changeset
- [x] test alpha package of Picasso in StaffPortal

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>
