### PR TITLE
feat(stepper): add `overflowEllipsis` prop

### DIFF
--- a/.changeset/light-mugs-prove.md
+++ b/.changeset/light-mugs-prove.md
@@ -1,0 +1,9 @@
+---
+'@toptal/picasso': minor
+---
+
+---
+
+### Stepper
+
+Add `overflowEllipsis` prop to enable proper ellipsis overflow for `Stepper` labels

--- a/cypress/component/Stepper.spec.tsx
+++ b/cypress/component/Stepper.spec.tsx
@@ -1,0 +1,46 @@
+import React from 'react'
+import { Stepper, StepperProps, Container } from '@toptal/picasso'
+
+const TestStepper = ({ overflowEllipsis }: Partial<StepperProps> = {}) => (
+  <Container style={{ width: '400px' }}>
+    <Stepper
+      data-testid='stepper'
+      overflowEllipsis={overflowEllipsis}
+      steps={['Step 1', 'Step 2', 'Step 3', 'Step 4', 'Step 5']}
+    />
+  </Container>
+)
+
+const component = 'Stepper'
+
+describe('Stepper', () => {
+  describe('when overflow ellipsis is not enabled', () => {
+    it('renders stepper without tooltip on hover', () => {
+      cy.mount(<TestStepper overflowEllipsis={false} />)
+
+      cy.getByTestId('stepper').find('span').last().trigger('click')
+
+      cy.getByRole('tooltip').should('not.exist')
+
+      cy.get('body').happoScreenshot({
+        component,
+        variant: 'stepper/when-overflow-ellipsis-disabled',
+      })
+    })
+  })
+
+  describe('when overflow ellipsis is enabled', () => {
+    it('renders stepper with tooltip on hover', () => {
+      cy.mount(<TestStepper overflowEllipsis />)
+
+      cy.getByTestId('stepper').find('span').last().trigger('click')
+
+      cy.getByRole('tooltip').contains('Step 5').should('be.visible')
+
+      cy.get('body').happoScreenshot({
+        component,
+        variant: 'stepper/when-overflow-ellipsis-enabled',
+      })
+    })
+  })
+})

--- a/packages/picasso/src/StepLabel/StepLabel.tsx
+++ b/packages/picasso/src/StepLabel/StepLabel.tsx
@@ -7,6 +7,7 @@ import { BaseProps, TextLabelProps, useTitleCase } from '@toptal/picasso-shared'
 import StepIcon from '../StepIcon'
 import styles from './styles'
 import toTitleCase from '../utils/to-title-case'
+import TypographyOverflow from '../TypographyOverflow'
 
 export interface Props
   extends BaseProps,
@@ -16,6 +17,7 @@ export interface Props
   children: string
   active?: boolean
   completed?: boolean
+  overflowEllipsis?: boolean
 }
 
 const useStyles = makeStyles<Theme>(styles, { name: 'PicassoStepLabel' })
@@ -27,6 +29,7 @@ export const StepLabel = (props: Props) => {
     children,
     completed,
     hideLabel,
+    overflowEllipsis,
     style,
     titleCase: propsTitleCase,
     ...rest
@@ -34,22 +37,35 @@ export const StepLabel = (props: Props) => {
   const titleCase = useTitleCase(propsTitleCase)
   const classes = useStyles()
 
+  const withOverflowEllipsis = !hideLabel && overflowEllipsis
+  const labelElement = (
+    <span className={classes.label}>
+      {titleCase ? toTitleCase(children) : children}
+    </span>
+  )
+
   return (
     <MUIStepLabel
       {...rest}
       classes={{
         labelContainer: cx({
           [classes.root]: !hideLabel || active,
+          [classes.labelContainerOverflowEllipsis]: withOverflowEllipsis,
         }),
-        label: cx({ [classes.hidden]: hideLabel && !active }),
+        label: cx({
+          [classes.hidden]: hideLabel && !active,
+          [classes.labelOverflowEllipsis]: withOverflowEllipsis,
+        }),
       }}
       className={className}
       icon={<StepIcon active={active} completed={completed} />}
       style={style}
     >
-      <span className={classes.label}>
-        {titleCase ? toTitleCase(children) : children}
-      </span>
+      {withOverflowEllipsis ? (
+        <TypographyOverflow>{labelElement}</TypographyOverflow>
+      ) : (
+        labelElement
+      )}
     </MUIStepLabel>
   )
 }

--- a/packages/picasso/src/StepLabel/styles.ts
+++ b/packages/picasso/src/StepLabel/styles.ts
@@ -25,6 +25,12 @@ export default ({ palette, breakpoints: { down } }: Theme) =>
     hidden: {
       display: 'none',
     },
+    labelContainerOverflowEllipsis: {
+      display: 'grid',
+    },
+    labelOverflowEllipsis: {
+      overflow: 'hidden',
+    },
     root: {
       marginLeft: '0.5em',
     },

--- a/packages/picasso/src/Stepper/Stepper.tsx
+++ b/packages/picasso/src/Stepper/Stepper.tsx
@@ -18,6 +18,8 @@ export interface StepperBaseProps
   active?: number
   /** Array of the step labels */
   steps: string[]
+  /** Enable overflow ellipsis for labels */
+  overflowEllipsis?: boolean
 }
 
 export interface Props extends StepperBaseProps {
@@ -37,6 +39,7 @@ const Stepper = forwardRef<HTMLDivElement, Props>((props, ref) => {
     style,
     titleCase,
     direction = 'horizontal',
+    overflowEllipsis = false,
     ...rest
   } = props
   const classes = useStyles()
@@ -57,6 +60,7 @@ const Stepper = forwardRef<HTMLDivElement, Props>((props, ref) => {
             active={stepIndex === active}
             hideLabel={hideLabels}
             titleCase={titleCase}
+            overflowEllipsis={overflowEllipsis}
           >
             {label}
           </StepLabel>
@@ -70,6 +74,7 @@ Stepper.defaultProps = {
   active: 0,
   hideLabels: false,
   direction: 'horizontal',
+  overflowEllipsis: false,
   steps: [],
 }
 

--- a/packages/picasso/src/Stepper/story/Overflow.example.tsx
+++ b/packages/picasso/src/Stepper/story/Overflow.example.tsx
@@ -1,0 +1,19 @@
+import React from 'react'
+import { Stepper, Container } from '@toptal/picasso'
+import styled from 'styled-components'
+
+const StyledContainer = styled(Container)`
+  width: 450px;
+  border: 1px solid #000;
+`
+
+const Example = () => (
+  <StyledContainer padded='medium'>
+    <Stepper
+      overflowEllipsis
+      steps={['Step 1', 'Step 2', 'Step 3', 'Step 4', 'Step 5']}
+    />
+  </StyledContainer>
+)
+
+export default Example

--- a/packages/picasso/src/Stepper/story/index.jsx
+++ b/packages/picasso/src/Stepper/story/index.jsx
@@ -23,3 +23,7 @@ page
   .addExample('Stepper/story/Default.example.tsx', 'Default')
   .addExample('Stepper/story/WithoutLabels.example.tsx', 'Without Labels')
   .addExample('Stepper/story/Vertical.example.tsx', 'Vertical')
+  .addExample('Stepper/story/Overflow.example.tsx', {
+    title: 'Overflow',
+    takeScreenshot: false,
+  })

--- a/yarn.lock
+++ b/yarn.lock
@@ -13218,21 +13218,7 @@ happo-cypress@^3.0.1:
   dependencies:
     happo-e2e "^1.0.3"
 
-happo-e2e@^1.0.3, happo-e2e@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.npmjs.org/happo-e2e/-/happo-e2e-1.1.0.tgz"
-  integrity sha512-6vHmYfqnCNr+Eur+rOzUSGrsCsjBXtNFi/PwDkyk5ejRJ072aQEL7VnDosEsbiNMK5uCUsX5UprV4L1buezzpA==
-  dependencies:
-    archiver "^5.3.0"
-    base64-stream "^1.0.0"
-    crypto-js "^4.1.1"
-    https-proxy-agent "^5.0.0"
-    mkdirp "^1.0.4"
-    node-fetch "^2.0.0"
-    parse-srcset "^1.0.2"
-    string.prototype.replaceall "^1.0.6"
-
-happo-e2e@^1.2.0:
+happo-e2e@^1.0.3, happo-e2e@^1.1.0, happo-e2e@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/happo-e2e/-/happo-e2e-1.2.0.tgz#a7bdc71c48fe4fcdd51fc9dfac0c58a7410017d3"
   integrity sha512-F94HEJgAq1dnZXlty9t7E/uTHrKJlTsem1oqkPpH6EkqXKasWGShEo+f74YvXzxwBlzs+Kw3vVT0E+ibOVmKHw==


### PR DESCRIPTION
[SPT-2844]

### Description

Add `overflowEllipsis` prop to enable proper ellipsis overflow with the tooltip for `Stepper` labels

### How to test

- Open https://picasso.toptal.net/SPT-2844-stepper-overflow/?path=/story/components-stepper--stepper
- Scroll to the `overflow` section
- Check that tooltip is visible when hovering over labels with `overflow: ellipsis`
- Check that tooltip is not visible when hovering over labels without `overflow: ellipsis`

### Screenshots

![image](https://user-images.githubusercontent.com/9210534/179463033-035d7dc2-1cd7-4d84-b180-2512b7fdf53c.png)

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[SPT-2844]: https://toptal-core.atlassian.net/browse/SPT-2844?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ