### PR TITLE
feat(DatePicker): add footer and indicated in a range of dates

### DIFF
--- a/.changeset/fluffy-hairs-argue.md
+++ b/.changeset/fluffy-hairs-argue.md
@@ -1,0 +1,11 @@
+---
+'@toptal/picasso': minor
+---
+
+---
+
+### DatePicker
+
+- add custom footer and indicated date range options
+
+

--- a/cypress/component/DatePicker.spec.tsx
+++ b/cypress/component/DatePicker.spec.tsx
@@ -1,4 +1,10 @@
-import { Container, DatePicker, DatePickerProps } from '@toptal/picasso'
+import {
+  Container,
+  DatePicker,
+  DatePickerProps,
+  Link,
+  Typography,
+} from '@toptal/picasso'
 import React, { useState } from 'react'
 
 const TestDatePicker = (props: Partial<DatePickerProps>) => {
@@ -59,6 +65,52 @@ describe('DatePicker', () => {
     cy.get('body').happoScreenshot({
       component,
       variant: 'custom-value-parser',
+    })
+  })
+
+  it('renders orange dot indicators in days between a date range', () => {
+    const indicatedIntervals = [
+      { start: new Date('2022-07-11'), end: new Date('2022-07-16') },
+      { start: new Date('2022-07-18'), end: new Date('2022-07-23') },
+    ]
+
+    cy.mount(
+      <TestDatePicker
+        indicatedIntervals={indicatedIntervals}
+        value={new Date('2022-07-14')}
+        testIds={{
+          input: 'date-picker-with-indicators',
+        }}
+      />
+    )
+
+    cy.getByTestId('date-picker-with-indicators').focus()
+
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'indicated-intervals',
+    })
+  })
+
+  it('renders a customized footer', () => {
+    cy.mount(
+      <TestDatePicker
+        footer={
+          <Typography size='small'>
+            Got a question? <Link href='#'>Talk to us</Link>
+          </Typography>
+        }
+        testIds={{
+          input: 'date-picker-with-footer',
+        }}
+      />
+    )
+
+    cy.getByTestId('date-picker-with-footer').focus()
+
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'customized-footer',
     })
   })
 })

--- a/packages/picasso/src/Calendar/Calendar.tsx
+++ b/packages/picasso/src/Calendar/Calendar.tsx
@@ -17,6 +17,7 @@ import {
 import styles from './styles'
 import CalendarMonthHeader from '../CalendarMonthHeader'
 import CalendarContainer from '../CalendarContainer'
+import { CalendarIndicators } from '../CalendarIndicators'
 
 type SimpleReactCalendarRangeType = {
   start: Date
@@ -53,6 +54,7 @@ export interface Props
   value?: DateOrDateRangeType
   activeMonth?: Date
   disabledIntervals?: { start: Date; end: Date }[]
+  indicatedIntervals?: { start: Date; end: Date }[]
   weekStartsOn?: number
   renderMonthHeader?: (props: MonthHeaderProps) => JSX.Element | null
   renderRoot?: (props: CalendarProps) => JSX.Element
@@ -79,6 +81,7 @@ export const Calendar = forwardRef<HTMLDivElement, Props>(function Calendar(
     minDate,
     maxDate,
     disabledIntervals,
+    indicatedIntervals,
     renderDay,
     weekStartsOn,
     renderRoot = rootProps => <CalendarContainer {...rootProps} />,
@@ -132,7 +135,6 @@ export const Calendar = forwardRef<HTMLDivElement, Props>(function Calendar(
               className={cx(classes.day, {
                 [classes.selected]: isSelected,
                 [classes.selectable]: isSelectable,
-                [classes.today]: isToday,
                 [classes.grayed]:
                   (isMonthPrev || isMonthNext) && !isSelected && !isDisabled,
                 [classes.disabled]: isDisabled || !isSelectable,
@@ -145,6 +147,12 @@ export const Calendar = forwardRef<HTMLDivElement, Props>(function Calendar(
               type='button'
             >
               {getDayFormatted(date)}
+              <CalendarIndicators
+                date={date}
+                indicatedIntervals={indicatedIntervals}
+                isSelected={isSelected}
+                isToday={isToday}
+              />
             </button>
           )
 

--- a/packages/picasso/src/Calendar/styles.ts
+++ b/packages/picasso/src/Calendar/styles.ts
@@ -14,6 +14,7 @@ export default ({ palette, sizes }: Theme) =>
       height: '2.5rem',
       width: '2.5rem',
       minWidth: '2.5rem',
+      minHeight: '2.5em',
       verticalAlign: 'middle',
       fontSize: '0.75rem',
       userSelect: 'none',
@@ -27,6 +28,7 @@ export default ({ palette, sizes }: Theme) =>
       border: 'none',
       outline: 0,
       borderRadius: sizes.borderRadius.small,
+      flexDirection: 'column',
     },
     weekDays: {
       display: 'flex',
@@ -75,20 +77,6 @@ export default ({ palette, sizes }: Theme) =>
 
       '&$today:after': {
         backgroundColor: palette.common.white,
-      },
-    },
-    today: {
-      display: 'flex',
-      flexDirection: 'column',
-
-      '&:after': {
-        content: '""',
-        height: '0.25rem',
-        width: '0.25rem',
-        borderRadius: '50%',
-        background: palette.blue.main,
-        position: 'absolute',
-        bottom: '0.375rem',
       },
     },
     grayed: {

--- a/packages/picasso/src/CalendarIndicators/CalendarIndicators.tsx
+++ b/packages/picasso/src/CalendarIndicators/CalendarIndicators.tsx
@@ -1,0 +1,49 @@
+import React, { useMemo } from 'react'
+import { makeStyles, Theme } from '@material-ui/core/styles'
+import cx from 'classnames'
+
+import styles from './styles'
+
+export interface Props {
+  indicatedIntervals?: { start: Date; end: Date }[]
+  date: Date
+  isSelected: boolean
+  isToday: boolean
+}
+
+const useStyles = makeStyles<Theme>(styles, {
+  name: 'PicassoCalendarIndicators',
+})
+
+export const CalendarIndicators = ({
+  date,
+  indicatedIntervals,
+  isSelected,
+  isToday,
+}: Props) => {
+  const classes = useStyles()
+
+  const isIndicated = useMemo(() => {
+    return (
+      indicatedIntervals != null &&
+      indicatedIntervals.some(({ start, end }) => date >= start && date <= end)
+    )
+  }, [indicatedIntervals, date])
+
+  if (isToday || indicatedIntervals) {
+    return (
+      <div className={classes.indicators}>
+        {isToday && (
+          <div
+            className={cx(classes.today, {
+              [classes.selected]: isSelected,
+            })}
+          />
+        )}
+        {isIndicated && <div className={classes.indicated} />}
+      </div>
+    )
+  }
+
+  return null
+}

--- a/packages/picasso/src/CalendarIndicators/index.ts
+++ b/packages/picasso/src/CalendarIndicators/index.ts
@@ -1,0 +1,1 @@
+export * from './CalendarIndicators'

--- a/packages/picasso/src/CalendarIndicators/styles.ts
+++ b/packages/picasso/src/CalendarIndicators/styles.ts
@@ -1,0 +1,29 @@
+import { Theme, createStyles } from '@material-ui/core/styles'
+
+export default ({ palette }: Theme) =>
+  createStyles({
+    indicators: {
+      display: 'flex',
+      flexDirection: 'row',
+      justifyContent: 'space-around',
+      width: '1.3em',
+      position: 'absolute',
+      bottom: '0.375rem',
+    },
+    indicated: {
+      content: '""',
+      height: '0.25rem',
+      width: '0.25rem',
+      borderRadius: '50%',
+      background: palette.yellow.main,
+    },
+    today: {
+      height: '0.25rem',
+      width: '0.25rem',
+      borderRadius: '50%',
+      background: palette.blue.main,
+    },
+    selected: {
+      background: palette.common.white,
+    },
+  })

--- a/packages/picasso/src/DatePicker/DatePicker.tsx
+++ b/packages/picasso/src/DatePicker/DatePicker.tsx
@@ -109,6 +109,10 @@ export interface Props
     calendar?: string
     input?: string
   }
+  /** Adds a customized footer at the bottom of the calendar */
+  footer?: ReactNode
+  /** Shows orange dot indicator in days between a date range */
+  indicatedIntervals?: { start: Date; end: Date }[]
 }
 
 export const DatePicker = (props: Props) => {
@@ -137,6 +141,8 @@ export const DatePicker = (props: Props) => {
     status,
     popperProps,
     disabled,
+    footer,
+    indicatedIntervals,
     ...rest
   } = props
   const classes = useStyles()
@@ -409,12 +415,14 @@ export const DatePicker = (props: Props) => {
             minDate={normalizedMinDate}
             maxDate={normalizedMaxDate}
             disabledIntervals={disabledIntervals}
+            indicatedIntervals={indicatedIntervals}
             renderDay={renderDay}
             onChange={handleCalendarChange}
             onBlur={handleBlur}
             className={classes.calendar}
             weekStartsOn={weekStartsOn}
           />
+          {footer && <div className={classes.footer}>{footer}</div>}
         </Popper>
       )}
     </>

--- a/packages/picasso/src/DatePicker/story/WithFooter.example.tsx
+++ b/packages/picasso/src/DatePicker/story/WithFooter.example.tsx
@@ -1,0 +1,24 @@
+import React, { useState } from 'react'
+import { DatePicker, Link, Typography } from '@toptal/picasso'
+
+const WithFooterRendering = () => {
+  const [datepickerValue, setDatepickerValue] = useState<Date>()
+
+  return (
+    <div style={{ height: '50vh' }}>
+      <DatePicker
+        value={datepickerValue}
+        onChange={date => {
+          setDatepickerValue(date as Date)
+        }}
+        footer={
+          <Typography size='small'>
+            Got a question? <Link href='#'>Talk to us</Link>
+          </Typography>
+        }
+      />
+    </div>
+  )
+}
+
+export default WithFooterRendering

--- a/packages/picasso/src/DatePicker/story/WithIndicatedRange.example.tsx
+++ b/packages/picasso/src/DatePicker/story/WithIndicatedRange.example.tsx
@@ -1,0 +1,25 @@
+import React, { useState } from 'react'
+import { DatePicker } from '@toptal/picasso'
+
+const WithIndicatedRangeRendering = () => {
+  const [datepickerValue, setDatepickerValue] = useState<Date>()
+
+  const indicatedIntervals = [
+    { start: new Date('2022-07-11'), end: new Date('2022-07-16') },
+    { start: new Date('2022-07-18'), end: new Date('2022-07-23') },
+  ]
+
+  return (
+    <div style={{ height: '50vh' }}>
+      <DatePicker
+        value={datepickerValue}
+        indicatedIntervals={indicatedIntervals}
+        onChange={date => {
+          setDatepickerValue(date as Date)
+        }}
+      />
+    </div>
+  )
+}
+
+export default WithIndicatedRangeRendering

--- a/packages/picasso/src/DatePicker/story/index.jsx
+++ b/packages/picasso/src/DatePicker/story/index.jsx
@@ -74,3 +74,13 @@ page
       'Type any year value like `2015` to get a random date within this year',
     takeScreenshot: false,
   })
+  .addExample('DatePicker/story/WithIndicatedRange.example.tsx', {
+    title: 'With Indicated Range',
+    description: 'Show as indicated a range of dates',
+    takeScreenshot: false,
+  })
+  .addExample('DatePicker/story/WithFooter.example.tsx', {
+    title: 'With Footer',
+    description: 'Show a custom footer at the bottom of the calendar',
+    takeScreenshot: false,
+  })

--- a/packages/picasso/src/DatePicker/styles.ts
+++ b/packages/picasso/src/DatePicker/styles.ts
@@ -1,8 +1,15 @@
-import { createStyles } from '@material-ui/core/styles'
+import { createStyles, Theme } from '@material-ui/core/styles'
 
-export default () =>
+export default ({ palette, shadows, sizes }: Theme) =>
   createStyles({
     calendar: {
       outline: 'none',
+    },
+    footer: {
+      backgroundColor: palette.grey.lightest,
+      boxShadow: shadows[5],
+      borderRadius: `0 0 ${sizes.borderRadius.small} ${sizes.borderRadius.small}`,
+      padding: '0.625rem 1.187rem',
+      width: '20.5rem',
     },
   })

--- a/packages/picasso/src/DatePicker/test.tsx
+++ b/packages/picasso/src/DatePicker/test.tsx
@@ -515,6 +515,19 @@ describe('DatePicker', () => {
         expect(queryByTestId('day-button-selected')).toBeInTheDocument()
       })
     })
+
+    describe('when `footer` option is passed', () => {
+      it('should appear a footer at the bottom of the calendar', async () => {
+        const { getByText, getByPlaceholderText } = renderDatePicker({
+          ...defaultProps,
+          footer: <>Footer</>,
+        })
+
+        fireEvent.focus(getByPlaceholderText(defaultProps.placeholder))
+
+        expect(getByText('Footer')).toBeInTheDocument()
+      })
+    })
   })
 
   const defaultProps = {


### PR DESCRIPTION
[SDE-374](https://toptal-core.atlassian.net/browse/SDE-374)

### Description
In our current [initiative](https://toptal-core.atlassian.net/browse/PI-1934), we'll need some improvements in the DatePicker component to be used in Client Portal and Staff Portal. So in this PR, we have developed some features listed below:
 
- Option to highlight with a yellow indicator a specific range of dates
- Option to add a customized footer to the bottom of the calendar

### How to test

- Access [https://picasso.toptal.net/sde-374-improve-date-picker-features/](https://picasso.toptal.net/sde-374-improve-date-picker-features/?16717e025189d3d36ab4e71ddaf4e01018d3a5fd)
- Verify each feature example at Datepicker section
- Compare requirements in the ticket with implementation

### Screenshots

| Features                             | Screenshots                           |
| --------------------------------------- | --------------------------------------- |
| With Indicated Range | ![indicated](https://user-images.githubusercontent.com/5639968/178621235-93524bf3-ac31-43b6-892b-bd3b29622333.png) |
| With Footer | ![footer](https://user-images.githubusercontent.com/5639968/176520436-1dd5f50a-0673-4d48-a990-deacb728cf00.png) |

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests

**Breaking change**

- [N/A] codemod is created and showcased in the changeset
- [N/A] test alpha package of Picasso in StaffPortal

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>
