### PR TITLE
fix(TagSelector): update testids property definition

### DIFF
--- a/.changeset/long-sloths-pump.md
+++ b/.changeset/long-sloths-pump.md
@@ -1,0 +1,5 @@
+---
+'@toptal/picasso': patch
+---
+
+Support all testids values inherited from Autocomplete in the TagSelector component

--- a/.changeset/long-sloths-pump.md
+++ b/.changeset/long-sloths-pump.md
@@ -2,4 +2,7 @@
 '@toptal/picasso': patch
 ---
 
-Support all testids values inherited from Autocomplete in the TagSelector component
+---
+### TagSelector
+
+- support all testids values inherited from Autocomplete

--- a/packages/picasso/src/TagSelector/TagSelector.tsx
+++ b/packages/picasso/src/TagSelector/TagSelector.tsx
@@ -10,7 +10,10 @@ import React, {
 import { BaseProps } from '@toptal/picasso-shared'
 import { PopperOptions } from 'popper.js'
 
-import Autocomplete, { Item as AutocompleteItem } from '../Autocomplete'
+import Autocomplete, {
+  AutocompleteProps,
+  Item as AutocompleteItem,
+} from '../Autocomplete'
 import TagSelectorInput from '../TagSelectorInput'
 import { Props as InputProps } from '../Input'
 import TagSelectorLabel from '../TagSelectorLabel'
@@ -106,9 +109,7 @@ export interface Props
   popperContainer?: HTMLElement
   /** Options provided to the popper.js instance */
   popperOptions?: PopperOptions
-  testIds?: {
-    validIcon?: string
-  }
+  testIds?: AutocompleteProps['testIds']
 }
 
 export const TagSelector = forwardRef<HTMLInputElement, Props>(


### PR DESCRIPTION
### Description

The `TagSelector` component has its own property definition that allows to pass the `validationIcon` of the `testids` property only. In some cases there is a need to specify, e.g. `input` field of `testids` property, but there is no way to do it for now.
This PR extends `testids` property of the `TagSelector` component and allows to specify any field that is supported by internally used `Autocomplete` component.

### How to test

- There must be no visual changes

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| Insert screenshots or screen recordings | Insert screenshots or screen recordings |

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests

**Breaking change**

- ~codemod is created and showcased in the changeset~
- ~test alpha package of Picasso in StaffPortal~

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>
