### PR TITLE
fix(Select): forward ref properly

### DIFF
--- a/.changeset/ninety-ligers-scream.md
+++ b/.changeset/ninety-ligers-scream.md
@@ -1,0 +1,9 @@
+---
+'@toptal/picasso': patch
+---
+
+---
+
+### Select
+
+- forward ref properly

--- a/packages/picasso/src/Select/Select.tsx
+++ b/packages/picasso/src/Select/Select.tsx
@@ -15,6 +15,7 @@ import {
   getOptionText,
   renderOption
 } from '../SelectBase'
+import { documentable, forwardRef } from '../utils'
 
 const purifyProps = (
   props: SelectProps<any, any>
@@ -32,26 +33,30 @@ const purifyProps = (
   return disableUnsupportedProps('Select', props, sizeOptions)
 }
 
-export const Select = <T extends ValueType, M extends boolean = false>({
-  native,
-  ...props
-}: SelectProps<T, M>) => {
-  usePropDeprecationWarning({
-    props,
-    name: 'error',
-    componentName: 'Select',
-    description:
-      'Use the `status` prop instead. `error` is deprecated and will be removed in the next major release.'
-  })
+export const Select = documentable(
+  forwardRef(
+    <T extends ValueType, M extends boolean = false>(
+      { native, ...props }: SelectProps<T, M>,
+      ref: React.Ref<HTMLInputElement> | null
+    ) => {
+      usePropDeprecationWarning({
+        props,
+        name: 'error',
+        componentName: 'Select',
+        description:
+          'Use the `status` prop instead. `error` is deprecated and will be removed in the next major release.'
+      })
 
-  return native ? (
-    // eslint-disable-next-line react/jsx-props-no-spreading
-    <NativeSelect {...purifyProps(props)} />
-  ) : (
-    // eslint-disable-next-line react/jsx-props-no-spreading
-    <NonNativeSelect {...purifyProps(props)} />
+      return native ? (
+        // eslint-disable-next-line react/jsx-props-no-spreading
+        <NativeSelect {...purifyProps(props)} ref={ref} />
+      ) : (
+        // eslint-disable-next-line react/jsx-props-no-spreading
+        <NonNativeSelect {...purifyProps(props)} ref={ref} />
+      )
+    }
   )
-}
+)
 
 Select.defaultProps = {
   disabled: false,

--- a/packages/picasso/src/utils/forward-ref.ts
+++ b/packages/picasso/src/utils/forward-ref.ts
@@ -7,7 +7,7 @@ export type Component<T, P> = T & {
 
 /**
  * Wraps the exotic generic functional component type returned by the `forwardRef`.
- * This function adopts the type of the exotic compoennt to take `defaultProps` and
+ * This function adopts the type of the exotic component to take `defaultProps` and
  * `displayName`.
  *
  * @see forwardRef


### PR DESCRIPTION
### Description

`Select` component does not forward ref to the `NativeSelect` and `NonNativeSelect` components although they handle that properly. Attempt to pass `ref` to the `Select` results in the following error:

![image](https://user-images.githubusercontent.com/4757057/171858272-14064b19-83e7-4789-a797-07999f973333.png)


### How to test

Try to pass a `ref` to the `Select` component, something like:

```js
import React, { useEffect, useRef } from "react";
import { Select } from "@toptal/picasso";

const TestComponent = () => {
  const ref = useRef<HTMLInputElement>(null);

  useEffect(() => {
    console.log(ref.current);
  }, [ref]);

  return <Select options={[]} ref={ref} />;
};
```

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- n/a ~~Annotate all `props` in component with documentation~~
- n/a ~~Create `examples` for component~~
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure that all PR checks are green
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- ~~Covered with tests~~ 

**Breaking change**

- ~~codemod is created and showcased in the changeset~~
-  ~~test alpha package of Picasso in StaffPortal~~

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>
