### PR TITLE
chore(happo): add happo tests to release.yml

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -90,7 +90,6 @@ jobs:
       - name: Visual Tests
         run: yarn happo:ci
         env:
-          CURRENT_SHA: ${{ github.sha }}
           HAPPO_PROJECT: Picasso/Storybook
           HAPPO_API_KEY: ${{ secrets.HAPPO_API_KEY }}
           HAPPO_API_SECRET: ${{ secrets.HAPPO_API_SECRET }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -168,14 +168,14 @@ jobs:
           FALLBACK_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}?check_suite_focus=true
         with:
           channel-id: '-frontend-exp-team-notifications'
-          slack-message: ":x: <!here> Current master version of Picasso is <${{ env.FAILURE_URL || env.FALLBACK_URL }}|broken>."
+          slack-message: ':x: <!here> Current master version of Picasso is <${{ env.FAILURE_URL || env.FALLBACK_URL }}|broken>.'
 
       - name: Send a Slack notification on success release
         if: ${{ success() && steps.changesets.outputs.published == 'true' }}
         uses: slackapi/slack-github-action@v1.14.0
         with:
           channel-id: '-frontend-exp-team-notifications'
-          slack-message: "Current master version of Picasso successfully released :green_heart:"
+          slack-message: 'Current master version of Picasso successfully released :green_heart:'
         env:
           SLACK_BOT_TOKEN: ${{ env.SLACK_BOT_TOKEN }}
       - name: Send a Slack notification on success PR merge
@@ -183,7 +183,7 @@ jobs:
         uses: slackapi/slack-github-action@v1.14.0
         with:
           channel-id: '-frontend-exp-team-notifications'
-          slack-message: "A new PR was merged to Picasso :parrotspin:"
+          slack-message: 'A new PR was merged to Picasso :parrotspin:'
         env:
           SLACK_BOT_TOKEN: ${{ env.SLACK_BOT_TOKEN }}
 
@@ -195,3 +195,14 @@ jobs:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       HAPPO_API_KEY: ${{ secrets.HAPPO_API_KEY }}
       HAPPO_API_SECRET: ${{ secrets.HAPPO_API_SECRET }}
+
+  happo-tests:
+    name: Happo Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Happo Tests
+        run: yarn happo:ci
+        env:
+          HAPPO_PROJECT: Picasso/Storybook
+          HAPPO_API_KEY: ${{ secrets.HAPPO_API_KEY }}
+          HAPPO_API_SECRET: ${{ secrets.HAPPO_API_SECRET }}


### PR DESCRIPTION
### Description

This PR is about adding happo test action to release workflow because tests should be run after merging the PR to master. This way, happo will retain the existing tests and use them while comparing with upcoming PRs.

### How to test

- nothing available to test

**Breaking change**

- [ ] codemod is created and showcased in the changeset
- [ ] test alpha package of Picasso in StaffPortal

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>
