### PR TITLE
fix: fix type errors and remove redundant prop for storybook components

### DIFF
--- a/.storybook/components/PicassoBook/TabChapter.tsx
+++ b/.storybook/components/PicassoBook/TabChapter.tsx
@@ -13,7 +13,7 @@ class TabChapter extends Chapter {
   }
 
   toStoryBook() {
-    const { title, info, hideOnCompactLayout = true } = this.options
+    const { title, info } = this.options as ChapterOptions
 
     const tabs = this.collection.map(section => {
       const { title, subtitle, sectionFn } = section.toStoryBook()
@@ -21,13 +21,11 @@ class TabChapter extends Chapter {
       return {
         name: title,
         description: subtitle,
-        content: sectionFn()
+        content: sectionFn(),
       }
     })
 
-    const render = () => (
-      <TabsSection tabs={tabs} hideOnCompactLayout={hideOnCompactLayout} />
-    )
+    const render = () => <TabsSection tabs={tabs} />
 
     const tabsSection = new Section({
       title,
@@ -36,15 +34,15 @@ class TabChapter extends Chapter {
       options: {
         decorator: (story: () => ReactNode) => (
           <div className='tab-chapter-container'>{story()}</div>
-        )
+        ),
       },
-      takeScreenshot: false
+      takeScreenshot: false,
     })
 
     return {
       ...this.options,
       title: '',
-      sections: [tabsSection.toStoryBook()]
+      sections: [tabsSection.toStoryBook()],
     }
   }
 }

--- a/.storybook/components/PicassoBook/components/TabsSection/TabsSection.tsx
+++ b/.storybook/components/PicassoBook/components/TabsSection/TabsSection.tsx
@@ -13,11 +13,10 @@ export interface TabOptions {
 
 interface Props {
   tabs: TabOptions[]
-  hideOnCompactLayout?: boolean
 }
 
 const TabsSection: FunctionComponent<Props> = props => {
-  const { tabs, hideOnCompactLayout } = props
+  const { tabs } = props
 
   const [selectedTab, setSelectedTab] = React.useState(0)
 
@@ -26,12 +25,6 @@ const TabsSection: FunctionComponent<Props> = props => {
   }
 
   const hasMultiple = tabs.length > 1
-
-  const isCompactLayout = useBreakpoint('small')
-
-  if (isCompactLayout && hideOnCompactLayout) {
-    return <Typography size='medium'>Not visible on smaller screens</Typography>
-  }
 
   return (
     <Paper>

--- a/.storybook/utils/documentation-generator.ts
+++ b/.storybook/utils/documentation-generator.ts
@@ -46,7 +46,7 @@ const merge = <T extends { [key: string]: unknown }>(
 
   Object.keys(o2).forEach(key => {
     if (destination[key]) {
-      Object.assign(destination[key], o2[key])
+      Object.assign(destination[key] as object, o2[key])
     } else {
       destination[key] = o2[key]
     }
@@ -76,7 +76,7 @@ class DocumentationGenerator {
     if (typeName.match(FUNCTION_TYPE_REGEX)) {
       return {
         name: 'function',
-        description: typeName
+        description: typeName,
       }
     }
 
@@ -86,14 +86,14 @@ class DocumentationGenerator {
 
       if (type.value && Array.isArray(type.value)) {
         baseShape = {
-          enums: type.value.map(({ value }: any) => value)
+          enums: type.value.map(({ value }: any) => value),
         }
       }
 
       return {
         name: typeName,
         description: '',
-        ...baseShape
+        ...baseShape,
       }
     }
 
@@ -104,7 +104,7 @@ class DocumentationGenerator {
 
       return {
         name: '[]',
-        description: `${objectDescription}[]`
+        description: `${objectDescription}[]`,
       }
     }
 
@@ -113,7 +113,7 @@ class DocumentationGenerator {
       const objectDescription = this.generateObjectDescription(typeName)
       return {
         name: 'object',
-        description: objectDescription
+        description: objectDescription,
       }
     }
 
@@ -122,14 +122,14 @@ class DocumentationGenerator {
       const enums = typeName.split('|').map(value => value.trim())
       return {
         name: 'enum',
-        enums
+        enums,
       }
     }
 
     // Simple types
     return {
       name: typeName,
-      description: ''
+      description: '',
     }
   }
 
@@ -194,7 +194,7 @@ ${propsTable}
         defaultValue: this.resolveDefaultValue(defaultValue),
         description: description.replace(DEPRECATED_KEYWORD, ''),
         deprecated: description.startsWith(DEPRECATED_KEYWORD),
-        required
+        required,
       }
     }) as PropDocumentationMap
   }


### PR DESCRIPTION
### Description

- removed the unused `hideOnCompactLayout` prop from the storybook components
- fixed a type issue on storybook utils

### How to test

- No visual difference. You can run the storybook on your local and check for terminal errors.

### Development checks

- Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- Annotate all `props` in component with documentation
- Create `examples` for component
- Ensure that deployed demo has expected results and good examples
- [x] Ensure that all PR checks are green
- Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- Covered with tests

**Breaking change**

- codemod is created and showcased in the changeset
- test alpha package of Picasso in StaffPortal

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>
