### PR TITLE
fix: revert github-script to v4

### DIFF
--- a/.github/workflows/davinci-alpha-package.yml
+++ b/.github/workflows/davinci-alpha-package.yml
@@ -18,7 +18,7 @@ jobs:
       STATUS_TARGET_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
     steps:
       - name: Feedback on action started
-        uses: actions/github-script@v6
+        uses: actions/github-script@v4
         with:
           github-token: ${{ env.GITHUB_TOKEN }}
           script: |
@@ -47,7 +47,7 @@ jobs:
           fetch-depth: 0 # otherwise, you will fail to push refs to dest repo
 
       - name: Set status check - pending
-        uses: actions/github-script@v6
+        uses: actions/github-script@v4
         with:
           github-token: ${{ env.GITHUB_TOKEN }}
           script: |
@@ -70,7 +70,7 @@ jobs:
 
       - name: Alpha package — Handle success
         if: ${{ success() }}
-        uses: actions/github-script@v6
+        uses: actions/github-script@v4
         env:
           versions: ${{ steps.alpha-package.outputs.versions }}
         with:
@@ -86,7 +86,7 @@ jobs:
 
       - name: Set status check - success / failure / error
         if: ${{ always() }}
-        uses: actions/github-script@v6
+        uses: actions/github-script@v4
         with:
           github-token: ${{ env.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,7 @@ jobs:
 
       - name: Add no-jira label to "Version Package" PR
         if: ${{ steps.changesets.outputs.published != 'true' }}
-        uses: actions/github-script@v6
+        uses: actions/github-script@v4
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
@@ -92,7 +92,7 @@ jobs:
             }
       - name: Edit "Version Package" PR
         if: ${{ steps.changesets.outputs.published != 'true' }}
-        uses: actions/github-script@v6
+        uses: actions/github-script@v4
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |

--- a/.github/workflows/request-review-on-pr.yml
+++ b/.github/workflows/request-review-on-pr.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Create PR review request
-        uses: actions/github-script@v6
+        uses: actions/github-script@v4
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |


### PR DESCRIPTION
### Description

Revert github-script to v4 and deal with bumping the version in separate task

### Development checks

- Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- Make sure that additions and changes on design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- Annotate all `props` in component with documentation
- Create `examples` for component
- Ensure that deployed demo has expected results and good examples
- Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- Self reviewed
- Covered with tests

**Breaking change**

- codemod is created and showcased in the changeset
- test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>
