### PR TITLE
chore: use davinci github actions directly

### DIFF
--- a/.changeset/sweet-pugs-fail.md
+++ b/.changeset/sweet-pugs-fail.md
@@ -1,0 +1,5 @@
+---
+'@toptal/picasso': patch
+---
+
+- Use davinci github actions directly

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,15 @@ updates:
   labels:
     - no-jira
   versioning-strategy: increase
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: weekly
+    time: "07:00"
+  open-pull-requests-limit: 4
+  pull-request-branch-name:
+    separator: "-"
+  labels:
+    - no-jira
+    - dependencies
+    - github-actions

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,7 +16,7 @@ updates:
   schedule:
     interval: weekly
     time: "07:00"
-  open-pull-requests-limit: 4
+  open-pull-requests-limit: 2
   pull-request-branch-name:
     separator: "-"
   labels:

--- a/.github/workflows/davinci-alpha-package.yml
+++ b/.github/workflows/davinci-alpha-package.yml
@@ -46,14 +46,6 @@ jobs:
           ref: ${{ steps.get-branch.outputs.branch }}
           fetch-depth: 0 # otherwise, you will fail to push refs to dest repo
 
-      - name: Checkout davinci GHAs
-        uses: actions/checkout@v2
-        with:
-          repository: toptal/davinci-github-actions
-          ref: v2.2.1
-          token: ${{ env.GITHUB_TOKEN }}
-          path: ./.github/actions/
-
       - name: Set status check - pending
         uses: actions/github-script@v4
         with:
@@ -71,7 +63,7 @@ jobs:
 
       - name: Trigger alpha package
         id: alpha-package
-        uses: ./.github/actions/build-publish-alpha-package
+        uses: toptal/davinci-github-actions/build-publish-alpha-package@v3.0.1
         with:
           npm-token: ${{ env.NPM_TOKEN }}
           branch: ${{ steps.get-branch.outputs.branch }}

--- a/.github/workflows/davinci-alpha-package.yml
+++ b/.github/workflows/davinci-alpha-package.yml
@@ -63,7 +63,7 @@ jobs:
 
       - name: Trigger alpha package
         id: alpha-package
-        uses: toptal/davinci-github-actions/build-publish-alpha-package@v3.0.1
+        uses: toptal/davinci-github-actions/build-publish-alpha-package@v3.0.2
         with:
           npm-token: ${{ env.NPM_TOKEN }}
           branch: ${{ steps.get-branch.outputs.branch }}

--- a/.github/workflows/davinci-integration-tests.yml
+++ b/.github/workflows/davinci-integration-tests.yml
@@ -28,15 +28,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Checkout davinci GHAs
-        uses: actions/checkout@v2
-        with:
-          repository: toptal/davinci-github-actions
-          ref: v2.2.1
-          token: ${{ env.TOPTAL_DEVBOT_TOKEN }}
-          path: ./.github/actions/
-
-      - uses: ./.github/actions/yarn-install
+      - uses: toptal/davinci-github-actions/yarn-install@v3.0.1
 
       - name: Build packages
         run: yarn build:package
@@ -62,18 +54,10 @@ jobs:
       - name: Checkout project
         uses: actions/checkout@v2
 
-      - name: Checkout davinci GHAs
-        uses: actions/checkout@v2
-        with:
-          repository: toptal/davinci-github-actions
-          ref: v2.2.1
-          token: ${{ env.TOPTAL_DEVBOT_TOKEN }}
-          path: ./.github/actions/
-
       - name: Setup node
         uses: actions/setup-node@v2
 
-      - uses: ./.github/actions/yarn-install
+      - uses: toptal/davinci-github-actions/yarn-install@v3.0.1
 
       - name: Get cached packages
         uses: actions/cache@v2
@@ -82,7 +66,7 @@ jobs:
           key: ${{ runner.os }}-pkgs-${{ github.run_id }} }}
 
       - name: Run integration tests
-        uses: ./.github/actions/integration-tests
+        uses: toptal/davinci-github-actions/integration-tests@v3.0.1
 
   finalize-integtation-tests:
     name: Finalize Integration Tests
@@ -92,15 +76,7 @@ jobs:
       - name: Checkout project
         uses: actions/checkout@v2
 
-      - name: Checkout davinci GHAs
-        uses: actions/checkout@v2
-        with:
-          repository: toptal/davinci-github-actions
-          ref: v2.2.1
-          token: ${{ env.TOPTAL_DEVBOT_TOKEN }}
-          path: ./.github/actions/
-
-      - uses: ./.github/actions/yarn-install
+      - uses: toptal/davinci-github-actions/yarn-install@v3.0.1
 
       - name: Finalize Happo
         run: npx happo-e2e finalize

--- a/.github/workflows/davinci-integration-tests.yml
+++ b/.github/workflows/davinci-integration-tests.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - uses: toptal/davinci-github-actions/yarn-install@v3.0.1
+      - uses: toptal/davinci-github-actions/yarn-install@v3.0.2
 
       - name: Build packages
         run: yarn build:package
@@ -57,7 +57,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v2
 
-      - uses: toptal/davinci-github-actions/yarn-install@v3.0.1
+      - uses: toptal/davinci-github-actions/yarn-install@v3.0.2
 
       - name: Get cached packages
         uses: actions/cache@v2
@@ -66,7 +66,7 @@ jobs:
           key: ${{ runner.os }}-pkgs-${{ github.run_id }} }}
 
       - name: Run integration tests
-        uses: toptal/davinci-github-actions/integration-tests@v3.0.1
+        uses: toptal/davinci-github-actions/integration-tests@v3.0.2
 
   finalize-integtation-tests:
     name: Finalize Integration Tests
@@ -76,7 +76,7 @@ jobs:
       - name: Checkout project
         uses: actions/checkout@v2
 
-      - uses: toptal/davinci-github-actions/yarn-install@v3.0.1
+      - uses: toptal/davinci-github-actions/yarn-install@v3.0.2
 
       - name: Finalize Happo
         run: npx happo-e2e finalize

--- a/.github/workflows/handle-contribution.yml
+++ b/.github/workflows/handle-contribution.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Call notify jira about contribution
     steps:
-      - uses: toptal/davinci-github-actions/notify-jira-about-contribution@v3.0.1
+      - uses: toptal/davinci-github-actions/notify-jira-about-contribution@v3.0.2
         with:
           team: frontend-experience-eng
           repo: ${{ github.event.repository.name }}

--- a/.github/workflows/handle-contribution.yml
+++ b/.github/workflows/handle-contribution.yml
@@ -12,14 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Call notify jira about contribution
     steps:
-      - uses: actions/checkout@v2
-        with:
-          repository: toptal/davinci-github-actions
-          ref: v2.2.1
-          token: ${{ secrets.TOPTAL_DEVBOT_TOKEN }}
-          path: ./.github/actions/
-
-      - uses: ./.github/actions/notify-jira-about-contribution
+      - uses: toptal/davinci-github-actions/notify-jira-about-contribution@v3.0.1
         with:
           team: frontend-experience-eng
           repo: ${{ github.event.repository.name }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -32,7 +32,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - uses: toptal/davinci-github-actions/build-push-image@v3.0.1
+      - uses: toptal/davinci-github-actions/build-push-image@v3.0.2
         env:
           GITHUB_TOKEN: ${{ env.TOPTAL_DEVBOT_TOKEN }}
           GCR_ACCOUNT_KEY: ${{ secrets.GCR_ACCOUNT_KEY }}
@@ -52,7 +52,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - uses: toptal/davinci-github-actions/yarn-install@v3.0.1
+      - uses: toptal/davinci-github-actions/yarn-install@v3.0.2
 
       - name: Danger
         env:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -32,15 +32,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Checkout davinci GHAs
-        uses: actions/checkout@v2
-        with:
-          repository: toptal/davinci-github-actions
-          ref: v2.2.1
-          token: ${{ env.TOPTAL_DEVBOT_TOKEN }}
-          path: ./.github/actions/
-
-      - uses: ./.github/actions/build-push-image
+      - uses: toptal/davinci-github-actions/build-push-image@v3.0.1
         env:
           GITHUB_TOKEN: ${{ env.TOPTAL_DEVBOT_TOKEN }}
           GCR_ACCOUNT_KEY: ${{ secrets.GCR_ACCOUNT_KEY }}
@@ -60,15 +52,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Checkout davinci GHAs
-        uses: actions/checkout@v2
-        with:
-          repository: toptal/davinci-github-actions
-          ref: v2.2.1
-          token: ${{ env.TOPTAL_DEVBOT_TOKEN }}
-          path: ./.github/actions/
-
-      - uses: ./.github/actions/yarn-install
+      - uses: toptal/davinci-github-actions/yarn-install@v3.0.1
 
       - name: Danger
         env:

--- a/.github/workflows/visual-testing.yml
+++ b/.github/workflows/visual-testing.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v2
 
-      - uses: toptal/davinci-github-actions/yarn-install@v3.0.1
+      - uses: toptal/davinci-github-actions/yarn-install@v3.0.2
 
       - name: Happo Tests
         run: yarn happo:storybook

--- a/.github/workflows/visual-testing.yml
+++ b/.github/workflows/visual-testing.yml
@@ -32,18 +32,10 @@ jobs:
       - name: Checkout project
         uses: actions/checkout@v2
 
-      - name: Checkout davinci GHAs
-        uses: actions/checkout@v2
-        with:
-          repository: toptal/davinci-github-actions
-          ref: v2.2.1
-          token: ${{ env.TOPTAL_DEVBOT_TOKEN }}
-          path: ./.github/actions/
-
       - name: Setup node
         uses: actions/setup-node@v2
 
-      - uses: ./.github/actions/yarn-install
+      - uses: toptal/davinci-github-actions/yarn-install@v3.0.1
 
       - name: Happo Tests
         run: yarn happo:storybook


### PR DESCRIPTION
### Description

We need to use davinci GH Actions directly

### How to test

- Run CI command

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Ensure that all PR checks are green
- [x] Self reviewed

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>
