### PR TITLE
fix(TagSelector): fix using TagSelector with initialValue

### DIFF
--- a/.changeset/young-grapes-type.md
+++ b/.changeset/young-grapes-type.md
@@ -1,0 +1,9 @@
+---
+'@toptal/picasso': patch
+'@toptal/picasso-forms': patch
+---
+
+---
+### TagSelector
+
+- fix using TagSelector with form's initial values

--- a/packages/picasso-forms/src/Form/story/Default.example.tsx
+++ b/packages/picasso-forms/src/Form/story/Default.example.tsx
@@ -37,6 +37,11 @@ const filterOptions = (str = '', options: Item[] = []): Item[] | null => {
   return result.length > 0 ? result : null
 }
 
+const initialValues = {
+  'default-gender': 'female',
+  'default-skills': [skills[0]],
+}
+
 const Example = () => {
   const [skillInputValue, setSkillInputValue] =
     useState<string>(EMPTY_INPUT_VALUE)
@@ -52,7 +57,7 @@ const Example = () => {
     <Form
       autoComplete='off'
       onSubmit={values => window.alert(JSON.stringify(values, undefined, 2))}
-      initialValues={{ 'default-gender': 'female' }}
+      initialValues={initialValues}
     >
       <Form.Input
         enableReset

--- a/packages/picasso-forms/src/Form/story/Default.example.tsx
+++ b/packages/picasso-forms/src/Form/story/Default.example.tsx
@@ -39,7 +39,6 @@ const filterOptions = (str = '', options: Item[] = []): Item[] | null => {
 
 const initialValues = {
   'default-gender': 'female',
-  'default-skills': [skills[0]],
 }
 
 const Example = () => {

--- a/packages/picasso-forms/src/Form/test.tsx
+++ b/packages/picasso-forms/src/Form/test.tsx
@@ -55,6 +55,37 @@ const renderForm = (
   )
 }
 
+interface FormData {
+  firstName: string
+  skills: any[]
+}
+
+const skillOptions = [
+  { value: '0', text: 'HTML' },
+  { value: '1', text: 'CSS' },
+  { value: '2', text: 'Javascript' },
+]
+
+const initialValues: FormData = {
+  firstName: 'Bruce',
+  skills: [skillOptions[0]],
+}
+
+const renderFormWithInitialValues = (onSubmit: (values: FormData) => void) => {
+  return render(
+    <Form onSubmit={values => onSubmit(values)} initialValues={initialValues}>
+      <Form.Input name='firstName' placeholder='test input' />
+      <Form.TagSelector
+        name='skills'
+        label='Skills'
+        options={skillOptions}
+        inputValue=''
+      />
+      <Button type='submit'>Submit</Button>
+    </Form>
+  )
+}
+
 const scrollToMock = scrollTo as jest.Mock
 
 describe('Form', () => {
@@ -153,6 +184,20 @@ describe('Form', () => {
           expect(getByTestId('valid-icon')).toBeInTheDocument()
         })
       })
+    })
+  })
+
+  describe('when initial values provided', () => {
+    it('fills up the fields with provided value', async () => {
+      const onSubmit = jest.fn()
+
+      const { getByText } = renderFormWithInitialValues(onSubmit)
+
+      await act(() => {
+        fireEvent.click(getByText('Submit'))
+      })
+
+      expect(onSubmit).toHaveBeenCalledWith(initialValues)
     })
   })
 })

--- a/packages/picasso-forms/src/Form/test.tsx
+++ b/packages/picasso-forms/src/Form/test.tsx
@@ -56,8 +56,7 @@ const renderForm = (
 }
 
 interface FormData {
-  firstName: string
-  skills: any[]
+  skills: { value: string; text: string }[]
 }
 
 const skillOptions = [
@@ -67,14 +66,14 @@ const skillOptions = [
 ]
 
 const initialValues: FormData = {
-  firstName: 'Bruce',
   skills: [skillOptions[0]],
 }
 
-const renderFormWithInitialValues = (onSubmit: (values: FormData) => void) => {
+const renderTagSelectorWithInitialValue = (
+  onSubmit: (values: FormData) => void
+) => {
   return render(
     <Form onSubmit={values => onSubmit(values)} initialValues={initialValues}>
-      <Form.Input name='firstName' placeholder='test input' />
       <Form.TagSelector
         name='skills'
         label='Skills'
@@ -187,11 +186,11 @@ describe('Form', () => {
     })
   })
 
-  describe('when initial values provided', () => {
-    it('fills up the fields with provided value', async () => {
+  describe('when initial values provided to form', () => {
+    it('fills TagSelector field with provided values', async () => {
       const onSubmit = jest.fn()
 
-      const { getByText } = renderFormWithInitialValues(onSubmit)
+      const { getByText } = renderTagSelectorWithInitialValue(onSubmit)
 
       await act(() => {
         fireEvent.click(getByText('Submit'))

--- a/packages/picasso-forms/src/TagSelector/TagSelector.tsx
+++ b/packages/picasso-forms/src/TagSelector/TagSelector.tsx
@@ -34,10 +34,6 @@ export const TagSelector = (props: Props) => {
   )
 }
 
-TagSelector.defaultProps = {
-  initialValue: [],
-}
-
 TagSelector.displayName = 'TagSelector'
 
 export default TagSelector

--- a/packages/picasso-forms/src/TagSelector/TagSelector.tsx
+++ b/packages/picasso-forms/src/TagSelector/TagSelector.tsx
@@ -28,7 +28,11 @@ export const TagSelector = (props: Props) => {
       }
     >
       {(inputProps: TagSelectorProps) => {
-        return <PicassoTagSelector {...inputProps} />
+        const { value, ...restOfInputProps } = inputProps
+        // avoid passing empty string to TagSelector
+        const valueAsArray = value ? value : []
+
+        return <PicassoTagSelector {...restOfInputProps} value={valueAsArray} />
       }}
     </InputField>
   )

--- a/packages/picasso-forms/src/TagSelector/TagSelector.tsx
+++ b/packages/picasso-forms/src/TagSelector/TagSelector.tsx
@@ -30,7 +30,7 @@ export const TagSelector = (props: Props) => {
       {(inputProps: TagSelectorProps) => {
         const { value, ...restOfInputProps } = inputProps
         // avoid passing empty string to TagSelector
-        const valueAsArray = value ? value : []
+        const valueAsArray = Array.isArray(value) ? value : []
 
         return <PicassoTagSelector {...restOfInputProps} value={valueAsArray} />
       }}

--- a/packages/picasso/src/TagSelector/TagSelector.tsx
+++ b/packages/picasso/src/TagSelector/TagSelector.tsx
@@ -133,7 +133,7 @@ export const TagSelector = forwardRef<HTMLInputElement, Props>(
       renderLabel: customRenderLabel,
       renderOption,
       showOtherOption,
-      value,
+      value: values = [],
       width,
       popperContainer,
       popperOptions,
@@ -142,9 +142,6 @@ export const TagSelector = forwardRef<HTMLInputElement, Props>(
       testIds,
       ...rest
     } = props
-
-    // being sure that values will be an array
-    const values = value ? value : []
 
     usePropDeprecationWarning({
       props,

--- a/packages/picasso/src/TagSelector/TagSelector.tsx
+++ b/packages/picasso/src/TagSelector/TagSelector.tsx
@@ -133,7 +133,7 @@ export const TagSelector = forwardRef<HTMLInputElement, Props>(
       renderLabel: customRenderLabel,
       renderOption,
       showOtherOption,
-      value: values = [],
+      value,
       width,
       popperContainer,
       popperOptions,
@@ -142,6 +142,9 @@ export const TagSelector = forwardRef<HTMLInputElement, Props>(
       testIds,
       ...rest
     } = props
+
+    // being sure that values will be an array
+    const values = value ? value : []
 
     usePropDeprecationWarning({
       props,


### PR DESCRIPTION
[FX-2913]

### Description

Due to the default prop value of initialValue, it wasn't possible to set initialValues for TagSelector field.

### How to test

- use Form's default story to see TagSelector working fine
- bug was visible after creating a new app from `davinci new app`

### Screenshots

From newly created davinci app
<img width="726" alt="Screen Shot 2022-07-21 at 09 19 34" src="https://user-images.githubusercontent.com/7733167/180143245-12a37f0d-e4eb-4472-a920-c7907314be6b.png">
<img width="553" alt="Screen Shot 2022-07-21 at 09 17 47" src="https://user-images.githubusercontent.com/7733167/180143194-6984e0c0-20ca-498a-b81d-a9b5923cab2f.png">

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- Make sure that additions and changes on design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- Annotate all `props` in component with documentation
- Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests

**Breaking change**

- codemod is created and showcased in the changeset
- test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-2913]: https://toptal-core.atlassian.net/browse/FX-2913?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ