### PR TITLE
fix: [FX-2739] Fix circularity in RichTextEditor and LineChart - part 6

### DIFF
--- a/packages/picasso-charts/src/LineChart/LineChart.tsx
+++ b/packages/picasso-charts/src/LineChart/LineChart.tsx
@@ -29,7 +29,8 @@ import {
   ChartDataPoint,
   Domain,
   LineConfig,
-  OrderedChartDataPoint
+  OrderedChartDataPoint,
+  HighlightConfig
 } from '../types'
 
 const {
@@ -47,12 +48,6 @@ type RechartsOnMouseMove = CoordinatePayload | null
 
 export type ReferenceLineType = {
   y: number
-  color: string
-}
-
-export type HighlightConfig = {
-  from: number
-  to: number
   color: string
 }
 

--- a/packages/picasso-charts/src/LineChart/index.ts
+++ b/packages/picasso-charts/src/LineChart/index.ts
@@ -3,6 +3,6 @@ import { OmitInternalProps } from '@toptal/picasso-shared'
 import { Props } from './LineChart'
 
 export { default } from './LineChart'
-export type { HighlightConfig, ReferenceLineType } from './LineChart'
+export type { ReferenceLineType } from './LineChart'
 
 export type LineChartProps = OmitInternalProps<Props>

--- a/packages/picasso-charts/src/index.ts
+++ b/packages/picasso-charts/src/index.ts
@@ -1,9 +1,5 @@
 export { default as LineChart } from './LineChart'
-export type {
-  HighlightConfig,
-  LineChartProps,
-  ReferenceLineType
-} from './LineChart'
+export type { LineChartProps, ReferenceLineType } from './LineChart'
 export { default as BarChart } from './BarChart'
 export type { BarChartProps } from './BarChart'
 export type {
@@ -11,6 +7,7 @@ export type {
   BaseLineChartProps,
   LineConfig,
   ChartDataPoint,
-  OrderedChartDataPoint
+  OrderedChartDataPoint,
+  HighlightConfig
 } from './types'
 // hygen code generator inserts export statements above this comment.

--- a/packages/picasso-charts/src/types.ts
+++ b/packages/picasso-charts/src/types.ts
@@ -68,3 +68,9 @@ export type BaseLineChartProps = BaseChartProps & {
   /** The formatter function of tick. */
   formatYAxisTick?: (value: number, domain: Domain) => string
 }
+
+export type HighlightConfig = {
+  from: number
+  to: number
+  color: string
+}

--- a/packages/picasso-charts/src/utils/to-recharts-highlight-format/to-recharts-highlight-format.tsx
+++ b/packages/picasso-charts/src/utils/to-recharts-highlight-format/to-recharts-highlight-format.tsx
@@ -1,4 +1,4 @@
-import { HighlightConfig } from '../../LineChart'
+import { HighlightConfig } from '../../types'
 import CHART_CONSTANTS from '../constants'
 
 const {

--- a/packages/picasso/src/RichTextEditor/index.ts
+++ b/packages/picasso/src/RichTextEditor/index.ts
@@ -1,9 +1,7 @@
 import { OmitInternalProps } from '@toptal/picasso-shared'
 
 import { Props } from './RichTextEditor'
-import { FormatType, HeaderValue } from './store/toolbar'
 
 export { default } from './RichTextEditor'
-export type { FormatType, HeaderValue }
-export * from './types'
+export type { RichTextEditorChangeHandler } from './types'
 export type RichTextEditorProps = OmitInternalProps<Props>

--- a/packages/picasso/src/RichTextEditorToolbar/RichTextEditorToolbar.tsx
+++ b/packages/picasso/src/RichTextEditorToolbar/RichTextEditorToolbar.tsx
@@ -6,8 +6,7 @@ import Container from '../Container'
 import Select from '../Select'
 import styles from './styles'
 import TextEditorButton from '../RichTextEditorButton'
-import { ButtonHandlerType, SelectOnChangeHandler } from './types'
-import { FormatType } from '../RichTextEditor'
+import { ButtonHandlerType, SelectOnChangeHandler, FormatType } from './types'
 
 type Props = {
   disabled: boolean

--- a/packages/picasso/src/RichTextEditorToolbar/types.ts
+++ b/packages/picasso/src/RichTextEditorToolbar/types.ts
@@ -1,6 +1,16 @@
 import { ChangeEvent, MouseEventHandler } from 'react'
 
-import { HeaderValue } from '../RichTextEditor'
+export type HeaderValue = '3' | ''
+export type BoldValue = boolean
+export type ItalicValue = boolean
+export type ListValue = 'bullet' | 'ordered' | false
+
+export type FormatType = {
+  bold: BoldValue
+  italic: ItalicValue
+  list: ListValue
+  header: HeaderValue
+}
 
 export type ButtonHandlerType = MouseEventHandler<HTMLButtonElement>
 


### PR DESCRIPTION
[FX-2739]

### Description

Fix circularity issues in LineChart and RichTextEditor

### How to test

- `yarn circularity`
- You should see no circularity issues 🎉 

### Screenshots

<img width="787" alt="Screenshot 2022-05-18 at 17 51 10" src="https://user-images.githubusercontent.com/2836281/169071205-c23d6c4e-0572-488d-a0f0-a044b5d3462e.png">


<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-2739]: https://toptal-core.atlassian.net/browse/FX-2739?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ