### PR TITLE
style: move resize handler of multiline input to the outer corner

### DIFF
--- a/.changeset/large-socks-give.md
+++ b/.changeset/large-socks-give.md
@@ -1,0 +1,10 @@
+---
+'@toptal/picasso': minor
+---
+
+---
+
+### Input
+
+- show success icon at the bottom of multiline input
+- move resize handler of multiline input to the outer corner

--- a/.changeset/tender-trainers-jog.md
+++ b/.changeset/tender-trainers-jog.md
@@ -1,7 +1,0 @@
----
-'@toptal/picasso': patch
----
-
-### Input
-
-style: move resize handler of multiline input to the outer corner

--- a/.changeset/tender-trainers-jog.md
+++ b/.changeset/tender-trainers-jog.md
@@ -1,0 +1,7 @@
+---
+'@toptal/picasso': patch
+---
+
+### Input
+
+style: move resize handler of multiline input to the outer corner

--- a/packages/picasso/src/Input/Input.tsx
+++ b/packages/picasso/src/Input/Input.tsx
@@ -282,7 +282,7 @@ export const Input = forwardRef<HTMLInputElement, Props>(function Input(
           }),
           [classes.rootMultilineResizable]: multiline && multilineResizable
         }),
-        input: cx({
+        input: cx([classes.input], {
           [classes.inputMultilineResizable]: multiline && multilineResizable
         })
       }}

--- a/packages/picasso/src/Input/Input.tsx
+++ b/packages/picasso/src/Input/Input.tsx
@@ -282,7 +282,7 @@ export const Input = forwardRef<HTMLInputElement, Props>(function Input(
           }),
           [classes.rootMultilineResizable]: multiline && multilineResizable
         }),
-        input: cx([classes.input], {
+        input: cx(classes.input, {
           [classes.inputMultilineResizable]: multiline && multilineResizable
         })
       }}

--- a/packages/picasso/src/Input/Input.tsx
+++ b/packages/picasso/src/Input/Input.tsx
@@ -279,9 +279,10 @@ export const Input = forwardRef<HTMLInputElement, Props>(function Input(
             status,
             limit,
             counter
-          })
+          }),
+          [classes.rootMultilineResizable]: multiline && multilineResizable
         }),
-        input: cx(classes.input, {
+        input: cx({
           [classes.inputMultilineResizable]: multiline && multilineResizable
         })
       }}

--- a/packages/picasso/src/Input/__snapshots__/test.tsx.snap
+++ b/packages/picasso/src/Input/__snapshots__/test.tsx.snap
@@ -100,7 +100,7 @@ exports[`Input should show manual resize handler 1`] = `
     class="Picasso-root"
   >
     <div
-      class="MuiInputBase-root MuiOutlinedInput-root PicassoOutlinedInput-root PicassoInput-root PicassoInput-rootMultiline PicassoOutlinedInput-rootAuto PicassoOutlinedInput-rootMedium MuiInputBase-multiline MuiOutlinedInput-multiline MuiInputBase-adornedStart MuiOutlinedInput-adornedStart MuiInputBase-adornedEnd MuiOutlinedInput-adornedEnd"
+      class="MuiInputBase-root MuiOutlinedInput-root PicassoOutlinedInput-root PicassoInput-root PicassoInput-rootMultiline PicassoInput-rootMultilineResizable PicassoOutlinedInput-rootAuto PicassoOutlinedInput-rootMedium MuiInputBase-multiline MuiOutlinedInput-multiline MuiInputBase-adornedStart MuiOutlinedInput-adornedStart MuiInputBase-adornedEnd MuiOutlinedInput-adornedEnd"
     >
       <textarea
         aria-invalid="false"

--- a/packages/picasso/src/Input/story/MultilineExpand.example.tsx
+++ b/packages/picasso/src/Input/story/MultilineExpand.example.tsx
@@ -31,6 +31,21 @@ const Example = () => {
           />
         </Container>
       </Container>
+      <Container padded='small'>
+        <Typography variant='heading' size='small'>
+          With auto-expand (up to 5 rows), manual resize and status bar
+        </Typography>
+        <Container right='small'>
+          <Input
+            multiline
+            multilineResizable
+            rows={2}
+            rowsMax={5}
+            status='success'
+            placeholder='With auto-expand and manual resize...'
+          />
+        </Container>
+      </Container>
     </Container>
   )
 }

--- a/packages/picasso/src/Input/styles.ts
+++ b/packages/picasso/src/Input/styles.ts
@@ -23,7 +23,7 @@ export default ({ palette }: Theme) =>
       resize: 'vertical',
       overflow: 'hidden',
       '&::-webkit-resizer': {
-        backgroundSize: '8px 8px',
+        backgroundSize: '0.5rem 0.5rem',
         backgroundRepeat: 'no-repeat',
         backgroundPosition: 'center center',
         backgroundImage: `url("data:image/svg+xml;base64,PHN2ZyB3aWR0aD0nOCcgaGVpZ2h0PSc4JyB2aWV3Qm94PScwIDAgOCA4JyBmaWxsPSdub25lJyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnPjxwYXRoIGZpbGwtcnVsZT0nZXZlbm9kZCcgY2xpcC1ydWxlPSdldmVub2RkJyBkPSdNNi42NDYzNiAwLjY0NjQ4NEw3LjM1MzQ3IDEuMzUzNTlMMS4zNTM0NyA3LjM1MzU5TDAuNjQ2MzYyIDYuNjQ2NDhMNi42NDYzNiAwLjY0NjQ4NFpNNy4zNTM0NyA0LjM1MzU5TDQuMzUzNDcgNy4zNTM1OUwzLjY0NjM2IDYuNjQ2NDhMNi42NDYzNiAzLjY0NjQ4TDcuMzUzNDcgNC4zNTM1OVonIGZpbGw9JyNEOEQ5REMnLz48L3N2Zz4=")`

--- a/packages/picasso/src/Input/styles.ts
+++ b/packages/picasso/src/Input/styles.ts
@@ -19,7 +19,17 @@ export default ({ palette }: Theme) =>
       minHeight: '3.75rem',
       paddingBottom: '1.875rem'
     },
+    rootMultilineResizable: {
+      resize: 'vertical',
+      overflow: 'hidden',
+      '&::-webkit-resizer': {
+        backgroundSize: '8px 8px',
+        backgroundRepeat: 'no-repeat',
+        backgroundPosition: 'center center',
+        backgroundImage: `url("data:image/svg+xml;base64,PHN2ZyB3aWR0aD0nOCcgaGVpZ2h0PSc4JyB2aWV3Qm94PScwIDAgOCA4JyBmaWxsPSdub25lJyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnPjxwYXRoIGZpbGwtcnVsZT0nZXZlbm9kZCcgY2xpcC1ydWxlPSdldmVub2RkJyBkPSdNNi42NDYzNiAwLjY0NjQ4NEw3LjM1MzQ3IDEuMzUzNTlMMS4zNTM0NyA3LjM1MzU5TDAuNjQ2MzYyIDYuNjQ2NDhMNi42NDYzNiAwLjY0NjQ4NFpNNy4zNTM0NyA0LjM1MzU5TDQuMzUzNDcgNy4zNTM1OUwzLjY0NjM2IDYuNjQ2NDhMNi42NDYzNiAzLjY0NjQ4TDcuMzUzNDcgNC4zNTM1OVonIGZpbGw9JyNEOEQ5REMnLz48L3N2Zz4=")`
+      }
+    },
     inputMultilineResizable: {
-      resize: 'vertical'
+      height: '100% !important'
     }
   })


### PR DESCRIPTION
[TACO-1436]

### Description

This PR moves the resize handler of the multiline input to the outermost corner (a.k.a the container).

The inspiration for the new visual is based on the following design: https://www.figma.com/file/Lp9meoy0qlvH05GNUeQ2lW/Talent-Application-Form?node-id=201%3A9579.

Notes: I'm using the `::-webkit-resizer` pseudo selector that is experimental and supported by webkit browsers (https://caniuse.com/mdn-css_selectors_-webkit-resizer). FF doesn't have an equivalent. The good thing is that any browser that does not support the selector would just render the native resize handler (see screenshots below).

### How to test

Check the "Forms > Input > Multiline expand and resize | Textarea" section of the storybook.

### Screenshots

| Brower | Before.                                 | After.                                  |
| ---------- | --------------------------------------- | --------------------------------------- |
| Webkit | ![before](https://user-images.githubusercontent.com/4757057/168798534-389d8cae-8b76-4a63-b3fd-d75b7f824982.png) | ![after](https://user-images.githubusercontent.com/4757057/168798895-c62161f5-264d-4e04-b6a0-d81708d8f301.png) |
| Firefox | ![ff-before](https://user-images.githubusercontent.com/4757057/168798597-de8ab767-8870-47be-ac0e-bbd423b6405d.png) | ![ff-after](https://user-images.githubusercontent.com/4757057/168798620-3e606ec9-860c-4f17-b441-1b9d623766b5.png) |

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure that tests pass by running `yarn test`
- [x] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests

**Breaking change**

- n/a ~~codemod is created and showcased in the changeset~~
- n/a ~~test alpha package of Picasso in StaffPortal~~

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[TACO-1436]: https://toptal-core.atlassian.net/browse/TACO-1436?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ