### PR TITLE
fix(InputField): fix input valid state when it's changed after submit

### DIFF
--- a/.changeset/happy-dolls-wave.md
+++ b/.changeset/happy-dolls-wave.md
@@ -1,0 +1,13 @@
+---
+'@toptal/picasso-forms': patch
+---
+
+---
+
+### InputField
+
+- Fix valid state of a field when it has a submit error and dirty since last submit
+
+### Form.ConfigProvider
+
+- Forbid simultaneous usage of `showValidState` and `validateOnSubmit`

--- a/packages/picasso-forms/src/FormConfig/FormConfig.ts
+++ b/packages/picasso-forms/src/FormConfig/FormConfig.ts
@@ -2,10 +2,27 @@ import { createContext, useContext } from 'react'
 
 export type RequiredVariant = 'default' | 'asterisk'
 
-export interface FormConfigProps {
-  validateOnSubmit?: boolean
+type ValidationOnSubmitConfig = {
+  showValidState?: false
+  validateOnSubmit: true
+}
+
+type ShowValidStateConfig = {
+  showValidState: true
+  validateOnSubmit?: false
+}
+
+type NoValidationConfig = {
+  showValidState?: false
+  validateOnSubmit?: false
+}
+
+export type FormConfigProps = (
+  | ValidationOnSubmitConfig
+  | ShowValidStateConfig
+  | NoValidationConfig
+) & {
   requiredVariant?: RequiredVariant
-  showValidState?: boolean
 }
 
 export const FormConfigContext = createContext<FormConfigProps>({})

--- a/packages/picasso-forms/src/InputField/InputField.tsx
+++ b/packages/picasso-forms/src/InputField/InputField.tsx
@@ -23,11 +23,7 @@ export const getInputStatus = <T extends ValueType>(
     return 'error'
   }
 
-  if (meta.dirtySinceLastSubmit) {
-    return 'default'
-  }
-
-  if (meta.submitError) {
+  if (!meta.dirtySinceLastSubmit && meta.submitError) {
     return 'error'
   }
 

--- a/packages/picasso-forms/src/InputField/test.ts
+++ b/packages/picasso-forms/src/InputField/test.ts
@@ -14,14 +14,45 @@ describe('getInputStatus', () => {
     })
   })
 
+  it('returns "default" when field has not been touched', () => {
+    const meta: FieldMetaState<string> = {
+      touched: false,
+    }
+
+    expect(getInputStatus(meta, { showValidState: true })).toBe('default')
+  })
+
   describe('when field has a submit error', () => {
-    it('returns "error"', () => {
+    it('returns "error" if the field is not dirty since last submit', () => {
       const meta: FieldMetaState<string> = {
         touched: true,
         submitError: 'Some error message',
+        dirtySinceLastSubmit: false,
       }
 
       expect(getInputStatus(meta, { showValidState: false })).toBe('error')
+    })
+
+    describe('when field has been dirty since last submit', () => {
+      it('returns "success" if show valid state is enabled', () => {
+        const meta: FieldMetaState<string> = {
+          touched: true,
+          submitError: 'Some error message',
+          dirtySinceLastSubmit: true,
+        }
+
+        expect(getInputStatus(meta, { showValidState: true })).toBe('success')
+      })
+
+      it('returns "default" if show valid state is not enabled for the form', () => {
+        const meta: FieldMetaState<string> = {
+          touched: true,
+          submitError: 'Some error message',
+          dirtySinceLastSubmit: true,
+        }
+
+        expect(getInputStatus(meta, { showValidState: false })).toBe('default')
+      })
     })
   })
 
@@ -29,18 +60,6 @@ describe('getInputStatus', () => {
     it('returns "default"', () => {
       const meta: FieldMetaState<string> = {
         touched: false,
-      }
-
-      expect(getInputStatus(meta, { showValidState: false })).toBe('default')
-    })
-  })
-
-  describe('when field has been dirty since last submit and has no error', () => {
-    it('returns "default"', () => {
-      const meta: FieldMetaState<string> = {
-        touched: true,
-        submitError: 'Some error message',
-        dirtySinceLastSubmit: true,
       }
 
       expect(getInputStatus(meta, { showValidState: false })).toBe('default')


### PR DESCRIPTION
[FX-2822]

### Description

Fix the incorrect valid state of the input field when it was fixed after submitting an invalid value.

### How to reproduce

- Open ["Form Level Status Configuration" on picassot.toptal.net](https://picasso.toptal.net/?path=/story/picasso-forms-form--form#form-level-status-configuration)
- Click "Submit". You'll see the validation error (that's correct behavior).
- Enter a text in the input field. Instead of the green check icon, you'll see no valid state.

    ![image](https://user-images.githubusercontent.com/3861498/171215960-0c70cb56-9c57-41f9-b1bb-ac5620b37610.png)


### How to test

- Repeat action from the `How to reproduce` section. But instead, use ["Form Level Status Configuration" section from the demo](https://picasso.toptal.net/fx-2822-form-shows-incorrect-validation-status/?path=/story/picasso-forms-form--form#form-level-status-configuration)
    - You should be able to submit the form with Enter and see the green check icon
    - You should be able to see the green check icon once you fixed data after submission of empty form

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure that tests pass by running `yarn test`
- [x] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests

**Breaking change**

- [x] codemod is created and showcased in the changeset
- [x] test alpha package of Picasso in StaffPortal

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-2822]: https://toptal-core.atlassian.net/browse/FX-2822?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ