### PR TITLE
chore: fix typescript validator

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "test:unit:debug": "cross-env NODE_OPTIONS=--inspect-brk yarn test:unit",
     "test:unit:ci": "yarn test:unit --maxWorkers=4 --ci",
     "test:unit:watch": "yarn test:unit --watch",
-    "typecheck": "tsc --noEmit & tsc -p ./cypress/tsconfig.json",
+    "typecheck": "tsc --noEmit && tsc -p ./cypress/tsconfig.json",
     "prepublish": "if [ -f 'yarn.lock' ]; then yarn-deduplicate yarn.lock; fi",
     "prepare": "husky install"
   },

--- a/packages/picasso-forms/src/FormConfig/FormConfig.ts
+++ b/packages/picasso-forms/src/FormConfig/FormConfig.ts
@@ -4,11 +4,11 @@ export type RequiredVariant = 'default' | 'asterisk'
 
 type ValidationOnSubmitConfig = {
   showValidState?: false
-  validateOnSubmit: true
+  validateOnSubmit?: true
 }
 
 type ShowValidStateConfig = {
-  showValidState: true
+  showValidState?: true
   validateOnSubmit?: false
 }
 
@@ -17,6 +17,7 @@ type NoValidationConfig = {
   validateOnSubmit?: false
 }
 
+// reason for different types is that we want to deny the user to set both showValidState and validateOnSubmit to true
 export type FormConfigProps = (
   | ValidationOnSubmitConfig
   | ShowValidStateConfig


### PR DESCRIPTION
### Description

Fix incorrect TS validator
Fix type issue on FormConfig context provider

### How to test

- there shouldn't be a TS error anymore


<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>
