### PR TITLE
chore: skip stories with animations for happo storybook

### DIFF
--- a/packages/picasso-charts/src/BarChart/story/index.jsx
+++ b/packages/picasso-charts/src/BarChart/story/index.jsx
@@ -25,7 +25,8 @@ page
       await testPage.mouse.move(100, 100)
       await makeScreenshot()
     },
-    delay: 500
+    delay: 500,
+    takeScreenshot: false
   })
   .addExample('BarChart/story/Customized.example.tsx', {
     title: 'Customized',
@@ -35,7 +36,8 @@ page
       await testPage.mouse.move(100, 100)
       await makeScreenshot()
     },
-    delay: 500
+    delay: 500,
+    takeScreenshot: false
   })
   .addExample('BarChart/story/HideBarLabel.example.tsx', {
     title: 'Hide bar label',

--- a/packages/picasso-charts/src/BarChart/story/index.jsx
+++ b/packages/picasso-charts/src/BarChart/story/index.jsx
@@ -27,7 +27,7 @@ page
     },
     delay: 500,
     takeScreenshot: false
-  })
+  }) // skipped for animations
   .addExample('BarChart/story/Customized.example.tsx', {
     title: 'Customized',
     description:
@@ -38,7 +38,7 @@ page
     },
     delay: 500,
     takeScreenshot: false
-  })
+  }) // skipped for animations
   .addExample('BarChart/story/HideBarLabel.example.tsx', {
     title: 'Hide bar label',
     description:

--- a/packages/topkit-analytics-charts/src/CategoriesChart/story/index.jsx
+++ b/packages/topkit-analytics-charts/src/CategoriesChart/story/index.jsx
@@ -59,4 +59,4 @@ page.createChapter().addExample('CategoriesChart/story/Default.example.tsx', {
   title: 'Default',
   delay: 500,
   takeScreenshot: false
-})
+}) // skipped for animations

--- a/packages/topkit-analytics-charts/src/CategoriesChart/story/index.jsx
+++ b/packages/topkit-analytics-charts/src/CategoriesChart/story/index.jsx
@@ -57,5 +57,6 @@ page.createTabChapter('Props').addComponentDocs({
 
 page.createChapter().addExample('CategoriesChart/story/Default.example.tsx', {
   title: 'Default',
-  delay: 500
+  delay: 500,
+  takeScreenshot: false
 })


### PR DESCRIPTION
### Description

The PR is about skipping happo visual testing for stories with animations. This is a temporary fix and they will be taken care of later.

### How to test

- `Picasso/Storybook` happo CI job should be green now

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>
