### PR TITLE
chore: use davinci config for `resetMocks`

### DIFF
--- a/jest.spec.js
+++ b/jest.spec.js
@@ -13,7 +13,5 @@ module.exports = {
     '^@toptal/picasso-provider$':
       '<rootDir>packages/picasso-provider/src/index.ts',
     '^@toptal/picasso-root/(.*)$': '<rootDir>/$1'
-  },
-
-  resetMocks: false
+  }
 }

--- a/packages/picasso/src/Autocomplete/use-autocomplete/test.ts
+++ b/packages/picasso/src/Autocomplete/use-autocomplete/test.ts
@@ -3,6 +3,7 @@
 import { act, renderHook } from '@testing-library/react-hooks'
 import { waitFor } from '@toptal/picasso/test-utils'
 
+import { Item } from '../types'
 import {
   useAutocomplete,
   getNextWrappingIndex,
@@ -27,9 +28,7 @@ const MOCKED_EVENT = {
   target: { value: '' }
 } as any
 
-const defaultGetDisplayValue = jest
-  .fn()
-  .mockImplementation(option => option?.text ?? '')
+const defaultGetDisplayValue = (option: Item | null) => option?.text ?? ''
 
 const renderUseAutocomplete = ({
   value = '',
@@ -47,9 +46,6 @@ const renderUseAutocomplete = ({
   )
 
 describe('useAutocomplete', () => {
-  beforeEach(() => {
-    defaultGetDisplayValue.mockClear()
-  })
   it('works', () => {
     const { result } = renderUseAutocomplete()
 

--- a/packages/picasso/src/DatePicker/test.tsx
+++ b/packages/picasso/src/DatePicker/test.tsx
@@ -278,9 +278,13 @@ describe('DatePicker', () => {
 
     describe('should work with `parseInputValue`', () => {
       describe('when parser returns parsed date', () => {
-        const parseInputValue: DatePickerInputCustomValueParser = jest
-          .fn()
-          .mockImplementation(() => new Date(2021, 0, 1))
+        let parseInputValue: DatePickerInputCustomValueParser
+
+        beforeEach(() => {
+          parseInputValue = jest
+            .fn()
+            .mockImplementation(() => new Date(2021, 0, 1))
+        })
 
         it('calls `onChange` handler with the parsed date', async () => {
           const handleChange = jest.fn()

--- a/packages/picasso/src/Popper/test.tsx
+++ b/packages/picasso/src/Popper/test.tsx
@@ -1,11 +1,9 @@
 import React from 'react'
 import MUIPopper from '@material-ui/core/Popper'
 import { usePicassoRoot } from '@toptal/picasso-provider'
-import { makeStyles } from '@material-ui/core/styles'
 import { render } from '@testing-library/react'
 
 import Popper, { Props, getPopperOptions } from './Popper'
-import styles from './styles'
 
 jest.mock('@material-ui/core/Popper', () => jest.fn(() => null))
 jest.mock('@toptal/picasso-provider', () => ({
@@ -23,7 +21,6 @@ jest.mock('../utils/use-width-of', () => ({
 const mockedUsePicassoRoot = usePicassoRoot as jest.Mock<
   ReturnType<typeof usePicassoRoot>
 >
-const mockedMakeStyles = makeStyles as jest.Mock<ReturnType<typeof makeStyles>>
 const mockedMUIPopper = MUIPopper as jest.Mock<ReturnType<typeof MUIPopper>>
 
 const rootDiv = document.createElement('div')
@@ -74,13 +71,6 @@ describe('Popper', () => {
   beforeEach(() => {
     mockedMUIPopper.mockClear()
     mockedUsePicassoRoot.mockReturnValue(rootDiv)
-  })
-
-  it('creates useStyle hook properly', () => {
-    expect(mockedMakeStyles).toHaveBeenCalledTimes(1)
-    expect(mockedMakeStyles).toHaveBeenCalledWith(styles, {
-      name: 'PicassoPopper'
-    })
   })
 
   describe('when container prop is passed', () => {

--- a/packages/picasso/src/QuillEditor/hooks/useDefaultValue/test.ts
+++ b/packages/picasso/src/QuillEditor/hooks/useDefaultValue/test.ts
@@ -3,21 +3,28 @@ import Quill from 'quill'
 import Delta from 'quill-delta'
 
 import useDefaultValue from './useDefaultValue'
-const deltaMock = {
-  ops: [
-    { insert: 'Gandalf', attributes: { bold: true } },
-    { insert: ' the ' },
-    { insert: 'Grey', attributes: { italic: true } }
-  ]
-} as Delta
-const quillMock = {
-  clipboard: {
-    convert: jest.fn((): Delta => deltaMock)
-  },
-  setContents: jest.fn()
-} as unknown as Quill
 
 describe('useDefaultValue', () => {
+  let deltaMock: Delta
+  let quillMock: Quill
+
+  beforeEach(() => {
+    deltaMock = {
+      ops: [
+        { insert: 'Gandalf', attributes: { bold: true } },
+        { insert: ' the ' },
+        { insert: 'Grey', attributes: { italic: true } }
+      ]
+    } as Delta
+
+    quillMock = {
+      clipboard: {
+        convert: jest.fn((): Delta => deltaMock)
+      },
+      setContents: jest.fn()
+    } as unknown as Quill
+  })
+
   it('does nothing without defaultValue', () => {
     const quill = quillMock
     const defaultValue = ''

--- a/packages/picasso/src/SelectBase/hooks/use-select-state/test.ts
+++ b/packages/picasso/src/SelectBase/hooks/use-select-state/test.ts
@@ -1,6 +1,19 @@
 import { renderHook, act } from '@testing-library/react-hooks'
 
-import useSelectState, { Props } from './use-select-state'
+import { Option } from '../../types'
+import useSelectState, { Props, EMPTY_INPUT_VALUE } from './use-select-state'
+import useHighlightedIndex from '../use-highlighted-index'
+import {
+  getMultipleSelection,
+  getSingleSelection,
+  getSelectedOptions,
+  DEFAULT_LIMIT,
+  filterOptions,
+  flattenOptions,
+  limitOptions
+} from '../../utils'
+
+const utils = jest.requireActual('../../utils')
 
 const DEFAULT_OPTIONS = [
   { text: 'One', value: '1' },
@@ -8,9 +21,76 @@ const DEFAULT_OPTIONS = [
   { text: 'Three', value: '3' }
 ]
 
-const defaultGetDisplayValue = jest
-  .fn()
-  .mockImplementation(option => option?.text ?? '')
+const defaultGetDisplayValue = (option: Option | null) => option?.text ?? ''
+
+jest.mock('../use-highlighted-index')
+jest.mock('../../utils')
+
+const mockedUseHighlightedIndex = useHighlightedIndex as jest.Mock<
+  ReturnType<typeof useHighlightedIndex>
+>
+const mockedGetMultipleSelection = getMultipleSelection as jest.Mock<
+  ReturnType<typeof getMultipleSelection>
+>
+const mockedGetSingleSelection = getSingleSelection as jest.Mock<
+  ReturnType<typeof getSingleSelection>
+>
+const mockedGetSelectedOptions = getSelectedOptions as jest.Mock<
+  ReturnType<typeof getSelectedOptions>
+>
+const mockedFilterOptions = filterOptions as jest.Mock<
+  ReturnType<typeof filterOptions>
+>
+const mockedLimitOptions = limitOptions as jest.Mock<
+  ReturnType<typeof limitOptions>
+>
+const mockedFlattenOptions = flattenOptions as jest.Mock<
+  ReturnType<typeof flattenOptions>
+>
+
+const options: Option[] = [
+  {
+    text: 'OPTION_TEXT+1',
+    value: 'OPTION_VALUE+1'
+  },
+  {
+    text: 'OPTION_TEXT+2',
+    value: 'OPTION_VALUE+2'
+  }
+]
+
+const filteredOptions: Option[] = [
+  {
+    text: 'FILTERED_OPTION_TEXT+1',
+    value: 'FILTERED_OPTION_VALUE+1'
+  },
+  {
+    text: 'FILTERED_OPTION_TEXT+2',
+    value: 'FILTERED_OPTION_VALUE+2'
+  }
+]
+
+const limitedOptions: Option[] = [
+  {
+    text: 'LIMITED_OPTION_TEXT+1',
+    value: 'LIMITED_OPTION_VALUE+1'
+  },
+  {
+    text: 'LIMITED_OPTION_TEXT+2',
+    value: 'LIMITED_OPTION_VALUE+2'
+  }
+]
+
+const flattenedOptions: Option[] = [
+  {
+    text: 'FLATTENED_OPTION_TEXT+1',
+    value: 'FLATTENED_OPTION_VALUE+1'
+  },
+  {
+    text: 'FLATTENED_OPTION_TEXT+2',
+    value: 'FLATTENED_OPTION_VALUE+2'
+  }
+]
 
 const renderUseSelectState = (initialProps: Partial<Props> = {}) =>
   renderHook(
@@ -33,74 +113,196 @@ const renderUseSelectState = (initialProps: Partial<Props> = {}) =>
 
 describe('useSelectState', () => {
   beforeEach(() => {
-    defaultGetDisplayValue.mockClear()
+    mockedUseHighlightedIndex.mockImplementation(() => [0, jest.fn()])
+    mockedGetMultipleSelection.mockImplementation(utils.getMultipleSelection)
+    mockedGetSingleSelection.mockImplementation(utils.getSingleSelection)
+    mockedGetSelectedOptions.mockImplementation(() => options)
+    mockedFilterOptions.mockImplementation(() => filteredOptions)
+    mockedLimitOptions.mockImplementation(() => limitedOptions)
+    mockedFlattenOptions.mockImplementation(() => flattenedOptions)
   })
 
-  it('returns initial state', () => {
-    const { result } = renderUseSelectState()
-
-    expect(result.current.selectedOptions).toEqual([])
-    expect(result.current.isOpen).toBe(false)
-    expect(result.current.canOpen).toBe(true)
-    expect(result.current.highlightedIndex).toBe(0)
-    expect(result.current.closeOnEnter).toBe(true)
-    expect(result.current.showSearch).toBe(false)
-    expect(result.current.filterOptionsValue).toBe('')
-    expect(result.current.displayValue).toBe('')
-    expect(result.current.emptySelectValue).toBe('')
+  afterEach(() => {
+    mockedUseHighlightedIndex.mockReset()
+    mockedGetMultipleSelection.mockReset()
+    mockedGetSingleSelection.mockReset()
+    mockedGetSelectedOptions.mockReset()
+    mockedFilterOptions.mockReset()
+    mockedLimitOptions.mockReset()
+    mockedFlattenOptions.mockReset()
   })
 
-  it('returns state with value', () => {
-    const { result } = renderUseSelectState({
-      value: DEFAULT_OPTIONS[0].value
+  describe('when multiple selection is off', () => {
+    describe('when no selected options', () => {
+      it('returns initial state', () => {
+        mockedGetSelectedOptions.mockReturnValueOnce([])
+
+        const { result } = renderUseSelectState()
+
+        expect(mockedGetSelectedOptions).toHaveBeenCalledWith(
+          flattenedOptions,
+          undefined
+        )
+
+        expect(result.current.selectedOptions).toEqual([])
+        expect(result.current.isOpen).toBe(false)
+        expect(result.current.canOpen).toBe(true)
+        expect(result.current.highlightedIndex).toBe(0)
+        expect(result.current.closeOnEnter).toBe(true)
+        expect(result.current.showSearch).toBe(false)
+        expect(result.current.filterOptionsValue).toBe('')
+        expect(result.current.displayValue).toBe('')
+        expect(result.current.emptySelectValue).toBe('')
+      })
+
+      describe('when value is changed on re-render', () => {
+        it('updates display value and selected options automatically', () => {
+          mockedGetSelectedOptions.mockReturnValueOnce([])
+
+          const { result, rerender } = renderUseSelectState()
+
+          expect(mockedFlattenOptions).toHaveBeenCalledWith(DEFAULT_OPTIONS)
+          expect(mockedGetSelectedOptions).toHaveBeenCalledTimes(1)
+          expect(mockedGetSelectedOptions).toHaveBeenCalledWith(
+            flattenedOptions,
+            undefined
+          )
+          expect(result.current.selectedOptions).toEqual([])
+          expect(result.current.displayValue).toBe('')
+
+          mockedGetSelectedOptions.mockReturnValueOnce(options)
+
+          rerender({ value: 'NEW_VALUE' })
+
+          expect(mockedGetSelectedOptions).toHaveBeenCalledTimes(2)
+          expect(mockedGetSelectedOptions).toHaveBeenCalledWith(
+            flattenedOptions,
+            'NEW_VALUE'
+          )
+          expect(result.current.selectedOptions).toEqual(options)
+          expect(result.current.displayValue).toBe('OPTION_TEXT+1')
+        })
+      })
     })
 
-    expect(result.current.selectedOptions).toEqual([DEFAULT_OPTIONS[0]])
-    expect(result.current.isOpen).toBe(false)
-    expect(result.current.canOpen).toBe(true)
-    expect(result.current.highlightedIndex).toBe(0)
-    expect(result.current.closeOnEnter).toBe(true)
-    expect(result.current.showSearch).toBe(false)
-    expect(result.current.filterOptionsValue).toBe('')
-    expect(result.current.displayValue).toEqual(DEFAULT_OPTIONS[0].text)
-    expect(result.current.emptySelectValue).toBe('')
-  })
+    describe('when selected value is specified', () => {
+      it('returns state with value', () => {
+        const { result } = renderUseSelectState({
+          value: 'FLATTENED_OPTION_VALUE+1'
+        })
 
-  it('returns multiple state with value', () => {
-    const { result } = renderUseSelectState({
-      value: [DEFAULT_OPTIONS[0].value, DEFAULT_OPTIONS[1].value],
-      multiple: true
+        expect(mockedGetMultipleSelection).not.toHaveBeenCalled()
+        expect(mockedGetSingleSelection).toHaveBeenCalledWith({
+          text: 'OPTION_TEXT+1',
+          value: 'OPTION_VALUE+1'
+        })
+        expect(mockedGetSelectedOptions).toHaveBeenCalledWith(
+          flattenedOptions,
+          'FLATTENED_OPTION_VALUE+1'
+        )
+
+        expect(result.current.selectedOptions).toEqual(options)
+        expect(result.current.isOpen).toBe(false)
+        expect(result.current.canOpen).toBe(true)
+        expect(result.current.highlightedIndex).toBe(0)
+        expect(result.current.closeOnEnter).toBe(true)
+        expect(result.current.showSearch).toBe(false)
+        expect(result.current.filterOptionsValue).toBe('')
+        expect(result.current.displayValue).toBe('OPTION_TEXT+1')
+        expect(result.current.emptySelectValue).toBe('')
+      })
     })
-
-    expect(result.current.selectedOptions).toEqual([
-      DEFAULT_OPTIONS[0],
-      DEFAULT_OPTIONS[1]
-    ])
-    expect(result.current.isOpen).toBe(false)
-    expect(result.current.canOpen).toBe(true)
-    expect(result.current.highlightedIndex).toBe(0)
-    expect(result.current.closeOnEnter).toBe(false)
-    expect(result.current.showSearch).toBe(false)
-    expect(result.current.filterOptionsValue).toBe('')
-    expect(result.current.displayValue).toBe(
-      `${DEFAULT_OPTIONS[0].text}, ${DEFAULT_OPTIONS[1].text}`
-    )
-    expect(result.current.emptySelectValue).toEqual([])
   })
 
-  it('show search when there is more items than threshold allows', () => {
-    const { result } = renderUseSelectState({ searchThreshold: 2 })
+  describe('when multiple selection is used', () => {
+    describe('when selected value is specified', () => {
+      it('returns multiple state with value', () => {
+        const { result } = renderUseSelectState({
+          value: ['FLATTENED_OPTION_VALUE+1', 'FLATTENED_OPTION_VALUE+2'],
+          multiple: true
+        })
 
-    expect(result.current.showSearch).toBe(true)
-  })
+        expect(mockedGetMultipleSelection).toHaveBeenCalledWith(options)
+        expect(mockedFilterOptions).toHaveBeenCalledWith({
+          options: DEFAULT_OPTIONS,
+          filterOptionsValue: EMPTY_INPUT_VALUE,
+          getDisplayValue: defaultGetDisplayValue
+        })
+        expect(mockedGetSingleSelection).not.toHaveBeenCalled()
 
-  it('forces search when threshold is higher than max number of elements to show', () => {
-    const { result } = renderUseSelectState({
-      searchThreshold: 3,
-      limit: 2
+        expect(result.current.selectedOptions).toEqual(options)
+        expect(result.current.isOpen).toBe(false)
+        expect(result.current.canOpen).toBe(true)
+        expect(result.current.highlightedIndex).toBe(0)
+        expect(result.current.closeOnEnter).toBe(false)
+        expect(result.current.showSearch).toBe(false)
+        expect(result.current.filterOptionsValue).toBe('')
+        expect(result.current.displayValue).toBe('OPTION_TEXT+1, OPTION_TEXT+2')
+        expect(result.current.emptySelectValue).toEqual([])
+      })
     })
+  })
 
-    expect(result.current.showSearch).toBe(true)
+  describe('when there is more items than threshold allows', () => {
+    it('shows search', () => {
+      const { result } = renderUseSelectState({ searchThreshold: 1 })
+
+      expect(result.current.showSearch).toBe(true)
+    })
+  })
+
+  describe('when threshold is higher than max number of elements to show', () => {
+    it('forces search', () => {
+      const { result } = renderUseSelectState({
+        searchThreshold: 3,
+        limit: 2
+      })
+
+      expect(result.current.showSearch).toBe(true)
+    })
+  })
+
+  describe('when filter options callback was called', () => {
+    it('filters options correctly', () => {
+      const newFilteredOptions = [{ text: 'FILTERED', value: 'FILTERED' }]
+      const newLimitedOptions = [{ text: 'LIMITED', value: 'LIMITED' }]
+      const { result } = renderUseSelectState()
+
+      expect(mockedLimitOptions).toHaveBeenCalledTimes(1)
+      expect(mockedLimitOptions).toHaveBeenCalledWith({
+        options: filteredOptions,
+        limit: DEFAULT_LIMIT
+      })
+      expect(mockedFilterOptions).toHaveBeenCalledTimes(1)
+      expect(mockedFilterOptions).toHaveBeenCalledWith({
+        options: DEFAULT_OPTIONS,
+        filterOptionsValue: '',
+        getDisplayValue: defaultGetDisplayValue
+      })
+      expect(result.current.filterOptionsValue).toBe('')
+      expect(result.current.filteredOptions).toEqual(limitedOptions)
+
+      mockedFilterOptions.mockImplementationOnce(() => newFilteredOptions)
+      mockedLimitOptions.mockImplementationOnce(() => newLimitedOptions)
+
+      act(() => {
+        result.current.setFilterOptionsValue('one')
+      })
+
+      expect(mockedLimitOptions).toHaveBeenCalledTimes(2)
+      expect(mockedLimitOptions).toHaveBeenCalledWith({
+        options: newFilteredOptions,
+        limit: DEFAULT_LIMIT
+      })
+      expect(mockedFilterOptions).toHaveBeenCalledTimes(2)
+      expect(mockedFilterOptions).toHaveBeenCalledWith({
+        options: DEFAULT_OPTIONS,
+        filterOptionsValue: 'one',
+        getDisplayValue: defaultGetDisplayValue
+      })
+      expect(result.current.filterOptionsValue).toBe('one')
+      expect(result.current.filteredOptions).toEqual(newLimitedOptions)
+    })
   })
 
   it('toggles isOpen state', () => {
@@ -115,28 +317,6 @@ describe('useSelectState', () => {
       result.current.close()
     })
     expect(result.current.isOpen).toBe(false)
-  })
-
-  it('filters options correctly', () => {
-    const { result } = renderUseSelectState()
-
-    act(() => {
-      result.current.setFilterOptionsValue('one')
-    })
-    expect(result.current.filterOptionsValue).toBe('one')
-    expect(result.current.filteredOptions).toEqual([DEFAULT_OPTIONS[0]])
-  })
-
-  it('updates display value and selected options automatically', () => {
-    const { result, rerender } = renderUseSelectState()
-
-    expect(result.current.selectedOptions).toEqual([])
-    expect(result.current.displayValue).toBe('')
-
-    rerender({ value: DEFAULT_OPTIONS[0].value })
-
-    expect(result.current.selectedOptions).toEqual([DEFAULT_OPTIONS[0]])
-    expect(result.current.displayValue).toEqual(DEFAULT_OPTIONS[0].text)
   })
 
   describe('when select is opened but has became disabled', () => {

--- a/packages/picasso/src/SelectBase/hooks/use-select-state/test.ts
+++ b/packages/picasso/src/SelectBase/hooks/use-select-state/test.ts
@@ -29,9 +29,11 @@ jest.mock('../../utils')
 const mockedUseHighlightedIndex = useHighlightedIndex as jest.Mock<
   ReturnType<typeof useHighlightedIndex>
 >
+
 const mockedGetMultipleSelection = getMultipleSelection as jest.Mock<
   ReturnType<typeof getMultipleSelection>
 >
+
 const mockedGetSingleSelection = getSingleSelection as jest.Mock<
   ReturnType<typeof getSingleSelection>
 >
@@ -120,16 +122,6 @@ describe('useSelectState', () => {
     mockedFilterOptions.mockImplementation(() => filteredOptions)
     mockedLimitOptions.mockImplementation(() => limitedOptions)
     mockedFlattenOptions.mockImplementation(() => flattenedOptions)
-  })
-
-  afterEach(() => {
-    mockedUseHighlightedIndex.mockReset()
-    mockedGetMultipleSelection.mockReset()
-    mockedGetSingleSelection.mockReset()
-    mockedGetSelectedOptions.mockReset()
-    mockedFilterOptions.mockReset()
-    mockedLimitOptions.mockReset()
-    mockedFlattenOptions.mockReset()
   })
 
   describe('when multiple selection is off', () => {

--- a/packages/picasso/src/TypographyOverflow/test.tsx
+++ b/packages/picasso/src/TypographyOverflow/test.tsx
@@ -1,16 +1,46 @@
-import React from 'react'
-import { fireEvent, render, waitFor } from '@toptal/picasso/test-utils'
+import React, { ReactNode } from 'react'
+import { render, act } from '@toptal/picasso/test-utils'
 
+import Tooltip from '../Tooltip'
+import Typography from '../Typography'
+import { isOverflown } from '../utils'
 import TypographyOverflow from '.'
-jest.mock('../utils/is-overflown', () => ({
+
+jest.mock('../Tooltip', () => {
+  return {
+    __esModule: true,
+    default: jest.fn(({ children, ...rest }: { children: ReactNode }) => (
+      <span {...rest}>{children}</span>
+    ))
+  }
+})
+jest.mock('../Typography', () => {
+  return {
+    __esModule: true,
+    default: jest.fn(({ children }: { children: ReactNode }) => (
+      <span>{children}</span>
+    ))
+  }
+})
+jest.mock('../utils', () => ({
   __esModule: true,
-  default: jest.fn(() => true)
+  isOverflown: jest.fn(() => true)
 }))
 
+const mockedTooltip = Tooltip as unknown as jest.Mock<
+  ReturnType<typeof Tooltip>
+>
+const mockedTypography = Typography as unknown as jest.Mock<
+  ReturnType<typeof Typography>
+>
+const mockedIsOverflown = isOverflown as jest.Mock<
+  ReturnType<typeof isOverflown>
+>
+
 describe('TypographyOverflow', () => {
-  describe('when overflow happened', () => {
-    it('renders tooltip by default', async () => {
-      const { getByTestId, queryByTestId } = render(
+  describe('initial render', () => {
+    it('renders only typography', () => {
+      render(
         <TypographyOverflow
           tooltipContent={<p data-testid='tooltip' />}
           data-testid='typography'
@@ -19,26 +49,74 @@ describe('TypographyOverflow', () => {
         </TypographyOverflow>
       )
 
-      // no tooltip by default
-      expect(queryByTestId('tooltip')).not.toBeInTheDocument()
+      expect(mockedTooltip).toHaveBeenCalledTimes(0)
+      expect(mockedTypography).toHaveBeenCalledTimes(1)
+    })
+  })
 
-      // check tooltip opens
-      // current implementation swaps elements on mouse enter, so another event is needed
-      fireEvent.mouseOver(getByTestId('typography'))
-      fireEvent.mouseOver(getByTestId('typography'))
-      await waitFor(() => {
-        expect(queryByTestId('tooltip')).toBeInTheDocument()
-      })
+  describe('when overflow happened', () => {
+    describe('when mouse is entered a typography and mouse left the tooltip', () => {
+      it('renders tooltip and then close it', () => {
+        mockedIsOverflown.mockReturnValueOnce(true)
 
-      // check tooltip hides
-      fireEvent.mouseLeave(getByTestId('typography'))
-      await waitFor(() => {
-        expect(queryByTestId('tooltip')).not.toBeInTheDocument()
+        render(
+          <TypographyOverflow
+            tooltipContent={<p data-testid='tooltip' />}
+            data-testid='typography'
+          >
+            Just Typography
+          </TypographyOverflow>
+        )
+
+        act(() => {
+          mockedTypography.mock.calls[0][0].onMouseEnter({
+            currentTarget: true
+          })
+        })
+
+        expect(mockedTooltip).toHaveBeenCalledTimes(1)
+        expect(mockedTypography).toHaveBeenCalledTimes(1)
+
+        act(() => {
+          mockedTooltip.mock.calls[0][0].onClose()
+          mockedTooltip.mock.calls[0][0].onTransitionExited()
+        })
+
+        expect(mockedTooltip).toHaveBeenCalledTimes(1)
+        expect(mockedTypography).toHaveBeenCalledTimes(2)
       })
     })
 
-    it('does not render tooltip if it is disabled', async () => {
-      const { getByTestId, queryByTestId } = render(
+    describe('when mouse is NOT entered a typography', () => {
+      it('does not render tooltip', () => {
+        mockedIsOverflown.mockReturnValueOnce(false)
+
+        render(
+          <TypographyOverflow
+            tooltipContent={<p data-testid='tooltip' />}
+            data-testid='typography'
+          >
+            Just Typography
+          </TypographyOverflow>
+        )
+
+        act(() => {
+          mockedTypography.mock.calls[0][0].onMouseEnter({
+            currentTarget: true
+          })
+        })
+
+        expect(mockedTooltip).toHaveBeenCalledTimes(0)
+        expect(mockedTypography).toHaveBeenCalledTimes(1)
+      })
+    })
+  })
+
+  describe('when tooltip is disabled', () => {
+    it('does not render tooltip', () => {
+      mockedIsOverflown.mockReturnValueOnce(true)
+
+      render(
         <TypographyOverflow
           disableTooltip
           tooltipContent={<p data-testid='tooltip' />}
@@ -48,11 +126,12 @@ describe('TypographyOverflow', () => {
         </TypographyOverflow>
       )
 
-      // check tooltip never opens
-      fireEvent.mouseEnter(getByTestId('typography'))
-      await waitFor(() => {
-        expect(queryByTestId('tooltip')).not.toBeInTheDocument()
+      act(() => {
+        mockedTypography.mock.calls[0][0].onClick({ currentTarget: true })
       })
+
+      expect(mockedTooltip).toHaveBeenCalledTimes(0)
+      expect(mockedTypography).toHaveBeenCalledTimes(1)
     })
   })
 })


### PR DESCRIPTION
[FX-2702]

### Description

We want to be consistent and use Davinci config for jest as much as possible. We remove `resetMocks` from our custom config, so the value will be `true`.

### How to test

- CI should be green

### Development checks

- Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- Annotate all `props` in component with documentation
- Create `examples` for component
- Ensure that deployed demo has expected results and good examples
- [x] Ensure that tests pass by running `yarn test`
- Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
- Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- Covered with tests

**Breaking change**

- codemod is created and showcased in the changeset
- test alpha package of Picasso in StaffPortal

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-2702]: https://toptal-core.atlassian.net/browse/FX-2702?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ