### PR TITLE
chore: revert back focusing errored field after form submission

### DIFF
--- a/packages/picasso-forms/src/utils/scroll-to.ts
+++ b/packages/picasso-forms/src/utils/scroll-to.ts
@@ -1,5 +1,10 @@
+const UNHIDDEN_INPUT_SELECTOR = 'input:not([type=hidden])'
+
 export const scrollTo = (field: HTMLElement) => {
   if (typeof field.scrollIntoView === 'function') {
     field.scrollIntoView({ block: 'center', behavior: 'smooth' })
   }
+  field
+    .querySelector<HTMLInputElement>(UNHIDDEN_INPUT_SELECTOR)
+    ?.focus({ preventScroll: true })
 }

--- a/packages/picasso-forms/src/utils/scroll-to.ts
+++ b/packages/picasso-forms/src/utils/scroll-to.ts
@@ -1,10 +1,10 @@
-const UNHIDDEN_INPUT_SELECTOR = 'input:not([type=hidden])'
+const NOT_HIDDEN_INPUT_SELECTOR = 'input:not([type=hidden])'
 
 export const scrollTo = (field: HTMLElement) => {
   if (typeof field.scrollIntoView === 'function') {
     field.scrollIntoView({ block: 'center', behavior: 'smooth' })
   }
   field
-    .querySelector<HTMLInputElement>(UNHIDDEN_INPUT_SELECTOR)
+    .querySelector<HTMLInputElement>(NOT_HIDDEN_INPUT_SELECTOR)
     ?.focus({ preventScroll: true })
 }


### PR DESCRIPTION
[FX-2569]

### Description

Some time ago, we decided to remove the focusing errored field after form submission feature due to a lack of ability to discriminate the focused field with or without error. Soon, we will introduce new design for focused & errored field so this feature can be reverted back.

### How to test

- open the Form page on storybook and pick one of the form examples
- try to submit with an error, the browser should scroll to the first errored field
- check if the field is already focused without any of your interactions

### Development checks

- Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- Annotate all `props` in component with documentation
- Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure that all PR checks are green
- Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- Covered with tests

**Breaking change**

- codemod is created and showcased in the changeset
- test alpha package of Picasso in StaffPortal

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-2569]: https://toptal-core.atlassian.net/browse/FX-2569?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ