### PR TITLE
fix(Form): fix form validation when submit with clicking Enter

### DIFF
--- a/.changeset/nice-guests-act.md
+++ b/.changeset/nice-guests-act.md
@@ -1,0 +1,9 @@
+---
+'@toptal/picasso-forms': patch
+---
+
+---
+
+# Form
+
+Fix form validation when submit with clicking Enter if it has `validateOnBlur={true}`

--- a/cypress/component/RichTextEditor.spec.tsx
+++ b/cypress/component/RichTextEditor.spec.tsx
@@ -74,15 +74,6 @@ const setAliases = () => {
 }
 
 describe('RichTextEditor', () => {
-  it('renders default editor', () => {
-    cy.mount(renderEditor(defaultProps))
-
-    // waits for lazy-loaded QuillEditor component
-    cy.get(editorSelector)
-
-    cy.get('body').happoScreenshot()
-  })
-
   describe('when in an invalid state', () => {
     it('shows error', () => {
       cy.mount(renderEditor({ ...defaultProps, status: 'error' }))

--- a/packages/picasso-forms/src/Form/Form.tsx
+++ b/packages/picasso-forms/src/Form/Form.tsx
@@ -26,7 +26,7 @@ const setActiveFieldTouched = <
   FormValues = object,
   InitialFormValues = Partial<FormValues>
 >(
-  args: any[],
+  _: any[],
   state: MutableState<FormValues, InitialFormValues>
 ) => {
   const activeFieldName = state.formState.active

--- a/packages/picasso-forms/src/Form/Form.tsx
+++ b/packages/picasso-forms/src/Form/Form.tsx
@@ -147,7 +147,7 @@ export const Form = <T extends AnyObject = AnyObject>(props: Props<T>) => {
 
   return (
     <FormContext.Provider value={validationObject}>
-      <FinalForm<T>
+      <FinalForm
         render={({ form, handleSubmit }) => (
           <FormRenderer
             autoComplete={autoComplete}

--- a/packages/picasso-forms/src/Form/Form.tsx
+++ b/packages/picasso-forms/src/Form/Form.tsx
@@ -119,7 +119,7 @@ export const Form = <T extends AnyObject = AnyObject>(props: Props<T>) => {
     showError(failedSubmitMessage, undefined, { persist: true })
   }
 
-  const handleFinalFormSubmit = async (
+  const handleSubmit = async (
     values: T,
     form: FormApi<T>,
     callback?: (errors?: SubmissionErrors) => void
@@ -148,18 +148,18 @@ export const Form = <T extends AnyObject = AnyObject>(props: Props<T>) => {
   return (
     <FormContext.Provider value={validationObject}>
       <FinalForm
-        render={({ form, handleSubmit }) => (
+        render={({ form, handleSubmit: handleFormRendererSubmit }) => (
           <FormRenderer
             autoComplete={autoComplete}
             data-testid={dataTestId}
-            onSubmit={handleSubmit}
+            onSubmit={handleFormRendererSubmit}
             validateOnBlur={validateOnBlur}
             setActiveFieldTouched={form.mutators.setActiveFieldTouched}
           >
             {children}
           </FormRenderer>
         )}
-        onSubmit={handleFinalFormSubmit}
+        onSubmit={handleSubmit}
         decorators={[...decorators, scrollToErrorDecorator]}
         mutators={{
           ...mutators,

--- a/packages/picasso-forms/src/Form/FormRenderer.tsx
+++ b/packages/picasso-forms/src/Form/FormRenderer.tsx
@@ -1,0 +1,37 @@
+import React, { useCallback } from 'react'
+import { Form, Container, FormProps } from '@toptal/picasso'
+
+interface Props extends FormProps {
+  setActiveFieldTouched: () => void
+  validateOnBlur?: boolean
+}
+export const FormRenderer = (props: Props) => {
+  const { onSubmit, setActiveFieldTouched, children, validateOnBlur, ...rest } =
+    props
+
+  const handleNativeSubmit = useCallback(
+    (event: React.SyntheticEvent<HTMLFormElement>) => {
+      if (validateOnBlur) {
+        // force validation for active field
+        setActiveFieldTouched()
+      }
+
+      onSubmit?.(event)
+    },
+    [onSubmit, setActiveFieldTouched, validateOnBlur]
+  )
+
+  return (
+    <Container>
+      <Form {...rest} onSubmit={handleNativeSubmit}>
+        {children}
+      </Form>
+    </Container>
+  )
+}
+
+FormRenderer.defaultProps = {}
+
+FormRenderer.displayName = 'FormRenderer'
+
+export default FormRenderer

--- a/packages/picasso/src/RichTextEditor/story/index.jsx
+++ b/packages/picasso/src/RichTextEditor/story/index.jsx
@@ -16,10 +16,7 @@ page
 
 page
   .createChapter()
-  .addExample('RichTextEditor/story/Default.example.tsx', {
-    title: 'Default',
-    takeScreenshot: false,
-  })
+  .addExample('RichTextEditor/story/Default.example.tsx', 'Default')
   .addExample('RichTextEditor/story/DefaultValue.example.tsx', {
     title: 'Default value',
     takeScreenshot: false,


### PR DESCRIPTION
[FX-2828]

### Description

Fix form validation when submitting by clicking Enter.

### Notes

- The issue has been reported in the `final-form` package in 2019 and it hasn’t been solved since then. https://github.com/final-form/final-form/issues/213.
- The only solution, for now, is to trigger validation of the active input field manually. The best solution to do that is to use the `FromApi#blur` function of `final-form`. It changes only the state of final form objects and it doesn't trigger the native blur event or callbacks of input fields. 

### How to reproduce

- Open ["Form Level Status Configuration" on picassot.toptal.net](https://picasso.toptal.net/?path=/story/picasso-forms-form--form#form-level-status-configuration)
- Add `validateOnBlur` property to the `<Form />` element
- Type something in the input and press Enter
- You'll see a validation error from the `required` validator even though the value is presented

    ![image](https://user-images.githubusercontent.com/3861498/171214838-bc13c9a5-a82c-4f46-b309-0eab1f9244b0.png)
    
### How to test

- Repeat action from the `How to reproduce` section. But instead, use ["Form Level Status Configuration" section from the demo](https://picasso.toptal.net/fx-2828-fix-form-validation-submit-on-enter/?path=/story/picasso-forms-form--form#form-level-status-configuration)
    - You should be able to submit the form with Enter and see the green check icon
    - You should be able to see the green check icon once you fixed data after submission of empty form

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure that tests pass by running `yarn test`
- [x] Ensure that visuals tests pass by running `yarn test:visual`. If not - check the documentation [how to fix visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests

**Breaking change**

- [x] codemod is created and showcased in the changeset
- [x] test alpha package of Picasso in StaffPortal

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run visual` - Run visual tests
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-2828]: https://toptal-core.atlassian.net/browse/FX-2828?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ