### PR TITLE
chore: improve happo screenshot names for cypress

### DIFF
--- a/cypress/component/Accordion.spec.tsx
+++ b/cypress/component/Accordion.spec.tsx
@@ -83,15 +83,25 @@ const AccordionCustomSummary = () => {
   )
 }
 
+const component = 'Accordion'
+
 describe('Accordion', () => {
   it('renders', () => {
     cy.mount(<TestAccordion />)
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'default',
+    })
   })
+
   it('renders disabled', () => {
     cy.mount(<TestAccordion disabled />)
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'disabled',
+    })
   })
+
   it('renders border variants', () => {
     cy.mount(
       <>
@@ -100,8 +110,12 @@ describe('Accordion', () => {
         <TestAccordion borders='all' />
       </>
     )
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'all-borders',
+    })
   })
+
   it('renders expanded initially', () => {
     cy.mount(
       <>
@@ -109,16 +123,26 @@ describe('Accordion', () => {
         <TestAccordion expanded />
       </>
     )
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'expanded',
+    })
   })
+
   it('renders collapsed initially', () => {
     cy.mount(<TestAccordion expanded={false} />)
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'collapsed',
+    })
   })
 
   it('renders custom expand icon', () => {
     cy.mount(<TestAccordion expandIcon={<Check16 />} />)
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'custom-expand-icon',
+    })
   })
 })
 describe('Accordion with custom summary', () => {
@@ -127,12 +151,18 @@ describe('Accordion with custom summary', () => {
     cy.getByTestId('trigger').click()
     cy.getByTestId('content').should('not.be.visible')
 
-    cy.getByTestId('accordion-custom-summary').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'custom-summary/before-expanded',
+    })
 
     cy.getByTestId('trigger').click()
     cy.getByTestId('content').should('be.visible')
 
-    cy.getByTestId('accordion-custom-summary').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'custom-summary/after-expanded',
+    })
   })
 
   it('interacts with accordion content', () => {

--- a/cypress/component/ApplicationUpdateNotification.spec.tsx
+++ b/cypress/component/ApplicationUpdateNotification.spec.tsx
@@ -28,12 +28,17 @@ const ApplicationUpdateNotificationExample = () => {
   )
 }
 
+const component = 'ApplicationUpdateNotification'
+
 describe('ApplicationUpdateNotification', () => {
   it('renders notification when click on trigger', () => {
     cy.mount(<ApplicationUpdateNotificationExample />)
 
     cy.getByTestId('trigger').click()
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'default/after-triggered',
+    })
   })
 
   it('renders notification when click on trigger and close when click on notification button', () => {

--- a/cypress/component/Autocomplete.spec.tsx
+++ b/cypress/component/Autocomplete.spec.tsx
@@ -119,11 +119,17 @@ const TestAutocomplete = (props: Partial<AutocompleteProps>) => (
   <Autocomplete value='' options={OPTIONS} testIds={testIds} {...props} />
 )
 
+const component = 'Autocomplete'
+
+// eslint-disable-next-line max-lines-per-function
 describe('Autocomplete', () => {
   it('renders', () => {
     cy.mount(<TestAutocomplete />)
 
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'default/before-clicked',
+    })
   })
 
   it('renders a list of options when clicked', () => {
@@ -132,7 +138,10 @@ describe('Autocomplete', () => {
     cy.getByTestId(testIds.input).click()
     cy.getByRole('menu').should('be.visible')
 
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'default/after-clicked',
+    })
   })
 
   it('renders a list of options with descriptions when clicked', () => {
@@ -151,7 +160,10 @@ describe('Autocomplete', () => {
     cy.getByTestId(testIds.input).click()
     cy.getByRole('menu').should('be.visible')
 
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'with-description/after-clicked',
+    })
   })
 
   it('renders disabled autocomplete', () => {
@@ -162,7 +174,10 @@ describe('Autocomplete', () => {
       </>
     )
 
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'disabled',
+    })
   })
 
   it('renders a reset button', () => {
@@ -177,11 +192,18 @@ describe('Autocomplete', () => {
       'visibility: visible'
     )
 
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'with-reset-button',
+    })
   })
+
   it('renders a placeholder', () => {
     cy.mount(<TestAutocomplete placeholder='Start a country...' />)
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'with-placeholder',
+    })
   })
 
   it('renders the selected value even if a placeholder is specified', () => {
@@ -191,7 +213,10 @@ describe('Autocomplete', () => {
         <TestAutocomplete value='Croatia' placeholder='Start a country...' />
       </>
     )
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'with-placeholder/with-value',
+    })
   })
 
   it('renders start and end adornments', () => {
@@ -205,7 +230,10 @@ describe('Autocomplete', () => {
         />
       </>
     )
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'with-adornments',
+    })
   })
 
   it('renders an icon unless a start adornment is specified', () => {
@@ -215,7 +243,10 @@ describe('Autocomplete', () => {
         <TestAutocomplete icon={<Check16 />} startAdornment={<Globe16 />} />
       </>
     )
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'with-adornments-and-icon',
+    })
   })
 
   it('renders loading and error states', () => {
@@ -232,7 +263,10 @@ describe('Autocomplete', () => {
     // eslint-disable-next-line cypress/no-unnecessary-waiting
     cy.wait(100)
 
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'loading-and-error-states',
+    })
   })
 
   it('renders in different widths', () => {
@@ -243,7 +277,10 @@ describe('Autocomplete', () => {
         <TestAutocomplete width='shrink' />
       </>
     )
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'with-different-widths',
+    })
   })
 
   it('renders in different menu widths', () => {
@@ -252,7 +289,10 @@ describe('Autocomplete', () => {
     cy.getByTestId(testIds.input).click()
     cy.getByRole('menu').should('be.visible')
 
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'with-different-menu-widths',
+    })
   })
 
   it('renders other option', () => {
@@ -261,7 +301,10 @@ describe('Autocomplete', () => {
     cy.getByTestId(testIds.input).click()
     cy.getByRole('menu').should('be.visible')
 
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'with-other-option',
+    })
   })
 
   it('renders no options text', () => {
@@ -277,7 +320,10 @@ describe('Autocomplete', () => {
     cy.getByTestId(testIds.input).click()
     cy.getByRole('menu').should('be.visible')
 
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'with-no-options',
+    })
   })
 
   it('renders powered by google', () => {
@@ -288,7 +334,10 @@ describe('Autocomplete', () => {
     cy.getByTestId(testIds.input).click()
     cy.getByRole('menu').should('be.visible')
 
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'powered-by-google',
+    })
   })
 
   it('focuses Autocomplete with dynamic options should NOT open options list', () => {

--- a/cypress/component/Avatar.spec.tsx
+++ b/cypress/component/Avatar.spec.tsx
@@ -34,6 +34,8 @@ const renderExample = ({ size, variant, src }: Props) => (
   </>
 )
 
+const component = 'Avatar'
+
 const createSizeTests = (variant: Props['variant']) => {
   describe(`${variant} variant`, () => {
     SIZES.forEach(size =>
@@ -44,7 +46,10 @@ const createSizeTests = (variant: Props['variant']) => {
           cy.mount(renderExample({ size, variant, src: file }))
         )
 
-        cy.get('body').happoScreenshot()
+        cy.get('body').happoScreenshot({
+          component,
+          variant: `size-variants/${size}`,
+        })
       })
     )
   })

--- a/cypress/component/AvatarGroup.spec.tsx
+++ b/cypress/component/AvatarGroup.spec.tsx
@@ -8,6 +8,8 @@ const generatePeople = (
 
 const SIZES = ['xxsmall', 'xsmall', 'small', 'medium', 'large'] as const
 
+const component = 'AvatarGroup'
+
 describe('AvatarGroup', () => {
   SIZES.forEach(size =>
     it(`renders in ${size} size`, () => {
@@ -29,7 +31,10 @@ describe('AvatarGroup', () => {
         )
       })
 
-      cy.get('body').happoScreenshot()
+      cy.get('body').happoScreenshot({
+        component,
+        variant: `size-variants/${size}`,
+      })
     })
   )
 })

--- a/cypress/component/Badge.spec.tsx
+++ b/cypress/component/Badge.spec.tsx
@@ -1,6 +1,8 @@
 import React from 'react'
 import { Badge, Container, Avatar } from '@toptal/picasso'
 
+const component = 'Badge'
+
 /* eslint-disable max-lines-per-function */
 describe('Badge', () => {
   it('renders with defaults', () => {
@@ -11,7 +13,10 @@ describe('Badge', () => {
         </Container>
       </Container>
     )
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'default',
+    })
   })
 
   describe('white variant', () => {
@@ -32,7 +37,10 @@ describe('Badge', () => {
           </Container>
         </Container>
       )
-      cy.get('body').happoScreenshot()
+      cy.get('body').happoScreenshot({
+        component,
+        variant: 'white/small-size',
+      })
     })
 
     it('renders medium', () => {
@@ -55,7 +63,10 @@ describe('Badge', () => {
           </Container>
         </Container>
       )
-      cy.get('body').happoScreenshot()
+      cy.get('body').happoScreenshot({
+        component,
+        variant: 'white/medium-size',
+      })
     })
 
     it('renders large', () => {
@@ -78,7 +89,10 @@ describe('Badge', () => {
           </Container>
         </Container>
       )
-      cy.get('body').happoScreenshot()
+      cy.get('body').happoScreenshot({
+        component,
+        variant: 'white/large-size',
+      })
     })
 
     it('renders custom max count', () => {
@@ -100,7 +114,10 @@ describe('Badge', () => {
           </Container>
         </Container>
       )
-      cy.get('body').happoScreenshot()
+      cy.get('body').happoScreenshot({
+        component,
+        variant: 'white/custom-max-count',
+      })
     })
   })
   describe('red variant', () => {
@@ -121,7 +138,10 @@ describe('Badge', () => {
           </Container>
         </Container>
       )
-      cy.get('body').happoScreenshot()
+      cy.get('body').happoScreenshot({
+        component,
+        variant: 'red/small-size',
+      })
     })
 
     it('renders medium', () => {
@@ -144,7 +164,10 @@ describe('Badge', () => {
           </Container>
         </Container>
       )
-      cy.get('body').happoScreenshot()
+      cy.get('body').happoScreenshot({
+        component,
+        variant: 'red/medium-size',
+      })
     })
 
     it('renders large', () => {
@@ -167,7 +190,10 @@ describe('Badge', () => {
           </Container>
         </Container>
       )
-      cy.get('body').happoScreenshot()
+      cy.get('body').happoScreenshot({
+        component,
+        variant: 'red/large-size',
+      })
     })
 
     it('renders custom max count', () => {
@@ -189,7 +215,10 @@ describe('Badge', () => {
           </Container>
         </Container>
       )
-      cy.get('body').happoScreenshot()
+      cy.get('body').happoScreenshot({
+        component,
+        variant: 'red/custom-max-count',
+      })
     })
 
     it('renders overlay badge', () => {
@@ -246,7 +275,10 @@ describe('Badge', () => {
           </Container>
         </>
       )
-      cy.get('body').happoScreenshot()
+      cy.get('body').happoScreenshot({
+        component,
+        variant: 'overlay',
+      })
     })
   })
 })

--- a/cypress/component/BarChart.spec.tsx
+++ b/cypress/component/BarChart.spec.tsx
@@ -52,11 +52,16 @@ const assertCustomTooltipContent = (text: string) => {
   cy.getByTestId('tooltip').should('be.visible').and('contain', text)
 }
 
+const component = 'BarChart'
+
 describe('BarChart', () => {
   it('renders default chart with default tooltip on hover', () => {
     cy.mount(<TestBarChart />)
 
-    hoverOverBar('Apple').get('body').happoScreenshot()
+    hoverOverBar('Apple').get('body').happoScreenshot({
+      component,
+      variant: 'default-chart/default-tooltip',
+    })
     assertTooltipContent('Appleengineers hired : 500')
 
     hoverOverBar('Google')
@@ -80,7 +85,10 @@ describe('BarChart', () => {
       />
     )
 
-    hoverOverBar('Berlin').get('body').happoScreenshot()
+    hoverOverBar('Berlin').get('body').happoScreenshot({
+      component,
+      variant: 'custom-chart/custom-tooltip',
+    })
     assertCustomTooltipContent('Infected: 4000Recovered: 2400')
 
     hoverOverBar('Milan')
@@ -90,7 +98,10 @@ describe('BarChart', () => {
   it('hides label of each bar via passed `showBarLabel` prop being set to `false`', () => {
     cy.mount(<TestBarChart showBarLabel={false} tooltip={false} />)
 
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'no-label',
+    })
   })
 })
 

--- a/cypress/component/ButtonAction.spec.tsx
+++ b/cypress/component/ButtonAction.spec.tsx
@@ -1,6 +1,8 @@
 import React from 'react'
 import { Button, Container } from '@toptal/picasso'
 
+const component = 'ButtonAction'
+
 describe('ButtonAction', () => {
   it('renders', () => {
     cy.mount(
@@ -12,6 +14,9 @@ describe('ButtonAction', () => {
         </Container>
       </>
     )
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'default',
+    })
   })
 })

--- a/cypress/component/ButtonCheckbox.spec.tsx
+++ b/cypress/component/ButtonCheckbox.spec.tsx
@@ -1,6 +1,8 @@
 import React from 'react'
 import { Button, Container } from '@toptal/picasso'
 
+const component = 'ButtonCheckbox'
+
 describe('Button.Checkbox', () => {
   it('renders different sizes', () => {
     cy.mount(
@@ -11,7 +13,10 @@ describe('Button.Checkbox', () => {
       </Container>
     )
 
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'all-sizes',
+    })
   })
 
   it('renders different states', () => {
@@ -27,6 +32,9 @@ describe('Button.Checkbox', () => {
       </Container>
     )
 
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'all-states',
+    })
   })
 })

--- a/cypress/component/ButtonCircular.spec.tsx
+++ b/cypress/component/ButtonCircular.spec.tsx
@@ -2,6 +2,8 @@ import React from 'react'
 import { Button, Container, Settings16 } from '@toptal/picasso'
 import { palette } from '@toptal/picasso/utils'
 
+const component = 'ButtonCircular'
+
 describe('Button.Circular', () => {
   it('renders flat variant', () => {
     cy.mount(
@@ -18,6 +20,9 @@ describe('Button.Circular', () => {
         <Button.Circular variant='flat' disabled icon={<Settings16 />} />
       </Container>
     )
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'flat',
+    })
   })
 })

--- a/cypress/component/ButtonRadio.spec.tsx
+++ b/cypress/component/ButtonRadio.spec.tsx
@@ -1,6 +1,8 @@
 import React from 'react'
 import { Button, Container } from '@toptal/picasso'
 
+const component = 'ButtonRadio'
+
 describe('Button.Radio', () => {
   it('renders different sizes', () => {
     cy.mount(
@@ -11,7 +13,10 @@ describe('Button.Radio', () => {
       </Container>
     )
 
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'all-sizes',
+    })
   })
 
   it('renders different states', () => {
@@ -27,6 +32,9 @@ describe('Button.Radio', () => {
       </Container>
     )
 
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'all-states',
+    })
   })
 })

--- a/cypress/component/ButtonSplit.spec.tsx
+++ b/cypress/component/ButtonSplit.spec.tsx
@@ -11,6 +11,8 @@ const menu = (
   </Menu>
 )
 
+const component = 'ButtonSplit'
+
 describe('Button.Split', () => {
   it('opens dropdown when menu button is clicked', () => {
     cy.mount(
@@ -23,6 +25,9 @@ describe('Button.Split', () => {
 
     cy.getByTestId('menu-button').click()
 
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'default/after-clicked',
+    })
   })
 })

--- a/cypress/component/Calendar.spec.tsx
+++ b/cypress/component/Calendar.spec.tsx
@@ -6,6 +6,8 @@ const TestCalendar = (props: ComponentProps<typeof Calendar>) => (
   <Calendar {...props} />
 )
 
+const component = 'Calendar'
+
 describe('Calendar', () => {
   // cy.clock() fixes the time so that the screenshots
   // in happo are not affected by server timezone
@@ -17,7 +19,10 @@ describe('Calendar', () => {
     it('renders default', () => {
       cy.mount(<TestCalendar onChange={noop} />)
 
-      cy.get('body').happoScreenshot()
+      cy.get('body').happoScreenshot({
+        component,
+        variant: 'no-custom-renderer',
+      })
     })
   })
 
@@ -62,7 +67,10 @@ describe('Calendar', () => {
         />
       )
 
-      cy.get('body').happoScreenshot()
+      cy.get('body').happoScreenshot({
+        component,
+        variant: 'no-custom-renderer/with-custom-layout',
+      })
     })
   })
 })

--- a/cypress/component/CategoriesChart.spec.tsx
+++ b/cypress/component/CategoriesChart.spec.tsx
@@ -13,11 +13,16 @@ const TestCategoriesChart = () => (
   </div>
 )
 
+const component = 'CategoriesChart'
+
 describe('CategoriesChart', () => {
   it('renders default chart', () => {
     cy.mount(<TestCategoriesChart />)
 
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'default',
+    })
   })
 })
 

--- a/cypress/component/Colors.spec.tsx
+++ b/cypress/component/Colors.spec.tsx
@@ -1,10 +1,15 @@
 import React from 'react'
 import Colors from '@toptal/picasso/utils/Colors/story/Default.example'
 
+const component = 'Colors'
+
 describe('Colors palette', () => {
   it('renders palette', () => {
     cy.mount(<Colors />)
 
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'default',
+    })
   })
 })

--- a/cypress/component/Container.spec.tsx
+++ b/cypress/component/Container.spec.tsx
@@ -27,23 +27,34 @@ const renderColorVariants = () =>
     </Container>
   ))
 
+const component = 'Container'
+
 describe('Container', () => {
   it('renders', () => {
     cy.mount(<Container>Some text</Container>)
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'default',
+    })
   })
 
   describe('colored variants', () => {
     it('renders all variants', () => {
       cy.mount(<>{renderColorVariants()}</>)
-      cy.get('body').happoScreenshot()
+      cy.get('body').happoScreenshot({
+        component,
+        variant: 'all-colors',
+      })
     })
 
     it('renders all variants with grey background', () => {
       cy.mount(
         <div style={{ backgroundColor: 'grey' }}>{renderColorVariants()}</div>
       )
-      cy.get('body').happoScreenshot()
+      cy.get('body').happoScreenshot({
+        component,
+        variant: 'all-colors/with-grey-background',
+      })
     })
   })
 
@@ -64,6 +75,9 @@ describe('Container', () => {
         ))}
       </>
     )
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'white-and-transparent/with-borders',
+    })
   })
 })

--- a/cypress/component/DatePicker.spec.tsx
+++ b/cypress/component/DatePicker.spec.tsx
@@ -13,11 +13,16 @@ const TestDatePicker = (props: Partial<DatePickerProps>) => {
   )
 }
 
+const component = 'DatePicker'
+
 describe('DatePicker', () => {
   it('renders autofocus', () => {
     cy.mount(<TestDatePicker autoFocus />)
 
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'autofocus',
+    })
   })
 
   it('renders range', () => {
@@ -28,7 +33,10 @@ describe('DatePicker', () => {
       />
     )
 
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'range',
+    })
   })
 
   it('renders value parsed by custom value parser', () => {
@@ -48,6 +56,9 @@ describe('DatePicker', () => {
 
     cy.getByTestId('date-picker-input').clear().type('2015')
 
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'custom-value-parser',
+    })
   })
 })

--- a/cypress/component/Drawer.spec.tsx
+++ b/cypress/component/Drawer.spec.tsx
@@ -84,6 +84,8 @@ const TestDrawerBehindModal = (props: Partial<DrawerProps>) => {
   )
 }
 
+const component = 'Drawer'
+
 describe('Drawer', () => {
   it('renders with narrow width and custom title', () => {
     cy.mount(
@@ -99,28 +101,40 @@ describe('Drawer', () => {
     )
 
     cy.getByTestId('trigger').click()
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'narrow-width/with-custom-title',
+    })
   })
 
   it('renders with regular width and title', () => {
     cy.mount(<TestDrawer width='regular' title='This is a regular Drawer' />)
 
     cy.getByTestId('trigger').click()
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'regular-width/with-title',
+    })
   })
 
   it('renders with medium width and notification', () => {
     cy.mount(<TestDrawerWithNotification width='medium' />)
 
     cy.getByTestId('trigger').click()
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'medium-width/with-notification',
+    })
   })
 
   it('renders with wide width and without title', () => {
     cy.mount(<TestDrawer width='wide' />)
 
     cy.getByTestId('trigger').click()
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'wide-width/without-title',
+    })
   })
 
   it('renders with ultra-wide width behind Modal', () => {
@@ -129,6 +143,9 @@ describe('Drawer', () => {
     cy.getByTestId('open-drawer').click()
     cy.getByTestId('open-modal').click()
 
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'ultra-wide/behind-modal',
+    })
   })
 })

--- a/cypress/component/Dropzone.spec.tsx
+++ b/cypress/component/Dropzone.spec.tsx
@@ -7,10 +7,15 @@ const renderDropzone = (props?: DropzoneProps) => (
   </Container>
 )
 
+const component = 'Dropzone'
+
 describe('Dropzone', () => {
   it('renders without props', () => {
     cy.mount(renderDropzone())
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'default',
+    })
   })
 
   it('renders with hint', () => {
@@ -21,7 +26,10 @@ describe('Dropzone', () => {
     )
     cy.contains('Max file size').should('be.visible')
 
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'with-hint',
+    })
   })
 
   it('renders with error', () => {
@@ -31,7 +39,10 @@ describe('Dropzone', () => {
         hint: 'Max file size: 25MB',
       })
     )
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'error',
+    })
   })
 
   it('renders with uploading files', () => {
@@ -42,18 +53,27 @@ describe('Dropzone', () => {
         ],
       })
     )
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'uploading',
+    })
   })
 
   it('renders hovered', () => {
     cy.mount(renderDropzone({ hovered: true }))
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'hovered-state',
+    })
   })
 
   it('renders focused', () => {
     cy.mount(renderDropzone({ focused: true }))
 
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'focused-state',
+    })
   })
 
   it('renders with progress bar', () => {
@@ -68,7 +88,10 @@ describe('Dropzone', () => {
         ],
       })
     )
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'uploading/with-progress-bar',
+    })
   })
 
   it('renders disabled', () => {
@@ -85,7 +108,10 @@ describe('Dropzone', () => {
         onRemove: () => {},
       })
     )
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'disabled',
+    })
   })
 
   it('renders completed with multiple files', () => {
@@ -107,6 +133,9 @@ describe('Dropzone', () => {
         onRemove: () => {},
       })
     )
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'completed/with-multiple-files',
+    })
   })
 })

--- a/cypress/component/EnvironmentBanner.spec.tsx
+++ b/cypress/component/EnvironmentBanner.spec.tsx
@@ -1,19 +1,32 @@
 import React from 'react'
 import { EnvironmentBanner } from '@toptal/picasso'
 
+const component = 'EnvironmentBanner'
+
 describe('EnvironmentBanner', () => {
   it('renders in development enviroment', () => {
     cy.mount(
       <EnvironmentBanner environment='development' productName='Picasso' />
     )
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'development-environment',
+    })
   })
+
   it('renders in staging enviroment', () => {
     cy.mount(<EnvironmentBanner environment='staging' productName='Picasso' />)
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'staging-environment',
+    })
   })
+
   it('renders in temploy enviroment', () => {
     cy.mount(<EnvironmentBanner environment='temploy' productName='Picasso' />)
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'temploy-environment',
+    })
   })
 })

--- a/cypress/component/FieldRequirements.spec.tsx
+++ b/cypress/component/FieldRequirements.spec.tsx
@@ -44,14 +44,22 @@ const FieldRequirementsExample = (
   />
 )
 
+const component = 'FieldRequirements'
+
 describe('FieldRequirements', () => {
   it('renders requirements with bullets and checks for default', () => {
     cy.mount(<FieldRequirementsExample value='dene' />)
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'default',
+    })
   })
 
   it('renders requirements with close icons and checks for error', () => {
     cy.mount(<FieldRequirementsExample error />)
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'error',
+    })
   })
 })

--- a/cypress/component/FileInput.spec.tsx
+++ b/cypress/component/FileInput.spec.tsx
@@ -5,6 +5,8 @@ const TestFileInput = (props: FileInputProps = {}) => (
   <FileInput hint='No file uploaded.' {...props} />
 )
 
+const component = 'FileInput'
+
 describe('FileInput', () => {
   it('opens file dialog', () => {
     cy.mount(<TestFileInput />)
@@ -21,12 +23,18 @@ describe('FileInput', () => {
       .click()
       .should(() => expect(openFileDialog).to.be.called)
 
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'default/after-clicked',
+    })
   })
 
   it('renders with changed label', () => {
     cy.mount(<TestFileInput buttonLabel='Upload File' />)
 
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'custom-label',
+    })
   })
 })

--- a/cypress/component/Form.spec.tsx
+++ b/cypress/component/Form.spec.tsx
@@ -291,6 +291,8 @@ const DisabledStateExample = () => {
   )
 }
 
+const component = 'Form'
+
 describe('Form', () => {
   it('submits the form with success result', () => {
     cy.mount(<FormExample />)
@@ -345,6 +347,9 @@ describe('Form', () => {
   it('disabled state visual', () => {
     cy.mount(<DisabledStateExample />)
 
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'disabled',
+    })
   })
 })

--- a/cypress/component/Icon.spec.tsx
+++ b/cypress/component/Icon.spec.tsx
@@ -2,6 +2,8 @@ import React from 'react'
 import { Container, Typography } from '@toptal/picasso'
 import * as icons from '@toptal/picasso/Icon'
 
+const component = 'Icon'
+
 describe('Icon', () => {
   it('renders all icons', () => {
     cy.mount(
@@ -25,6 +27,9 @@ describe('Icon', () => {
         })}
       </Container>
     )
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'all-icons',
+    })
   })
 })

--- a/cypress/component/Link.spec.tsx
+++ b/cypress/component/Link.spec.tsx
@@ -34,6 +34,8 @@ const TestUserBadgeLink = () => {
   )
 }
 
+const component = 'Link'
+
 describe('Link', () => {
   it('renders', () => {
     cy.mount(
@@ -41,7 +43,10 @@ describe('Link', () => {
         <Link>Link</Link>
       </Typography>
     )
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'default',
+    })
   })
 
   it('renders action variant', () => {
@@ -50,7 +55,10 @@ describe('Link', () => {
         <Link variant='action'>Action link</Link>
       </Typography>
     )
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'action',
+    })
   })
 
   describe('when action variant and disabled', () => {
@@ -62,7 +70,10 @@ describe('Link', () => {
           </Link>
         </Typography>
       )
-      cy.get('body').happoScreenshot()
+      cy.get('body').happoScreenshot({
+        component,
+        variant: 'disabled/without-underline',
+      })
     })
   })
 
@@ -74,7 +85,10 @@ describe('Link', () => {
         </Typography>
       </Container>
     )
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'default/with-white-color',
+    })
   })
 
   it('renders big link', () => {
@@ -83,7 +97,10 @@ describe('Link', () => {
         Big <Link>link</Link>
       </Typography>
     )
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'heading/large',
+    })
   })
 
   it('renders without underline', () => {
@@ -92,12 +109,18 @@ describe('Link', () => {
         <Link noUnderline>Link</Link>
       </Typography>
     )
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'default/without-underline',
+    })
   })
 
   it('renders user badge link', () => {
     cy.mount(<TestUserBadgeLink />)
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'with-user-badge',
+    })
   })
 
   describe('when hover over the link', () => {

--- a/cypress/component/List.spec.tsx
+++ b/cypress/component/List.spec.tsx
@@ -11,12 +11,17 @@ const generateListItems = (total: number, listItemProps?: any) =>
       </List.Item>
     ))
 
+const component = 'List'
+
 describe('List', () => {
   describe('Unordered', () => {
     it('renders unordered', () => {
       cy.mount(<List>{generateListItems(5)}</List>)
 
-      cy.get('body').happoScreenshot()
+      cy.get('body').happoScreenshot({
+        component,
+        variant: 'unordered',
+      })
     })
 
     it('renders with custom icons', () => {
@@ -26,7 +31,10 @@ describe('List', () => {
 
       cy.mount(<List>{generateListItems(5, listItemProps)}</List>)
 
-      cy.get('body').happoScreenshot()
+      cy.get('body').happoScreenshot({
+        component,
+        variant: 'custom-icons',
+      })
     })
 
     context('when put into reduced font-size container', () => {
@@ -38,7 +46,10 @@ describe('List', () => {
           </Container>
         )
 
-        cy.get('body').happoScreenshot()
+        cy.get('body').happoScreenshot({
+          component,
+          variant: 'inside-reduced-font-size-container',
+        })
       })
     })
   })
@@ -47,7 +58,10 @@ describe('List', () => {
     it('renders ordered', () => {
       cy.mount(<List variant='ordered'>{generateListItems(5)}</List>)
 
-      cy.get('body').happoScreenshot()
+      cy.get('body').happoScreenshot({
+        component,
+        variant: 'ordered',
+      })
     })
 
     it('renders with custom start', () => {

--- a/cypress/component/Menu.spec.tsx
+++ b/cypress/component/Menu.spec.tsx
@@ -87,22 +87,34 @@ describe('Menu', () => {
   it('navigates drilldown menu', () => {
     cy.mount(<MenuExample variant='drilldown' />)
     cy.getByTestId('menu-b').should('not.exist')
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'drilldown/before-mouseover-item',
+    })
 
     cy.getByTestId('item-b').trigger('mouseover')
     cy.getByTestId('menu-b').should('be.visible')
     cy.getByTestId('menu-b1').should('not.exist')
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'drilldown/after-mouseover-item',
+    })
 
     cy.getByTestId('item-b1').trigger('mouseover')
     cy.getByTestId('menu-b').should('be.visible')
     cy.getByTestId('menu-b1').should('be.visible')
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'drilldown/after-mouseover-subitem',
+    })
 
     cy.getByTestId('menu-b1').trigger('mouseout')
     cy.getByTestId('item-b').trigger('mouseover')
     cy.getByTestId('menu-b').should('be.visible')
     cy.getByTestId('menu-b1').should('not.exist')
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'drilldown/after-mouseout-subitem',
+    })
   })
 })

--- a/cypress/component/Modal.spec.tsx
+++ b/cypress/component/Modal.spec.tsx
@@ -134,46 +134,69 @@ const TestModalOverflown = (props: Partial<Omit<ModalProps, 'open'>>) => (
   </Modal>
 )
 
+const component = 'Modal'
+
 describe('Modal', () => {
   it('renders', () => {
     cy.mount(<TestModalForm />)
 
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'default',
+    })
   })
 
   it('renders aligned to top', () => {
     cy.mount(<TestModalForm align='top' />)
 
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'align-top',
+    })
   })
 
   it('renders without backdrop', () => {
     cy.mount(<TestModalForm hideBackdrop />)
 
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'without-backdrop',
+    })
   })
 
   it('renders small', () => {
     cy.mount(<TestModalForm size='small' />)
 
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'size/small',
+    })
   })
 
   it('renders large', () => {
     cy.mount(<TestModalForm size='large' />)
 
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'size/large',
+    })
   })
 
   it('renders full-screen', () => {
     cy.mount(<TestModalForm size='full-screen' />)
 
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'size/full-screen',
+    })
   })
 
   it('renders overflown', () => {
     cy.mount(<TestModalOverflown />)
 
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'overflown',
+    })
   })
 })

--- a/cypress/component/Note.spec.tsx
+++ b/cypress/component/Note.spec.tsx
@@ -11,9 +11,14 @@ const NoteExample = () => (
   </Note>
 )
 
+const component = 'Note'
+
 describe('Note', () => {
   it('renders', () => {
     cy.mount(<NoteExample />)
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'default',
+    })
   })
 })

--- a/cypress/component/NumberInput.spec.tsx
+++ b/cypress/component/NumberInput.spec.tsx
@@ -11,18 +11,26 @@ const NumberInputExample = ({ status }: Partial<NumberInputProps>) => (
   />
 )
 
+const component = 'NumberInput'
+
 describe('NumberInput', () => {
   it('renders', () => {
     cy.mount(<NumberInputExample />)
 
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'default',
+    })
   })
 
   describe('when in a valid state', () => {
     it('shows valid icon', () => {
       cy.mount(<NumberInputExample status='success' />)
 
-      cy.get('body').happoScreenshot()
+      cy.get('body').happoScreenshot({
+        component,
+        variant: 'valid',
+      })
     })
   })
 
@@ -30,7 +38,10 @@ describe('NumberInput', () => {
     it('shows error', () => {
       cy.mount(<NumberInputExample status='error' />)
 
-      cy.get('body').happoScreenshot()
+      cy.get('body').happoScreenshot({
+        component,
+        variant: 'error',
+      })
     })
   })
 })

--- a/cypress/component/Pagination.spec.tsx
+++ b/cypress/component/Pagination.spec.tsx
@@ -20,38 +20,58 @@ const PaginationExample = ({
   )
 }
 
+const component = 'Pagination'
+
 describe('Pagination', () => {
   it('renders', () => {
     cy.mount(<PaginationExample activePage={3} totalPages={5} />)
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'default',
+    })
   })
 
   it('renders start ellipsis', () => {
     cy.mount(<PaginationExample activePage={5} totalPages={5} />)
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'forced-start-ellipsis',
+    })
   })
 
   it('renders end ellipsis', () => {
     cy.mount(<PaginationExample activePage={1} totalPages={5} />)
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'forced-end-ellipsis',
+    })
   })
 
   it('renders both ellipsis', () => {
     cy.mount(<PaginationExample activePage={5} totalPages={10} />)
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'forced-both-ellipsis',
+    })
   })
 
   it('renders both ellipsis with custom siblings count', () => {
     cy.mount(
       <PaginationExample activePage={5} totalPages={10} siblingCount={3} />
     )
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'forced-both-ellipsis/sibling-count',
+    })
   })
 
   it('renders compact', () => {
     cy.mount(
       <PaginationExample activePage={5} totalPages={10} variant='compact' />
     )
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'compact',
+    })
   })
 })

--- a/cypress/component/PasswordInput.spec.tsx
+++ b/cypress/component/PasswordInput.spec.tsx
@@ -13,15 +13,23 @@ const PasswordInputExample = ({ status }: Partial<PasswordInputProps>) => (
   />
 )
 
+const component = 'PasswordInput'
+
 describe('PasswordInput', () => {
   describe('when toggle button clicked', () => {
     it('shows password', () => {
       cy.mount(<PasswordInputExample />)
-      cy.get('body').happoScreenshot()
+      cy.get('body').happoScreenshot({
+        component,
+        variant: 'default/before-toggle-clicked',
+      })
 
       cy.getByTestId('password-input-toggle').click()
 
-      cy.get('body').happoScreenshot()
+      cy.get('body').happoScreenshot({
+        component,
+        variant: 'default/before-toggle-clicked',
+      })
     })
   })
 
@@ -29,7 +37,10 @@ describe('PasswordInput', () => {
     it('shows valid icon', () => {
       cy.mount(<PasswordInputExample status='success' />)
 
-      cy.get('body').happoScreenshot()
+      cy.get('body').happoScreenshot({
+        component,
+        variant: 'success-state',
+      })
     })
   })
 })

--- a/cypress/component/ProgressBar.spec.tsx
+++ b/cypress/component/ProgressBar.spec.tsx
@@ -1,42 +1,62 @@
 import React from 'react'
 import { ProgressBar } from '@toptal/picasso'
 
+const component = 'ProgressBar'
+
 describe('ProgressBar', () => {
   it('renders', () => {
     cy.mount(<ProgressBar value={50} />)
 
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'default',
+    })
   })
 
   it('renders empty progress bar when value  <= 0', () => {
     cy.mount(<ProgressBar value={0} />)
 
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'default/with-empty-value',
+    })
   })
 
   it('renders full progress bar when value >= 100', () => {
     cy.mount(<ProgressBar value={100} />)
 
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'default/with-full-value',
+    })
   })
 
   describe('with percentage', () => {
     it('renders', () => {
       cy.mount(<ProgressBar value={50} showPercentage />)
 
-      cy.get('body').happoScreenshot()
+      cy.get('body').happoScreenshot({
+        component,
+        variant: 'percentage',
+      })
     })
 
     it('renders empty progress bar when value <= 0', () => {
       cy.mount(<ProgressBar value={0} showPercentage />)
 
-      cy.get('body').happoScreenshot()
+      cy.get('body').happoScreenshot({
+        component,
+        variant: 'percentage/empty-value',
+      })
     })
 
     it('renders full progress bar when value >= 100', () => {
       cy.mount(<ProgressBar value={100} showPercentage />)
 
-      cy.get('body').happoScreenshot()
+      cy.get('body').happoScreenshot({
+        component,
+        variant: 'percentage/full-value',
+      })
     })
   })
 })

--- a/cypress/component/PromptModal.spec.tsx
+++ b/cypress/component/PromptModal.spec.tsx
@@ -2,6 +2,8 @@ import React from 'react'
 import { PromptModal } from '@toptal/picasso'
 import { noop } from '@toptal/picasso/utils'
 
+const component = 'PromptModal'
+
 describe('PromptModal', () => {
   it('renders on desktop and mobile', () => {
     cy.mount(
@@ -13,10 +15,14 @@ describe('PromptModal', () => {
         submitText='OK'
       />
     )
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'default',
+    })
 
     cy.get('body').happoScreenshot({
-      component: 'PromptModal',
+      component,
+      variant: 'to-small-target',
       targets: [
         // eslint-disable-next-line @typescript-eslint/ban-ts-comment
         // @ts-ignore

--- a/cypress/component/Rating.spec.tsx
+++ b/cypress/component/Rating.spec.tsx
@@ -20,12 +20,18 @@ const renderRating = (props = defaultProps) => (
   </Container>
 )
 
+const component = 'RatingStars'
+
 describe('Rating.Stars', () => {
   it('renders default rating', () => {
     cy.mount(renderRating())
 
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'default',
+    })
   })
+
   it('renders rating hover', () => {
     cy.mount(
       renderRating({
@@ -41,13 +47,21 @@ describe('Rating.Stars', () => {
       })
     )
 
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'interactive/after-hovered',
+    })
   })
+
   it('renders large rating', () => {
     cy.mount(renderRating({ ...defaultProps, size: 'large' }))
 
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'size/large',
+    })
   })
+
   it('renders large rating hover', () => {
     const size = 'large'
 
@@ -66,13 +80,21 @@ describe('Rating.Stars', () => {
       })
     )
 
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'interactive-and-size-large/after-hovered',
+    })
   })
+
   it('renders inactive rating', () => {
     cy.mount(renderRating({ ...defaultProps, interactive: false }))
 
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'inactive',
+    })
   })
+
   it('renders custom icon rating', () => {
     const customValue = 3
 
@@ -85,6 +107,9 @@ describe('Rating.Stars', () => {
       })
     )
 
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'custom-icon',
+    })
   })
 })

--- a/cypress/component/RatingThumbs.spec.tsx
+++ b/cypress/component/RatingThumbs.spec.tsx
@@ -11,7 +11,7 @@ const renderRatingThumbs = (props: Partial<RatingThumbsProps> = {}) => (
   </Container>
 )
 
-const screenshot = () => cy.get('body').happoScreenshot()
+const component = 'RatingThumbs'
 
 describe('Rating.Thumbs', () => {
   describe('when using different values', () => {
@@ -19,7 +19,10 @@ describe('Rating.Thumbs', () => {
       it(`renders the correct thumb as active if any [value: ${value}]`, () => {
         cy.mount(renderRatingThumbs({ value }))
 
-        screenshot()
+        cy.get('body').happoScreenshot({
+          component,
+          variant: 'various-values',
+        })
       })
     }
   })
@@ -29,7 +32,10 @@ describe('Rating.Thumbs', () => {
       it(`renders the correct size thumb [size: ${size}]`, () => {
         cy.mount(renderRatingThumbs({ size }))
 
-        screenshot()
+        cy.get('body').happoScreenshot({
+          component,
+          variant: 'all-sizes',
+        })
       })
     }
   })

--- a/cypress/component/RichText.spec.tsx
+++ b/cypress/component/RichText.spec.tsx
@@ -125,11 +125,15 @@ const ast: ASTType = {
 }
 
 const style = { maxWidth: '500px' }
+const component = 'RichText'
 
 describe('RichText', () => {
   it('renders picasso components correctly', () => {
     cy.mount(<RichText style={style} value={ast} />)
 
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'default',
+    })
   })
 })

--- a/cypress/component/RichTextEditor.spec.tsx
+++ b/cypress/component/RichTextEditor.spec.tsx
@@ -73,12 +73,17 @@ const setAliases = () => {
   cy.getByTestId(wrapper).as('wrapper')
 }
 
+const component = 'RichTextEditor'
+
 describe('RichTextEditor', () => {
   describe('when in an invalid state', () => {
     it('shows error', () => {
       cy.mount(renderEditor({ ...defaultProps, status: 'error' }))
 
-      cy.get('body').happoScreenshot()
+      cy.get('body').happoScreenshot({
+        component,
+        variant: 'error',
+      })
     })
   })
 
@@ -174,7 +179,10 @@ describe('RichTextEditor', () => {
     cy.get('@olButton').realClick()
     cy.get('@editor').realType('ordered list item{enter}')
 
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'default/after-typed-and-formatted',
+    })
   })
 
   describe('select all and delete', () => {
@@ -299,7 +307,10 @@ describe('RichTextEditor', () => {
       // render editor
       cy.mount(renderEditor({ ...defaultProps, disabled: true }))
 
-      cy.get('body').happoScreenshot()
+      cy.get('body').happoScreenshot({
+        component,
+        variant: 'disabled',
+      })
     })
 
     it('cannot be focused', () => {

--- a/cypress/component/Section.spec.tsx
+++ b/cypress/component/Section.spec.tsx
@@ -110,11 +110,16 @@ const TestSection = ({
   )
 }
 
+const component = 'Section'
+
 describe('Section', () => {
   it('renders', () => {
     cy.mount(<TestSection />)
 
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'default',
+    })
   })
 
   it('renders with actions', () => {
@@ -128,24 +133,36 @@ describe('Section', () => {
       />
     )
 
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'default/with-actions',
+    })
   })
 
   it('renders with bordered variant', () => {
     cy.mount(<TestSection variant='bordered' />)
 
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'bordered',
+    })
   })
   it('renders with withHeaderBar variant', () => {
     cy.mount(<TestSection variant='withHeaderBar' />)
 
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'with-header-bar',
+    })
   })
   describe('when collapsible', () => {
     it('renders initially collapsed', () => {
       cy.mount(<TestSection collapsible />)
 
-      cy.get('body').happoScreenshot()
+      cy.get('body').happoScreenshot({
+        component,
+        variant: 'collapsed',
+      })
     })
 
     it('renders initially expanded', () => {
@@ -161,7 +178,10 @@ describe('Section', () => {
         />
       )
 
-      cy.get('body').happoScreenshot()
+      cy.get('body').happoScreenshot({
+        component,
+        variant: 'expanded',
+      })
     })
   })
 })

--- a/cypress/component/Select.spec.tsx
+++ b/cypress/component/Select.spec.tsx
@@ -160,13 +160,18 @@ const pressEnter = () => {
 
 const getNativeSelect = () => cy.get('select')
 
+const component = 'Select'
+
 /* eslint-disable max-lines-per-function */
 /* eslint-disable max-statements */
 describe('Select', () => {
   it('renders', () => {
     cy.mount(<TestSelect />)
 
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'default',
+    })
   })
 
   it('renders open', () => {
@@ -174,7 +179,10 @@ describe('Select', () => {
 
     openSelect()
 
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'default/after-clicked',
+    })
   })
 
   it('reveals partially visible option when it is hovered', () => {
@@ -202,26 +210,38 @@ describe('Select', () => {
       lastHalfVisibleOption?.dispatchEvent(mouseOverEvent)
 
       // the options list should slightly scroll to show the hovered option
-      return cy.get('body').happoScreenshot()
+      return cy.get('body').happoScreenshot({
+        component,
+        variant: 'default/after-hovered-partially-visible-last-option',
+      })
     })
   })
 
   it('renders disabled', () => {
     cy.mount(<TestSelect disabled />)
 
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'disabled',
+    })
   })
 
   it('renders with value', () => {
     cy.mount(<TestSelect value={OPTIONS[0].value} />)
 
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'default/after-selected',
+    })
   })
 
   it('renders with error', () => {
     cy.mount(<TestSelect status='error' />)
 
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'error',
+    })
   })
 
   it('renders in different width modes', () => {
@@ -232,7 +252,10 @@ describe('Select', () => {
       </>
     )
 
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'different-widths',
+    })
   })
 
   it('renders loading', () => {
@@ -240,13 +263,19 @@ describe('Select', () => {
 
     openSelect()
 
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'loading',
+    })
   })
 
   it('renders loading in native mode', () => {
     cy.mount(<TestSelect native loading />)
 
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'native-loading',
+    })
   })
 
   it('renders with custom menu width', () => {
@@ -254,7 +283,10 @@ describe('Select', () => {
 
     openSelect()
 
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'custom-menu-width',
+    })
   })
 
   it('renders reset button', () => {
@@ -273,13 +305,19 @@ describe('Select', () => {
       'visibility: visible'
     )
 
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'with-reset-button',
+    })
   })
 
   it('renders in small size', () => {
     cy.mount(<TestSelect size='small' />)
 
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'size/small',
+    })
   })
 
   it('renders options with description', () => {
@@ -294,7 +332,10 @@ describe('Select', () => {
 
     openSelect()
 
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'options-with-description',
+    })
   })
 
   it('renders with icon', () => {
@@ -306,7 +347,10 @@ describe('Select', () => {
       </>
     )
 
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'with-icon',
+    })
   })
 
   it('changes native select value', () => {
@@ -329,7 +373,10 @@ describe('Select', () => {
       </>
     )
 
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'various-states',
+    })
   })
 
   it('highlights grouped options via keys correctly', () => {
@@ -395,7 +442,10 @@ describe('Select', () => {
 
       cy.getByTestId('select').click().find('input').should('be.focused')
 
-      cy.get('body').happoScreenshot()
+      cy.get('body').happoScreenshot({
+        component,
+        variant: 'with-search-input',
+      })
 
       // focuses on the Search input by clicking on the input
       cy.getByTestId('search-input')

--- a/cypress/component/ShowMore.spec.tsx
+++ b/cypress/component/ShowMore.spec.tsx
@@ -3,16 +3,23 @@ import { ShowMore } from '@toptal/picasso'
 
 const text =
   '1. More about contact\r\n\r\nlocation:\r\n\r\nblah blah blah blah blah\r\n\r\nblah blah blah blah blah\r\n\r\nblah blah blah blah blah\r\n\r\nblah blah blah\r\n\r\n2. More about contact\r\n\r\nlocation:\r\n\r\nblah blah blah blah blah\r\n\r\nblah blah blah blah blah\r\n\r\nblah blah blah blah blah\r\n\r\nblah blah blah\r\n\r\n1. More about contact\r\n\r\nlocation:\r\n\r\nblah blah blah blah blah\r\n\r\nblah blah blah blah blah\r\n\r\nblah blah blah blah blah\r\n\r\nblah blah blah'
+const component = 'ShowMore'
 
 describe('ShowMore', () => {
   it('renders expanded ShowMore with line breaks', () => {
     cy.mount(<ShowMore initialExpanded>{text}</ShowMore>)
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'expanded',
+    })
   })
 
   it('renders not expanded ShowMore with line breaks', () => {
     cy.mount(<ShowMore>{text}</ShowMore>)
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'collapsed',
+    })
   })
 
   it('renders ShowMore without line breaks', () => {
@@ -37,7 +44,10 @@ describe('ShowMore', () => {
         deleniti, beatae quo? Eaque similique nemo omnis quasi?
       </ShowMore>
     )
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'without-line-breaks',
+    })
   })
 
   it('Renders 0 rows', () => {
@@ -57,6 +67,9 @@ describe('ShowMore', () => {
     )
 
     cy.getByTestId(contentWrapper).should('have.value', '')
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'zero-rows',
+    })
   })
 })

--- a/cypress/component/Slider.spec.tsx
+++ b/cypress/component/Slider.spec.tsx
@@ -29,22 +29,33 @@ const renderLabel = (value: number | number[]) => {
   return <Typography color='inherit'>GMT+{formattedVal}:00</Typography>
 }
 
+const component = 'Slider'
+
 describe('Slider', () => {
   it('renders single', () => {
     cy.mount(<TestSlider value={10} />)
 
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'single',
+    })
   })
 
   it('renders range', () => {
     cy.mount(<TestSlider value={[10, 20]} tooltipFormat={renderLabel} />)
 
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'range',
+    })
   })
 
   it('renders range with tooltips intersect', () => {
     cy.mount(<TestSlider value={[10, 11]} tooltipFormat={renderLabel} />)
 
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'range/when-tooltip-intersect',
+    })
   })
 })

--- a/cypress/component/Stepper.spec.tsx
+++ b/cypress/component/Stepper.spec.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { Stepper, Container } from '@toptal/picasso'
 
 const STEPS = ['Step 1', 'Step 2', 'Step 3', 'Step 4']
+const component = 'Stepper'
 
 describe('Stepper', () => {
   describe('with label', () => {
@@ -11,7 +12,10 @@ describe('Stepper', () => {
           <Stepper steps={STEPS} />
         </Container>
       )
-      cy.get('body').happoScreenshot()
+      cy.get('body').happoScreenshot({
+        component,
+        variant: 'with-label',
+      })
     })
 
     it('renders first step active', () => {
@@ -20,7 +24,10 @@ describe('Stepper', () => {
           <Stepper active={1} steps={STEPS} />
         </Container>
       )
-      cy.get('body').happoScreenshot()
+      cy.get('body').happoScreenshot({
+        component,
+        variant: 'with-label/first-step-active',
+      })
     })
     it('renders third step active', () => {
       cy.mount(
@@ -28,7 +35,10 @@ describe('Stepper', () => {
           <Stepper active={3} steps={STEPS} />
         </Container>
       )
-      cy.get('body').happoScreenshot()
+      cy.get('body').happoScreenshot({
+        component,
+        variant: 'with-label/third-step-active',
+      })
     })
     it('renders all steps active', () => {
       cy.mount(
@@ -36,7 +46,10 @@ describe('Stepper', () => {
           <Stepper active={4} steps={STEPS} />
         </Container>
       )
-      cy.get('body').happoScreenshot()
+      cy.get('body').happoScreenshot({
+        component,
+        variant: 'with-label/all-steps-active',
+      })
     })
   })
 
@@ -47,7 +60,10 @@ describe('Stepper', () => {
           <Stepper steps={STEPS} hideLabels />
         </Container>
       )
-      cy.get('body').happoScreenshot()
+      cy.get('body').happoScreenshot({
+        component,
+        variant: 'without-label',
+      })
     })
 
     it('renders first step active', () => {
@@ -56,7 +72,10 @@ describe('Stepper', () => {
           <Stepper active={1} steps={STEPS} hideLabels />
         </Container>
       )
-      cy.get('body').happoScreenshot()
+      cy.get('body').happoScreenshot({
+        component,
+        variant: 'without-label/first-step-active',
+      })
     })
     it('renders third step active', () => {
       cy.mount(
@@ -64,7 +83,10 @@ describe('Stepper', () => {
           <Stepper active={3} steps={STEPS} hideLabels />
         </Container>
       )
-      cy.get('body').happoScreenshot()
+      cy.get('body').happoScreenshot({
+        component,
+        variant: 'without-label/third-step-active',
+      })
     })
     it('renders all steps active', () => {
       cy.mount(
@@ -72,7 +94,10 @@ describe('Stepper', () => {
           <Stepper active={4} steps={STEPS} hideLabels />
         </Container>
       )
-      cy.get('body').happoScreenshot()
+      cy.get('body').happoScreenshot({
+        component,
+        variant: 'without-label/all-steps-active',
+      })
     })
   })
 
@@ -83,7 +108,10 @@ describe('Stepper', () => {
           <Stepper.Vertical steps={STEPS} />
         </Container>
       )
-      cy.get('body').happoScreenshot()
+      cy.get('body').happoScreenshot({
+        component,
+        variant: 'vertical',
+      })
     })
 
     it('renders first step active', () => {
@@ -92,7 +120,10 @@ describe('Stepper', () => {
           <Stepper.Vertical active={1} steps={STEPS} />
         </Container>
       )
-      cy.get('body').happoScreenshot()
+      cy.get('body').happoScreenshot({
+        component,
+        variant: 'vertical/first-step-active',
+      })
     })
     it('renders third step active', () => {
       cy.mount(
@@ -100,7 +131,10 @@ describe('Stepper', () => {
           <Stepper.Vertical active={3} steps={STEPS} />
         </Container>
       )
-      cy.get('body').happoScreenshot()
+      cy.get('body').happoScreenshot({
+        component,
+        variant: 'vertical/third-step-active',
+      })
     })
     it('renders all steps active', () => {
       cy.mount(
@@ -108,7 +142,10 @@ describe('Stepper', () => {
           <Stepper.Vertical active={4} steps={STEPS} />
         </Container>
       )
-      cy.get('body').happoScreenshot()
+      cy.get('body').happoScreenshot({
+        component,
+        variant: 'vertical/all-steps-active',
+      })
     })
   })
 })

--- a/cypress/component/Table.spec.tsx
+++ b/cypress/component/Table.spec.tsx
@@ -281,71 +281,106 @@ type Data = {
   defaultExpanded: boolean
 }
 
+const component = 'Table'
+
 describe('Table', () => {
   it('renders default', () => {
     cy.mount(renderTable())
 
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'default',
+    })
   })
 
   it('renders clear', () => {
     cy.mount(renderTable({ variant: 'clear' }))
 
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'clear',
+    })
   })
 
   it('renders striped', () => {
     cy.mount(renderTable({ variant: 'striped' }))
 
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'striped',
+    })
   })
 
   it('renders bordered', () => {
     cy.mount(renderTable({ variant: 'bordered' }))
 
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'bordered',
+    })
   })
 
   it('renders narrow', () => {
     cy.mount(renderTable({ spacing: 'narrow' }))
 
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'narrow',
+    })
   })
 
   it('renders compact', () => {
     cy.mount(renderTable({ spacing: 'compact' }))
 
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'compact',
+    })
   })
 
   it('renders compact and striped', () => {
     cy.mount(renderTable({ variant: 'striped', spacing: 'compact' }))
 
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'compact-and-striped',
+    })
   })
 
   it('renders narrow and clear', () => {
     cy.mount(renderTable({ variant: 'clear', spacing: 'narrow' }))
 
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'narrow-and-clear',
+    })
   })
 
   it('renders with section heading', () => {
     cy.mount(renderTable({}, ['January']))
 
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'with-section-heading',
+    })
   })
 
   it('renders with multiple section headings', () => {
     cy.mount(renderTable({}, ['January', 'February']))
 
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'with-multiple-section-heading',
+    })
   })
 
   it('renders selectable table', () => {
     cy.mount(<SelectableExample />)
 
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'selectable',
+    })
   })
 
   it('renders expandable rows', () => {
@@ -378,7 +413,10 @@ describe('Table', () => {
 
     cy.mount(<TableExpandableRowsExample localData={localData} />)
 
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'expandable-rows',
+    })
 
     cy.getByTestId('job').as('job').should('be.visible')
 
@@ -420,7 +458,10 @@ describe('Table', () => {
 
     cy.mount(<TableExpandableRowsExample localData={localData} />)
 
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'expandable-rows/default-expanded',
+    })
 
     cy.getByTestId('job').as('job').should('be.visible')
 

--- a/cypress/component/TableCell.spec.tsx
+++ b/cypress/component/TableCell.spec.tsx
@@ -28,6 +28,8 @@ const AlignExample = () => (
   </div>
 )
 
+const component = 'TableCell'
+
 describe('TableCell', () => {
   it('row spans', () => {
     cy.mount(
@@ -43,12 +45,18 @@ describe('TableCell', () => {
         </Table.Body>
       </Table>
     )
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'row-span',
+    })
   })
 
   it('aligns cells', () => {
     cy.mount(<AlignExample />)
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'align-cells',
+    })
   })
 })
 

--- a/cypress/component/Tabs.spec.tsx
+++ b/cypress/component/Tabs.spec.tsx
@@ -64,23 +64,34 @@ const renderTabs = ({
   )
 }
 
+const component = 'Tabs'
+
 describe('Tabs', () => {
   it('renders', () => {
     cy.mount(renderTabs())
 
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'default',
+    })
   })
 
   it('renders disabled', () => {
     cy.mount(renderTabs({ disabledIndicies: [1] }))
 
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'disabled',
+    })
   })
 
   it('renders with icon', () => {
     cy.mount(renderTabs({ withIconIndicies: [0, 3] }))
 
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'with-icon',
+    })
   })
 
   it('navigates with scroll buttons', () => {
@@ -90,7 +101,10 @@ describe('Tabs', () => {
     cy.get(getTabSelector(4)).should('not.be.visible')
     cy.get(getScrollButtonSelector('left')).should('not.exist')
     cy.get(getScrollButtonSelector('right')).should('be.visible')
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'with-scroll-buttons',
+    })
 
     cy.get(getScrollButtonSelector('right')).click()
     cy.get(getTabSelector(0)).should('not.be.visible')

--- a/cypress/component/Tag.spec.tsx
+++ b/cypress/component/Tag.spec.tsx
@@ -68,6 +68,8 @@ const renderRectangularTag = ({ variant }: RectangularTagArgs) => (
   </Container>
 )
 
+const component = 'Tag'
+
 describe('Tag', () => {
   it('allows to overflow with ellipsis', () => {
     cy.mount(
@@ -79,7 +81,10 @@ describe('Tag', () => {
         </Tag>
       </Container>
     )
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'overflow-with-ellipsis',
+    })
   })
 
   it('renders in group', () => {
@@ -91,60 +96,104 @@ describe('Tag', () => {
         <Tag>Vue JS</Tag>
       </Tag.Group>
     )
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'group',
+    })
   })
+
   describe('Regular', () => {
     describe('Variants', () => {
       it('renders as blue', () => {
         cy.mount(renderRegularTag({ variant: 'blue' }))
 
-        cy.get('body').happoScreenshot()
+        cy.get('body').happoScreenshot({
+          component,
+          variant: 'regular/blue',
+        })
       })
+
       it('renders as grey', () => {
         cy.mount(renderRegularTag({ variant: 'light-grey' }))
 
-        cy.get('body').happoScreenshot()
+        cy.get('body').happoScreenshot({
+          component,
+          variant: 'regular/grey',
+        })
       })
+
       it('renders as green', () => {
         cy.mount(renderRegularTag({ variant: 'green' }))
 
-        cy.get('body').happoScreenshot()
+        cy.get('body').happoScreenshot({
+          component,
+          variant: 'regular/green',
+        })
       })
+
       it('renders as yellow', () => {
         cy.mount(renderRegularTag({ variant: 'yellow' }))
 
-        cy.get('body').happoScreenshot()
+        cy.get('body').happoScreenshot({
+          component,
+          variant: 'regular/yellow',
+        })
       })
+
       it('renders as red', () => {
         cy.mount(renderRegularTag({ variant: 'red' }))
 
-        cy.get('body').happoScreenshot()
+        cy.get('body').happoScreenshot({
+          component,
+          variant: 'regular/red',
+        })
       })
     })
+
     describe('Interactive', () => {
       it('renders', () => {
         cy.mount(renderCheckableTag({}))
-        cy.get('body').happoScreenshot()
+        cy.get('body').happoScreenshot({
+          component,
+          variant: 'interactive',
+        })
       })
+
       it('renders hovered', () => {
         cy.mount(renderCheckableTag({ hovered: true }))
-        cy.get('body').happoScreenshot()
+        cy.get('body').happoScreenshot({
+          component,
+          variant: 'interactive/hovered',
+        })
       })
+
       it('renders selected', () => {
         cy.mount(renderCheckableTag({ checked: true }))
-        cy.get('body').happoScreenshot()
+        cy.get('body').happoScreenshot({
+          component,
+          variant: 'interactive/checked',
+        })
       })
+
       it('renders selected hovered', () => {
         cy.mount(renderCheckableTag({ checked: true, hovered: true }))
-        cy.get('body').happoScreenshot()
+        cy.get('body').happoScreenshot({
+          component,
+          variant: 'interactive/checked-and-hovered',
+        })
       })
+
       it('renders disabled', () => {
         cy.mount(
           renderCheckableTag({ checked: true, hovered: true, disabled: true })
         )
-        cy.get('body').happoScreenshot()
+        cy.get('body').happoScreenshot({
+          component,
+          variant: 'disabled/disabled',
+        })
       })
     })
+
     it('renders', () => {
       cy.mount(
         <Container padded='small'>
@@ -152,7 +201,10 @@ describe('Tag', () => {
         </Container>
       )
 
-      cy.get('body').happoScreenshot()
+      cy.get('body').happoScreenshot({
+        component,
+        variant: 'default',
+      })
     })
     it('renders with Icon', () => {
       cy.mount(
@@ -161,7 +213,10 @@ describe('Tag', () => {
         </Container>
       )
 
-      cy.get('body').happoScreenshot()
+      cy.get('body').happoScreenshot({
+        component,
+        variant: 'with-icon',
+      })
     })
     it('renders with remove button', () => {
       cy.mount(
@@ -177,7 +232,10 @@ describe('Tag', () => {
         </>
       )
 
-      cy.get('body').happoScreenshot()
+      cy.get('body').happoScreenshot({
+        component,
+        variant: 'with-remove-button',
+      })
     })
     it('renders disabled', () => {
       cy.mount(
@@ -212,7 +270,10 @@ describe('Tag', () => {
         </>
       )
 
-      cy.get('body').happoScreenshot()
+      cy.get('body').happoScreenshot({
+        component,
+        variant: 'disabled',
+      })
     })
     it('renders with connection', () => {
       cy.mount(
@@ -239,7 +300,10 @@ describe('Tag', () => {
           </Container>
         </>
       )
-      cy.get('body').happoScreenshot()
+      cy.get('body').happoScreenshot({
+        component,
+        variant: 'with-connection',
+      })
     })
   })
 
@@ -247,41 +311,68 @@ describe('Tag', () => {
     describe('Variants', () => {
       it('renders red', () => {
         cy.mount(renderRectangularTag({ variant: 'red' }))
-        cy.get('body').happoScreenshot()
+        cy.get('body').happoScreenshot({
+          component,
+          variant: 'rectangular/red',
+        })
       })
       it('renders yellow', () => {
         cy.mount(renderRectangularTag({ variant: 'yellow' }))
-        cy.get('body').happoScreenshot()
+        cy.get('body').happoScreenshot({
+          component,
+          variant: 'rectangular/yellow',
+        })
       })
       it('renders green', () => {
         cy.mount(renderRectangularTag({ variant: 'green' }))
-        cy.get('body').happoScreenshot()
+        cy.get('body').happoScreenshot({
+          component,
+          variant: 'rectangular/green',
+        })
       })
       it('renders dark grey', () => {
         cy.mount(renderRectangularTag({ variant: 'dark-grey' }))
-        cy.get('body').happoScreenshot()
+        cy.get('body').happoScreenshot({
+          component,
+          variant: 'rectangular/dark-grey',
+        })
       })
       it('renders light grey', () => {
         cy.mount(renderRectangularTag({ variant: 'light-grey' }))
-        cy.get('body').happoScreenshot()
+        cy.get('body').happoScreenshot({
+          component,
+          variant: 'rectangular/light-grey',
+        })
       })
     })
     describe('Indicators', () => {
       it('renders red indicator', () => {
         cy.mount(renderIndicatorTag({ indicator: 'red' }))
-        cy.get('body').happoScreenshot()
+        cy.get('body').happoScreenshot({
+          component,
+          variant: 'red-indicator',
+        })
       })
       it('renders yellow indicator', () => {
         cy.mount(renderIndicatorTag({ indicator: 'yellow' }))
-        cy.get('body').happoScreenshot()
+        cy.get('body').happoScreenshot({
+          component,
+          variant: 'yellow-indicator',
+        })
       })
       it('renders green indicator', () => {
         cy.mount(renderIndicatorTag({ indicator: 'green' }))
-        cy.get('body').happoScreenshot()
+        cy.get('body').happoScreenshot({
+          component,
+          variant: 'green-indicator',
+        })
       })
       it('renders blue indicator', () => {
         cy.mount(renderIndicatorTag({ indicator: 'blue' }))
-        cy.get('body').happoScreenshot()
+        cy.get('body').happoScreenshot({
+          component,
+          variant: 'blue-indicator',
+        })
       })
     })
   })

--- a/cypress/component/Timeline.spec.tsx
+++ b/cypress/component/Timeline.spec.tsx
@@ -70,28 +70,42 @@ const renderTimeline = ({
   </div>
 )
 
+const component = 'Timeline'
+
 describe('Timeline', () => {
   it('renders', () => {
     cy.mount(renderTimeline())
 
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'default',
+    })
   })
 
   it('renders with dates', () => {
     cy.mount(renderTimeline({ hasDates: true }))
 
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'with-dates',
+    })
   })
 
   it('renders with dates and icons', () => {
     cy.mount(renderTimeline({ hasDates: true, hasIcons: true }))
 
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'with-dates-and-icons',
+    })
   })
 
   it('renders without last connector', () => {
     cy.mount(renderTimeline({ hasDates: true, trimLastConnector: true }))
 
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'without-last-connector',
+    })
   })
 })

--- a/cypress/component/Tooltip.spec.tsx
+++ b/cypress/component/Tooltip.spec.tsx
@@ -239,32 +239,49 @@ const DropdownTooltipExample = () => {
   )
 }
 
+const component = 'Tooltip'
+
 describe('Tooltip', () => {
   it('renders by default', () => {
     cy.mount(<SnapshotTooltipExample />)
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'default',
+    })
   })
 
   it('renders with disabled portals', () => {
     cy.mount(<SnapshotTooltipExample disablePortal />)
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'with-disabled-portals',
+    })
   })
 
   it('renders compact', () => {
     cy.mount(<SnapshotTooltipExample compact />)
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'compact',
+    })
   })
 
   it('renders long text with max width', () => {
     cy.mount(<SnapshotTooltipExample content={TOOLTIP_LONG_TEXT} />)
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'long-text-with-max-width',
+    })
   })
 
   it('renders long text with no max width', () => {
     cy.mount(
       <SnapshotTooltipExample content={TOOLTIP_LONG_TEXT} maxWidth='none' />
     )
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'long-text-without-max-width',
+    })
   })
 
   it('renders without overflow prevention', () => {
@@ -274,17 +291,26 @@ describe('Tooltip', () => {
         preventOverflow={false}
       />
     )
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'without-overflow-prevention',
+    })
   })
 
   it('renders with different placements', () => {
     cy.mount(<PlacementTooltipExample />)
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'with-different-placements',
+    })
   })
 
   it('renders inside and outside of a modal', () => {
     cy.mount(<ModalTooltipExample />)
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'inside-and-outside-modal',
+    })
   })
 
   it('renders on hover, and hides on click', () => {
@@ -313,7 +339,10 @@ describe('Tooltip', () => {
     cy.getByTestId(testIds.tooltipContent).should('not.exist')
     cy.get('@trigger').realHover()
     cy.getByTestId(testIds.tooltipContent).should('exist')
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'inside-checkbox',
+    })
     cy.get('@trigger').click()
     cy.getByTestId(testIds.tooltipContent).should('not.be.visible')
   })
@@ -327,7 +356,10 @@ describe('Tooltip', () => {
     cy.getByTestId(testIds.tooltipContent).should('not.exist')
     cy.getByTestId(testIds.radioTrigger).realHover()
     cy.getByTestId(testIds.tooltipContent).should('be.visible')
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'inside-radio',
+    })
     cy.getByTestId(testIds.radioTrigger).click()
     cy.getByTestId(testIds.tooltipContent).should('not.be.visible')
   })
@@ -356,7 +388,10 @@ describe('Tooltip', () => {
     cy.mount(<LinkTooltipExample />)
     cy.getByTestId(testIds.tooltipTrigger).as('Trigger').realHover()
     cy.getByTestId(testIds.tooltipContent).as('Content').should('be.visible')
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'inside-link',
+    })
 
     cy.get('@Content').click()
     cy.url().should('include', '#link')
@@ -371,7 +406,10 @@ describe('Tooltip', () => {
 
     cy.getByTestId(testIds.autocompleteInput).click()
     cy.getByTestId(testIds.tooltipContent).should('exist')
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'inside-autocomplete',
+    })
   })
 
   it('renders inside a dropdown', () => {
@@ -379,6 +417,9 @@ describe('Tooltip', () => {
 
     cy.getByTestId(testIds.dropdownTrigger).click()
     cy.getByTestId(testIds.tooltipContent).should('be.visible')
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'inside-dropdown',
+    })
   })
 })

--- a/cypress/component/Typography.spec.tsx
+++ b/cypress/component/Typography.spec.tsx
@@ -1,6 +1,8 @@
 import React from 'react'
 import { Typography } from '@toptal/picasso'
 
+const component = 'Typography'
+
 describe('Typography', () => {
   it('renders body', () => {
     cy.mount(
@@ -19,7 +21,10 @@ describe('Typography', () => {
         </div>
       </>
     )
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'body/all-sizes',
+    })
   })
 
   it('renders headings', () => {
@@ -30,12 +35,18 @@ describe('Typography', () => {
         </Typography>
       ))
     )
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'heading/all-sizes',
+    })
   })
 
   it('renders with a line through', () => {
     cy.mount(<Typography lineThrough>Text</Typography>)
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'line-through',
+    })
   })
 
   it('renders underlined', () => {
@@ -45,7 +56,10 @@ describe('Typography', () => {
         <Typography underline='dashed'>Text</Typography>
       </>
     )
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'underlined',
+    })
   })
 
   it('renders colored', () => {
@@ -74,6 +88,9 @@ describe('Typography', () => {
         </div>
       </>
     )
-    cy.get('body').happoScreenshot()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'all-colors',
+    })
   })
 })


### PR DESCRIPTION
[FX-2850]

### Description

PR is about giving better names for happo screenshots. It is important to group the components on Picasso/Cypress happo reports

### How to test

- checking variant names' corrections would be enough

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| <img width="930" alt="Screen Shot 2022-06-24 at 10 31 14" src="https://user-images.githubusercontent.com/7733167/175486131-79945837-013b-421c-b736-d636437b801c.png"> | waiting for happo report |

### Development checks

- Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- Annotate all `props` in component with documentation
- Create `examples` for component
- Ensure that deployed demo has expected results and good examples
- Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [ ] Self reviewed
- Covered with tests

**Breaking change**

- codemod is created and showcased in the changeset
- test alpha package of Picasso in StaffPortal

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-2850]: https://toptal-core.atlassian.net/browse/FX-2850?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ