### PR TITLE
feat: change picasso provider to a peerDep

### DIFF
--- a/.changeset/bright-students-crash.md
+++ b/.changeset/bright-students-crash.md
@@ -1,0 +1,10 @@
+---
+'@toptal/picasso': major
+'@toptal/picasso-shared': major
+---
+
+---
+
+### dependencies
+
+- `picasso-provider` is now a peer dependency of `picasso`, you should add it to your own project as a `dependency`

--- a/packages/picasso/package.json
+++ b/packages/picasso/package.json
@@ -28,10 +28,10 @@
     "react": ">=16.12.0 < 19.0.0",
     "react-dom": ">=16.12.0 < 19.0.0",
     "react-helmet": "6.1.0",
+    "@toptal/picasso-provider": "^1.2.0",
     "typescript": "4.6.x"
   },
   "dependencies": {
-    "@toptal/picasso-provider": "^1.2.0",
     "@toptal/picasso-shared": "^8.2.2",
     "ap-style-title-case": "^1.1.2",
     "classnames": "^2.3.1",
@@ -58,6 +58,7 @@
   },
   "devDependencies": {
     "@babel/types": "^7.15.0",
+    "@toptal/picasso-provider": "^1.2.0",
     "@testing-library/jest-dom": "^5.16.4",
     "@testing-library/react": "^13.0.0",
     "@testing-library/react-hooks": "^7.0.2",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -25,17 +25,18 @@
   "peerDependencies": {
     "react": ">=16.12.0 < 19.0.0",
     "typescript": "4.6.x",
+    "@toptal/picasso-provider": "^1.1.4",
     "react-dom": ">=16.12.0 < 19.0.0"
   },
   "dependencies": {
-    "@toptal/picasso-provider": "^1.1.4",
     "classnames": "^2.3.1",
     "color": "^4.2.3",
     "notistack": "1.0.6"
   },
   "devDependencies": {
     "@types/classnames": "^2.3.1",
-    "@types/color": "^3.0.3"
+    "@types/color": "^3.0.3",
+    "@toptal/picasso-provider": "^1.1.4"
   },
   "sideEffects": [
     "**/styles.ts",


### PR DESCRIPTION
[FX-2781](https://toptal-core.atlassian.net/browse/FX-2781)

### Description

Change `picasso-provider` to a `peerDependency` on `picasso` and `picasso-shared`. This should solve the problem of conflicts between different versions and runtime instances in a monorepo scenario.

### How to test

- You can use the alpha package to test on staff-portal

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure that all PR checks are green
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests

**Breaking change**

- [x] codemod is created and showcased in the changeset
- [x] test alpha package of Picasso in StaffPortal

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>
