### PR TITLE
chore(TagSelector): add min-width to underlying input

### DIFF
--- a/.changeset/proud-emus-destroy.md
+++ b/.changeset/proud-emus-destroy.md
@@ -1,0 +1,9 @@
+---
+'@toptal/picasso': patch
+---
+
+--
+
+### TagSelector
+
+- fix input's width issue after adding multiple tags

--- a/.changeset/proud-emus-destroy.md
+++ b/.changeset/proud-emus-destroy.md
@@ -2,7 +2,7 @@
 '@toptal/picasso': patch
 ---
 
---
+---
 
 ### TagSelector
 

--- a/packages/picasso/src/TagSelectorInput/styles.ts
+++ b/packages/picasso/src/TagSelectorInput/styles.ts
@@ -17,6 +17,7 @@ export default () =>
       cursor: 'pointer',
 
       '& > input': {
+        minWidth: rem('48px'),
         flexGrow: 1,
         width: 0,
         height: rem('24px'),

--- a/packages/picasso/src/TagSelectorInput/styles.ts
+++ b/packages/picasso/src/TagSelectorInput/styles.ts
@@ -17,7 +17,7 @@ export default () =>
       cursor: 'pointer',
 
       '& > input': {
-        minWidth: rem('48px'),
+        minWidth: '3em',
         flexGrow: 1,
         width: 0,
         height: rem('24px'),


### PR DESCRIPTION
[FX-1944]

### Description

According to the ticket description, I have added a meaningful min-width to the input class.

### How to test

- you can play with the custom option story and add your own options to squeeze the width.

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| <img width="373" alt="Screen Shot 2022-07-26 at 15 55 31" src="https://user-images.githubusercontent.com/7733167/181010956-d972db0f-3c05-46ef-ab08-15079cc68f40.png"> | <img width="373" alt="Screen Shot 2022-07-26 at 15 55 25" src="https://user-images.githubusercontent.com/7733167/181010990-d2031c33-488e-4b59-a06c-50edeaee96f9.png"> |

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- Make sure that additions and changes on design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- Annotate all `props` in component with documentation
- Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests

**Breaking change**

- codemod is created and showcased in the changeset
- test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-1499]: https://toptal-core.atlassian.net/browse/FX-1499?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[FX-1944]: https://toptal-core.atlassian.net/browse/FX-1944?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ