### PR TITLE
fix(TagSelector): fix selected items filtering for custom key

### DIFF
--- a/.changeset/gorgeous-donkeys-call.md
+++ b/.changeset/gorgeous-donkeys-call.md
@@ -1,0 +1,9 @@
+---
+'@toptal/picasso': patch
+---
+
+---
+
+### TagSelector
+
+- fix selected items filtering when custom key provided

--- a/packages/picasso/src/TagSelector/TagSelector.tsx
+++ b/packages/picasso/src/TagSelector/TagSelector.tsx
@@ -25,14 +25,25 @@ export interface Item extends AutocompleteItem {
 
 const EMPTY_INPUT_VALUE = ''
 
-export const isIncluded = (
-  items: Item[],
-  currentItem: Item,
+export const filterOutSelectedOptions = (
+  options?: Item[] | null,
+  values?: Item[] | null,
   getKey = (item: Item) => item.value
-) => {
-  const currentItemKey = getKey(currentItem)
+): AutocompleteItem[] | null => {
+  if (!options) {
+    return null
+  }
 
-  return items.some(item => getKey(item) === currentItemKey)
+  if (!values || values.length === 0) {
+    return options
+  }
+
+  const valuesKeyMap = values.reduce(
+    (acc, item) => acc.add(getKey(item) as string),
+    new Set<string>()
+  )
+
+  return options.filter(option => !valuesKeyMap.has(getKey(option) as string))
 }
 
 const getItemText = (item: Item | null) =>
@@ -192,7 +203,7 @@ export const TagSelector = forwardRef<HTMLInputElement, Props>(
     }
 
     const autocompleteOptions: AutocompleteItem[] | null =
-      options && options.filter(option => !isIncluded(values, option, getKey))
+      filterOutSelectedOptions(options, values, getKey)
 
     const renderLabel = (item: Item) => {
       const displayValue = getDisplayValue(item)

--- a/packages/picasso/src/TagSelector/TagSelector.tsx
+++ b/packages/picasso/src/TagSelector/TagSelector.tsx
@@ -25,8 +25,15 @@ export interface Item extends AutocompleteItem {
 
 const EMPTY_INPUT_VALUE = ''
 
-export const isIncluded = (items: Item[], currentItem: Item) =>
-  items.some(({ value }) => value === currentItem.value)
+export const isIncluded = (
+  items: Item[],
+  currentItem: Item,
+  getKey = (item: Item) => item.value
+) => {
+  const currentItemKey = getKey(currentItem)
+
+  return items.some(item => getKey(item) === currentItemKey)
+}
 
 const getItemText = (item: Item | null) =>
   (item && item.text) || EMPTY_INPUT_VALUE
@@ -185,7 +192,7 @@ export const TagSelector = forwardRef<HTMLInputElement, Props>(
     }
 
     const autocompleteOptions: AutocompleteItem[] | null =
-      options && options.filter(option => !isIncluded(values, option))
+      options && options.filter(option => !isIncluded(values, option, getKey))
 
     const renderLabel = (item: Item) => {
       const displayValue = getDisplayValue(item)

--- a/packages/picasso/src/TagSelector/TagSelector.tsx
+++ b/packages/picasso/src/TagSelector/TagSelector.tsx
@@ -38,12 +38,12 @@ export const filterOutSelectedOptions = (
     return options
   }
 
-  const valuesKeyMap = values.reduce(
+  const valuesKeySet = values.reduce(
     (acc, item) => acc.add(getKey(item) as string),
     new Set<string>()
   )
 
-  return options.filter(option => !valuesKeyMap.has(getKey(option) as string))
+  return options.filter(option => !valuesKeySet.has(getKey(option) as string))
 }
 
 const getItemText = (item: Item | null) =>

--- a/packages/picasso/src/TagSelector/TagSelector.tsx
+++ b/packages/picasso/src/TagSelector/TagSelector.tsx
@@ -26,16 +26,12 @@ export interface Item extends AutocompleteItem {
 const EMPTY_INPUT_VALUE = ''
 
 export const filterOutSelectedOptions = (
-  options?: Item[] | null,
-  values?: Item[] | null,
+  options: Item[] | null,
+  values: Item[],
   getKey = (item: Item) => item.value
 ): AutocompleteItem[] | null => {
   if (!options) {
     return null
-  }
-
-  if (!values || values.length === 0) {
-    return options
   }
 
   const valuesKeySet = values.reduce(

--- a/packages/picasso/src/TagSelector/test.tsx
+++ b/packages/picasso/src/TagSelector/test.tsx
@@ -7,7 +7,7 @@ import {
 } from '@toptal/picasso/test-utils'
 import { OmitInternalProps } from '@toptal/picasso-shared'
 
-import TagSelector, { Props, isIncluded } from './TagSelector'
+import TagSelector, { Props, filterOutSelectedOptions } from './TagSelector'
 
 const testOptions = [
   { value: 'AF', text: 'Afghanistan', id: '100' },
@@ -124,32 +124,28 @@ describe('TagSelector', () => {
   })
 })
 
-describe('isIncluded', () => {
+describe('filterOutSelectedOptions', () => {
   it("compares object's value attribute by default", () => {
-    const actual = isIncluded(testOptions, testOptions[0])
+    const resultOptions = filterOutSelectedOptions(testOptions, [
+      testOptions[0],
+    ])
 
-    expect(actual).toBe(true)
+    expect(resultOptions).toEqual(expect.arrayContaining(testOptions.slice(1)))
   })
 
   describe('when custom getKey function is provided', () => {
     it('uses custom function', () => {
       const getKey = jest.fn(item => item.id as string)
 
-      const actual = isIncluded(testOptions, testOptions[3], getKey)
+      const resultOptions = filterOutSelectedOptions(
+        testOptions,
+        [testOptions[0]],
+        getKey
+      )
 
-      expect(actual).toBe(true)
-      // 1 for 3rd option + 4 for each list item
-      expect(getKey).toHaveBeenCalledTimes(5)
+      expect(resultOptions).toEqual(
+        expect.arrayContaining(testOptions.slice(1))
+      )
     })
-  })
-
-  it.each`
-    value   | text              | result
-    ${'AF'} | ${'Afghanistan'}  | ${true}
-    ${'NO'} | ${'Non existing'} | ${false}
-  `('compares object by value', ({ value, text, result }) => {
-    const actual = isIncluded(testOptions, { text, value })
-
-    expect(actual).toEqual(result)
   })
 })

--- a/packages/picasso/src/TagSelector/test.tsx
+++ b/packages/picasso/src/TagSelector/test.tsx
@@ -10,10 +10,10 @@ import { OmitInternalProps } from '@toptal/picasso-shared'
 import TagSelector, { Props, isIncluded } from './TagSelector'
 
 const testOptions = [
-  { value: 'AF', text: 'Afghanistan' },
-  { value: 'AI', text: 'Aland Islands' },
-  { value: 'ALB', text: 'Albania' },
-  { value: 'ALG', text: 'Algeria' },
+  { value: 'AF', text: 'Afghanistan', id: '100' },
+  { value: 'AI', text: 'Aland Islands', id: '101' },
+  { value: 'ALB', text: 'Albania', id: '102' },
+  { value: 'ALG', text: 'Algeria', id: '103' },
 ]
 
 const testProps = {
@@ -125,10 +125,22 @@ describe('TagSelector', () => {
 })
 
 describe('isIncluded', () => {
-  it('compares object by reference', () => {
+  it("compares object's value attribute by default", () => {
     const actual = isIncluded(testOptions, testOptions[0])
 
     expect(actual).toBe(true)
+  })
+
+  describe('when custom getKey function is provided', () => {
+    it('uses custom function', () => {
+      const getKey = jest.fn(item => item.id as string)
+
+      const actual = isIncluded(testOptions, testOptions[3], getKey)
+
+      expect(actual).toBe(true)
+      // 1 for 3rd option + 4 for each list item
+      expect(getKey).toHaveBeenCalledTimes(5)
+    })
   })
 
   it.each`


### PR DESCRIPTION
[FX-2845]

### Description

- fixed the bug about being unable to filter selected items if custom `getKey` provided
- I will also add a new test for `TagSelector` on this PR: https://github.com/toptal/picasso/pull/2873. I didn't do it here to avoid conflicts with that PR.

### How to reproduce

go to https://picasso.toptal.net/?path=/story/forms-tagselector--tagselector#custom-option-rendering and try to select more than one item

### How to test

- from the temploy, go to `TagSelector` page and select more than one item on both `custom-label` and `custom-option` examples.

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- Annotate all `props` in component with documentation
- Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure that all PR checks are green
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests

**Breaking change**

- codemod is created and showcased in the changeset
- test alpha package of Picasso in StaffPortal

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-2845]: https://toptal-core.atlassian.net/browse/FX-2845?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ