### PR TITLE
fix(TagSelector): fix options not showing on every click

### DIFF
--- a/.changeset/tame-plums-unite.md
+++ b/.changeset/tame-plums-unite.md
@@ -1,0 +1,8 @@
+---
+'@toptal/picasso': patch
+---
+
+---
+### Autocomplete
+
+- fix: options not showing on every click

--- a/.changeset/tame-plums-unite.md
+++ b/.changeset/tame-plums-unite.md
@@ -5,4 +5,4 @@
 ---
 ### Autocomplete
 
-- fix: options not showing on every click
+- show options on every click

--- a/packages/picasso/src/Autocomplete/Autocomplete.tsx
+++ b/packages/picasso/src/Autocomplete/Autocomplete.tsx
@@ -274,6 +274,7 @@ export const Autocomplete = forwardRef<HTMLInputElement, Props>(
     )
 
     const inputWrapperRef = useRef<HTMLDivElement>(null)
+    const inputProps = getInputProps()
 
     return (
       <div
@@ -287,7 +288,7 @@ export const Autocomplete = forwardRef<HTMLInputElement, Props>(
         aria-expanded={isOpen}
         aria-haspopup='listbox'
       >
-        <Container flex ref={inputWrapperRef}>
+        <Container flex ref={inputWrapperRef} onClick={inputProps.onClick}>
           {!enableAutofill && name && (
             <input
               type='hidden'
@@ -298,7 +299,7 @@ export const Autocomplete = forwardRef<HTMLInputElement, Props>(
           )}
           <InputComponent
             {...rest}
-            {...getInputProps()}
+            {...inputProps}
             status={error ? 'error' : status}
             icon={icon}
             disabled={disabled}


### PR DESCRIPTION
[TACO-1656]

### Description

When `TagSelector` has enough options selected to wrap on two lines or more clicking on it may not open the popper menu. This is due to the fact the click event is attached to the autocomplete input inside the component. This PR fixes this by attaching the same click handler to the parent container.

### How to test

Use the "Initially set value" sub-section under "TagSelector" page in the story book to test it.

### Screenshots

**Before**

https://user-images.githubusercontent.com/4757057/177348074-7119ba4e-6936-4520-882c-d00da2932232.mp4

**After**

https://user-images.githubusercontent.com/4757057/177347758-b1e20732-4164-442b-b187-d755df86e00b.mp4


### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests

**Breaking change**

- n/a ~~codemod is created and showcased in the changeset~~
- n/a ~~test alpha package of Picasso in StaffPortal~~

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[TACO-1656]: https://toptal-core.atlassian.net/browse/TACO-1656?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ