### PR TITLE
feat(DatePicker): add footer, highlight and tooltip in a range of dates

### DIFF
--- a/.changeset/polite-cars-notice.md
+++ b/.changeset/polite-cars-notice.md
@@ -1,0 +1,5 @@
+---
+'@toptal/picasso': minor
+---
+
+add footer, highlight and tooltip in a range of dates at DatePicker

--- a/packages/picasso/src/Calendar/__snapshots__/test.tsx.snap
+++ b/packages/picasso/src/Calendar/__snapshots__/test.tsx.snap
@@ -117,6 +117,9 @@ exports[`Calendar renders 1`] = `
               value="Mon Jan 28 2019 00:00:00 GMT+0000 (Coordinated Universal Time)"
             >
               28
+              <div
+                class="PicassoCalendar-indicators"
+              />
             </button>
             <button
               class="PicassoCalendar-day PicassoCalendar-selectable PicassoCalendar-grayed"
@@ -126,6 +129,9 @@ exports[`Calendar renders 1`] = `
               value="Tue Jan 29 2019 00:00:00 GMT+0000 (Coordinated Universal Time)"
             >
               29
+              <div
+                class="PicassoCalendar-indicators"
+              />
             </button>
             <button
               class="PicassoCalendar-day PicassoCalendar-selectable PicassoCalendar-grayed"
@@ -135,6 +141,9 @@ exports[`Calendar renders 1`] = `
               value="Wed Jan 30 2019 00:00:00 GMT+0000 (Coordinated Universal Time)"
             >
               30
+              <div
+                class="PicassoCalendar-indicators"
+              />
             </button>
             <button
               class="PicassoCalendar-day PicassoCalendar-selectable PicassoCalendar-grayed"
@@ -144,6 +153,9 @@ exports[`Calendar renders 1`] = `
               value="Thu Jan 31 2019 00:00:00 GMT+0000 (Coordinated Universal Time)"
             >
               31
+              <div
+                class="PicassoCalendar-indicators"
+              />
             </button>
             <button
               class="PicassoCalendar-day PicassoCalendar-selectable"
@@ -153,6 +165,9 @@ exports[`Calendar renders 1`] = `
               value="Fri Feb 01 2019 00:00:00 GMT+0000 (Coordinated Universal Time)"
             >
               1
+              <div
+                class="PicassoCalendar-indicators"
+              />
             </button>
             <button
               class="PicassoCalendar-day PicassoCalendar-selectable"
@@ -162,6 +177,9 @@ exports[`Calendar renders 1`] = `
               value="Sat Feb 02 2019 00:00:00 GMT+0000 (Coordinated Universal Time)"
             >
               2
+              <div
+                class="PicassoCalendar-indicators"
+              />
             </button>
             <button
               class="PicassoCalendar-day PicassoCalendar-selectable"
@@ -171,6 +189,9 @@ exports[`Calendar renders 1`] = `
               value="Sun Feb 03 2019 00:00:00 GMT+0000 (Coordinated Universal Time)"
             >
               3
+              <div
+                class="PicassoCalendar-indicators"
+              />
             </button>
           </div>
           <div
@@ -184,6 +205,9 @@ exports[`Calendar renders 1`] = `
               value="Mon Feb 04 2019 00:00:00 GMT+0000 (Coordinated Universal Time)"
             >
               4
+              <div
+                class="PicassoCalendar-indicators"
+              />
             </button>
             <button
               class="PicassoCalendar-day PicassoCalendar-selectable"
@@ -193,6 +217,9 @@ exports[`Calendar renders 1`] = `
               value="Tue Feb 05 2019 00:00:00 GMT+0000 (Coordinated Universal Time)"
             >
               5
+              <div
+                class="PicassoCalendar-indicators"
+              />
             </button>
             <button
               class="PicassoCalendar-day PicassoCalendar-selectable"
@@ -202,6 +229,9 @@ exports[`Calendar renders 1`] = `
               value="Wed Feb 06 2019 00:00:00 GMT+0000 (Coordinated Universal Time)"
             >
               6
+              <div
+                class="PicassoCalendar-indicators"
+              />
             </button>
             <button
               class="PicassoCalendar-day PicassoCalendar-selectable"
@@ -211,6 +241,9 @@ exports[`Calendar renders 1`] = `
               value="Thu Feb 07 2019 00:00:00 GMT+0000 (Coordinated Universal Time)"
             >
               7
+              <div
+                class="PicassoCalendar-indicators"
+              />
             </button>
             <button
               class="PicassoCalendar-day PicassoCalendar-selectable"
@@ -220,6 +253,9 @@ exports[`Calendar renders 1`] = `
               value="Fri Feb 08 2019 00:00:00 GMT+0000 (Coordinated Universal Time)"
             >
               8
+              <div
+                class="PicassoCalendar-indicators"
+              />
             </button>
             <button
               class="PicassoCalendar-day PicassoCalendar-selectable"
@@ -229,6 +265,9 @@ exports[`Calendar renders 1`] = `
               value="Sat Feb 09 2019 00:00:00 GMT+0000 (Coordinated Universal Time)"
             >
               9
+              <div
+                class="PicassoCalendar-indicators"
+              />
             </button>
             <button
               class="PicassoCalendar-day PicassoCalendar-selectable"
@@ -238,6 +277,9 @@ exports[`Calendar renders 1`] = `
               value="Sun Feb 10 2019 00:00:00 GMT+0000 (Coordinated Universal Time)"
             >
               10
+              <div
+                class="PicassoCalendar-indicators"
+              />
             </button>
           </div>
           <div
@@ -251,6 +293,9 @@ exports[`Calendar renders 1`] = `
               value="Mon Feb 11 2019 00:00:00 GMT+0000 (Coordinated Universal Time)"
             >
               11
+              <div
+                class="PicassoCalendar-indicators"
+              />
             </button>
             <button
               class="PicassoCalendar-day PicassoCalendar-selectable"
@@ -260,6 +305,9 @@ exports[`Calendar renders 1`] = `
               value="Tue Feb 12 2019 00:00:00 GMT+0000 (Coordinated Universal Time)"
             >
               12
+              <div
+                class="PicassoCalendar-indicators"
+              />
             </button>
             <button
               class="PicassoCalendar-day PicassoCalendar-selectable"
@@ -269,6 +317,9 @@ exports[`Calendar renders 1`] = `
               value="Wed Feb 13 2019 00:00:00 GMT+0000 (Coordinated Universal Time)"
             >
               13
+              <div
+                class="PicassoCalendar-indicators"
+              />
             </button>
             <button
               class="PicassoCalendar-day PicassoCalendar-selectable"
@@ -278,6 +329,9 @@ exports[`Calendar renders 1`] = `
               value="Thu Feb 14 2019 00:00:00 GMT+0000 (Coordinated Universal Time)"
             >
               14
+              <div
+                class="PicassoCalendar-indicators"
+              />
             </button>
             <button
               class="PicassoCalendar-day PicassoCalendar-selectable"
@@ -287,6 +341,9 @@ exports[`Calendar renders 1`] = `
               value="Fri Feb 15 2019 00:00:00 GMT+0000 (Coordinated Universal Time)"
             >
               15
+              <div
+                class="PicassoCalendar-indicators"
+              />
             </button>
             <button
               class="PicassoCalendar-day PicassoCalendar-selectable"
@@ -296,6 +353,9 @@ exports[`Calendar renders 1`] = `
               value="Sat Feb 16 2019 00:00:00 GMT+0000 (Coordinated Universal Time)"
             >
               16
+              <div
+                class="PicassoCalendar-indicators"
+              />
             </button>
             <button
               class="PicassoCalendar-day PicassoCalendar-selectable"
@@ -305,6 +365,9 @@ exports[`Calendar renders 1`] = `
               value="Sun Feb 17 2019 00:00:00 GMT+0000 (Coordinated Universal Time)"
             >
               17
+              <div
+                class="PicassoCalendar-indicators"
+              />
             </button>
           </div>
           <div
@@ -318,6 +381,9 @@ exports[`Calendar renders 1`] = `
               value="Mon Feb 18 2019 00:00:00 GMT+0000 (Coordinated Universal Time)"
             >
               18
+              <div
+                class="PicassoCalendar-indicators"
+              />
             </button>
             <button
               class="PicassoCalendar-day PicassoCalendar-selectable"
@@ -327,6 +393,9 @@ exports[`Calendar renders 1`] = `
               value="Tue Feb 19 2019 00:00:00 GMT+0000 (Coordinated Universal Time)"
             >
               19
+              <div
+                class="PicassoCalendar-indicators"
+              />
             </button>
             <button
               class="PicassoCalendar-day PicassoCalendar-selectable"
@@ -336,6 +405,9 @@ exports[`Calendar renders 1`] = `
               value="Wed Feb 20 2019 00:00:00 GMT+0000 (Coordinated Universal Time)"
             >
               20
+              <div
+                class="PicassoCalendar-indicators"
+              />
             </button>
             <button
               class="PicassoCalendar-day PicassoCalendar-selectable"
@@ -345,6 +417,9 @@ exports[`Calendar renders 1`] = `
               value="Thu Feb 21 2019 00:00:00 GMT+0000 (Coordinated Universal Time)"
             >
               21
+              <div
+                class="PicassoCalendar-indicators"
+              />
             </button>
             <button
               class="PicassoCalendar-day PicassoCalendar-selectable"
@@ -354,6 +429,9 @@ exports[`Calendar renders 1`] = `
               value="Fri Feb 22 2019 00:00:00 GMT+0000 (Coordinated Universal Time)"
             >
               22
+              <div
+                class="PicassoCalendar-indicators"
+              />
             </button>
             <button
               class="PicassoCalendar-day PicassoCalendar-selectable"
@@ -363,6 +441,9 @@ exports[`Calendar renders 1`] = `
               value="Sat Feb 23 2019 00:00:00 GMT+0000 (Coordinated Universal Time)"
             >
               23
+              <div
+                class="PicassoCalendar-indicators"
+              />
             </button>
             <button
               class="PicassoCalendar-day PicassoCalendar-selectable"
@@ -372,6 +453,9 @@ exports[`Calendar renders 1`] = `
               value="Sun Feb 24 2019 00:00:00 GMT+0000 (Coordinated Universal Time)"
             >
               24
+              <div
+                class="PicassoCalendar-indicators"
+              />
             </button>
           </div>
           <div
@@ -385,6 +469,9 @@ exports[`Calendar renders 1`] = `
               value="Mon Feb 25 2019 00:00:00 GMT+0000 (Coordinated Universal Time)"
             >
               25
+              <div
+                class="PicassoCalendar-indicators"
+              />
             </button>
             <button
               class="PicassoCalendar-day PicassoCalendar-selectable"
@@ -394,6 +481,9 @@ exports[`Calendar renders 1`] = `
               value="Tue Feb 26 2019 00:00:00 GMT+0000 (Coordinated Universal Time)"
             >
               26
+              <div
+                class="PicassoCalendar-indicators"
+              />
             </button>
             <button
               class="PicassoCalendar-day PicassoCalendar-selectable"
@@ -403,6 +493,9 @@ exports[`Calendar renders 1`] = `
               value="Wed Feb 27 2019 00:00:00 GMT+0000 (Coordinated Universal Time)"
             >
               27
+              <div
+                class="PicassoCalendar-indicators"
+              />
             </button>
             <button
               class="PicassoCalendar-day PicassoCalendar-selectable"
@@ -412,6 +505,9 @@ exports[`Calendar renders 1`] = `
               value="Thu Feb 28 2019 00:00:00 GMT+0000 (Coordinated Universal Time)"
             >
               28
+              <div
+                class="PicassoCalendar-indicators"
+              />
             </button>
             <button
               class="PicassoCalendar-day PicassoCalendar-selectable PicassoCalendar-grayed"
@@ -421,6 +517,9 @@ exports[`Calendar renders 1`] = `
               value="Fri Mar 01 2019 00:00:00 GMT+0000 (Coordinated Universal Time)"
             >
               1
+              <div
+                class="PicassoCalendar-indicators"
+              />
             </button>
             <button
               class="PicassoCalendar-day PicassoCalendar-selectable PicassoCalendar-grayed"
@@ -430,6 +529,9 @@ exports[`Calendar renders 1`] = `
               value="Sat Mar 02 2019 00:00:00 GMT+0000 (Coordinated Universal Time)"
             >
               2
+              <div
+                class="PicassoCalendar-indicators"
+              />
             </button>
             <button
               class="PicassoCalendar-day PicassoCalendar-selectable PicassoCalendar-grayed"
@@ -439,6 +541,9 @@ exports[`Calendar renders 1`] = `
               value="Sun Mar 03 2019 00:00:00 GMT+0000 (Coordinated Universal Time)"
             >
               3
+              <div
+                class="PicassoCalendar-indicators"
+              />
             </button>
           </div>
         </div>

--- a/packages/picasso/src/Calendar/styles.ts
+++ b/packages/picasso/src/Calendar/styles.ts
@@ -1,7 +1,7 @@
 import { Theme, createStyles } from '@material-ui/core/styles'
 import { alpha, rem } from '@toptal/picasso-shared'
 
-export default ({ palette, sizes }: Theme) =>
+export default ({ palette }: Theme) =>
   createStyles({
     root: {
       display: 'none',
@@ -11,9 +11,9 @@ export default ({ palette, sizes }: Theme) =>
       display: 'flex',
     },
     day: {
-      height: '2.5rem',
-      width: '2.5rem',
-      minWidth: '2.5rem',
+      height: '2rem',
+      width: '2rem',
+      minWidth: '2rem',
       verticalAlign: 'middle',
       fontSize: '0.75rem',
       userSelect: 'none',
@@ -22,11 +22,14 @@ export default ({ palette, sizes }: Theme) =>
       justifyContent: 'center',
       background: palette.common.white,
       position: 'relative',
-      margin: 0,
       padding: 0,
       border: 'none',
       outline: 0,
-      borderRadius: sizes.borderRadius.small,
+      flexDirection: 'column',
+      margin: '0 0 0.3rem 0.3rem',
+      '&:first-child': {
+        marginLeft: 0,
+      },
     },
     weekDays: {
       display: 'flex',
@@ -55,6 +58,7 @@ export default ({ palette, sizes }: Theme) =>
 
       '&:hover, &:focus': {
         backgroundColor: alpha(palette.blue.main, 0.24),
+        borderRadius: '10%',
       },
 
       '&$startSelection:hover, &$endSelection:hover': {
@@ -77,22 +81,18 @@ export default ({ palette, sizes }: Theme) =>
         backgroundColor: palette.common.white,
       },
     },
-    highlighted: {
-      backgroundColor: '#f00',
+    indicators: {
+      display: 'flex',
+      flexDirection: 'row',
     },
     today: {
-      display: 'flex',
-      flexDirection: 'column',
-
-      '&:after': {
-        content: '""',
-        height: '0.25rem',
-        width: '0.25rem',
-        borderRadius: '50%',
-        background: palette.blue.main,
-        position: 'absolute',
-        bottom: '0.375rem',
-      },
+      content: '""',
+      height: '0.25rem',
+      width: '0.25rem',
+      borderRadius: '50%',
+      background: palette.blue.main,
+      marginRight: '0.375rem',
+      marginTop: '0.175rem',
     },
     grayed: {
       color: palette.grey.main2,

--- a/packages/picasso/src/Calendar/styles.ts
+++ b/packages/picasso/src/Calendar/styles.ts
@@ -77,6 +77,9 @@ export default ({ palette, sizes }: Theme) =>
         backgroundColor: palette.common.white,
       },
     },
+    highlighted: {
+      backgroundColor: '#f00',
+    },
     today: {
       display: 'flex',
       flexDirection: 'column',

--- a/packages/picasso/src/CalendarIndicators/CalendarIndicators.tsx
+++ b/packages/picasso/src/CalendarIndicators/CalendarIndicators.tsx
@@ -1,0 +1,37 @@
+import React from 'react'
+import { makeStyles, Theme } from '@material-ui/core/styles'
+
+import styles from './styles'
+
+export interface Props {
+  indicatedIntervals?: { start: Date; end: Date }[]
+  date: Date
+}
+
+const useStyles = makeStyles<Theme>(styles, {
+  name: 'PicassoCalendarIndicators',
+})
+
+export const CalendarIndicators = ({ indicatedIntervals, date }: Props) => {
+  const classes = useStyles()
+
+  const isIndicated = (day: Date) => {
+    if (!indicatedIntervals) {
+      return false
+    }
+
+    for (let index = 0; index < indicatedIntervals.length; index++) {
+      const interval = indicatedIntervals[index]
+
+      if (interval.start <= day && day <= interval.end) {
+        return true
+      }
+    }
+  }
+
+  if (isIndicated(date)) {
+    return <div className={classes.indicated} />
+  }
+
+  return <></>
+}

--- a/packages/picasso/src/CalendarIndicators/__snapshots__/test.tsx.snap
+++ b/packages/picasso/src/CalendarIndicators/__snapshots__/test.tsx.snap
@@ -1,0 +1,13 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CalendarIndicators renders 1`] = `
+<div>
+  <div
+    class="Picasso-root"
+  >
+    <div
+      class="PicassoCalendarIndicators-indicated"
+    />
+  </div>
+</div>
+`;

--- a/packages/picasso/src/CalendarIndicators/index.ts
+++ b/packages/picasso/src/CalendarIndicators/index.ts
@@ -1,0 +1,1 @@
+export * from './CalendarIndicators'

--- a/packages/picasso/src/CalendarIndicators/styles.ts
+++ b/packages/picasso/src/CalendarIndicators/styles.ts
@@ -1,0 +1,13 @@
+import { Theme, createStyles } from '@material-ui/core/styles'
+
+export default ({ palette }: Theme) =>
+  createStyles({
+    indicated: {
+      content: '""',
+      height: '0.25rem',
+      width: '0.25rem',
+      borderRadius: '50%',
+      background: palette.yellow.main,
+      marginTop: '0.175rem',
+    },
+  })

--- a/packages/picasso/src/CalendarIndicators/test.tsx
+++ b/packages/picasso/src/CalendarIndicators/test.tsx
@@ -1,0 +1,22 @@
+import React from 'react'
+import { render } from '@toptal/picasso/test-utils'
+
+import { CalendarIndicators } from './CalendarIndicators'
+
+describe('CalendarIndicators', () => {
+  it('renders', () => {
+    const indicatedIntervals = [
+      { start: new Date('2022-07-11'), end: new Date('2022-07-16') },
+      { start: new Date('2022-07-18'), end: new Date('2022-07-23') },
+    ]
+
+    const { container } = render(
+      <CalendarIndicators
+        indicatedIntervals={indicatedIntervals}
+        date={new Date('2022-07-18')}
+      />
+    )
+
+    expect(container).toMatchSnapshot()
+  })
+})

--- a/packages/picasso/src/CalendarTooltip/CalendarTooltip.tsx
+++ b/packages/picasso/src/CalendarTooltip/CalendarTooltip.tsx
@@ -1,0 +1,41 @@
+import React from 'react'
+
+import Tooltip from '../Tooltip'
+
+export interface Props {
+  tooltipIntervals?: { start: Date; end: Date; tooltip: string }[]
+  date: Date
+  children: React.ReactElement
+}
+
+export const CalendarTooltip = ({
+  tooltipIntervals,
+  date,
+  children,
+}: Props) => {
+  const hasTooltip = (day: Date) => {
+    if (!tooltipIntervals) {
+      return null
+    }
+
+    for (let index = 0; index < tooltipIntervals.length; index++) {
+      const interval = tooltipIntervals[index]
+
+      if (interval.start <= day && day <= interval.end) {
+        return interval.tooltip
+      }
+    }
+  }
+
+  const tooltip = hasTooltip(date)
+
+  if (tooltip) {
+    return (
+      <Tooltip content={tooltip} placement='bottom' compact>
+        {children}
+      </Tooltip>
+    )
+  }
+
+  return children
+}

--- a/packages/picasso/src/CalendarTooltip/__snapshots__/test.tsx.snap
+++ b/packages/picasso/src/CalendarTooltip/__snapshots__/test.tsx.snap
@@ -1,0 +1,13 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CalendarTooltip renders 1`] = `
+<div>
+  <div
+    class="Picasso-root"
+  >
+    <span>
+      13
+    </span>
+  </div>
+</div>
+`;

--- a/packages/picasso/src/CalendarTooltip/index.ts
+++ b/packages/picasso/src/CalendarTooltip/index.ts
@@ -1,0 +1,1 @@
+export * from './CalendarTooltip'

--- a/packages/picasso/src/CalendarTooltip/test.tsx
+++ b/packages/picasso/src/CalendarTooltip/test.tsx
@@ -1,0 +1,27 @@
+import React from 'react'
+import { render } from '@toptal/picasso/test-utils'
+
+import { CalendarTooltip } from './CalendarTooltip'
+
+describe('CalendarTooltip', () => {
+  it('renders', () => {
+    const tooltipIntervals = [
+      {
+        start: new Date('2022-06-26'),
+        end: new Date('2022-06-30'),
+        tooltip: '10 business days notice period',
+      },
+    ]
+
+    const { container } = render(
+      <CalendarTooltip
+        tooltipIntervals={tooltipIntervals}
+        date={new Date('2022-07-18')}
+      >
+        <span>13</span>
+      </CalendarTooltip>
+    )
+
+    expect(container).toMatchSnapshot()
+  })
+})

--- a/packages/picasso/src/DatePicker/DatePicker.tsx
+++ b/packages/picasso/src/DatePicker/DatePicker.tsx
@@ -79,6 +79,10 @@ export interface Props
   displayDateFormat?: string
   /** Date range where selection is not allowed */
   disabledIntervals?: { start: Date; end: Date }[]
+  /** TOOOODOOOOO */
+  highlightedIntervals?: { start: Date; end: Date }[]
+  /** TOOOODOOOOO */
+  tooltipIntervals?: { start: Date; end: Date, tooltip: String }[]
   /** Date format that user will see during manual input */
   editDateFormat?: string
   /** Specify icon which should be rendered inside `DatePicker` */
@@ -126,6 +130,8 @@ export const DatePicker = (props: Props) => {
     minDate,
     maxDate,
     disabledIntervals,
+    highlightedIntervals,
+    tooltipIntervals,
     popperContainer,
     renderDay,
     weekStartsOn,
@@ -409,6 +415,8 @@ export const DatePicker = (props: Props) => {
             minDate={normalizedMinDate}
             maxDate={normalizedMaxDate}
             disabledIntervals={disabledIntervals}
+            highlightedIntervals={highlightedIntervals}
+            tooltipIntervals={tooltipIntervals}
             renderDay={renderDay}
             onChange={handleCalendarChange}
             onBlur={handleBlur}

--- a/packages/picasso/src/DatePicker/DatePicker.tsx
+++ b/packages/picasso/src/DatePicker/DatePicker.tsx
@@ -79,10 +79,10 @@ export interface Props
   displayDateFormat?: string
   /** Date range where selection is not allowed */
   disabledIntervals?: { start: Date; end: Date }[]
-  /** TOOOODOOOOO */
-  highlightedIntervals?: { start: Date; end: Date }[]
-  /** TOOOODOOOOO */
-  tooltipIntervals?: { start: Date; end: Date, tooltip: String }[]
+  /** Shows indicators in a range of dates */
+  indicatedIntervals?: { start: Date; end: Date }[]
+  /** Adds some description in a tooltip for a range of dates */
+  tooltipIntervals?: { start: Date; end: Date; tooltip: string }[]
   /** Date format that user will see during manual input */
   editDateFormat?: string
   /** Specify icon which should be rendered inside `DatePicker` */
@@ -112,7 +112,10 @@ export interface Props
   testIds?: InputProps['testIds'] & {
     calendar?: string
     input?: string
+    footer?: string
   }
+  /** Adds a customized footer at the bottom of the calendar */
+  footer?: ReactNode
 }
 
 export const DatePicker = (props: Props) => {
@@ -130,7 +133,7 @@ export const DatePicker = (props: Props) => {
     minDate,
     maxDate,
     disabledIntervals,
-    highlightedIntervals,
+    indicatedIntervals,
     tooltipIntervals,
     popperContainer,
     renderDay,
@@ -143,6 +146,7 @@ export const DatePicker = (props: Props) => {
     status,
     popperProps,
     disabled,
+    footer,
     ...rest
   } = props
   const classes = useStyles()
@@ -415,7 +419,7 @@ export const DatePicker = (props: Props) => {
             minDate={normalizedMinDate}
             maxDate={normalizedMaxDate}
             disabledIntervals={disabledIntervals}
-            highlightedIntervals={highlightedIntervals}
+            indicatedIntervals={indicatedIntervals}
             tooltipIntervals={tooltipIntervals}
             renderDay={renderDay}
             onChange={handleCalendarChange}
@@ -423,6 +427,11 @@ export const DatePicker = (props: Props) => {
             className={classes.calendar}
             weekStartsOn={weekStartsOn}
           />
+          {footer && (
+            <div className={classes.footer} data-testid={testIds?.footer}>
+              {footer}
+            </div>
+          )}
         </Popper>
       )}
     </>

--- a/packages/picasso/src/DatePicker/story/WithFooter.example.tsx
+++ b/packages/picasso/src/DatePicker/story/WithFooter.example.tsx
@@ -1,0 +1,24 @@
+import React, { useState } from 'react'
+import { DatePicker, Link } from '@toptal/picasso'
+
+const WithFooterRendering = () => {
+  const [datepickerValue, setDatepickerValue] = useState<Date>()
+
+  return (
+    <div style={{ height: '50vh' }}>
+      <DatePicker
+        value={datepickerValue}
+        onChange={date => {
+          setDatepickerValue(date as Date)
+        }}
+        footer={
+          <>
+            Got a question? <Link href='#'>Talk to us</Link>
+          </>
+        }
+      />
+    </div>
+  )
+}
+
+export default WithFooterRendering

--- a/packages/picasso/src/DatePicker/story/WithHighlightedRange.example.tsx
+++ b/packages/picasso/src/DatePicker/story/WithHighlightedRange.example.tsx
@@ -1,0 +1,28 @@
+import React, { useState } from 'react'
+import { DatePicker } from '@toptal/picasso'
+
+const WithHighlightedRangeRendering = () => {
+  const [datepickerValue, setDatepickerValue] = useState<Date>()
+
+  const highlightedIntervals = [
+    { start: new Date('2022-06-28'), end: new Date('2022-06-30') },
+  ]
+  const tooltipIntervals = [
+    { start: new Date('2022-06-26'), end: new Date('2022-06-30'), tooltip: '10 business days notice period' },
+  ]
+
+  return (
+    <div style={{ height: '50vh' }}>
+      <DatePicker
+        value={datepickerValue}
+        highlightedIntervals={highlightedIntervals}
+        tooltipIntervals={tooltipIntervals}
+        onChange={date => {
+          setDatepickerValue(date as Date)
+        }}
+      />
+    </div>
+  )
+}
+
+export default WithHighlightedRangeRendering

--- a/packages/picasso/src/DatePicker/story/WithIndicatedRange.example.tsx
+++ b/packages/picasso/src/DatePicker/story/WithIndicatedRange.example.tsx
@@ -1,0 +1,30 @@
+import React, { useState } from 'react'
+import { DatePicker } from '@toptal/picasso'
+
+const WithIndicatedRangeRendering = () => {
+  const [datepickerValue, setDatepickerValue] = useState<Date>()
+
+  const disabledIntervals = [
+    { start: new Date('2022-07-01'), end: new Date('2022-07-04') },
+  ]
+
+  const indicatedIntervals = [
+    { start: new Date('2022-07-11'), end: new Date('2022-07-16') },
+    { start: new Date('2022-07-18'), end: new Date('2022-07-23') },
+  ]
+
+  return (
+    <div style={{ height: '50vh' }}>
+      <DatePicker
+        value={datepickerValue}
+        disabledIntervals={disabledIntervals}
+        indicatedIntervals={indicatedIntervals}
+        onChange={date => {
+          setDatepickerValue(date as Date)
+        }}
+      />
+    </div>
+  )
+}
+
+export default WithIndicatedRangeRendering

--- a/packages/picasso/src/DatePicker/story/WithTooltipRange.example.tsx
+++ b/packages/picasso/src/DatePicker/story/WithTooltipRange.example.tsx
@@ -1,21 +1,21 @@
 import React, { useState } from 'react'
 import { DatePicker } from '@toptal/picasso'
 
-const WithHighlightedRangeRendering = () => {
+const WithTooltipRangeRendering = () => {
   const [datepickerValue, setDatepickerValue] = useState<Date>()
 
-  const highlightedIntervals = [
-    { start: new Date('2022-06-28'), end: new Date('2022-06-30') },
-  ]
   const tooltipIntervals = [
-    { start: new Date('2022-06-26'), end: new Date('2022-06-30'), tooltip: '10 business days notice period' },
+    {
+      start: new Date('2022-06-26'),
+      end: new Date('2022-06-30'),
+      tooltip: '10 business days notice period',
+    },
   ]
 
   return (
     <div style={{ height: '50vh' }}>
       <DatePicker
         value={datepickerValue}
-        highlightedIntervals={highlightedIntervals}
         tooltipIntervals={tooltipIntervals}
         onChange={date => {
           setDatepickerValue(date as Date)
@@ -25,4 +25,4 @@ const WithHighlightedRangeRendering = () => {
   )
 }
 
-export default WithHighlightedRangeRendering
+export default WithTooltipRangeRendering

--- a/packages/picasso/src/DatePicker/story/index.jsx
+++ b/packages/picasso/src/DatePicker/story/index.jsx
@@ -74,3 +74,7 @@ page
       'Type any year value like `2015` to get a random date within this year',
     takeScreenshot: false,
   })
+  .addExample('DatePicker/story/WithHighlightedRange.example.tsx', {
+    title: 'WithHighlightedRange',
+    takeScreenshot: false,
+  })

--- a/packages/picasso/src/DatePicker/story/index.jsx
+++ b/packages/picasso/src/DatePicker/story/index.jsx
@@ -74,7 +74,18 @@ page
       'Type any year value like `2015` to get a random date within this year',
     takeScreenshot: false,
   })
-  .addExample('DatePicker/story/WithHighlightedRange.example.tsx', {
-    title: 'WithHighlightedRange',
+  .addExample('DatePicker/story/WithIndicatedRange.example.tsx', {
+    title: 'With Indicated Range',
+    description: 'Show as indicated a range of dates',
+    takeScreenshot: false,
+  })
+  .addExample('DatePicker/story/WithTooltipRange.example.tsx', {
+    title: 'With Tooltip Range',
+    description: 'Show some description in a tooltip for a range of dates',
+    takeScreenshot: false,
+  })
+  .addExample('DatePicker/story/WithFooter.example.tsx', {
+    title: 'With Footer',
+    description: 'Show a custom footer at the bottom of the calendar',
     takeScreenshot: false,
   })

--- a/packages/picasso/src/DatePicker/styles.ts
+++ b/packages/picasso/src/DatePicker/styles.ts
@@ -1,8 +1,20 @@
-import { createStyles } from '@material-ui/core/styles'
+import { createStyles, Theme } from '@material-ui/core/styles'
 
-export default () =>
+import { rem } from '~/packages/shared/src'
+
+export default ({ palette, shadows }: Theme) =>
   createStyles({
     calendar: {
       outline: 'none',
+    },
+    footer: {
+      marginTop: '-0.09rem',
+      backgroundColor: palette.grey.lightest,
+      boxShadow: shadows[5],
+      borderRadius: '0 0 4px 4px',
+      color: palette.grey.dark,
+      fontSize: rem('13px'),
+      padding: '0.625rem 1.187rem',
+      width: '20.5rem',
     },
   })

--- a/packages/picasso/src/DatePicker/test.tsx
+++ b/packages/picasso/src/DatePicker/test.tsx
@@ -515,6 +515,19 @@ describe('DatePicker', () => {
         expect(queryByTestId('day-button-selected')).toBeInTheDocument()
       })
     })
+
+    describe('when `footer` option is passed', () => {
+      it('should appear a footer at the bottom of the calendar', async () => {
+        const { queryByTestId, getByPlaceholderText } = renderDatePicker({
+          ...defaultProps,
+          footer: <>Test</>,
+        })
+
+        fireEvent.focus(getByPlaceholderText(defaultProps.placeholder))
+
+        expect(queryByTestId('footer')).toBeInTheDocument()
+      })
+    })
   })
 
   const defaultProps = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -13218,21 +13218,7 @@ happo-cypress@^3.0.1:
   dependencies:
     happo-e2e "^1.0.3"
 
-happo-e2e@^1.0.3, happo-e2e@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.npmjs.org/happo-e2e/-/happo-e2e-1.1.0.tgz"
-  integrity sha512-6vHmYfqnCNr+Eur+rOzUSGrsCsjBXtNFi/PwDkyk5ejRJ072aQEL7VnDosEsbiNMK5uCUsX5UprV4L1buezzpA==
-  dependencies:
-    archiver "^5.3.0"
-    base64-stream "^1.0.0"
-    crypto-js "^4.1.1"
-    https-proxy-agent "^5.0.0"
-    mkdirp "^1.0.4"
-    node-fetch "^2.0.0"
-    parse-srcset "^1.0.2"
-    string.prototype.replaceall "^1.0.6"
-
-happo-e2e@^1.2.0:
+happo-e2e@^1.0.3, happo-e2e@^1.1.0, happo-e2e@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/happo-e2e/-/happo-e2e-1.2.0.tgz#a7bdc71c48fe4fcdd51fc9dfac0c58a7410017d3"
   integrity sha512-F94HEJgAq1dnZXlty9t7E/uTHrKJlTsem1oqkPpH6EkqXKasWGShEo+f74YvXzxwBlzs+Kw3vVT0E+ibOVmKHw==


### PR DESCRIPTION
[SDE-374](https://toptal-core.atlassian.net/browse/SDE-374)

### Description
In our current [initiative](https://toptal-core.atlassian.net/browse/PI-1934), we'll need some improvements in the DatePicker component to be used in Client Portal and Staff Portal. So in this PR, we have developed some features listed below:
 
- Option to define tooltips to a specific range of date
- Option to highlight with yellow indicator a specific range of dates
- Option to add a customized footer to the bottom of the calendar

### How to test

- Access [https://picasso.toptal.net/sde-374-improve-date-picker-features/](https://picasso.toptal.net/sde-374-improve-date-picker-features/?16717e025189d3d36ab4e71ddaf4e01018d3a5fd)
- Verify each feature example at Datepicker section
- Compare requirements in the ticket with implementation

### Screenshots

| Features                             | Screenshots                           |
| --------------------------------------- | --------------------------------------- |
| With Indicated Range | ![indicated](https://user-images.githubusercontent.com/5639968/178621235-93524bf3-ac31-43b6-892b-bd3b29622333.png) |
| With Tooltip Range | ![tooltip](https://user-images.githubusercontent.com/5639968/176520510-7b3d1167-cb99-4387-aadf-b75eef6a1dde.png) |
| With Footer | ![footer](https://user-images.githubusercontent.com/5639968/176520436-1dd5f50a-0673-4d48-a990-deacb728cf00.png) |

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests

**Breaking change**

- [N/A] codemod is created and showcased in the changeset
- [N/A] test alpha package of Picasso in StaffPortal

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>
