### PR TITLE
feat(Autocomplete): add onResetClick prop

### DIFF
--- a/.changeset/proud-ligers-grab.md
+++ b/.changeset/proud-ligers-grab.md
@@ -1,0 +1,9 @@
+---
+'@toptal/picasso': minor
+---
+
+---
+
+### Autocomplete
+
+- add `onResetClick` prop

--- a/packages/picasso/src/Autocomplete/Autocomplete.tsx
+++ b/packages/picasso/src/Autocomplete/Autocomplete.tsx
@@ -107,6 +107,10 @@ export interface Props
   enableAutofill?: boolean
   /** Whether to render reset icon when there is a value in the input */
   enableReset?: boolean
+  /** Callback invoked when reset button was clicked */
+  onResetClick?: (
+    event: MouseEvent<HTMLButtonElement & HTMLAnchorElement>
+  ) => void
   /** DOM element that wraps the Popper */
   popperContainer?: HTMLElement
   /** Options provided to the popper.js instance */
@@ -156,6 +160,7 @@ export const Autocomplete = forwardRef<HTMLInputElement, Props>(
       onFocus,
       onKeyDown,
       onOtherOptionSelect,
+      onResetClick,
       onSelect,
       options,
       otherOptionText = 'Other option: ',
@@ -215,6 +220,7 @@ export const Autocomplete = forwardRef<HTMLInputElement, Props>(
       getDisplayValue,
       onSelect,
       onOtherOptionSelect,
+      onResetClick,
       onChange,
       onKeyDown,
       onFocus,
@@ -350,6 +356,7 @@ Autocomplete.defaultProps = {
   onFocus: () => {},
   onBlur: () => {},
   onOtherOptionSelect: () => {},
+  onResetClick: () => {},
   onSelect: () => {},
   options: [],
   otherOptionText: 'Other option: ',

--- a/packages/picasso/src/Autocomplete/story/WithOnResetClick.example.tsx
+++ b/packages/picasso/src/Autocomplete/story/WithOnResetClick.example.tsx
@@ -1,0 +1,67 @@
+import React, { useState } from 'react'
+import { Autocomplete, AutocompleteItem, Form } from '@toptal/picasso'
+import { isSubstring } from '@toptal/picasso/utils'
+
+const allOptions = [
+  { text: 'Belarus' },
+  { text: 'Croatia' },
+  { text: 'Lithuania' },
+  { text: 'Slovakia' },
+  { text: 'Ukraine' },
+]
+
+const EMPTY_INPUT_VALUE = ''
+const getDisplayValue = (item: AutocompleteItem | null) =>
+  item ? item.text || '' : EMPTY_INPUT_VALUE
+
+const filterOptions = (str = '') => {
+  if (str === '') {
+    return allOptions
+  }
+
+  const result = allOptions.filter(option =>
+    isSubstring(str, getDisplayValue(option))
+  )
+
+  return result.length > 0 ? result : null
+}
+
+const Example = () => {
+  const [value, setValue] = useState(EMPTY_INPUT_VALUE)
+  const [options, setOptions] = useState<AutocompleteItem[] | null>(allOptions)
+
+  return (
+    <div>
+      <Form autoComplete='off'>
+        <Autocomplete
+          placeholder='Start typing country...'
+          value={value}
+          options={options}
+          onSelect={item => {
+            console.log('onSelect returns item object:', item)
+
+            const itemValue = getDisplayValue(item)
+
+            if (value !== itemValue) {
+              setValue(itemValue)
+            }
+          }}
+          onChange={newValue => {
+            console.log('onChange returns just item value:', newValue)
+
+            setOptions(filterOptions(newValue))
+            setValue(newValue)
+          }}
+          onResetClick={e => {
+            console.log(e)
+            alert('onResetClick has been called')
+          }}
+          getDisplayValue={getDisplayValue}
+          data-testid='autocomplete'
+        />
+      </Form>
+    </div>
+  )
+}
+
+export default Example

--- a/packages/picasso/src/Autocomplete/story/index.jsx
+++ b/packages/picasso/src/Autocomplete/story/index.jsx
@@ -107,3 +107,9 @@ when it makes sense to have autofill enabled.
       'we have to show the "Powered By Google" label.',
     takeScreenshot: false,
   })
+  .addExample('Autocomplete/story/WithOnResetClick.example.tsx', {
+    title: 'With onResetClick callback',
+    description:
+      'If you need to trigger a callback after Autocomplete input is cleared',
+    takeScreenshot: false,
+  })

--- a/packages/picasso/src/Autocomplete/use-autocomplete/test.ts
+++ b/packages/picasso/src/Autocomplete/use-autocomplete/test.ts
@@ -223,6 +223,25 @@ describe('useAutocomplete', () => {
     })
   })
 
+  it('calls onResetClick callback on reset click', () => {
+    const onResetClick = jest.fn()
+    const { result } = renderUseAutocomplete({ value: 'Picasso', onResetClick })
+
+    const input = result.current.getInputProps()
+
+    const stopPropagation = jest.fn()
+
+    act(() => {
+      input.onResetClick({ stopPropagation } as any)
+    })
+
+    expect(stopPropagation).toHaveBeenCalledTimes(1)
+    expect(onResetClick).toHaveBeenCalledTimes(1)
+    expect(onResetClick).toHaveBeenCalledWith({
+      stopPropagation,
+    })
+  })
+
   it('closes menu on blur', () => {
     const { result } = renderUseAutocomplete()
 

--- a/packages/picasso/src/Autocomplete/use-autocomplete/use-autocomplete.ts
+++ b/packages/picasso/src/Autocomplete/use-autocomplete/use-autocomplete.ts
@@ -79,6 +79,9 @@ export interface Props {
     value: string,
     event: MouseEvent | KeyboardEvent
   ) => void
+  onResetClick?: (
+    event: MouseEvent<HTMLButtonElement & HTMLAnchorElement>
+  ) => void
   onChange?: (value: string, options: ChangedOptions) => void
   onKeyDown?: (
     event: KeyboardEvent<HTMLInputElement>,
@@ -103,6 +106,7 @@ export const useAutocomplete = ({
   onBlur = () => {},
   onSelect = () => {},
   onOtherOptionSelect = () => {},
+  onResetClick = () => {},
   getDisplayValue,
   enableReset,
   showOtherOption,
@@ -300,6 +304,7 @@ export const useAutocomplete = ({
     ) => {
       event.stopPropagation()
       handleChange(getDisplayValue(null))
+      onResetClick(event)
     },
   })
 


### PR DESCRIPTION
[COMM-1025]

### Description

Add new `onResetClick` callback prop that is called after clearing autocomplete.
This task is blocking other teams

### How to test

- check [example in temploy](https://picasso.toptal.net/feat-add-onresetclick-to-autocomplete/?path=/story/forms-autocomplete--autocomplete#with-onresetclick-callback) or locally

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- Make sure that additions and changes on design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests

**Breaking change**

- codemod is created and showcased in the changeset
- test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[COMM-1025]: https://toptal-core.atlassian.net/browse/COMM-1025?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ