### PR TITLE
fix(Modal): refactor Modal's scroll lock to allow multiple modals mounted

### DIFF
--- a/.changeset/slow-oranges-approve.md
+++ b/.changeset/slow-oranges-approve.md
@@ -1,0 +1,9 @@
+---
+'@toptal/picasso': minor
+---
+
+---
+
+### Modal
+
+- Improve body scroll lock to properly handle multiple open modals

--- a/packages/picasso/src/Modal/Modal.tsx
+++ b/packages/picasso/src/Modal/Modal.tsx
@@ -13,7 +13,6 @@ import {
   StandardProps,
   SizeType,
   TransitionProps,
-  isBrowser,
 } from '@toptal/picasso-shared'
 import { usePicassoRoot, useBreakpoint } from '@toptal/picasso-provider'
 
@@ -168,33 +167,15 @@ export const Modal = forwardRef<HTMLElement, Props>(function Modal(props, ref) {
     }
   }, [open, rootRef])
 
-  const bodyOverflow = useRef<string>(
-    // eslint-disable-next-line ssr-friendly/no-dom-globals-in-react-fc
-    isBrowser() ? document.body.style.overflow : 'inherit'
-  )
-
   useEffect(() => {
-    const resetBodyOverflow = () => {
-      document.body.style.overflow = bodyOverflow.current
-    }
-    const currentModal = modalId.current
+    const currentModalId = modalId.current
 
     if (open) {
-      // TODO: [FX-1069] to be improved as part of https://toptal-core.atlassian.net/browse/FX-1069
-      bodyOverflow.current = document.body.style.overflow
-      document.body.style.overflow = 'hidden'
-
-      defaultManager.add(currentModal)
-    } else {
-      resetBodyOverflow()
-
-      defaultManager.remove(currentModal)
+      defaultManager.add(currentModalId)
     }
 
     return () => {
-      resetBodyOverflow()
-
-      defaultManager.remove(currentModal)
+      defaultManager.remove(currentModalId)
     }
   }, [open])
 

--- a/packages/picasso/src/Modal/test.tsx
+++ b/packages/picasso/src/Modal/test.tsx
@@ -1,6 +1,8 @@
 import React, { useState } from 'react'
 import {
   render,
+  screen,
+  cleanup,
   fireEvent,
   waitForElementToBeRemoved,
 } from '@toptal/picasso/test-utils'
@@ -41,6 +43,7 @@ const TestModalActions = ({
 
 let modalRoot: HTMLElement
 
+// eslint-disable-next-line max-lines-per-function
 describe('Modal', () => {
   beforeAll(() => {
     modalRoot = document.createElement('div')
@@ -189,5 +192,224 @@ describe('Modal', () => {
     expect(queryByText('Second modal content')).toBeTruthy()
 
     expect(baseElement).toMatchSnapshot()
+  })
+
+  describe('body scroll lock', () => {
+    afterEach(() => {
+      cleanup()
+      document.body.style.overflow = ''
+    })
+
+    it('drops scroll lock when initially open modal is mounted', () => {
+      render(<Modal open={true}>Hello from modal!</Modal>)
+
+      expect(document.body.style.overflow).toBe('hidden')
+    })
+
+    it('does not drop scroll lock when closed modal is mounted', () => {
+      render(<Modal open={false}>Hello from modal!</Modal>)
+
+      expect(document.body.style.overflow).toBe('')
+    })
+
+    describe('drops scroll lock as modal opens and lifts it as modal closes', () => {
+      it('always mounted modal', () => {
+        const TestComponent = () => {
+          const modal = useModal()
+
+          return (
+            <>
+              <Button data-testid='open-first' onClick={modal.showModal}>
+                Open first
+              </Button>
+
+              <Modal
+                open={modal.isOpen}
+                onClose={modal.hideModal}
+                testIds={{ closeButton: 'close-first' }}
+              >
+                <p>First modal content</p>
+              </Modal>
+            </>
+          )
+        }
+
+        render(<TestComponent />)
+        expect(document.body.style.overflow).toBe('')
+
+        fireEvent.click(screen.getByTestId('open-first'))
+        expect(document.body.style.overflow).toBe('hidden')
+
+        fireEvent.click(screen.getByTestId('close-first'))
+        expect(document.body.style.overflow).toBe('')
+      })
+
+      it('conditionally mounted modal', () => {
+        const TestComponent = () => {
+          const modal = useModal()
+
+          return (
+            <>
+              <Button data-testid='open-first' onClick={modal.showModal}>
+                Open first
+              </Button>
+              {modal.isOpen && (
+                <Modal
+                  open
+                  onClose={modal.hideModal}
+                  testIds={{ closeButton: 'close-first' }}
+                >
+                  <p>First modal content</p>
+                </Modal>
+              )}
+            </>
+          )
+        }
+
+        render(<TestComponent />)
+        expect(document.body.style.overflow).toBe('')
+
+        fireEvent.click(screen.getByTestId('open-first'))
+        expect(document.body.style.overflow).toBe('hidden')
+
+        fireEvent.click(screen.getByTestId('close-first'))
+        expect(document.body.style.overflow).toBe('')
+      })
+
+      it('restores prev body overflow value', () => {
+        const TestComponent = () => {
+          const modal = useModal()
+
+          return (
+            <>
+              <Button data-testid='open-first' onClick={modal.showModal}>
+                Open first
+              </Button>
+
+              <Modal
+                open={modal.isOpen}
+                onClose={modal.hideModal}
+                testIds={{ closeButton: 'close-first' }}
+              >
+                <p>First modal content</p>
+              </Modal>
+            </>
+          )
+        }
+
+        document.body.style.overflow = 'visible'
+
+        render(<TestComponent />)
+        expect(document.body.style.overflow).toBe('visible')
+
+        fireEvent.click(screen.getByTestId('open-first'))
+        expect(document.body.style.overflow).toBe('hidden')
+
+        fireEvent.click(screen.getByTestId('close-first'))
+        expect(document.body.style.overflow).toBe('visible')
+      })
+    })
+
+    describe('multiple modals', () => {
+      it('properly manages body scroll lock as modals open/close', () => {
+        const TestComponent = () => {
+          const modal1 = useModal()
+          const modal2 = useModal()
+
+          return (
+            <>
+              <Button data-testid='open-first' onClick={modal1.showModal}>
+                Open first
+              </Button>
+              <Button data-testid='open-second' onClick={modal2.showModal}>
+                Open second
+              </Button>
+
+              <Modal
+                open={modal1.isOpen}
+                onClose={modal1.hideModal}
+                testIds={{ closeButton: 'close-first' }}
+              >
+                <p>First modal content</p>
+              </Modal>
+              <Modal
+                open={modal2.isOpen}
+                onClose={modal2.hideModal}
+                testIds={{ closeButton: 'close-second' }}
+              >
+                <p>Second modal content</p>
+              </Modal>
+            </>
+          )
+        }
+
+        render(<TestComponent />)
+        expect(document.body.style.overflow).toBe('')
+
+        fireEvent.click(screen.getByTestId('open-first'))
+        expect(document.body.style.overflow).toBe('hidden')
+
+        fireEvent.click(screen.getByTestId('open-second'))
+        expect(document.body.style.overflow).toBe('hidden')
+
+        fireEvent.click(screen.getByTestId('close-first'))
+        expect(document.body.style.overflow).toBe('hidden')
+
+        fireEvent.click(screen.getByTestId('close-second'))
+        expect(document.body.style.overflow).toBe('')
+      })
+
+      // NOTE: See https://toptal-core.atlassian.net/browse/FX-1069?focusedCommentId=96115 for more details
+      it('properly restores body overflow when closed modal mounts/unmounts', () => {
+        const TestComponent = () => {
+          const modal1 = useModal()
+          const [isModal2Mounted, setModal2Mounted] = useState(false)
+
+          return (
+            <>
+              <Button data-testid='open-first' onClick={modal1.showModal}>
+                Open first
+              </Button>
+              <Button
+                data-testid={
+                  isModal2Mounted ? 'unmount-second' : 'mount-second'
+                }
+                onClick={() => setModal2Mounted(isMounted => !isMounted)}
+              >
+                Toggle second
+              </Button>
+
+              <Modal
+                open={modal1.isOpen}
+                onClose={modal1.hideModal}
+                testIds={{ closeButton: 'close-first' }}
+              >
+                <p>First modal content</p>
+              </Modal>
+              {isModal2Mounted && (
+                <Modal open={false}>
+                  <p>Second modal content</p>
+                </Modal>
+              )}
+            </>
+          )
+        }
+
+        render(<TestComponent />)
+        expect(document.body.style.overflow).toBe('')
+
+        fireEvent.click(screen.getByTestId('open-first'))
+        expect(document.body.style.overflow).toBe('hidden')
+
+        fireEvent.click(screen.getByTestId('mount-second'))
+        expect(document.body.style.overflow).toBe('hidden')
+
+        fireEvent.click(screen.getByTestId('close-first'))
+        expect(document.body.style.overflow).toBe('')
+
+        fireEvent.click(screen.getByTestId('unmount-second'))
+        expect(document.body.style.overflow).toBe('')
+      })
+    })
   })
 })

--- a/packages/picasso/src/utils/Modal/modal-manager.ts
+++ b/packages/picasso/src/utils/Modal/modal-manager.ts
@@ -1,5 +1,8 @@
+import { isBrowser } from '@toptal/picasso-shared'
+
 export class ModalManager {
   modals: number[] = []
+  scrollLock: { prevBodyOverflow: string } | undefined
 
   add(modalId: number) {
     if (this.modals.includes(modalId)) {
@@ -7,6 +10,7 @@ export class ModalManager {
     }
 
     this.modals.push(modalId)
+    this.dropScrollLock()
   }
 
   remove(modalId: number) {
@@ -17,11 +21,36 @@ export class ModalManager {
     }
 
     this.modals.splice(modalIndex, 1)
+    this.liftScrollLock()
   }
 
   isTopModal(modalId: number) {
     return (
       this.modals.length > 0 && this.modals[this.modals.length - 1] === modalId
     )
+  }
+
+  private dropScrollLock() {
+    if (!isBrowser()) {
+      return
+    }
+
+    if (!this.scrollLock) {
+      this.scrollLock = {
+        prevBodyOverflow: window.getComputedStyle(document.body).overflow,
+      }
+      document.body.style.overflow = 'hidden'
+    }
+  }
+
+  private liftScrollLock() {
+    if (!isBrowser()) {
+      return
+    }
+
+    if (this.scrollLock && this.modals.length === 0) {
+      document.body.style.overflow = this.scrollLock.prevBodyOverflow
+      this.scrollLock = undefined
+    }
   }
 }


### PR DESCRIPTION
[TOP-2262]
[FX-1069]

### Description

* ~Improve Modal's scroll lock logic to only remember previous body overflow once modal is open, so that additional modals that might be mounted to the react tree but closed won't remember 'overflow=hidden' into their `bodyOverflow` ref.~
* ~Prevent double-execution of `resetBodyOverflow` whenever modal closes~

Completely revised body scroll lock implementation to allow multiple modals mounted, properly drop scroll lock whenever any of them opens and lift scroll lock only after all of previously open modals are closed

### How to test

- FIXME: Add the steps describing how to verify your changes

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| Insert screenshots or screen recordings | Insert screenshots or screen recordings |

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure that all PR checks are green
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests

**Breaking change**

- ~codemod is created and showcased in the changeset~
- ~test alpha package of Picasso in StaffPortal~

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[TOP-2262]: https://toptal-core.atlassian.net/browse/TOP-2262?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FX-1069]: https://toptal-core.atlassian.net/browse/FX-1069?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ