### PR TITLE
feat: introduce happo hover screenshot command for cypress

### DIFF
--- a/cypress/component/Checkbox.spec.tsx
+++ b/cypress/component/Checkbox.spec.tsx
@@ -20,12 +20,12 @@ describe('Checkbox', () => {
   it('renders', () => {
     cy.mount(<TestCheckbox />)
 
-    cy.getByTestId('checkbox-unchecked').happoHoverScreenshot({
+    cy.getByTestId('checkbox-unchecked').hoverAndTakeHappoScreenshot({
       component: COMPONENT,
       variant: 'default-unchecked/after-hovered',
     })
 
-    cy.getByTestId('checkbox-checked').happoHoverScreenshot({
+    cy.getByTestId('checkbox-checked').hoverAndTakeHappoScreenshot({
       component: COMPONENT,
       variant: 'default-checked/after-hovered',
     })

--- a/cypress/component/Checkbox.spec.tsx
+++ b/cypress/component/Checkbox.spec.tsx
@@ -14,29 +14,30 @@ const TestCheckbox = () => (
   </Container>
 )
 
+const COMPONENT = 'Checkbox'
+
 describe('Checkbox', () => {
   it('renders', () => {
     cy.mount(<TestCheckbox />)
 
-    // happo doesn't retain hover state but it has a workaround
-    // "data-happo-hover" is being added and removed to mimic the state
-    cy.getByTestId('checkbox-unchecked')
-      .invoke('attr', 'data-happo-hover', true)
-      .get('body')
-      .happoScreenshot()
-    cy.getByTestId('checkbox-unchecked').invoke(
-      'removeAttr',
-      'data-happo-hover'
-    )
+    cy.getByTestId('checkbox-unchecked').happoHoverScreenshot({
+      component: COMPONENT,
+      variant: 'default-unchecked/after-hovered',
+    })
 
-    cy.getByTestId('checkbox-checked')
-      .invoke('attr', 'data-happo-hover', true)
-      .get('body')
-      .happoScreenshot()
-    cy.getByTestId('checkbox-checked').invoke('removeAttr', 'data-happo-hover')
+    cy.getByTestId('checkbox-checked').happoHoverScreenshot({
+      component: COMPONENT,
+      variant: 'default-checked/after-hovered',
+    })
 
     // our data-testid's are not being passed to the input
-    cy.get('input').first().focus().get('body').happoScreenshot()
-    cy.get('input').last().focus().get('body').happoScreenshot()
+    cy.get('input').first().focus().get('body').happoScreenshot({
+      component: COMPONENT,
+      variant: 'default-unchecked/after-focused',
+    })
+    cy.get('input').last().focus().get('body').happoScreenshot({
+      component: COMPONENT,
+      variant: 'default-checked/after-focused',
+    })
   })
 })

--- a/cypress/component/Checkbox.spec.tsx
+++ b/cypress/component/Checkbox.spec.tsx
@@ -14,29 +14,29 @@ const TestCheckbox = () => (
   </Container>
 )
 
-const COMPONENT = 'Checkbox'
+const component = 'Checkbox'
 
 describe('Checkbox', () => {
   it('renders', () => {
     cy.mount(<TestCheckbox />)
 
     cy.getByTestId('checkbox-unchecked').hoverAndTakeHappoScreenshot({
-      component: COMPONENT,
+      component,
       variant: 'default-unchecked/after-hovered',
     })
 
     cy.getByTestId('checkbox-checked').hoverAndTakeHappoScreenshot({
-      component: COMPONENT,
+      component,
       variant: 'default-checked/after-hovered',
     })
 
     // our data-testid's are not being passed to the input
     cy.get('input').first().focus().get('body').happoScreenshot({
-      component: COMPONENT,
+      component,
       variant: 'default-unchecked/after-focused',
     })
     cy.get('input').last().focus().get('body').happoScreenshot({
-      component: COMPONENT,
+      component,
       variant: 'default-checked/after-focused',
     })
   })

--- a/cypress/component/Dropdown.spec.tsx
+++ b/cypress/component/Dropdown.spec.tsx
@@ -54,7 +54,7 @@ const ComplexContent = () => {
   )
 }
 
-const COMPONENT = 'Dropdown'
+const component = 'Dropdown'
 
 describe('Dropdown', () => {
   it('renders with long list', () => {
@@ -66,13 +66,13 @@ describe('Dropdown', () => {
     cy.getByTestId('menu').parent().scrollTo('bottom')
 
     cy.get('body').happoScreenshot({
-      component: COMPONENT,
+      component,
       variant: 'long-list/after-clicked-with-scroll',
     })
 
     cy.getByTestId('content-overflow-visible').click()
     cy.get('body').happoScreenshot({
-      component: COMPONENT,
+      component,
       variant: 'long-list/after-clicked-without-scroll',
     })
   })
@@ -82,7 +82,7 @@ describe('Dropdown', () => {
 
     cy.getByTestId('trigger').realClick()
     cy.get('body').happoScreenshot({
-      component: COMPONENT,
+      component,
       variant: 'custom-content/after-clicked',
     })
   })

--- a/cypress/component/TagSelector.spec.tsx
+++ b/cypress/component/TagSelector.spec.tsx
@@ -223,7 +223,7 @@ describe('TagSelector', () => {
       .type('{downArrow}')
       .type('{enter}')
 
-    cy.get('a').happoHoverScreenshot({
+    cy.get('a').hoverAndTakeHappoScreenshot({
       component: COMPONENT_NAME,
       variant: 'custom-label-custom-option/after-selected-and-hovered-item',
     })

--- a/cypress/component/TagSelector.spec.tsx
+++ b/cypress/component/TagSelector.spec.tsx
@@ -134,7 +134,7 @@ const TagSelectorCustomLabelOptionRendererExample = () => {
   )
 }
 
-const COMPONENT_NAME = 'TagSelector'
+const component = 'TagSelector'
 
 describe('TagSelector', () => {
   it('renders', () => {
@@ -145,7 +145,7 @@ describe('TagSelector', () => {
       .realClick()
       .get('body')
       .happoScreenshot({
-        component: COMPONENT_NAME,
+        component,
         variant: 'default/after-clicked-combobox',
       })
 
@@ -154,7 +154,7 @@ describe('TagSelector', () => {
       .type('{enter}')
       .get('body')
       .happoScreenshot({
-        component: COMPONENT_NAME,
+        component,
         variant: 'default/after-selected-item',
       })
 
@@ -162,7 +162,7 @@ describe('TagSelector', () => {
       .realClick()
       .get('body')
       .happoScreenshot({
-        component: COMPONENT_NAME,
+        component,
         variant: 'default/after-deleted-item',
       })
 
@@ -170,7 +170,7 @@ describe('TagSelector', () => {
       .type('not existing item text')
       .get('body')
       .happoScreenshot({
-        component: COMPONENT_NAME,
+        component,
         variant: 'default/after-forced-no-result',
       })
   })
@@ -183,12 +183,12 @@ describe('TagSelector', () => {
       .type('not existing item text')
       .get('body')
       .happoScreenshot({
-        component: COMPONENT_NAME,
+        component,
         variant: 'other-option/after-forced-other-option',
       })
 
     cy.get('[role=option]').realClick().get('body').happoScreenshot({
-      component: COMPONENT_NAME,
+      component,
       variant: 'other-option/after-clicked-new-option',
     })
   })
@@ -214,7 +214,7 @@ describe('TagSelector', () => {
       .realClick()
       .get('body')
       .happoScreenshot({
-        component: COMPONENT_NAME,
+        component,
         variant: 'custom-label-custom-option/after-clicked-combobox',
       })
 
@@ -224,7 +224,7 @@ describe('TagSelector', () => {
       .type('{enter}')
 
     cy.get('a').hoverAndTakeHappoScreenshot({
-      component: COMPONENT_NAME,
+      component,
       variant: 'custom-label-custom-option/after-selected-and-hovered-item',
     })
   })

--- a/cypress/component/TagSelector.spec.tsx
+++ b/cypress/component/TagSelector.spec.tsx
@@ -223,15 +223,10 @@ describe('TagSelector', () => {
       .type('{downArrow}')
       .type('{enter}')
 
-    // happo doesn't retain hover state but it has a workaround
-    // "data-happo-hover" is being added and removed to mimic the state
-    cy.get('a')
-      .invoke('attr', 'data-happo-hover', true)
-      .get('body')
-      .happoScreenshot({
-        component: COMPONENT_NAME,
-        variant: 'custom-label-custom-option/after-selected-and-hovered-item',
-      })
+    cy.get('a').happoHoverScreenshot({
+      component: COMPONENT_NAME,
+      variant: 'custom-label-custom-option/after-selected-and-hovered-item',
+    })
   })
 })
 

--- a/cypress/support/commands.jsx
+++ b/cypress/support/commands.jsx
@@ -30,13 +30,13 @@ Cypress.Commands.add('getByRole', (role, options) => {
   return cy.get(`[role=${role}]`, options)
 })
 
-// happo doesn't retain hover state but it has a workaround (not official)
-// "data-happo-hover" is being added and removed to mimic the state and
-// happo will be able to detect the hover state
 Cypress.Commands.add(
   'hoverAndTakeHappoScreenshot',
   { prevSubject: true },
   (subject, options) => {
+    // happo doesn't retain hover state but it has a workaround (not official)
+    // "data-happo-hover" is being added and removed to mimic the state and
+    // happo will be able to detect the hover state
     cy.get(subject.selector)
       .invoke('attr', 'data-happo-hover', true)
       .get('body')

--- a/cypress/support/commands.jsx
+++ b/cypress/support/commands.jsx
@@ -30,8 +30,11 @@ Cypress.Commands.add('getByRole', (role, options) => {
   return cy.get(`[role=${role}]`, options)
 })
 
+// happo doesn't retain hover state but it has a workaround (not official)
+// "data-happo-hover" is being added and removed to mimic the state and
+// happo will be able to detect the hover state
 Cypress.Commands.add(
-  'happoHoverScreenshot',
+  'hoverAndTakeHappoScreenshot',
   { prevSubject: true },
   (subject, options) => {
     cy.get(subject.selector)

--- a/cypress/support/commands.jsx
+++ b/cypress/support/commands.jsx
@@ -30,6 +30,19 @@ Cypress.Commands.add('getByRole', (role, options) => {
   return cy.get(`[role=${role}]`, options)
 })
 
+Cypress.Commands.add(
+  'happoHoverScreenshot',
+  { prevSubject: true },
+  (subject, options) => {
+    cy.get(subject.selector)
+      .invoke('attr', 'data-happo-hover', true)
+      .get('body')
+      .happoScreenshot(options)
+
+    cy.get(subject.selector).invoke('removeAttr', 'data-happo-hover')
+  }
+)
+
 Cypress.Commands.add('mount', (component, options, props = {}) => {
   // Wrap any parent components needed
   // ie: return mount(<MyProvider>{component}</MyProvider>, options)

--- a/cypress/support/index.d.ts
+++ b/cypress/support/index.d.ts
@@ -9,7 +9,9 @@ declare global {
       isWithinViewport(): Chainable<Subject>
       getByTestId(testId: string): Chainable<Subject>
       getByRole(role: string): Chainable<Subject>
-      happoHoverScreenshot(options?: HappoScreenshotOptions): Chainable<Subject>
+      hoverAndTakeHappoScreenshot(
+        options?: HappoScreenshotOptions
+      ): Chainable<Subject>
       mount: typeof mount
     }
   }

--- a/cypress/support/index.d.ts
+++ b/cypress/support/index.d.ts
@@ -1,6 +1,7 @@
 /// <reference types="cypress" />
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { mount } from 'cypress/react'
+import { HappoScreenshotOptions } from 'happo-cypress'
 
 declare global {
   namespace Cypress {
@@ -8,6 +9,7 @@ declare global {
       isWithinViewport(): Chainable<Subject>
       getByTestId(testId: string): Chainable<Subject>
       getByRole(role: string): Chainable<Subject>
+      happoHoverScreenshot(options?: HappoScreenshotOptions): Chainable<Subject>
       mount: typeof mount
     }
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -25048,7 +25048,7 @@ webpack-virtual-modules@^0.2.2:
   dependencies:
     debug "^3.0.0"
 
-webpack@4, webpack@^4, webpack@^5.58.2:
+webpack@4, webpack@^4.0.0, webpack@^5.58.2:
   version "4.46.0"
   resolved "https://registry.yarnpkg.com/webpack/-/webpack-4.46.0.tgz#bf9b4404ea20a073605e0a011d188d77cb6ad542"
   integrity sha512-6jJuJjg8znb/xRItk7bkT0+Q7AHCYjjFnvKIWQPkNIOyRqoCGvkOs0ipeQzrqz4l5FtN5ZI/ukEHroeX/o1/5Q==


### PR DESCRIPTION
### Description

Happo has a workaround for hovered state screenshots. To not remember and copy this workaround, I introduced a cypress command to use.

### How to test

- there shouldn't be a happo change (except renames)

### Development checks

- Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- Annotate all `props` in component with documentation
- Create `examples` for component
- Ensure that deployed demo has expected results and good examples
- [x] Ensure that all PR checks are green
- Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- Covered with tests

**Breaking change**

- codemod is created and showcased in the changeset
- test alpha package of Picasso in StaffPortal

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>
