### PR TITLE
chore: dont add [skip-ci] to Version Package PR

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,32 +64,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.TOPTAL_BUILD_BOT_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN_PUBLISH }}
 
-      - name: Add no-jira label to "Version Package" PR
-        if: ${{ steps.changesets.outputs.published != 'true' }}
-        uses: actions/github-script@v6
-        with:
-          github-token: ${{secrets.GITHUB_TOKEN}}
-          script: |
-            // Get list of all open PRs with
-            // head branch "changeset-release/master"
-            // (there should be max 1 PR with such condition)
-            const { data } = await github.rest.pulls.list({
-              owner: 'toptal',
-              repo: 'picasso',
-              state: 'open',
-              head: 'toptal:changeset-release/master'
-            })
-            // add to all of them label "no-jira"
-            for await (let pr of data) {
-              github.rest.issues.addLabels({
-                owner: 'toptal',
-                repo: 'picasso',
-                issue_number: pr.number,
-                labels: [
-                  'no-jira'
-                ]
-              })
-            }
       - name: Edit "Version Package" PR
         if: ${{ steps.changesets.outputs.published != 'true' }}
         uses: actions/github-script@v6
@@ -106,6 +80,16 @@ jobs:
               head: 'toptal:changeset-release/master'
             })
             for await (let pr of data) {
+              // add to all of them label "no-jira"
+              github.rest.issues.addLabels({
+                owner: 'toptal',
+                repo: 'picasso',
+                issue_number: pr.number,
+                labels: [
+                  'no-jira'
+                ]
+              })
+            
               // append PR body with peerDependencies warning
               const hr = "\n_____"
               const warningTodo = "\n- [ ] ⚠️ "
@@ -113,13 +97,11 @@ jobs:
               const appendedMessage = hr + warningTodo + message
               const body = pr.body.includes(message) ? pr.body : pr.body + appendedMessage
 
-              // append title with [skip ci]
               github.rest.pulls.update({
                 owner: 'toptal',
                 repo: 'picasso',
                 pull_number: pr.number,
                 body: body,
-                title: pr.title.includes('[skip ci]') ? pr.title : `${pr.title} [skip ci]`,
               })
             }
 


### PR DESCRIPTION
### Description

Don't add `[skip-ci]` text into "Version Package" PR as its not needed any longer.
Also merged two jobs into one since they did basically the same thing - get all opened "Version Package" PRs and iterate over to:
- add `no-jira` label
- update PR body

### How to test

- code review should be enough

### Development checks

- Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- Make sure that additions and changes on design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- Annotate all `props` in component with documentation
- Create `examples` for component
- Ensure that deployed demo has expected results and good examples
- Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- Covered with tests

**Breaking change**

- codemod is created and showcased in the changeset
- test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>
