### PR TITLE
docs: add RFC for using picasso-provider as a peerDependency

### DIFF
--- a/docs/decisions/06-picasso-provider-as-a-peer-dependency.md
+++ b/docs/decisions/06-picasso-provider-as-a-peer-dependency.md
@@ -4,8 +4,8 @@
 
 Currently, `picasso-provider` is a "hard" dependency of `picasso`, meaning that
 each `picasso` module can have a different version of the `provider`. In setups
-were different packages of a monorepo have different versions of picasso this
-can be problematic as each one receive a different instance in runtime of the
+where different packages of a monorepo have different versions of picasso this
+can be problematic as each one receives a different instance in runtime of the
 same package.
 
 ## Proposal
@@ -16,7 +16,7 @@ a single version and runtime instance will be provided for all the projects.
 
 ### Drawbacks and limitations
 
-- The project that imports `picasso` must provide a `picasso-provider` as its
+- The project that imports `picasso` must add a `picasso-provider` to its
   dependencies
 
 ## Alternatives
@@ -25,4 +25,3 @@ a single version and runtime instance will be provided for all the projects.
   whole project
 - Each subproject has its own `<Picasso />` provider, instead of just one in
   the root of the project
-

--- a/docs/decisions/06-picasso-provider-as-a-peer-dependency.md
+++ b/docs/decisions/06-picasso-provider-as-a-peer-dependency.md
@@ -1,0 +1,28 @@
+# `picasso-provider` as a peer dependency
+
+## Problem
+
+Currently, `picasso-provider` is a "hard" dependency of `picasso`, meaning that
+each `picasso` module can have a different version of the `provider`. In setups
+were different packages of a monorepo have different versions of picasso this
+can be problematic as each one receive a different instance in runtime of the
+same package.
+
+## Proposal
+
+`picasso-provider` should be defined as `peerDependency` of both `picasso` and
+`picasso-shared` and to be provided from the projects that use it. This way only
+a single version and runtime instance will be provided for all the projects.
+
+### Drawbacks and limitations
+
+- The project that imports `picasso` must provide a `picasso-provider` as its
+  dependencies
+
+## Alternatives
+
+- We can keep using resolutions for asserting only one package version in the
+  whole project
+- Each subproject has its own `<Picasso />` provider, instead of just one in
+  the root of the project
+

--- a/docs/decisions/06-picasso-provider-as-a-peer-dependency.md
+++ b/docs/decisions/06-picasso-provider-as-a-peer-dependency.md
@@ -22,6 +22,27 @@ a single version and runtime instance will be provided for all the projects.
 ## Alternatives
 
 - We can keep using resolutions for asserting only one package version in the
-  whole project
+  whole project. Has the same result as proposed solution with a few cons.
+  * **Pros**:
+    - Already being used
+  * **Cons**:
+    + `yarn` doesn't warn when the resolution is being overridden to a version
+      that is incompatible with other dependencies. Meaning it will not trigger
+      a warning in case some of the picassos need a newer version than the being
+      resolved
+    + `resolutions` don't respect nesting, while peerDependencies can be nested,
+      meaning sub-projects can have different versions of the provider,
+      `resolutions` will override all depencies that need the provider to the
+      same
+    + `yarn` specific, other package managers don't support resolutions or have
+      different mechanisms for it
 - Each subproject has its own `<Picasso />` provider, instead of just one in
   the root of the project
+  * **Pros**:
+    + No need to have a separate project to `picasso-provider`
+    + Different projects can have totally different versions of `picasso`
+  * **Cons**:
+    + There's no generic or easy way of setting a single `picasso-provider` to
+      an app in Toptal monorepos
+    + Repeating code
+    + Might give raise to incosistencies between different apps


### PR DESCRIPTION
[FX-2781](https://toptal-core.atlassian.net/browse/FX-2781)

### Description

Add RFC for solving the problem of multiple `picasso-provider` runtime instances in monorepo projects as they contain different versions of `picasso` and/or `picasso-provider`. It also solves the problem were all dependencies must update `picasso-provider` when `picasso` is bumped, when declaring the provider as a `peerDep` we only need to bump it on the host project. 

When running the `changesets` plugin on a `picasso-provider` release with this configuration only the `devDependency` on `picasso` and `picasso-shared` will be bumped, not the `peerDependency`

### How to test

- You can check the branch on #2864 and run `yarn changeset version` it should bump all necessary versions and create a changelog the same as the `Version Packages` PR

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure that all PR checks are green
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests

**Breaking change**

- [x] codemod is created and showcased in the changeset
- [x] test alpha package of Picasso in StaffPortal

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>
