### PR TITLE
feat(OutlinedInput): add shadow for error-focused state

### DIFF
--- a/.changeset/fast-ears-hang.md
+++ b/.changeset/fast-ears-hang.md
@@ -1,0 +1,9 @@
+---
+'@toptal/picasso': patch
+---
+
+---
+
+### OutlinedInput
+
+- add red shadow when error input is focused

--- a/packages/picasso/src/OutlinedInput/styles.ts
+++ b/packages/picasso/src/OutlinedInput/styles.ts
@@ -72,6 +72,13 @@ PicassoProvider.override(
       },
       error: {
         backgroundColor: 'transparent',
+        '&$focused': {
+          '& $notchedOutline': {
+            borderWidth: '1px',
+            borderColor: palette.red.main,
+            ...outline(palette.red.main),
+          },
+        },
       },
     },
   })


### PR DESCRIPTION
[FX-2571]

### Description

Add red shadow when error input is focused according to [design](https://www.figma.com/file/5SCTOPrCDcHuk5We091GBn/Product-Library?node-id=1002%3A14361)

### How to test

- Open [temploy on form](https://picasso.toptal.net/fx-2571-outlinedinput-add-errored-focused-state/?path=/story/picasso-forms-form--form#default) and focus input with error

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- Annotate all `props` in component with documentation
- Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- Covered with tests

**Breaking change**

- codemod is created and showcased in the changeset
- test alpha package of Picasso in StaffPortal

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-2571]: https://toptal-core.atlassian.net/browse/FX-2571?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ