### PR TITLE
chore: use getByTestId and getByRole in Cypress

### DIFF
--- a/cypress/component/ApplicationUpdateNotification.spec.tsx
+++ b/cypress/component/ApplicationUpdateNotification.spec.tsx
@@ -32,22 +32,18 @@ describe('ApplicationUpdateNotification', () => {
   it('renders notification when click on trigger', () => {
     cy.mount(<ApplicationUpdateNotificationExample />)
 
-    cy.get('[data-testid="trigger"]').click()
+    cy.getByTestId('trigger').click()
     cy.get('body').happoScreenshot()
   })
 
   it('renders notification when click on trigger and close when click on notification button', () => {
     cy.mount(<ApplicationUpdateNotificationExample />)
 
-    cy.get('[data-testid="trigger"]').click()
-    cy.get('[data-testid="application-update-notification"]').should(
-      'be.visible'
-    )
+    cy.getByTestId('trigger').click()
+    cy.getByTestId('application-update-notification').should('be.visible')
 
-    cy.get('[data-testid="update-later-button"]').click()
+    cy.getByTestId('update-later-button').click()
 
-    cy.get('[data-testid="application-update-notification"]').should(
-      'not.be.visible'
-    )
+    cy.getByTestId('application-update-notification').should('not.be.visible')
   })
 })

--- a/cypress/component/BarChart.spec.tsx
+++ b/cypress/component/BarChart.spec.tsx
@@ -49,7 +49,7 @@ const assertTooltipContent = (text: string) => {
 }
 
 const assertCustomTooltipContent = (text: string) => {
-  cy.get('[data-testid="tooltip"]').should('be.visible').and('contain', text)
+  cy.getByTestId('tooltip').should('be.visible').and('contain', text)
 }
 
 describe('BarChart', () => {

--- a/cypress/component/ButtonSplit.spec.tsx
+++ b/cypress/component/ButtonSplit.spec.tsx
@@ -11,13 +11,6 @@ const menu = (
   </Menu>
 )
 
-const testIds = {
-  menuButton: 'menu-button',
-  actionButton: 'actionButton',
-}
-
-const getMenuButton = () => cy.get(`[data-testid=${testIds.menuButton}]`)
-
 describe('Button.Split', () => {
   it('opens dropdown when menu button is clicked', () => {
     cy.mount(
@@ -28,7 +21,7 @@ describe('Button.Split', () => {
       </Container>
     )
 
-    getMenuButton().click()
+    cy.getByTestId('menu-button').click()
 
     cy.get('body').happoScreenshot()
   })

--- a/cypress/component/DatePicker.spec.tsx
+++ b/cypress/component/DatePicker.spec.tsx
@@ -46,7 +46,7 @@ describe('DatePicker', () => {
       />
     )
 
-    cy.get('[data-testid=date-picker-input]').clear().type('2015')
+    cy.getByTestId('date-picker-input').clear().type('2015')
 
     cy.get('body').happoScreenshot()
   })

--- a/cypress/component/Form.spec.tsx
+++ b/cypress/component/Form.spec.tsx
@@ -300,7 +300,7 @@ describe('Form', () => {
 
     cy.getByTestId('success-submit-button').click()
 
-    cy.get('[role=alert]')
+    cy.getByRole('alert')
       .should('be.visible')
       .and('contain', 'Login successful!')
   })
@@ -321,7 +321,7 @@ describe('Form', () => {
       .should('be.visible')
       .isWithinViewport()
 
-    cy.get('[role=alert]')
+    cy.getByRole('alert')
       .should('be.visible')
       .and(
         'contain',
@@ -337,7 +337,7 @@ describe('Form', () => {
 
     cy.getByTestId('submit-with-custom-notification-button').click()
 
-    cy.get('[role=alert]')
+    cy.getByRole('alert')
       .should('be.visible')
       .and('contain', 'Custom Notification Message!')
   })

--- a/cypress/component/Form.spec.tsx
+++ b/cypress/component/Form.spec.tsx
@@ -298,7 +298,7 @@ describe('Form', () => {
     cy.get('#successName').type('name')
     cy.get('#successSurname').type('surname')
 
-    cy.get('[data-testid=success-submit-button]').click()
+    cy.getByTestId('success-submit-button').click()
 
     cy.get('[role=alert]')
       .should('be.visible')
@@ -311,12 +311,12 @@ describe('Form', () => {
     cy.get('#inlineErrorName').type('name')
     cy.get('#inlineErrorSurname').type('surname')
 
-    cy.get('[data-testid=submit-with-inline-error-button]').click()
+    cy.getByTestId('submit-with-inline-error-button').click()
 
     // eslint-disable-next-line cypress/no-unnecessary-waiting
     cy.wait(RESPONSE_TIME + ANIMATION_TIME)
 
-    cy.get('[data-testid=submit-with-inline-error-first-name]')
+    cy.getByTestId('submit-with-inline-error-first-name')
       .contains('Unknown first name')
       .should('be.visible')
       .isWithinViewport()
@@ -335,7 +335,7 @@ describe('Form', () => {
     cy.get('#customNotificationErrorName').type('name')
     cy.get('#customNotificationErrorSurname').type('surname')
 
-    cy.get('[data-testid=submit-with-custom-notification-button]').click()
+    cy.getByTestId('submit-with-custom-notification-button').click()
 
     cy.get('[role=alert]')
       .should('be.visible')

--- a/cypress/component/Link.spec.tsx
+++ b/cypress/component/Link.spec.tsx
@@ -108,7 +108,7 @@ describe('Link', () => {
         </Typography>
       )
 
-      cy.get('[data-testid="link"]')
+      cy.getByTestId('link')
         .realHover()
         .should(
           'have.css',
@@ -128,7 +128,7 @@ describe('Link', () => {
         </Typography>
       )
 
-      cy.get('[data-testid="link"]')
+      cy.getByTestId('link')
         .realHover()
         .should(
           'have.css',
@@ -148,7 +148,7 @@ describe('Link', () => {
         </Typography>
       )
 
-      cy.get('[data-testid="link"]')
+      cy.getByTestId('link')
         .realHover()
         .should('have.css', 'text-decoration', 'none solid rgb(32, 78, 207)')
     })
@@ -164,7 +164,7 @@ describe('Link', () => {
         </Typography>
       )
 
-      cy.get('[data-testid="link"]')
+      cy.getByTestId('link')
         .realHover()
         .should('have.css', 'text-decoration', 'none solid rgb(32, 78, 207)')
     })
@@ -183,13 +183,9 @@ describe('Link', () => {
         </>
       )
 
-      cy.get('[data-testid="blue-link"]').should(
-        'have.css',
-        'color',
-        PURPLE_MAIN
-      )
+      cy.getByTestId('blue-link').should('have.css', 'color', PURPLE_MAIN)
 
-      cy.get('[data-testid="white-link"]').should('have.css', 'color', GREY)
+      cy.getByTestId('white-link').should('have.css', 'color', GREY)
     })
   })
 })

--- a/cypress/component/List.spec.tsx
+++ b/cypress/component/List.spec.tsx
@@ -57,7 +57,7 @@ describe('List', () => {
         </List>
       )
 
-      cy.get('[data-testid="list"]').children().last().contains(13)
+      cy.getByTestId('list').children().last().contains(13)
     })
   })
 })

--- a/cypress/component/Menu.spec.tsx
+++ b/cypress/component/Menu.spec.tsx
@@ -1,13 +1,9 @@
 import React from 'react'
 import { Container, Menu, MenuProps } from '@toptal/picasso'
 
-const testIds = {
-  menuItem: 'menu-back',
-}
-
 const MenuExample = (props: MenuProps) => {
   const menuForItemB1 = (
-    <Menu data-testid='menu-b1' testIds={testIds}>
+    <Menu data-testid='menu-b1' testIds={{ menuItem: 'menu-back' }}>
       <Menu.Item data-testid='item-b1-1'>Item B1-1</Menu.Item>
       <Menu.Item data-testid='item-b1-2'>Item B1-2</Menu.Item>
     </Menu>
@@ -21,7 +17,7 @@ const MenuExample = (props: MenuProps) => {
   )
 
   const menuForItemB = (
-    <Menu data-testid='menu-b' testIds={testIds}>
+    <Menu data-testid='menu-b' testIds={{ menuItem: 'menu-back' }}>
       <Menu.Item menu={menuForItemB1} data-testid='item-b1'>
         Item B1
       </Menu.Item>
@@ -49,7 +45,7 @@ describe('Menu', () => {
   it('navigates slide menu', () => {
     cy.mount(<MenuExample />)
     cy.getByTestId('menu-b').should('not.exist')
-    cy.get(`[data-testid="${testIds.menuItem}"]`).should('not.exist')
+    cy.getByTestId('menu-back').should('not.exist')
     cy.get('body').happoScreenshot({
       component,
       variant: 'slide-menu',
@@ -71,7 +67,7 @@ describe('Menu', () => {
       variant: 'slide-menu/after-clicked-item-to-open-another-sub-menu',
     })
 
-    cy.get(`[data-testid="${testIds.menuItem}"`).last().click()
+    cy.getByTestId('menu-back').last().click()
     cy.getByTestId('menu-b').should('be.visible')
     cy.getByTestId('menu-b1').should('not.exist')
     cy.get('body').click().happoScreenshot({
@@ -79,9 +75,9 @@ describe('Menu', () => {
       variant: 'slide-menu/after-clicked-back-to-prev-sub-menu',
     })
 
-    cy.get(`[data-testid="${testIds.menuItem}"`).click()
+    cy.getByTestId('menu-back').click()
     cy.getByTestId('menu-b').should('not.exist')
-    cy.get(`[data-testid="${testIds.menuItem}"]`).should('not.exist')
+    cy.getByTestId('menu-back').should('not.exist')
     cy.get('body').happoScreenshot({
       component,
       variant: 'slide-menu/after-clicked-back-to-original-menu',

--- a/cypress/component/Menu.spec.tsx
+++ b/cypress/component/Menu.spec.tsx
@@ -48,39 +48,39 @@ const component = 'Menu'
 describe('Menu', () => {
   it('navigates slide menu', () => {
     cy.mount(<MenuExample />)
-    cy.get('[data-testid="menu-b"]').should('not.exist')
+    cy.getByTestId('menu-b').should('not.exist')
     cy.get(`[data-testid="${testIds.menuItem}"]`).should('not.exist')
     cy.get('body').happoScreenshot({
       component,
       variant: 'slide-menu',
     })
 
-    cy.get('[data-testid="item-b"]').click()
-    cy.get('[data-testid="menu-b"]').should('be.visible')
-    cy.get('[data-testid="menu-b1"]').should('not.exist')
+    cy.getByTestId('item-b').click()
+    cy.getByTestId('menu-b').should('be.visible')
+    cy.getByTestId('menu-b1').should('not.exist')
     cy.get('body').happoScreenshot({
       component,
       variant: 'slide-menu/after-clicked-item-to-open-sub-menu',
     })
 
-    cy.get('[data-testid="item-b1"]').click()
-    cy.get('[data-testid="menu-b1"]').should('be.visible')
-    cy.get('[data-testid="menu-b2"]').should('not.exist')
+    cy.getByTestId('item-b1').click()
+    cy.getByTestId('menu-b1').should('be.visible')
+    cy.getByTestId('menu-b2').should('not.exist')
     cy.get('body').click().happoScreenshot({
       component,
       variant: 'slide-menu/after-clicked-item-to-open-another-sub-menu',
     })
 
     cy.get(`[data-testid="${testIds.menuItem}"`).last().click()
-    cy.get('[data-testid="menu-b"]').should('be.visible')
-    cy.get('[data-testid="menu-b1"]').should('not.exist')
+    cy.getByTestId('menu-b').should('be.visible')
+    cy.getByTestId('menu-b1').should('not.exist')
     cy.get('body').click().happoScreenshot({
       component,
       variant: 'slide-menu/after-clicked-back-to-prev-sub-menu',
     })
 
     cy.get(`[data-testid="${testIds.menuItem}"`).click()
-    cy.get('[data-testid="menu-b"]').should('not.exist')
+    cy.getByTestId('menu-b').should('not.exist')
     cy.get(`[data-testid="${testIds.menuItem}"]`).should('not.exist')
     cy.get('body').happoScreenshot({
       component,
@@ -90,23 +90,23 @@ describe('Menu', () => {
 
   it('navigates drilldown menu', () => {
     cy.mount(<MenuExample variant='drilldown' />)
-    cy.get('[data-testid="menu-b"]').should('not.exist')
+    cy.getByTestId('menu-b').should('not.exist')
     cy.get('body').happoScreenshot()
 
-    cy.get('[data-testid="item-b"]').trigger('mouseover')
-    cy.get('[data-testid="menu-b"]').should('be.visible')
-    cy.get('[data-testid="menu-b1"]').should('not.exist')
+    cy.getByTestId('item-b').trigger('mouseover')
+    cy.getByTestId('menu-b').should('be.visible')
+    cy.getByTestId('menu-b1').should('not.exist')
     cy.get('body').happoScreenshot()
 
-    cy.get('[data-testid="item-b1"]').trigger('mouseover')
-    cy.get('[data-testid="menu-b"]').should('be.visible')
-    cy.get('[data-testid="menu-b1"]').should('be.visible')
+    cy.getByTestId('item-b1').trigger('mouseover')
+    cy.getByTestId('menu-b').should('be.visible')
+    cy.getByTestId('menu-b1').should('be.visible')
     cy.get('body').happoScreenshot()
 
-    cy.get('[data-testid="menu-b1"]').trigger('mouseout')
-    cy.get('[data-testid="item-b"]').trigger('mouseover')
-    cy.get('[data-testid="menu-b"]').should('be.visible')
-    cy.get('[data-testid="menu-b1"]').should('not.exist')
+    cy.getByTestId('menu-b1').trigger('mouseout')
+    cy.getByTestId('item-b').trigger('mouseover')
+    cy.getByTestId('menu-b').should('be.visible')
+    cy.getByTestId('menu-b1').should('not.exist')
     cy.get('body').happoScreenshot()
   })
 })

--- a/cypress/component/PasswordInput.spec.tsx
+++ b/cypress/component/PasswordInput.spec.tsx
@@ -19,7 +19,7 @@ describe('PasswordInput', () => {
       cy.mount(<PasswordInputExample />)
       cy.get('body').happoScreenshot()
 
-      cy.get('[data-testid="password-input-toggle"]').click()
+      cy.getByTestId('password-input-toggle').click()
 
       cy.get('body').happoScreenshot()
     })

--- a/cypress/component/RichTextEditor.spec.tsx
+++ b/cypress/component/RichTextEditor.spec.tsx
@@ -65,12 +65,12 @@ const setSelectValue = (
 const setAliases = () => {
   // set aliases
   cy.get(editorSelector).as('editor')
-  cy.get(`[data-testid="${headerSelect}"]`).as('headerSelect')
-  cy.get(`[data-testid="${boldButton}"]`).as('boldButton')
-  cy.get(`[data-testid="${italicButton}"]`).as('italicButton')
-  cy.get(`[data-testid="${olButton}"]`).as('olButton')
-  cy.get(`[data-testid="${ulButton}"]`).as('ulButton')
-  cy.get(`[data-testid="${wrapper}"]`).as('wrapper')
+  cy.getByTestId(headerSelect).as('headerSelect')
+  cy.getByTestId(boldButton).as('boldButton')
+  cy.getByTestId(italicButton).as('italicButton')
+  cy.getByTestId(olButton).as('olButton')
+  cy.getByTestId(ulButton).as('ulButton')
+  cy.getByTestId(wrapper).as('wrapper')
 }
 
 describe('RichTextEditor', () => {

--- a/cypress/component/Select.spec.tsx
+++ b/cypress/component/Select.spec.tsx
@@ -141,18 +141,18 @@ const getNativeOption = (value: string | number) =>
   cy.get(`option[value="${value}"]`)
 
 const openSelect = () => {
-  cy.get('[data-testid="select"]').click()
+  cy.getByTestId('select').click()
 }
 
 const pressArrowDown = () => {
-  cy.get('[data-testid="select"]').trigger('keydown', {
+  cy.getByTestId('select').trigger('keydown', {
     key: 'ArrowDown',
     keyCode: 40,
   })
 }
 
 const pressEnter = () => {
-  cy.get('[data-testid="select"]').trigger('keydown', {
+  cy.getByTestId('select').trigger('keydown', {
     key: 'Enter',
     keyCode: 13,
   })
@@ -393,39 +393,36 @@ describe('Select', () => {
         />
       )
 
-      const searchInput = '[data-testid="search-input"]'
-      const selectInput = '[data-testid="select"]'
-
-      cy.get('[data-testid="select"]')
-        .click()
-        .find('input')
-        .should('be.focused')
+      cy.getByTestId('select').click().find('input').should('be.focused')
 
       cy.get('body').happoScreenshot()
 
       // focuses on the Search input by clicking on the input
-      cy.get(searchInput).click('center').find('input').should('be.focused')
+      cy.getByTestId('search-input')
+        .click('center')
+        .find('input')
+        .should('be.focused')
 
       // focuses on by click on the input wrapper
-      cy.get(selectInput)
+      cy.getByTestId('select')
         .click()
-        .get(searchInput)
+        .getByTestId('search-input')
         .click('bottom')
         .find('input')
         .should('be.focused')
 
       // focuses on by click on the search icon
-      cy.get(selectInput)
+      cy.getByTestId('select')
         .click()
-        .get(searchInput)
+        .getByTestId('search-input')
         .closest('[role="menuitem"]')
         .click(20, 20)
         .find('input')
         .should('be.focused')
 
       // focuses on by typing
-      cy.get(selectInput).click().type('option')
-      cy.get(searchInput).find('input').should('be.focused')
+      cy.getByTestId('select').click().type('option')
+      cy.getByTestId('search-input').find('input').should('be.focused')
     })
   })
 })

--- a/cypress/component/Select.spec.tsx
+++ b/cypress/component/Select.spec.tsx
@@ -267,7 +267,7 @@ describe('Select', () => {
     // Cypress does not go well with :hover CSS selectors
     // It can fire mouse events via JS, but can't simulate browser cursor behaviour
     // To fix this issue we're using a force method to show the button so the screenshot is correct
-    cy.get(`[data-testid="${testIds.resetButton}"]`).invoke(
+    cy.getByTestId(testIds.resetButton).invoke(
       'attr',
       'style',
       'visibility: visible'

--- a/cypress/component/ShowMore.spec.tsx
+++ b/cypress/component/ShowMore.spec.tsx
@@ -56,7 +56,7 @@ describe('ShowMore', () => {
       </ShowMore>
     )
 
-    cy.get(`[data-testid="${contentWrapper}"]`).should('have.value', '')
+    cy.getByTestId(contentWrapper).should('have.value', '')
     cy.get('body').happoScreenshot()
   })
 })

--- a/cypress/component/Table.spec.tsx
+++ b/cypress/component/Table.spec.tsx
@@ -382,7 +382,7 @@ describe('Table', () => {
 
     cy.getByTestId('job').as('job').should('be.visible')
 
-    cy.get(`[data-testid="expand-button-${localData[0].id}"]`)
+    cy.getByTestId(`expand-button-${localData[0].id}`)
       .as('expandButton')
       .realClick()
 
@@ -424,7 +424,7 @@ describe('Table', () => {
 
     cy.getByTestId('job').as('job').should('be.visible')
 
-    cy.get(`[data-testid="expand-button-${localData[0].id}"]`)
+    cy.getByTestId(`expand-button-${localData[0].id}`)
       .as('expandButton')
       .realClick()
 

--- a/cypress/component/Table.spec.tsx
+++ b/cypress/component/Table.spec.tsx
@@ -380,7 +380,7 @@ describe('Table', () => {
 
     cy.get('body').happoScreenshot()
 
-    cy.get('[data-testid="job"]').as('job').should('be.visible')
+    cy.getByTestId('job').as('job').should('be.visible')
 
     cy.get(`[data-testid="expand-button-${localData[0].id}"]`)
       .as('expandButton')
@@ -422,7 +422,7 @@ describe('Table', () => {
 
     cy.get('body').happoScreenshot()
 
-    cy.get('[data-testid="job"]').as('job').should('be.visible')
+    cy.getByTestId('job').as('job').should('be.visible')
 
     cy.get(`[data-testid="expand-button-${localData[0].id}"]`)
       .as('expandButton')

--- a/cypress/component/TagSelector.spec.tsx
+++ b/cypress/component/TagSelector.spec.tsx
@@ -187,7 +187,7 @@ describe('TagSelector', () => {
         variant: 'other-option/after-forced-other-option',
       })
 
-    cy.get('[role=option]').realClick().get('body').happoScreenshot({
+    cy.getByRole('option').realClick().get('body').happoScreenshot({
       component,
       variant: 'other-option/after-clicked-new-option',
     })
@@ -197,7 +197,7 @@ describe('TagSelector', () => {
     cy.mount(<InitiallySelectedOptionExample />)
 
     cy.get('input[type="text"]').click()
-    cy.get('[role=option]').as('options').should('have.length', 4)
+    cy.getByRole('option').as('options').should('have.length', 4)
     cy.get('@options').contains('Croatia').should('not.exist')
 
     cy.get('@options').contains('Belarus').click()


### PR DESCRIPTION
No ticket.

### Description

This is a quick cleanup for using the `getByTestId` and `getByRole` utilities everywhere in Cypress.

### How to test

- tests pass, inspect code

### Development checks

~- [ ] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)~
~- [ ] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)~
~- [ ] Annotate all `props` in component with documentation~
~- [ ] Create `examples` for component~
~- [ ] Ensure that deployed demo has expected results and good examples~
- [x] Ensure that all PR checks are green
~- [ ] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).~
- [x] Self reviewed
~- [ ] Covered with tests~
