### PR TITLE
feat(modal): adjust modal content top padding

### DIFF
--- a/.changeset/sweet-squids-crash.md
+++ b/.changeset/sweet-squids-crash.md
@@ -1,0 +1,9 @@
+---
+'@toptal/picasso': patch
+---
+
+---
+
+### Modal
+
+- adjust modal content top padding

--- a/packages/picasso/src/ModalContent/styles.ts
+++ b/packages/picasso/src/ModalContent/styles.ts
@@ -18,7 +18,7 @@ export default ({ palette }: Theme) => {
 
   return createStyles({
     modalContent: {
-      padding: WRAPPER_PADDING,
+      padding: `1.5em ${WRAPPER_PADDING} ${WRAPPER_PADDING}`,
       overflow: 'auto',
       flex: '1 1 auto',
     },


### PR DESCRIPTION
[no-jira]

### Description

There is a difference between the `Modal.Content` component in Picasso and [Figma Product Library](https://www.figma.com/file/5SCTOPrCDcHuk5We091GBn/Product-Library?node-id=280%3A15387). This change fixes this issue. Topic has discussed in the slack [channel](https://toptal-core.slack.com/archives/CERF5NHT3/p1657183527652579)

### How to test

- FIXME: Add the steps describing how to verify your changes

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| <img width="655" alt="image" src="https://user-images.githubusercontent.com/24292362/177963975-7fbb7528-9f07-4296-a305-a2c9f5906ded.png"> | <img width="653" alt="image" src="https://user-images.githubusercontent.com/24292362/177963872-7464fae8-92a1-4f87-ab4f-a72ff3e0b8e2.png"> |

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [n/a] Annotate all `props` in component with documentation
- [n/a] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [n/a] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [n/a] Covered with tests

**Breaking change**

- [n/a] codemod is created and showcased in the changeset
- [n/a] test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>
