### PR TITLE
fix(Form): fix field names for form story examples

### DIFF
--- a/packages/picasso-forms/src/Form/story/BackendCommunication.example.tsx
+++ b/packages/picasso-forms/src/Form/story/BackendCommunication.example.tsx
@@ -68,7 +68,7 @@ const BackendCommunicationExample = () => {
         />
         <Form.Input
           required
-          name={`${FORM_PREFIX}-inlineErrorSurnam`}
+          name={`${FORM_PREFIX}-inlineErrorSurname`}
           label='Last name'
           placeholder='e.g. Wayne'
           width='full'

--- a/packages/picasso-forms/src/Form/story/BackendCommunication.example.tsx
+++ b/packages/picasso-forms/src/Form/story/BackendCommunication.example.tsx
@@ -2,6 +2,8 @@ import React, { useCallback } from 'react'
 import { Container } from '@toptal/picasso'
 import { Form } from '@toptal/picasso-forms'
 
+const FORM_PREFIX = 'backendCommunication'
+
 const BackendCommunicationExample = () => {
   const handleSuccessSubmit = useCallback(
     (values: any) => api.successSubmit(values),
@@ -30,14 +32,14 @@ const BackendCommunicationExample = () => {
       >
         <Form.Input
           required
-          name='backendCommunication.successName'
+          name={`${FORM_PREFIX}-successName`}
           label='First name'
           placeholder='e.g. Bruce'
           width='full'
         />
         <Form.Input
           required
-          name='backendCommunication.successSurname'
+          name={`${FORM_PREFIX}-successSurname`}
           label='Last name'
           placeholder='e.g. Wayne'
           width='full'
@@ -59,14 +61,14 @@ const BackendCommunicationExample = () => {
       >
         <Form.Input
           required
-          name='backendCommunication.inlineErrorName'
+          name={`${FORM_PREFIX}-inlineErrorName`}
           label='First name'
           placeholder='e.g. Bruce'
           width='full'
         />
         <Form.Input
           required
-          name='backendCommunication.inlineErrorSurname'
+          name={`${FORM_PREFIX}-inlineErrorSurnam`}
           label='Last name'
           placeholder='e.g. Wayne'
           width='full'
@@ -85,14 +87,14 @@ const BackendCommunicationExample = () => {
       <Form onSubmit={handleSubmitWithCustomNotificationError}>
         <Form.Input
           required
-          name='backendCommunication.customNotificationErrorName'
+          name={`${FORM_PREFIX}-customNotificationErrorName`}
           label='First name'
           placeholder='e.g. Bruce'
           width='full'
         />
         <Form.Input
           required
-          name='backendCommunication.customNotificationErrorSurname'
+          name={`${FORM_PREFIX}-customNotificationErrorSurname`}
           label='Last name'
           placeholder='e.g. Wayne'
           width='full'

--- a/packages/picasso-forms/src/Form/story/BackendCommunication.example.tsx
+++ b/packages/picasso-forms/src/Form/story/BackendCommunication.example.tsx
@@ -2,8 +2,6 @@ import React, { useCallback } from 'react'
 import { Container } from '@toptal/picasso'
 import { Form } from '@toptal/picasso-forms'
 
-const FORM_PREFIX = 'backendCommunication'
-
 const BackendCommunicationExample = () => {
   const handleSuccessSubmit = useCallback(
     (values: any) => api.successSubmit(values),
@@ -32,14 +30,14 @@ const BackendCommunicationExample = () => {
       >
         <Form.Input
           required
-          name={`${FORM_PREFIX}-successName`}
+          name='backendCommunication-successName'
           label='First name'
           placeholder='e.g. Bruce'
           width='full'
         />
         <Form.Input
           required
-          name={`${FORM_PREFIX}-successSurname`}
+          name='backendCommunication-successSurname'
           label='Last name'
           placeholder='e.g. Wayne'
           width='full'
@@ -61,14 +59,14 @@ const BackendCommunicationExample = () => {
       >
         <Form.Input
           required
-          name={`${FORM_PREFIX}-inlineErrorName`}
+          name='backendCommunication-inlineErrorName'
           label='First name'
           placeholder='e.g. Bruce'
           width='full'
         />
         <Form.Input
           required
-          name={`${FORM_PREFIX}-inlineErrorSurname`}
+          name='backendCommunication-inlineErrorSurname'
           label='Last name'
           placeholder='e.g. Wayne'
           width='full'
@@ -87,14 +85,14 @@ const BackendCommunicationExample = () => {
       <Form onSubmit={handleSubmitWithCustomNotificationError}>
         <Form.Input
           required
-          name={`${FORM_PREFIX}-customNotificationErrorName`}
+          name='backendCommunication-customNotificationErrorName'
           label='First name'
           placeholder='e.g. Bruce'
           width='full'
         />
         <Form.Input
           required
-          name={`${FORM_PREFIX}-customNotificationErrorSurname`}
+          name='backendCommunication-customNotificationErrorSurname'
           label='Last name'
           placeholder='e.g. Wayne'
           width='full'

--- a/packages/picasso-forms/src/Form/story/CustomFormLevelConfiguration.example.tsx
+++ b/packages/picasso-forms/src/Form/story/CustomFormLevelConfiguration.example.tsx
@@ -6,8 +6,6 @@ const formConfig: FormConfigProps = {
   requiredVariant: 'asterisk',
 }
 
-const FORM_PREFIX = 'formConfig'
-
 const Example = () => (
   <Form.ConfigProvider value={formConfig}>
     <Form
@@ -15,7 +13,7 @@ const Example = () => (
     >
       <Form.Input
         required
-        name={`${FORM_PREFIX}-firstName`}
+        name='formConfig-firstName'
         label='First name'
         placeholder='e.g. Bruce'
       />

--- a/packages/picasso-forms/src/Form/story/CustomFormLevelConfiguration.example.tsx
+++ b/packages/picasso-forms/src/Form/story/CustomFormLevelConfiguration.example.tsx
@@ -6,12 +6,16 @@ const formConfig: FormConfigProps = {
   requiredVariant: 'asterisk',
 }
 
+const FORM_PREFIX = 'formConfig'
+
 const Example = () => (
   <Form.ConfigProvider value={formConfig}>
-    <Form onSubmit={() => {}}>
+    <Form
+      onSubmit={values => window.alert(JSON.stringify(values, undefined, 2))}
+    >
       <Form.Input
         required
-        name='formConfig.firstName'
+        name={`${FORM_PREFIX}-firstName`}
         label='First name'
         placeholder='e.g. Bruce'
       />

--- a/packages/picasso-forms/src/Form/story/CustomValidator.example.tsx
+++ b/packages/picasso-forms/src/Form/story/CustomValidator.example.tsx
@@ -20,20 +20,18 @@ const minMaxValidator = (value?: string | number) => {
   return undefined
 }
 
-const FORM_PREFIX = 'customValidator'
-
 const CustomValidatorExample = () => (
   <Form onSubmit={values => window.alert(JSON.stringify(values, undefined, 2))}>
     <Form.Input
       required
-      name={`${FORM_PREFIX}-userName`}
+      name='customValidator-userName'
       label='First name'
       placeholder='e.g. Bruce'
     />
     <Form.NumberInput
       required
       validate={minMaxValidator}
-      name={`${FORM_PREFIX}-userAge`}
+      name='customValidator-userAge'
       label="What's your age?"
       placeholder='e.g. 25'
     />

--- a/packages/picasso-forms/src/Form/story/CustomValidator.example.tsx
+++ b/packages/picasso-forms/src/Form/story/CustomValidator.example.tsx
@@ -20,18 +20,20 @@ const minMaxValidator = (value?: string | number) => {
   return undefined
 }
 
+const FORM_PREFIX = 'customValidator'
+
 const CustomValidatorExample = () => (
   <Form onSubmit={values => window.alert(JSON.stringify(values, undefined, 2))}>
     <Form.Input
       required
-      name='customValidator.userName'
+      name={`${FORM_PREFIX}-userName`}
       label='First name'
       placeholder='e.g. Bruce'
     />
     <Form.NumberInput
       required
       validate={minMaxValidator}
-      name='customValidator.userAge'
+      name={`${FORM_PREFIX}-userAge`}
       label="What's your age?"
       placeholder='e.g. 25'
     />

--- a/packages/picasso-forms/src/Form/story/Default.example.tsx
+++ b/packages/picasso-forms/src/Form/story/Default.example.tsx
@@ -37,8 +37,6 @@ const filterOptions = (str = '', options: Item[] = []): Item[] | null => {
   return result.length > 0 ? result : null
 }
 
-const FORM_PREFIX = 'default'
-
 const Example = () => {
   const [skillInputValue, setSkillInputValue] =
     useState<string>(EMPTY_INPUT_VALUE)
@@ -54,7 +52,7 @@ const Example = () => {
     <Form
       autoComplete='off'
       onSubmit={values => window.alert(JSON.stringify(values, undefined, 2))}
-      initialValues={{ [`${FORM_PREFIX}-gender`]: 'female' }}
+      initialValues={{ 'default-gender': 'female' }}
     >
       <Form.Input
         enableReset
@@ -62,29 +60,29 @@ const Example = () => {
           set('')
         }}
         required
-        name={`${FORM_PREFIX}-firstName`}
+        name='default-firstName'
         label='First name'
         placeholder='e.g. Bruce'
       />
       <Form.Input
         required
-        name={`${FORM_PREFIX}-lastName`}
+        name='default-lastName'
         label='Last name'
         placeholder='e.g. Wayne'
       />
       <Form.NumberInput
         enableReset
         required
-        name={`${FORM_PREFIX}-age`}
+        name='default-age'
         label="What's your age?"
         placeholder='e.g. 25'
       />
-      <Form.RadioGroup name={`${FORM_PREFIX}-gender`} label='Gender'>
+      <Form.RadioGroup name='default-gender' label='Gender'>
         <Form.Radio label='Male' value='male' />
         <Form.Radio label='Female' value='female' />
       </Form.RadioGroup>
       <Form.RadioGroup
-        name={`${FORM_PREFIX}-gender`}
+        name='default-gender'
         label='Gender'
         horizontal
         spacing={8}
@@ -92,28 +90,22 @@ const Example = () => {
         <Form.ButtonRadio value='male'>Male</Form.ButtonRadio>
         <Form.ButtonRadio value='female'>Female</Form.ButtonRadio>
       </Form.RadioGroup>
-      <Form.DatePicker
-        name={`${FORM_PREFIX}-dateOfBirth`}
-        label='Date of birth'
-      />
-      <Form.TimePicker
-        name={`${FORM_PREFIX}-timeOfBirth`}
-        label='Time of birth'
-      />
+      <Form.DatePicker name='default-dateOfBirth' label='Date of birth' />
+      <Form.TimePicker name='default-timeOfBirth' label='Time of birth' />
       <Form.TagSelector
-        name={`${FORM_PREFIX}-skills`}
+        name='default-skills'
         label='Skills'
         inputValue={skillInputValue}
         options={skillOptions}
         onInputChange={setSkillInputValue}
       />
-      <Form.CheckboxGroup name={`${FORM_PREFIX}-hobbies`} label='Hobbies'>
+      <Form.CheckboxGroup name='default-hobbies' label='Hobbies'>
         <Form.Checkbox label='Skiing' value='skiing' />
         <Form.Checkbox label='Free diving' value='freeDiving' />
         <Form.Checkbox label='Dancing' value='dancing' />
       </Form.CheckboxGroup>
       <Form.CheckboxGroup
-        name={`${FORM_PREFIX}-hobbies`}
+        name='default-hobbies'
         label='Hobbies'
         horizontal
         spacing={8}
@@ -127,7 +119,7 @@ const Example = () => {
       <Form.Select
         enableReset
         required
-        name={`${FORM_PREFIX}-businessType`}
+        name='default-businessType'
         label='Business type'
         width='auto'
         options={[
@@ -136,13 +128,13 @@ const Example = () => {
         ]}
       />
       <Form.Select
-        name={`${FORM_PREFIX}-origin_country`}
+        name='default-origin_country'
         label='Origin country'
         width='auto'
         options={countries}
       />
       <Form.Autocomplete
-        name={`${FORM_PREFIX}-current_country`}
+        name='default-current_country'
         label='Current country'
         placeholder='Start typing country...'
         width='auto'
@@ -166,33 +158,29 @@ const Example = () => {
         getDisplayValue={getAutocompleteDisplayValue}
       />
       <Form.Rating.Stars
-        name={`${FORM_PREFIX}-rating`}
+        name='default-rating'
         label='How much do you love Picasso?'
         required
       />
       <Form.Rating.Thumbs
-        name={`${FORM_PREFIX}-thumbs`}
+        name='default-thumbs'
         label='Would you recommend picasso?'
         required
       />
       <Form.FileInput
         required
-        name={`${FORM_PREFIX}-avatar`}
+        name='default-avatar'
         label='Avatar'
         status='No file selected.'
       />
-      <Form.Dropzone
-        label='Attachments'
-        required
-        name={`${FORM_PREFIX}-attachments`}
-      />
+      <Form.Dropzone label='Attachments' required name='default-attachments' />
       <Form.Checkbox
         required
-        name={`${FORM_PREFIX}-legal`}
+        name='default-legal'
         label='I confirm that I have legal permission from the client to feature this project.'
       />
       <Form.Switch
-        name={`${FORM_PREFIX}-publicProfile`}
+        name='default-publicProfile'
         label='Public Profile'
         width='auto'
       />

--- a/packages/picasso-forms/src/Form/story/Default.example.tsx
+++ b/packages/picasso-forms/src/Form/story/Default.example.tsx
@@ -37,6 +37,8 @@ const filterOptions = (str = '', options: Item[] = []): Item[] | null => {
   return result.length > 0 ? result : null
 }
 
+const FORM_PREFIX = 'default'
+
 const Example = () => {
   const [skillInputValue, setSkillInputValue] =
     useState<string>(EMPTY_INPUT_VALUE)
@@ -52,7 +54,7 @@ const Example = () => {
     <Form
       autoComplete='off'
       onSubmit={values => window.alert(JSON.stringify(values, undefined, 2))}
-      initialValues={{ gender: 'female' }}
+      initialValues={{ [`${FORM_PREFIX}-gender`]: 'female' }}
     >
       <Form.Input
         enableReset
@@ -60,29 +62,29 @@ const Example = () => {
           set('')
         }}
         required
-        name='default.firstName'
+        name={`${FORM_PREFIX}-firstName`}
         label='First name'
         placeholder='e.g. Bruce'
       />
       <Form.Input
         required
-        name='default.lastName'
+        name={`${FORM_PREFIX}-lastName`}
         label='Last name'
         placeholder='e.g. Wayne'
       />
       <Form.NumberInput
         enableReset
         required
-        name='default.age'
+        name={`${FORM_PREFIX}-age`}
         label="What's your age?"
         placeholder='e.g. 25'
       />
-      <Form.RadioGroup name='default.gender' label='Gender'>
+      <Form.RadioGroup name={`${FORM_PREFIX}-gender`} label='Gender'>
         <Form.Radio label='Male' value='male' />
         <Form.Radio label='Female' value='female' />
       </Form.RadioGroup>
       <Form.RadioGroup
-        name='default.gender'
+        name={`${FORM_PREFIX}-gender`}
         label='Gender'
         horizontal
         spacing={8}
@@ -90,22 +92,28 @@ const Example = () => {
         <Form.ButtonRadio value='male'>Male</Form.ButtonRadio>
         <Form.ButtonRadio value='female'>Female</Form.ButtonRadio>
       </Form.RadioGroup>
-      <Form.DatePicker name='default.dateOfBirth' label='Date of birth' />
-      <Form.TimePicker name='default.timeOfBirth' label='Time of birth' />
+      <Form.DatePicker
+        name={`${FORM_PREFIX}-dateOfBirth`}
+        label='Date of birth'
+      />
+      <Form.TimePicker
+        name={`${FORM_PREFIX}-timeOfBirth`}
+        label='Time of birth'
+      />
       <Form.TagSelector
-        name='default.skills'
+        name={`${FORM_PREFIX}-skills`}
         label='Skills'
         inputValue={skillInputValue}
         options={skillOptions}
         onInputChange={setSkillInputValue}
       />
-      <Form.CheckboxGroup name='default.hobbies' label='Hobbies'>
+      <Form.CheckboxGroup name={`${FORM_PREFIX}-hobbies`} label='Hobbies'>
         <Form.Checkbox label='Skiing' value='skiing' />
         <Form.Checkbox label='Free diving' value='freeDiving' />
         <Form.Checkbox label='Dancing' value='dancing' />
       </Form.CheckboxGroup>
       <Form.CheckboxGroup
-        name='default.hobbies'
+        name={`${FORM_PREFIX}-hobbies`}
         label='Hobbies'
         horizontal
         spacing={8}
@@ -119,7 +127,7 @@ const Example = () => {
       <Form.Select
         enableReset
         required
-        name='default.businessType'
+        name={`${FORM_PREFIX}-businessType`}
         label='Business type'
         width='auto'
         options={[
@@ -128,13 +136,13 @@ const Example = () => {
         ]}
       />
       <Form.Select
-        name='default.origin_country'
+        name={`${FORM_PREFIX}-origin_country`}
         label='Origin country'
         width='auto'
         options={countries}
       />
       <Form.Autocomplete
-        name='default.current_country'
+        name={`${FORM_PREFIX}-current_country`}
         label='Current country'
         placeholder='Start typing country...'
         width='auto'
@@ -158,29 +166,33 @@ const Example = () => {
         getDisplayValue={getAutocompleteDisplayValue}
       />
       <Form.Rating.Stars
-        name='default.rating'
+        name={`${FORM_PREFIX}-rating`}
         label='How much do you love Picasso?'
         required
       />
       <Form.Rating.Thumbs
-        name='default.thumbs'
+        name={`${FORM_PREFIX}-thumbs`}
         label='Would you recommend picasso?'
         required
       />
       <Form.FileInput
         required
-        name='default.avatar'
+        name={`${FORM_PREFIX}-avatar`}
         label='Avatar'
         status='No file selected.'
       />
-      <Form.Dropzone label='Attachments' required name='default.attachments' />
+      <Form.Dropzone
+        label='Attachments'
+        required
+        name={`${FORM_PREFIX}-attachments`}
+      />
       <Form.Checkbox
         required
-        name='default.legal'
+        name={`${FORM_PREFIX}-legal`}
         label='I confirm that I have legal permission from the client to feature this project.'
       />
       <Form.Switch
-        name='default.publicProfile'
+        name={`${FORM_PREFIX}-publicProfile`}
         label='Public Profile'
         width='auto'
       />

--- a/packages/picasso-forms/src/Form/story/Dropzone.example.tsx
+++ b/packages/picasso-forms/src/Form/story/Dropzone.example.tsx
@@ -4,14 +4,16 @@ import { Form } from '@toptal/picasso-forms'
 import { FileUpload } from '@toptal/picasso/FileInput'
 
 type FormType = {
-  attachments: FileUpload[]
+  'dropzone-attachments': FileUpload[]
 }
+
+const FORM_PREFIX = 'dropzone'
 
 const Example = () => {
   const MAX_SIZE = 2
   const initialAttachments = [{ file: new File(['resume.pdf'], 'resume.pdf') }]
 
-  const handleSubmit = ({ attachments }: FormType) => {
+  const handleSubmit = ({ 'dropzone-attachments': attachments }: FormType) => {
     window.alert(
       `Uploading: ${attachments.map(({ file }) => file.name).join(', ')}`
     )
@@ -22,12 +24,12 @@ const Example = () => {
       autoComplete='off'
       onSubmit={handleSubmit}
       initialValues={{
-        attachments: initialAttachments,
+        'dropzone-attachments': initialAttachments,
       }}
     >
       <Form.Dropzone
         required
-        name='dropzone.attachments'
+        name={`${FORM_PREFIX}-attachments`}
         dropzoneHint={`Max file size: ${MAX_SIZE}MB.`}
         hint='These documents will be used to analyze and identify your potential.'
       />

--- a/packages/picasso-forms/src/Form/story/Dropzone.example.tsx
+++ b/packages/picasso-forms/src/Form/story/Dropzone.example.tsx
@@ -7,8 +7,6 @@ type FormType = {
   'dropzone-attachments': FileUpload[]
 }
 
-const FORM_PREFIX = 'dropzone'
-
 const Example = () => {
   const MAX_SIZE = 2
   const initialAttachments = [{ file: new File(['resume.pdf'], 'resume.pdf') }]
@@ -29,7 +27,7 @@ const Example = () => {
     >
       <Form.Dropzone
         required
-        name={`${FORM_PREFIX}-attachments`}
+        name='dropzone-attachments'
         dropzoneHint={`Max file size: ${MAX_SIZE}MB.`}
         hint='These documents will be used to analyze and identify your potential.'
       />

--- a/packages/picasso-forms/src/Form/story/FieldRequirements.example.tsx
+++ b/packages/picasso-forms/src/Form/story/FieldRequirements.example.tsx
@@ -2,18 +2,15 @@ import React from 'react'
 import { Container } from '@toptal/picasso'
 import { Form } from '@toptal/picasso-forms'
 
-const PASSWORD_FIELD = `fieldRequirements-password`
-const CONFIRM_PASSWORD_FIELD = `fieldRequirements-confirmPassword`
-
 type FormType = {
-  [PASSWORD_FIELD]: string
-  [CONFIRM_PASSWORD_FIELD]: string
+  'fieldRequirements-password': string
+  'fieldRequirements-confirmPassword': string
 }
 
 const Example = () => {
   const handleSubmit = ({
-    [PASSWORD_FIELD]: password,
-    [CONFIRM_PASSWORD_FIELD]: confirmPassword,
+    'fieldRequirements-password': password,
+    'fieldRequirements-confirmPassword': confirmPassword,
   }: FormType) => {
     window.alert(`Password: ${password}, Confirm Password: ${confirmPassword}`)
   }
@@ -23,18 +20,25 @@ const Example = () => {
       autoComplete='off'
       onSubmit={handleSubmit}
       initialValues={{
-        [PASSWORD_FIELD]: '',
-        [CONFIRM_PASSWORD_FIELD]: '',
+        'fieldRequirements-password': '',
+        'fieldRequirements-confirmPassword': '',
       }}
     >
-      <Form.PasswordInput label='Password' name={PASSWORD_FIELD} required />
+      <Form.PasswordInput
+        label='Password'
+        name='fieldRequirements-password'
+        required
+      />
       <Form.PasswordInput
         label='Confirm password'
-        name={CONFIRM_PASSWORD_FIELD}
+        name='fieldRequirements-confirmPassword'
         hideRequirements
         required
         validate={(confirmPassword, allValues) => {
-          if ((allValues as FormType)[PASSWORD_FIELD] !== confirmPassword) {
+          if (
+            (allValues as FormType)['fieldRequirements-password'] !==
+            confirmPassword
+          ) {
             return 'Passwords do not match'
           }
         }}

--- a/packages/picasso-forms/src/Form/story/FieldRequirements.example.tsx
+++ b/packages/picasso-forms/src/Form/story/FieldRequirements.example.tsx
@@ -2,13 +2,19 @@ import React from 'react'
 import { Container } from '@toptal/picasso'
 import { Form } from '@toptal/picasso-forms'
 
+const PASSWORD_FIELD = `fieldRequirements-password`
+const CONFIRM_PASSWORD_FIELD = `fieldRequirements-confirmPassword`
+
 type FormType = {
-  password: string
-  confirmPassword: string
+  [PASSWORD_FIELD]: string
+  [CONFIRM_PASSWORD_FIELD]: string
 }
 
 const Example = () => {
-  const handleSubmit = ({ password, confirmPassword }: FormType) => {
+  const handleSubmit = ({
+    [PASSWORD_FIELD]: password,
+    [CONFIRM_PASSWORD_FIELD]: confirmPassword,
+  }: FormType) => {
     window.alert(`Password: ${password}, Confirm Password: ${confirmPassword}`)
   }
 
@@ -17,22 +23,18 @@ const Example = () => {
       autoComplete='off'
       onSubmit={handleSubmit}
       initialValues={{
-        password: '',
-        confirmPassword: '',
+        [PASSWORD_FIELD]: '',
+        [CONFIRM_PASSWORD_FIELD]: '',
       }}
     >
-      <Form.PasswordInput
-        label='Password'
-        name='fieldRequirements.password'
-        required
-      />
+      <Form.PasswordInput label='Password' name={PASSWORD_FIELD} required />
       <Form.PasswordInput
         label='Confirm password'
-        name='fieldRequirements.confirmPassword'
+        name={CONFIRM_PASSWORD_FIELD}
         hideRequirements
         required
         validate={(confirmPassword, allValues) => {
-          if ((allValues as FormType).password !== confirmPassword) {
+          if ((allValues as FormType)[PASSWORD_FIELD] !== confirmPassword) {
             return 'Passwords do not match'
           }
         }}

--- a/packages/picasso-forms/src/Form/story/FileInput.example.tsx
+++ b/packages/picasso-forms/src/Form/story/FileInput.example.tsx
@@ -3,10 +3,8 @@ import { Container } from '@toptal/picasso'
 import { Form } from '@toptal/picasso-forms'
 import { FileUpload } from '@toptal/picasso/FileInput'
 
-const FILE_INPUT_FIELD = 'fileInput-attachments'
-
 type FormType = {
-  [FILE_INPUT_FIELD]: FileUpload[]
+  'fileInput-attachments': FileUpload[]
 }
 
 const Example = () => {
@@ -16,7 +14,7 @@ const Example = () => {
     { file: new File(['resume.pdf'], 'resume.pdf') },
   ]
 
-  const handleSubmit = ({ [FILE_INPUT_FIELD]: attachments }: FormType) => {
+  const handleSubmit = ({ 'fileInput-attachments': attachments }: FormType) => {
     window.alert(
       `Uploading: ${attachments.map(({ file }) => file.name).join(', ')}`
     )
@@ -27,11 +25,11 @@ const Example = () => {
       autoComplete='off'
       onSubmit={handleSubmit}
       initialValues={{
-        [FILE_INPUT_FIELD]: initialAttachments,
+        'fileInput-attachments': initialAttachments,
       }}
     >
       <Form.FileInput
-        name={FILE_INPUT_FIELD}
+        name='fileInput-attachments'
         hint={`Max file size: ${MAX_SIZE}MB.`}
       />
       <Container top='small'>

--- a/packages/picasso-forms/src/Form/story/FileInput.example.tsx
+++ b/packages/picasso-forms/src/Form/story/FileInput.example.tsx
@@ -3,8 +3,10 @@ import { Container } from '@toptal/picasso'
 import { Form } from '@toptal/picasso-forms'
 import { FileUpload } from '@toptal/picasso/FileInput'
 
+const FILE_INPUT_FIELD = 'fileInput-attachments'
+
 type FormType = {
-  attachments: FileUpload[]
+  [FILE_INPUT_FIELD]: FileUpload[]
 }
 
 const Example = () => {
@@ -14,7 +16,7 @@ const Example = () => {
     { file: new File(['resume.pdf'], 'resume.pdf') },
   ]
 
-  const handleSubmit = ({ attachments }: FormType) => {
+  const handleSubmit = ({ [FILE_INPUT_FIELD]: attachments }: FormType) => {
     window.alert(
       `Uploading: ${attachments.map(({ file }) => file.name).join(', ')}`
     )
@@ -25,11 +27,11 @@ const Example = () => {
       autoComplete='off'
       onSubmit={handleSubmit}
       initialValues={{
-        attachments: initialAttachments,
+        [FILE_INPUT_FIELD]: initialAttachments,
       }}
     >
       <Form.FileInput
-        name='fileInput.attachments'
+        name={FILE_INPUT_FIELD}
         hint={`Max file size: ${MAX_SIZE}MB.`}
       />
       <Container top='small'>

--- a/packages/picasso-forms/src/Form/story/NoScrolling.example.tsx
+++ b/packages/picasso-forms/src/Form/story/NoScrolling.example.tsx
@@ -12,7 +12,7 @@ const NoScrollingExample = () => (
       <Form onSubmit={failWithAnError}>
         <Form.Input
           required
-          name='noScrollingDefault.fieldName'
+          name='noScrollingDefault-fieldName'
           label='With scrolling'
           placeholder='Some field'
         />
@@ -26,7 +26,7 @@ const NoScrollingExample = () => (
       <Form disableScrollOnError onSubmit={failWithAnError}>
         <Form.Input
           required
-          name='noScrollingDisableScroll.fieldName'
+          name='noScrollingDisableScroll-fieldName'
           label='No scrolling'
           placeholder='Some field'
         />

--- a/packages/picasso-forms/src/Form/story/ParseInput.example.tsx
+++ b/packages/picasso-forms/src/Form/story/ParseInput.example.tsx
@@ -11,7 +11,7 @@ const ParseInputExample = () => (
     </Container>
     <Container flex alignItems='flex-end'>
       <Form.Input
-        name='parseInput.firstName'
+        name='parseInput-firstName'
         label='First name'
         placeholder='e.g. Bruce'
         parse={(value: string) => value.trim()}

--- a/packages/picasso-forms/src/Form/story/RichTextEditor.example.tsx
+++ b/packages/picasso-forms/src/Form/story/RichTextEditor.example.tsx
@@ -15,7 +15,7 @@ const RichTextEditorExample = () => (
         defaultValue={DEFAULT_EXAMPLE}
         label='Text editor'
         id='editor'
-        name='richTextEditor.editor'
+        name='richTextEditor-editor'
       />
     </Container>
 

--- a/packages/picasso-forms/src/Form/story/Status.example.tsx
+++ b/packages/picasso-forms/src/Form/story/Status.example.tsx
@@ -8,10 +8,12 @@ const formConfig: FormConfigProps = {
 
 const Example = () => (
   <Form.ConfigProvider value={formConfig}>
-    <Form onSubmit={() => {}}>
+    <Form
+      onSubmit={values => window.alert(JSON.stringify(values, undefined, 2))}
+    >
       <Form.Input
         required
-        name='status.firstName'
+        name='status-firstName'
         label='First name'
         placeholder='e.g. Bruce'
       />

--- a/packages/picasso-forms/src/Form/story/TitleCase.example.tsx
+++ b/packages/picasso-forms/src/Form/story/TitleCase.example.tsx
@@ -4,6 +4,8 @@ import { Item } from '@toptal/picasso/Autocomplete'
 import { isSubstring } from '@toptal/picasso/utils'
 import { Form } from '@toptal/picasso-forms'
 
+const FORM_PREFIX = 'titleCase'
+
 const countries = [
   { value: 'Afghanistan', text: 'Afghanistan' },
   { value: 'Albania', text: 'Albania' },
@@ -52,7 +54,7 @@ const Example = () => {
     <Form
       autoComplete='off'
       onSubmit={values => window.alert(JSON.stringify(values, undefined, 2))}
-      initialValues={{ gender: 'female' }}
+      initialValues={{ [`${FORM_PREFIX}-gender`]: 'female' }}
     >
       <Form.Input
         titleCase
@@ -61,7 +63,7 @@ const Example = () => {
           set('')
         }}
         required
-        name='titleCase.firstName'
+        name={`${FORM_PREFIX}-firstName`}
         label='First name'
         placeholder='e.g. Bruce'
       />
@@ -69,27 +71,31 @@ const Example = () => {
         titleCase
         enableReset
         required
-        name='titleCase.age'
+        name={`${FORM_PREFIX}-age`}
         label="What's your age?"
         placeholder='e.g. 25'
       />
-      <Form.RadioGroup titleCase name='titleCase.gender' label='Select gender'>
+      <Form.RadioGroup
+        titleCase
+        name={`${FORM_PREFIX}-gender`}
+        label='Select gender'
+      >
         <Form.Radio label='Male' value='male' />
         <Form.Radio label='Female' value='female' />
       </Form.RadioGroup>
       <Form.DatePicker
         titleCase
-        name='titleCase.dateOfBirth'
+        name={`${FORM_PREFIX}-dateOfBirth`}
         label='Date of birth'
       />
       <Form.TimePicker
         titleCase
-        name='titleCase.timeOfBirth'
+        name={`${FORM_PREFIX}-timeOfBirth`}
         label='Time of birth'
       />
       <Form.TagSelector
         titleCase
-        name='titleCase.skills'
+        name={`${FORM_PREFIX}-skills`}
         label='Your skills'
         inputValue={skillInputValue}
         options={skillOptions}
@@ -97,7 +103,7 @@ const Example = () => {
       />
       <Form.CheckboxGroup
         titleCase
-        name='titleCase.hobbies'
+        name={`${FORM_PREFIX}-hobbies`}
         label='Your hobbies'
       >
         <Form.Checkbox label='Skiing' value='skiing' />
@@ -108,7 +114,7 @@ const Example = () => {
         titleCase
         enableReset
         required
-        name='titleCase.businessType'
+        name={`${FORM_PREFIX}-businessType`}
         label='Business type'
         width='auto'
         options={[
@@ -118,7 +124,7 @@ const Example = () => {
       />
       <Form.Autocomplete
         titleCase
-        name='titleCase.current_country'
+        name={`${FORM_PREFIX}-current_country`}
         label='Current country'
         placeholder='Start typing country...'
         width='auto'
@@ -142,31 +148,31 @@ const Example = () => {
         getDisplayValue={getAutocompleteDisplayValue}
       />
       <Form.Rating.Stars
-        name='titleCase.rating'
+        name={`${FORM_PREFIX}-rating`}
         label='How much do you love Picasso?'
         required
       />
       <Form.Rating.Thumbs
-        name='titleCase.thumbs'
+        name={`${FORM_PREFIX}-thumbs`}
         label='Would you recommend picasso?'
         required
       />
       <Form.FileInput
         titleCase
         required
-        name='titleCase.avatar'
+        name={`${FORM_PREFIX}-avatar`}
         label='Your avatar'
         status='No file selected.'
       />
       <Form.Checkbox
         titleCase
         required
-        name='titleCase.legal'
+        name={`${FORM_PREFIX}-legal`}
         label='I confirm that I have legal permission from the client to feature this project.'
       />
       <Form.Switch
         titleCase
-        name='titleCase.publicProfile'
+        name={`${FORM_PREFIX}-publicProfile`}
         label='Public profile'
         width='auto'
       />

--- a/packages/picasso-forms/src/Form/story/TitleCase.example.tsx
+++ b/packages/picasso-forms/src/Form/story/TitleCase.example.tsx
@@ -4,8 +4,6 @@ import { Item } from '@toptal/picasso/Autocomplete'
 import { isSubstring } from '@toptal/picasso/utils'
 import { Form } from '@toptal/picasso-forms'
 
-const FORM_PREFIX = 'titleCase'
-
 const countries = [
   { value: 'Afghanistan', text: 'Afghanistan' },
   { value: 'Albania', text: 'Albania' },
@@ -54,7 +52,7 @@ const Example = () => {
     <Form
       autoComplete='off'
       onSubmit={values => window.alert(JSON.stringify(values, undefined, 2))}
-      initialValues={{ [`${FORM_PREFIX}-gender`]: 'female' }}
+      initialValues={{ 'titleCase-gender': 'female' }}
     >
       <Form.Input
         titleCase
@@ -63,7 +61,7 @@ const Example = () => {
           set('')
         }}
         required
-        name={`${FORM_PREFIX}-firstName`}
+        name='titleCase-firstName'
         label='First name'
         placeholder='e.g. Bruce'
       />
@@ -71,31 +69,27 @@ const Example = () => {
         titleCase
         enableReset
         required
-        name={`${FORM_PREFIX}-age`}
+        name='titleCase-age'
         label="What's your age?"
         placeholder='e.g. 25'
       />
-      <Form.RadioGroup
-        titleCase
-        name={`${FORM_PREFIX}-gender`}
-        label='Select gender'
-      >
+      <Form.RadioGroup titleCase name='titleCase-gender' label='Select gender'>
         <Form.Radio label='Male' value='male' />
         <Form.Radio label='Female' value='female' />
       </Form.RadioGroup>
       <Form.DatePicker
         titleCase
-        name={`${FORM_PREFIX}-dateOfBirth`}
+        name='titleCase-dateOfBirth'
         label='Date of birth'
       />
       <Form.TimePicker
         titleCase
-        name={`${FORM_PREFIX}-timeOfBirth`}
+        name='titleCase-timeOfBirth'
         label='Time of birth'
       />
       <Form.TagSelector
         titleCase
-        name={`${FORM_PREFIX}-skills`}
+        name='titleCase-skills'
         label='Your skills'
         inputValue={skillInputValue}
         options={skillOptions}
@@ -103,7 +97,7 @@ const Example = () => {
       />
       <Form.CheckboxGroup
         titleCase
-        name={`${FORM_PREFIX}-hobbies`}
+        name='titleCase-hobbies'
         label='Your hobbies'
       >
         <Form.Checkbox label='Skiing' value='skiing' />
@@ -114,7 +108,7 @@ const Example = () => {
         titleCase
         enableReset
         required
-        name={`${FORM_PREFIX}-businessType`}
+        name='titleCase-businessType'
         label='Business type'
         width='auto'
         options={[
@@ -124,7 +118,7 @@ const Example = () => {
       />
       <Form.Autocomplete
         titleCase
-        name={`${FORM_PREFIX}-current_country`}
+        name='titleCase-current_country'
         label='Current country'
         placeholder='Start typing country...'
         width='auto'
@@ -148,31 +142,31 @@ const Example = () => {
         getDisplayValue={getAutocompleteDisplayValue}
       />
       <Form.Rating.Stars
-        name={`${FORM_PREFIX}-rating`}
+        name='titleCase-rating'
         label='How much do you love Picasso?'
         required
       />
       <Form.Rating.Thumbs
-        name={`${FORM_PREFIX}-thumbs`}
+        name='titleCase-thumbs'
         label='Would you recommend picasso?'
         required
       />
       <Form.FileInput
         titleCase
         required
-        name={`${FORM_PREFIX}-avatar`}
+        name='titleCase-avatar'
         label='Your avatar'
         status='No file selected.'
       />
       <Form.Checkbox
         titleCase
         required
-        name={`${FORM_PREFIX}-legal`}
+        name='titleCase-legal'
         label='I confirm that I have legal permission from the client to feature this project.'
       />
       <Form.Switch
         titleCase
-        name={`${FORM_PREFIX}-publicProfile`}
+        name='titleCase-publicProfile'
         label='Public profile'
         width='auto'
       />

--- a/packages/picasso-forms/src/Form/story/ValidateOnSubmit.example.tsx
+++ b/packages/picasso-forms/src/Form/story/ValidateOnSubmit.example.tsx
@@ -3,45 +3,44 @@ import { useField } from 'react-final-form'
 import { Container } from '@toptal/picasso'
 import { Form } from '@toptal/picasso-forms'
 
-const HIDE_FIELD = 'validateOnSubmit-hide'
-const NAME_FIELD = 'validateOnSubmit-name'
-const DOB_FIELD = 'validateOnSubmit-dob'
-
 type FormType = {
-  [HIDE_FIELD]: boolean
-  [NAME_FIELD]: {
+  'validateOnSubmit-hide': boolean
+  'validateOnSubmit-name': {
     first: string
     last: string
   }
-  [DOB_FIELD]: string
+  'validateOnSubmit-dob': string
 }
 
 const FormContent = () => {
   const {
     input: { value: hide },
-  } = useField(HIDE_FIELD)
+  } = useField('validateOnSubmit-hide')
 
   return (
     <>
-      <Form.Checkbox name={HIDE_FIELD} label='Check to hide fields below' />
+      <Form.Checkbox
+        name='validateOnSubmit-hide'
+        label='Check to hide fields below'
+      />
 
       {!hide && (
         <>
           <Form.Input
             enableReset
             required
-            name={`${NAME_FIELD}.first`}
+            name='validateOnSubmit-name.first'
             label='Your first name'
             placeholder='e.g. Bruce'
           />
           <Form.Input
             enableReset
             required
-            name={`${NAME_FIELD}.last`}
+            name='validateOnSubmit-name.last'
             label='Your last name'
             placeholder='e.g. Wayne'
           />
-          <Form.DatePicker required name={DOB_FIELD} label='DOB' />
+          <Form.DatePicker required name='validateOnSubmit-dob' label='DOB' />
         </>
       )}
     </>

--- a/packages/picasso-forms/src/Form/story/ValidateOnSubmit.example.tsx
+++ b/packages/picasso-forms/src/Form/story/ValidateOnSubmit.example.tsx
@@ -3,41 +3,45 @@ import { useField } from 'react-final-form'
 import { Container } from '@toptal/picasso'
 import { Form } from '@toptal/picasso-forms'
 
+const HIDE_FIELD = 'validateOnSubmit-hide'
+const NAME_FIELD = 'validateOnSubmit-name'
+const DOB_FIELD = 'validateOnSubmit-dob'
+
 type FormType = {
-  hide: boolean
-  name: {
+  [HIDE_FIELD]: boolean
+  [NAME_FIELD]: {
     first: string
     last: string
   }
-  dob: string
+  [DOB_FIELD]: string
 }
 
 const FormContent = () => {
   const {
     input: { value: hide },
-  } = useField('hide')
+  } = useField(HIDE_FIELD)
 
   return (
     <>
-      <Form.Checkbox name='hide' label='Check to hide fields below' />
+      <Form.Checkbox name={HIDE_FIELD} label='Check to hide fields below' />
 
       {!hide && (
         <>
           <Form.Input
             enableReset
             required
-            name='validateOnSubmit.first'
+            name={`${NAME_FIELD}.first`}
             label='Your first name'
             placeholder='e.g. Bruce'
           />
           <Form.Input
             enableReset
             required
-            name='validateOnSubmit.last'
+            name={`${NAME_FIELD}.last`}
             label='Your last name'
             placeholder='e.g. Wayne'
           />
-          <Form.DatePicker required name='dob' label='DOB' />
+          <Form.DatePicker required name={DOB_FIELD} label='DOB' />
         </>
       )}
     </>
@@ -69,8 +73,11 @@ const responseWithDelay = async (response: any) =>
   new Promise(resolve => setTimeout(() => resolve(response), 2000))
 
 const api = {
-  submit: async (values: FormType) => {
-    if (values.hide || values.name?.first.toLowerCase() === 'bruce') {
+  submit: async ({
+    'validateOnSubmit-name': name,
+    'validateOnSubmit-hide': hide,
+  }: FormType) => {
+    if (hide || name?.first.toLowerCase() === 'bruce') {
       return responseWithDelay(undefined)
     }
 


### PR DESCRIPTION
### Description

While testing something else, I realized that field names are incorrect for form stories. So, this PR is about fixing the field names to have correct form values.

While working on removing some of the dev environment warnings in this [PR](https://github.com/toptal/picasso/pull/2744), I had added dot notation for the field names. But I forgot to update the code parts that actually use values object for validation/submission. If you check this example from prod: https://picasso.toptal.net/?path=/story/picasso-forms-form--form#field-requirements
you will see that it is actually comparing wrong values from form-values API. Therefore, you can't submit the form in any case. There are some other examples also.

### How to test

- All form stories should be working fine now. You can enter some values and compare the submitted values

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| <img width="631" alt="Screen Shot 2022-06-13 at 12 51 52" src="https://user-images.githubusercontent.com/7733167/173328237-64db57a2-25bf-4b4b-94a6-0a5156c75ee6.png"> | <img width="631" alt="Screen Shot 2022-06-13 at 12 52 19" src="https://user-images.githubusercontent.com/7733167/173328268-ee6bf658-60da-49db-974c-5a5a58dd9838.png"> |

### Development checks

- Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- Annotate all `props` in component with documentation
- Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure that all PR checks are green
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- Covered with tests

**Breaking change**

- codemod is created and showcased in the changeset
- test alpha package of Picasso in StaffPortal

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>
