### PR TITLE
feat: allow injecting Picasso styles first

### DIFF
--- a/.changeset/polite-kiwis-rush.md
+++ b/.changeset/polite-kiwis-rush.md
@@ -1,0 +1,8 @@
+---
+'@toptal/picasso-provider': minor
+---
+
+---
+### Picasso
+
+- allow injecting Picasso styles first inside head

--- a/packages/picasso-provider/src/Picasso/Picasso.tsx
+++ b/packages/picasso-provider/src/Picasso/Picasso.tsx
@@ -240,6 +240,7 @@ Picasso.defaultProps = {
   responsive: true,
   reset: true,
   fixViewport: true,
+  injectFirst: undefined,
   RootComponent: PicassoRootNode
 }
 

--- a/packages/picasso-provider/src/Picasso/Picasso.tsx
+++ b/packages/picasso-provider/src/Picasso/Picasso.tsx
@@ -169,6 +169,12 @@ interface PicassoProps extends TextLabelProps {
   disableTransitions?: boolean
   /** Disables unique prefix for styles class names */
   disableClassNamePrefix?: boolean
+  /**
+   * By default, the styles are injected last in the <head> element of the page.
+   * As a result, they gain more specificity than any other style sheet.
+   * If you want to override Picasso's styles, set this prop.
+   */
+  injectFirst?: boolean
 }
 
 const Picasso = ({
@@ -184,7 +190,8 @@ const Picasso = ({
   titleCase,
   theme,
   disableTransitions,
-  disableClassNamePrefix
+  disableClassNamePrefix,
+  injectFirst
 }: PicassoProps) => {
   if (theme) {
     PicassoProvider.extendTheme(theme)
@@ -202,7 +209,10 @@ const Picasso = ({
   })
 
   return (
-    <StylesProvider generateClassName={generateClassName}>
+    <StylesProvider
+      generateClassName={generateClassName}
+      injectFirst={injectFirst}
+    >
       <MuiThemeProvider theme={PicassoProvider.theme}>
         <PicassoGlobalStylesProvider
           RootComponent={RootComponent}


### PR DESCRIPTION
[SP-2562]

### Description

We have an issue in Storybook that's coming from the fast that we use two styling libraries simultaneously. The issue is: `styled-components` library doesn't always destroy the style tags it created, even when components are unmounted. While Picasso works correctly and unmounts all of the `style` tags.

The issue appears when we render a new instance of Picasso (e.g. new storybook story), so it adds style tags back. But it appends them in the end of the `<head>` tag, so they appear after the ones related to `styled-components`. The order of styles changes and in some places it breaks the styling.

In this PR we allow to always add Picasso styles first, by using the same option provided by MUI framework:
https://v4.mui.com/styles/advanced/#injectfirst

### How to test

- Open some story
- Add `styles` tag once you've rendered the component, you can use this snippet:
```
const iframe = document.querySelector('#storybook-preview-iframe').contentDocument
const style = iframe.createElement('style')
style.setAttribute('id', 'my-styles')
iframe.querySelector('head').appendChild(style)
```
- Navigate to another story
- Picasso styles should come before the `style` tag you've added

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Annotate all `props` in component with documentation
- n/a Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure that all PR checks are green
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests

**Breaking change**

- n/a codemod is created and showcased in the changeset
- n/a test alpha package of Picasso in StaffPortal

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[SP-2562]: https://toptal-core.atlassian.net/browse/SP-2562?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ