### PR TITLE
docs: add rfc for visual tests placing

### DIFF
--- a/docs/decisions/05-visual-tests-placing.md
+++ b/docs/decisions/05-visual-tests-placing.md
@@ -2,7 +2,7 @@
 
 ## Problem
 
-Following the `docs/decisions/04-single-visual-tests-tool.md` decision, it should be clarified which tests belong to Storybook and which belong to Cypress Component Testing.
+Following the [Single Visual Tests tool](./04-single-visual-tests-tool.md) decision, it should be clarified which tests belong to Storybook and which belong to Cypress Component Testing.
 
 ## Goal
 


### PR DESCRIPTION
[FX-2641]

### Description

After the single tool for visual tests selection, we needed a document to state where to place which kinds of visual tests. This RFC should clarify that.

### How to test

- Review the document

- [x] Self reviewed


[FX-2641]: https://toptal-core.atlassian.net/browse/FX-2641?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ