### PR TITLE
chore: disable flaky TreeView story screenshots temporarily

### DIFF
--- a/packages/picasso/src/TreeView/story/index.jsx
+++ b/packages/picasso/src/TreeView/story/index.jsx
@@ -16,11 +16,13 @@ page
   .createChapter()
   .addExample('TreeView/story/Default.example.tsx', {
     title: 'Default',
+    takeScreenshot: false,
   })
   .addExample('TreeView/story/Selected.example.tsx', {
     title: 'With selected node',
     description:
       "To set the particular node selected, you need to set `node`'s attribute *selected* to `true`. Also there is additional attribute `selectedOffset` for adding an scroll offset for particular node",
+    takeScreenshot: false,
   })
   .addExample('TreeView/story/Modal.example.tsx', {
     title: 'With Modal',
@@ -28,9 +30,11 @@ page
   })
   .addExample('TreeView/story/CustomZoom.example.tsx', {
     title: 'Custom Zoom',
+    takeScreenshot: false,
   })
   .addExample('TreeView/story/AvatarSize.example.tsx', {
     title: 'Avatar Size',
+    takeScreenshot: false,
   })
   .addExample('TreeView/story/Horizontal.example.tsx', {
     title: 'Horizontal Direction',


### PR DESCRIPTION
No ticket.

### Description

TreeView tests are flaky. Need to disable them first, so that we don't block anyone.

### How to test

- Happo tests pass

### Development checks

- [x] Self reviewed
