### PR TITLE
feat(autocomplete): allow passing popper options

### DIFF
--- a/.changeset/tame-boats-kick.md
+++ b/.changeset/tame-boats-kick.md
@@ -1,0 +1,12 @@
+---
+'@toptal/picasso': minor
+---
+
+---
+### Autocomplete
+
+- allow passing popper options
+
+### TagSelector
+
+- allow passing popper options

--- a/packages/picasso/src/Autocomplete/Autocomplete.tsx
+++ b/packages/picasso/src/Autocomplete/Autocomplete.tsx
@@ -15,6 +15,7 @@ import { makeStyles, Theme } from '@material-ui/core/styles'
 import capitalize from '@material-ui/core/utils/capitalize'
 import cx from 'classnames'
 import { BaseProps } from '@toptal/picasso-shared'
+import { PopperOptions } from 'popper.js'
 
 import Input, { InputProps } from '../Input'
 import Menu from '../Menu'
@@ -106,6 +107,8 @@ export interface Props
   enableReset?: boolean
   /** DOM element that wraps the Popper */
   popperContainer?: HTMLElement
+  /** Options provided to the popper.js instance */
+  popperOptions?: PopperOptions
   inputProps?: BaseInputProps
   /** Show the "Powered By Google" label */
   poweredByGoogle?: boolean
@@ -155,6 +158,7 @@ export const Autocomplete = forwardRef<HTMLInputElement, Props>(
       otherOptionText = 'Other option: ',
       placeholder,
       popperContainer,
+      popperOptions,
       poweredByGoogle,
       renderOption,
       renderOtherOption,
@@ -320,6 +324,7 @@ export const Autocomplete = forwardRef<HTMLInputElement, Props>(
               open={isOpen && !loading}
               anchorEl={inputWrapperRef.current}
               container={popperContainer}
+              popperOptions={popperOptions}
             >
               {optionsMenu}
             </Popper>

--- a/packages/picasso/src/TagSelector/TagSelector.tsx
+++ b/packages/picasso/src/TagSelector/TagSelector.tsx
@@ -8,6 +8,7 @@ import React, {
   Fragment
 } from 'react'
 import { BaseProps } from '@toptal/picasso-shared'
+import { PopperOptions } from 'popper.js'
 
 import Autocomplete, { Item as AutocompleteItem } from '../Autocomplete'
 import TagSelectorInput from '../TagSelectorInput'
@@ -87,6 +88,8 @@ export interface Props
   }) => ReactNode
   /** DOM element that wraps the Popper */
   popperContainer?: HTMLElement
+  /** Options provided to the popper.js instance */
+  popperOptions?: PopperOptions
   testIds?: {
     validIcon?: string
   }
@@ -116,6 +119,7 @@ export const TagSelector = forwardRef<HTMLInputElement, Props>(
       value: values = [],
       width,
       popperContainer,
+      popperOptions,
       error,
       status,
       testIds,
@@ -233,6 +237,7 @@ export const TagSelector = forwardRef<HTMLInputElement, Props>(
         enableReset={false}
         getKey={getKey}
         popperContainer={popperContainer}
+        popperOptions={popperOptions}
         testIds={testIds}
       />
     )


### PR DESCRIPTION
[SPT-2729]

### Description

PR allows passing popper options to `Autocomplete` and `TagsSelector` components
Sometimes in some specific cases we want to override default popper options, for example to disable `preventOverflow` modifier

### How to test

- n/a

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Annotate all `props` in component with documentation
- [n/a] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure that all PR checks are green
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [n/a] Covered with tests

**Breaking change**

- [n/a] codemod is created and showcased in the changeset
- [n/a] test alpha package of Picasso in StaffPortal

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[SPT-2729]: https://toptal-core.atlassian.net/browse/SPT-2729?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ