### PR TITLE
feat(TagSelector): add `closeOnSelect` prop

### DIFF
--- a/.changeset/lemon-cups-jump.md
+++ b/.changeset/lemon-cups-jump.md
@@ -1,0 +1,8 @@
+---
+'@toptal/picasso': minor
+---
+
+---
+### TagSelector
+
+- introduce `closeOnSelect` prop

--- a/.changeset/lemon-cups-jump.md
+++ b/.changeset/lemon-cups-jump.md
@@ -5,4 +5,4 @@
 ---
 ### TagSelector
 
-- introduce `closeOnSelect` prop
+- introduce `closeOnSelect` prop that controls whether the options menu would be closed after selection. The default value is `true` - closing the options menu after each selection

--- a/packages/picasso/src/Autocomplete/Autocomplete.tsx
+++ b/packages/picasso/src/Autocomplete/Autocomplete.tsx
@@ -48,6 +48,8 @@ export interface Props
   disabled?: boolean
   /** Callback invoked when selection changes */
   onSelect?: (item: Item, event: MouseEvent | KeyboardEvent) => void
+  /** Whether to close popper upon selection */
+  closeOnSelect?: boolean
   /** Callback invoked when other option selected */
   onOtherOptionSelect?: (
     value: string,
@@ -148,6 +150,7 @@ export const Autocomplete = forwardRef<HTMLInputElement, Props>(
       menuWidth,
       name,
       noOptionsText = 'No options',
+      closeOnSelect,
       onBlur,
       onChange,
       onFocus,
@@ -208,6 +211,7 @@ export const Autocomplete = forwardRef<HTMLInputElement, Props>(
       value,
       disabled,
       options,
+      closeOnSelect,
       getDisplayValue,
       onSelect,
       onOtherOptionSelect,

--- a/packages/picasso/src/Autocomplete/use-autocomplete/test.ts
+++ b/packages/picasso/src/Autocomplete/use-autocomplete/test.ts
@@ -268,7 +268,7 @@ describe('useAutocomplete', () => {
     expect(result.current.isOpen).toBe(false)
   })
 
-  it('keeps the menu open when `closesOnSelect` is disabled', () => {
+  it('keeps the menu open when `closeOnSelect` is disabled', () => {
     const { result } = renderUseAutocomplete({ closeOnSelect: false })
 
     expect(result.current.isOpen).toBe(false)

--- a/packages/picasso/src/Autocomplete/use-autocomplete/test.ts
+++ b/packages/picasso/src/Autocomplete/use-autocomplete/test.ts
@@ -268,6 +268,31 @@ describe('useAutocomplete', () => {
     expect(result.current.isOpen).toBe(false)
   })
 
+  it('keeps the menu open when `closesOnSelect` is disabled', () => {
+    const { result } = renderUseAutocomplete({ closeOnSelect: false })
+
+    expect(result.current.isOpen).toBe(false)
+
+    const input = result.current.getInputProps()
+
+    act(() => {
+      input.onChange(MOCKED_EVENT)
+    })
+
+    expect(result.current.isOpen).toBe(true)
+
+    const itemProps = result.current.getItemProps(0, {
+      text: 'Ukraine',
+      value: 'UA',
+    })
+
+    act(() => {
+      itemProps.onClick(MOCKED_EVENT)
+    })
+
+    expect(result.current.isOpen).toBe(true)
+  })
+
   describe('works with key presses', () => {
     it('opens menu on enter keypress', () => {
       const { result } = renderUseAutocomplete()

--- a/packages/picasso/src/Autocomplete/use-autocomplete/use-autocomplete.ts
+++ b/packages/picasso/src/Autocomplete/use-autocomplete/use-autocomplete.ts
@@ -249,7 +249,9 @@ export const useAutocomplete = ({
           return
         }
 
-        setOpen(false)
+        if (closeOnSelect) {
+          setOpen(false)
+        }
         handleChange(getDisplayValue(null))
       }
 

--- a/packages/picasso/src/Autocomplete/use-autocomplete/use-autocomplete.ts
+++ b/packages/picasso/src/Autocomplete/use-autocomplete/use-autocomplete.ts
@@ -87,6 +87,7 @@ export interface Props {
   onFocus?: FocusEventHandler<HTMLInputElement>
   onBlur?: FocusEventHandler<HTMLInputElement>
   getDisplayValue: (item: Item | null) => string
+  closeOnSelect?: boolean
   enableReset?: boolean
   showOtherOption?: boolean
   disabled?: boolean
@@ -95,6 +96,7 @@ export interface Props {
 export const useAutocomplete = ({
   value,
   options = [],
+  closeOnSelect = true,
   onChange = () => {},
   onKeyDown = () => {},
   onFocus = () => {},
@@ -173,7 +175,9 @@ export const useAutocomplete = ({
   const getItemProps = (index: number, item: Item) => ({
     ...getBaseItemProps(index),
     onClick: (event: MouseEvent) => {
-      setOpen(false)
+      if (closeOnSelect) {
+        setOpen(false)
+      }
       handleChange(getDisplayValue(item), true)
       handleSelect(item, event)
     },
@@ -182,7 +186,9 @@ export const useAutocomplete = ({
   const getOtherItemProps = (index: number, newValue: string) => ({
     ...getBaseItemProps(index),
     onClick: (event: MouseEvent) => {
-      setOpen(false)
+      if (closeOnSelect) {
+        setOpen(false)
+      }
       onOtherOptionSelect(newValue, event)
     },
   })
@@ -256,7 +262,9 @@ export const useAutocomplete = ({
           return
         }
 
-        setOpen(false)
+        if (closeOnSelect) {
+          setOpen(false)
+        }
 
         const findSelectedItemUsingIndex = () =>
           highlightedIndex === null ? undefined : options?.[highlightedIndex]

--- a/packages/picasso/src/TagSelector/TagSelector.tsx
+++ b/packages/picasso/src/TagSelector/TagSelector.tsx
@@ -63,7 +63,7 @@ export interface Props
   loading?: boolean
   /** Text prefix for other option */
   otherOptionLabel?: string
-  /**  Callback invoked when other option selected */
+  /** Callback invoked when other option selected */
   onOtherOptionSelect?: (value: string) => void
   /** Allow to show the other option in the list of options */
   showOtherOption?: boolean
@@ -77,9 +77,11 @@ export interface Props
   getDisplayValue?: (item: Item | null) => string
   /**  Callback invoked when selection changes */
   onChange?: (value: Item[]) => void
+  /** Whether to close popper upon selection */
+  closeOnSelect?: boolean
   /** The value of the `input` element, required for a controlled component. */
   inputValue?: string
-  /**  Callback invoked when `input` element value is changed */
+  /** Callback invoked when `input` element value is changed */
   onInputChange?: (inputValue: string) => void
   /** Focus event handler */
   onFocus?: FocusEventHandler<HTMLInputElement>
@@ -263,6 +265,7 @@ TagSelector.defaultProps = {
   getDisplayValue: getItemText,
   loading: false,
   onChange: noop,
+  closeOnSelect: true,
   onInputChange: noop,
   onOtherOptionSelect: noop,
   options: [],

--- a/packages/picasso/src/TagSelector/story/KeepOpen.example.tsx
+++ b/packages/picasso/src/TagSelector/story/KeepOpen.example.tsx
@@ -1,0 +1,62 @@
+import React, { useState } from 'react'
+import { TagSelector, AutocompleteItem } from '@toptal/picasso'
+import { isSubstring } from '@toptal/picasso/utils'
+
+const allOptions = [
+  { value: 'AF', text: 'Afghanistan' },
+  { value: 'AI', text: 'Aland Islands' },
+  { value: 'ALB', text: 'Albania' },
+  { value: 'ALG', text: 'Algeria' },
+  { value: 'BY', text: 'Belarus' },
+  { value: 'HR', text: 'Croatia' },
+  { value: 'LU', text: 'Lithuania' },
+  { value: 'SK', text: 'Slovakia' },
+  { value: 'SP', text: 'Spain' },
+  { value: 'UA', text: 'Ukraine' },
+]
+
+const EMPTY_INPUT_VALUE = ''
+const getDisplayValue = (item: AutocompleteItem | null) =>
+  (item && item.text) || EMPTY_INPUT_VALUE
+const filterOptions = (str = '') => {
+  if (str === '') {
+    return allOptions
+  }
+
+  const result = allOptions.filter(option =>
+    isSubstring(str, getDisplayValue(option))
+  )
+
+  return result.length > 0 ? result : null
+}
+
+const Example = () => {
+  const [options, setOptions] = useState<AutocompleteItem[] | null>(allOptions)
+  const [value, setValue] = useState<AutocompleteItem[]>([])
+  const [inputValue, setInputValue] = useState(EMPTY_INPUT_VALUE)
+
+  return (
+    <div>
+      <TagSelector
+        data-testid='component'
+        options={options}
+        placeholder='Start typing...'
+        value={value}
+        inputValue={inputValue}
+        getDisplayValue={getDisplayValue}
+        closeOnSelect={false}
+        onChange={selectedValues => {
+          window.console.log('onChange values: ', selectedValues)
+          setValue(selectedValues)
+        }}
+        onInputChange={newInputValue => {
+          window.console.log('onInputChange value: ', newInputValue)
+          setInputValue(newInputValue)
+          setOptions(filterOptions(newInputValue))
+        }}
+      />
+    </div>
+  )
+}
+
+export default Example

--- a/packages/picasso/src/TagSelector/story/index.jsx
+++ b/packages/picasso/src/TagSelector/story/index.jsx
@@ -23,6 +23,10 @@ page
     'TagSelector/story/InitialSetValue.example.tsx',
     'Initially set value'
   )
+  .addExample('TagSelector/story/KeepOpen.example.tsx', {
+    title: 'Keep options open',
+    takeScreenshot: false,
+  }) // picasso-skip-visuals
   .addExample('TagSelector/story/CustomOptionRenderer.example.tsx', {
     title: 'Custom option rendering',
     takeScreenshot: false,

--- a/packages/picasso/src/TagSelector/story/index.jsx
+++ b/packages/picasso/src/TagSelector/story/index.jsx
@@ -25,7 +25,8 @@ page
   )
   .addExample('TagSelector/story/KeepOpen.example.tsx', {
     title: 'With closeOnSelect disabled',
-    description: 'Do not hide the options on selection',
+    description:
+      'Disabling closeOnSelect can be useful when the user always have to select multiple values at the same time',
     takeScreenshot: false,
   })
   .addExample('TagSelector/story/CustomOptionRenderer.example.tsx', {

--- a/packages/picasso/src/TagSelector/story/index.jsx
+++ b/packages/picasso/src/TagSelector/story/index.jsx
@@ -24,9 +24,10 @@ page
     'Initially set value'
   )
   .addExample('TagSelector/story/KeepOpen.example.tsx', {
-    title: 'Keep options open',
+    title: 'With closeOnSelect disabled',
+    description: 'Do not hide the options on selection',
     takeScreenshot: false,
-  }) // picasso-skip-visuals
+  })
   .addExample('TagSelector/story/CustomOptionRenderer.example.tsx', {
     title: 'Custom option rendering',
     takeScreenshot: false,


### PR DESCRIPTION
[TACO-1656]

### Description

This PR introduces `closeOnSelect` prop to the `TagSelector` component. 

When `closeOnSelect` is `true` (the default value) the options menu is closed after selecting an option. When `false` it does not :smile: 

Keeping the menu around makes selecting multiple values faster instead of having to go back and click on the input again. This is mostly a slowdown when using mouse/touchpad, navigating with the keyboard is not that troublesome.

### How to test

Open `TagSelector` section in story book and checkout the new "Keep options open" sub-section.

### Screenshots

**Before**

https://user-images.githubusercontent.com/4757057/177340738-8edaf1bb-5965-4bce-9d99-950936e3926a.mp4

**After**

https://user-images.githubusercontent.com/4757057/177341419-8bc5c5ff-5848-4d65-9966-05a36fe023c0.mp4


### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests

**Breaking change**

- n/a ~~codemod is created and showcased in the changeset~~
- n/a ~~test alpha package of Picasso in StaffPortal~~

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[TACO-1656]: https://toptal-core.atlassian.net/browse/TACO-1656?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ