### PR TITLE
feat(AvatarUpload): implement AvatarUpload

### DIFF
--- a/.changeset/blue-eels-compete.md
+++ b/.changeset/blue-eels-compete.md
@@ -1,0 +1,9 @@
+---
+'@toptal/picasso': minor
+---
+
+---
+
+### AvatarUpload
+
+- add new component for avatar uploads

--- a/cypress/component/AvatarUpload.spec.tsx
+++ b/cypress/component/AvatarUpload.spec.tsx
@@ -1,0 +1,66 @@
+import React from 'react'
+import { AvatarUpload, Container } from '@toptal/picasso'
+
+const component = 'AvatarUpload'
+
+describe('AvatarUpload', () => {
+  describe('when warning message provided', () => {
+    it('renders warning icon and tooltip', () => {
+      cy.mount(
+        <Container padded='small'>
+          <AvatarUpload
+            warningMessage={
+              <span data-testid='warning-content'>File is too big</span>
+            }
+            testIds={{
+              imageAvatar: 'image-avatar',
+              warningIcon: 'warning-icon',
+            }}
+          />
+        </Container>
+      )
+
+      cy.getByTestId('warning-icon').realHover()
+      cy.getByTestId('warning-content').should('be.visible')
+
+      cy.get('body').happoScreenshot({
+        component,
+        variant: 'with-warning-message/after-hover',
+      })
+    })
+  })
+
+  describe('when source file exists and component is hovered', () => {
+    let src = ''
+
+    beforeEach(() => {
+      // eslint-disable-next-line max-nested-callbacks, promise/catch-or-return
+      cy.fixture('pablo.jpg').then(image => {
+        src = 'data:image/jpg;base64,' + image
+
+        return image
+      })
+    })
+
+    it('renders upload icon over image avatar', () => {
+      cy.mount(
+        <Container padded='small'>
+          <AvatarUpload
+            src={src}
+            hovered
+            testIds={{
+              uploadIcon: 'upload-icon',
+            }}
+          />
+        </Container>
+      )
+
+      cy.getByTestId('upload-icon').should('be.visible')
+
+      cy.get('body').happoScreenshot({
+        component,
+        variant: 'with-source-file/after-hover',
+      })
+    })
+  })
+})

--- a/packages/picasso/src/AvatarUpload/AvatarUpload.tsx
+++ b/packages/picasso/src/AvatarUpload/AvatarUpload.tsx
@@ -1,0 +1,237 @@
+import React, { forwardRef, ReactNode, useCallback } from 'react'
+import { makeStyles, Theme } from '@material-ui/core'
+import { BaseProps, SizeType } from '@toptal/picasso-shared'
+import cx from 'classnames'
+import { useDropzone } from 'react-dropzone'
+
+import Container from '../Container'
+import { ExclamationSolid16, Upload24 } from '../Icon'
+import styles from './styles'
+import { AvatarUploadOptions, DropEvent, FileRejection } from './types'
+import Loader from '../Loader'
+import AvatarWrapper from '../Avatar/AvatarWrapper/AvatarWrapper'
+import ImageAvatar from '../Avatar/ImageAvatar/ImageAvatar'
+import Tooltip from '../Tooltip'
+import useAvatarUpload from './use-avatar-upload'
+import { Status } from '../OutlinedInput'
+
+export interface Props extends BaseProps {
+  /**
+   * Set accepted file types. See https://github.com/okonet/attr-accept for more information.
+   */
+  accept?: AvatarUploadOptions['accept']
+  /** Alt text */
+  alt?: string
+  /** Image URL */
+  src?: string
+  /** Size of the avatar */
+  size?: SizeType<'small' | 'large'>
+  /** Enable/disable the dropzone */
+  disabled?: boolean
+  /** Maximum file size (in bytes) */
+  maxSize?: number
+  /** Minimum file size (in bytes) */
+  minSize?: number
+  /**
+   * Callback for when the drop event occurs. Note that if file is not accepted, this callback is not invoked.,
+   * @type <T extends File>(files: T, event: DropEvent) => void
+   */
+  onDropAccepted?: AvatarUploadOptions['onDropAccepted']
+  /**
+   * Callback for when the drop event occurs. Note that if file is not rejected, this callback is not invoked.
+   * @type (fileRejection: FileRejection, event: DropEvent) => void
+   */
+  onDropRejected?: AvatarUploadOptions['onDropRejected']
+  /**
+   * Callback for when the drop event occurs. Note that the onDrop callback will always be invoked regardless if the dropped file was accepted or rejected.
+   * @type <T extends File>(acceptedFile: T | null, fileRejection: FileRejection | null, event: DropEvent) => void
+   */
+  onDrop?: AvatarUploadOptions['onDrop']
+  /**
+   * Custom validation function
+   * (file: File) => FileError | FileError[] | null
+   */
+  validator?: AvatarUploadOptions['validator']
+  /** Warning message to be used as a tooltip */
+  warningMessage?: ReactNode
+  /** Indicate `AvatarUpload` is in `error` or `default` state */
+  status?: Extract<Status, 'error' | 'default'>
+  /** Indicate whether the selected file is being uploaded */
+  uploading?: boolean
+  /** Indicate whether component has focused state */
+  focused?: boolean
+  /** Indicate whether component has hovered state */
+  hovered?: boolean
+  testIds?: {
+    imageAvatar?: string
+    warningIcon?: string
+    uploadIcon?: string
+    loader?: string
+  }
+}
+
+const useStyles = makeStyles<Theme, Props>(styles, {
+  name: 'PicassoAvatarUpload',
+})
+
+export const AvatarUpload = forwardRef<HTMLInputElement, Props>(
+  function AvatarUpload(props, ref) {
+    const {
+      className,
+      style,
+      status,
+      size = 'small',
+      uploading,
+      src,
+      alt,
+      warningMessage,
+      testIds,
+      focused: initiallyFocused,
+      hovered: initiallyHovered,
+      'data-testid': dataTestId,
+
+      // dropzoneOptions
+      accept,
+      minSize,
+      maxSize,
+      disabled,
+      onDrop,
+      onDropAccepted,
+      onDropRejected,
+      validator,
+    } = props
+
+    // callback overrides to return only one file to the parent component
+    const handleDrop = useCallback(
+      (
+        acceptedFiles: File[],
+        fileRejections: FileRejection[],
+        event: DropEvent
+      ) => {
+        if (onDrop) {
+          onDrop(acceptedFiles[0] ?? null, fileRejections[0] ?? null, event)
+        }
+      },
+      [onDrop]
+    )
+
+    const handleDropAccepted = useCallback(
+      (files: File[], event: DropEvent) => {
+        if (onDropAccepted) {
+          onDropAccepted(files[0], event)
+        }
+      },
+      [onDropAccepted]
+    )
+
+    const handleDropRejected = useCallback(
+      (fileRejections: FileRejection[], event: DropEvent) => {
+        if (onDropRejected) {
+          onDropRejected(fileRejections[0], event)
+        }
+      },
+      [onDropRejected]
+    )
+
+    const error = status === 'error'
+    const { getRootProps, isDragActive, getInputProps } = useDropzone({
+      accept,
+      minSize,
+      maxSize,
+      multiple: false,
+      disabled,
+      onDrop: handleDrop,
+      onDropAccepted: handleDropAccepted,
+      onDropRejected: handleDropRejected,
+      validator,
+    })
+
+    const {
+      callbacks,
+      focused,
+      hovered,
+      showImageAvatar,
+      showUploadIcon,
+      showLoadingIcon,
+      sourceFileExist,
+    } = useAvatarUpload({
+      focused: initiallyFocused,
+      hovered: initiallyHovered,
+      src,
+      isDragActive,
+      uploading,
+    })
+
+    const classes = useStyles({ ...props, focused })
+
+    const uploadedImageAvatar = showImageAvatar && (
+      <ImageAvatar
+        className={classes.imageAvatar}
+        size={size}
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        src={src!}
+        alt={alt}
+        data-testid={testIds?.imageAvatar}
+      />
+    )
+
+    const loadingIcon = showLoadingIcon && (
+      <Loader size='small' variant='inherit' data-testid={testIds?.loader} />
+    )
+    const uploadIcon = showUploadIcon && (
+      <Upload24 data-testid={testIds?.uploadIcon} />
+    )
+
+    const warningTooltip = warningMessage && (
+      <Tooltip content={warningMessage}>
+        <div className={classes.warningIcon}>
+          <ExclamationSolid16 data-testid={testIds?.warningIcon} />
+        </div>
+      </Tooltip>
+    )
+
+    return (
+      <Container
+        style={style}
+        ref={ref}
+        className={cx(classes.root, classes.size, className)}
+      >
+        <AvatarWrapper variant='square' size={size}>
+          <Container
+            {...getRootProps({
+              className: cx(classes.dropzone, classes.size, classes.corner, {
+                [classes.dragActive]: isDragActive,
+                [classes.disabled]: disabled,
+                [classes.error]: error,
+                [classes.focused]: focused,
+                [classes.reupload]: sourceFileExist,
+                [classes.hovered]: hovered,
+              }),
+            })}
+            {...callbacks}
+            data-testid={dataTestId}
+          >
+            <input {...getInputProps()} />
+            {loadingIcon}
+            {uploadIcon}
+          </Container>
+          {uploadedImageAvatar}
+          {!showImageAvatar && <div className={classes.leftBottomCorner} />}
+        </AvatarWrapper>
+        {warningTooltip}
+      </Container>
+    )
+  }
+)
+
+AvatarUpload.displayName = 'AvatarUpload'
+
+AvatarUpload.defaultProps = {
+  size: 'small',
+  disabled: false,
+  maxSize: Infinity,
+  minSize: 0,
+  accept: 'image/*',
+}
+
+export default AvatarUpload

--- a/packages/picasso/src/AvatarUpload/__snapshots__/test.tsx.snap
+++ b/packages/picasso/src/AvatarUpload/__snapshots__/test.tsx.snap
@@ -1,0 +1,42 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AvatarUpload renders 1`] = `
+<div>
+  <div
+    class="Picasso-root"
+  >
+    <div
+      class="PicassoAvatarUpload-root PicassoAvatarUpload-size PicassoAvatarUpload-size"
+    >
+      <div
+        class="PicassoAvatarWrapper-root PicassoAvatarWrapper-size PicassoAvatarWrapper-size PicassoAvatarWrapper-corner PicassoAvatarWrapper-corner"
+      >
+        <div
+          class="PicassoAvatarUpload-dropzone PicassoAvatarUpload-size PicassoAvatarUpload-size PicassoAvatarUpload-corner PicassoAvatarUpload-corner"
+          tabindex="0"
+        >
+          <input
+            accept="image/*"
+            autocomplete="off"
+            style="display: none;"
+            tabindex="-1"
+            type="file"
+          />
+          <svg
+            class="PicassoSvgUpload24-root"
+            style="min-width: 24px; min-height: 24px;"
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M2 18v3h19v-3h1v4H1v-4h1Zm9.5-16.207L16.207 6.5l-.707.707-3.501-3.501V19H11l-.001-15.294L7.5 7.207 6.793 6.5 11.5 1.793Z"
+            />
+          </svg>
+        </div>
+        <div
+          class="PicassoAvatarUpload-leftBottomCorner PicassoAvatarUpload-leftBottomCorner"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/packages/picasso/src/AvatarUpload/index.ts
+++ b/packages/picasso/src/AvatarUpload/index.ts
@@ -1,0 +1,7 @@
+import { OmitInternalProps } from '@toptal/picasso-shared'
+
+import { Props } from './AvatarUpload'
+export { default } from './AvatarUpload'
+export * from './types'
+
+export type AvatarUploadProps = OmitInternalProps<Props>

--- a/packages/picasso/src/AvatarUpload/story/Default.example.tsx
+++ b/packages/picasso/src/AvatarUpload/story/Default.example.tsx
@@ -1,0 +1,12 @@
+import React from 'react'
+import { AvatarUpload, Container } from '@toptal/picasso'
+
+const Example = () => {
+  return (
+    <Container padded='medium'>
+      <AvatarUpload />
+    </Container>
+  )
+}
+
+export default Example

--- a/packages/picasso/src/AvatarUpload/story/Sizes.example.tsx
+++ b/packages/picasso/src/AvatarUpload/story/Sizes.example.tsx
@@ -1,0 +1,20 @@
+import React from 'react'
+import { AvatarUpload, Container } from '@toptal/picasso'
+
+const Example = () => (
+  <Container flex gap='medium' padded='medium'>
+    <AvatarUpload alt='Jacqueline Roque. Pablo Picasso, 1954' />
+    <AvatarUpload
+      alt='Jacqueline Roque. Pablo Picasso, 1954'
+      src='./jacqueline-with-flowers-1954-square.jpg'
+    />
+    <AvatarUpload alt='Jacqueline Roque. Pablo Picasso, 1954' size='large' />
+    <AvatarUpload
+      alt='Jacqueline Roque. Pablo Picasso, 1954'
+      size='large'
+      src='./jacqueline-with-flowers-1954-square.jpg'
+    />
+  </Container>
+)
+
+export default Example

--- a/packages/picasso/src/AvatarUpload/story/States.example.tsx
+++ b/packages/picasso/src/AvatarUpload/story/States.example.tsx
@@ -1,0 +1,43 @@
+import React from 'react'
+import { AvatarUpload, Container, Typography } from '@toptal/picasso'
+
+const Example = () => (
+  <Container flex padded='medium' gap='medium'>
+    <Container flex direction='column' alignItems='center'>
+      <Typography variant='heading' size='small'>
+        Focused
+      </Typography>
+      <AvatarUpload alt='Jacqueline Roque. Pablo Picasso, 1954' focused />
+    </Container>
+
+    <Container flex direction='column' alignItems='center'>
+      <Typography variant='heading' size='small'>
+        Error
+      </Typography>
+      <AvatarUpload
+        alt='Jacqueline Roque. Pablo Picasso, 1954'
+        status='error'
+      />
+    </Container>
+
+    <Container flex direction='column' alignItems='center'>
+      <Typography variant='heading' size='small'>
+        Focused & Error
+      </Typography>
+      <AvatarUpload
+        alt='Jacqueline Roque. Pablo Picasso, 1954'
+        status='error'
+        focused
+      />
+    </Container>
+
+    <Container flex direction='column' alignItems='center'>
+      <Typography variant='heading' size='small'>
+        Loading
+      </Typography>
+      <AvatarUpload alt='Jacqueline Roque. Pablo Picasso, 1954' uploading />
+    </Container>
+  </Container>
+)
+
+export default Example

--- a/packages/picasso/src/AvatarUpload/story/Warning.example.tsx
+++ b/packages/picasso/src/AvatarUpload/story/Warning.example.tsx
@@ -1,0 +1,18 @@
+import React from 'react'
+import { AvatarUpload, Container } from '@toptal/picasso'
+
+const Example = () => (
+  <Container flex padded='medium' gap='medium'>
+    <AvatarUpload
+      alt='Jacqueline Roque. Pablo Picasso, 1954'
+      warningMessage='This is a warning message'
+    />
+    <AvatarUpload
+      alt='Jacqueline Roque. Pablo Picasso, 1954'
+      size='large'
+      warningMessage='This is a warning message'
+    />
+  </Container>
+)
+
+export default Example

--- a/packages/picasso/src/AvatarUpload/story/WithUpload.example.tsx
+++ b/packages/picasso/src/AvatarUpload/story/WithUpload.example.tsx
@@ -1,0 +1,61 @@
+import React, { useState } from 'react'
+import { AvatarUpload, Container } from '@toptal/picasso'
+import { FileRejection } from '@toptal/picasso/AvatarUpload'
+
+const Example = () => {
+  const { handleDrop, src, uploading } = useFile()
+
+  return (
+    <Container padded='medium'>
+      <AvatarUpload
+        alt='Jacqueline Roque. Pablo Picasso, 1954'
+        onDrop={handleDrop}
+        src={src}
+        uploading={uploading}
+      />
+    </Container>
+  )
+}
+
+export default Example
+
+const useFile = () => {
+  const [uploading, setUploading] = useState<boolean>(false)
+  const [src, setSrc] = useState<string | undefined>()
+
+  const handleDrop = (
+    acceptedFile: File | null,
+    fileRejection: FileRejection | null
+  ) => {
+    if (acceptedFile) {
+      // simulate upload
+      const reader = new FileReader()
+
+      reader.readAsDataURL(acceptedFile)
+
+      reader.onload = () => {
+        setUploading(true)
+
+        setTimeout(() => {
+          setUploading(false)
+
+          // simulate upload success
+          setSrc(reader.result as string)
+        }, 1000)
+      }
+
+      reader.onerror = error => {
+        console.log('Error: upload failed, ', error)
+      }
+    } else if (fileRejection) {
+      // file rejected
+      console.log(fileRejection.errors.join(', '))
+    }
+  }
+
+  return {
+    handleDrop,
+    src,
+    uploading,
+  }
+}

--- a/packages/picasso/src/AvatarUpload/story/index.jsx
+++ b/packages/picasso/src/AvatarUpload/story/index.jsx
@@ -1,0 +1,30 @@
+import PicassoBook from '~/.storybook/components/PicassoBook'
+import { AvatarUpload } from '../AvatarUpload'
+
+const page = PicassoBook.section('Components').createPage(
+  'AvatarUpload',
+  'Gets the image from file input and displays it in the Avatar component.'
+)
+
+page.createTabChapter('Props').addComponentDocs({
+  component: AvatarUpload,
+  name: 'AvatarUpload',
+})
+
+page
+  .createChapter()
+  .addExample('AvatarUpload/story/Default.example.tsx', {
+    title: 'Default',
+    takeScreenshot: false,
+  })
+  .addExample('AvatarUpload/story/WithUpload.example.tsx', {
+    title: 'With Upload',
+    takeScreenshot: false,
+    description: 'Simulates upload of an image on drop',
+  })
+  .addExample('AvatarUpload/story/Sizes.example.tsx', 'Sizes')
+  .addExample('AvatarUpload/story/Warning.example.tsx', {
+    title: 'Warning',
+    description: 'Hover warning icon to see the message',
+  })
+  .addExample('AvatarUpload/story/States.example.tsx', 'States')

--- a/packages/picasso/src/AvatarUpload/styles.ts
+++ b/packages/picasso/src/AvatarUpload/styles.ts
@@ -1,0 +1,167 @@
+import { alpha, SizeType } from '@toptal/picasso-shared'
+import { createStyles, Theme } from '@material-ui/core/styles'
+
+import { Status } from '../OutlinedInput'
+
+const getHypotenuseOfEqualSides = (sideLength: number) => {
+  return sideLength * Math.sqrt(2)
+}
+
+const smallCornerSize = 1
+const largeCornerSize = 1.5
+
+const SETTINGS = {
+  small: {
+    dimensions: 5,
+    cornerSize: smallCornerSize,
+    hypotenuse: getHypotenuseOfEqualSides(smallCornerSize),
+  },
+  large: {
+    dimensions: 10,
+    cornerSize: largeCornerSize,
+    hypotenuse: getHypotenuseOfEqualSides(largeCornerSize),
+  },
+} as const
+
+interface Props {
+  size?: SizeType<'small' | 'large'>
+  src?: string
+  status?: Extract<Status, 'error' | 'default'>
+  focused?: boolean
+}
+
+export default ({ palette, sizes, transitions }: Theme) => {
+  const dragActiveColor = alpha(palette.blue.main, 0.16)
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+  const hoverColor = alpha(palette.grey.darker!, 0.7)
+
+  return createStyles({
+    root: {
+      position: 'relative',
+    },
+    dropzone: {
+      display: 'flex',
+      justifyContent: 'center',
+      alignItems: 'center',
+      position: 'relative',
+      backgroundColor: palette.blue.lighter,
+      fontSize: '1rem',
+      flexShrink: 0,
+      flexGrow: 0,
+      zIndex: 1,
+      outline: 'none',
+      borderWidth: sizes.borderWidth,
+      borderColor: palette.blue.main,
+      color: palette.blue.main,
+      borderStyle: 'dashed',
+      transition: `all ${transitions.duration.short}ms ${transitions.easing.easeOut}`,
+      transitionProperty: 'background-color',
+      cursor: 'pointer',
+      '&$dragActive': {
+        background: `linear-gradient(0deg, ${dragActiveColor}, ${dragActiveColor}), ${palette.blue.lighter}`,
+      },
+      '&$reupload:not($dragActive)': {
+        borderStyle: 'none',
+        background: 'none',
+
+        '&$hovered': {
+          backgroundColor: hoverColor,
+          color: palette.common.white,
+        },
+      },
+      '&$disabled': {
+        backgroundColor: palette.grey.lighter,
+        '&:hover': {
+          cursor: 'no-drop',
+          borderColor: palette.grey.light2,
+        },
+      },
+      '&$error': {
+        borderColor: palette.red.main,
+        color: palette.red.main,
+      },
+      '&$focused': {
+        borderStyle: 'solid',
+        borderWidth: 3,
+      },
+    },
+    dragActive: {},
+    disabled: {},
+    error: {},
+    reupload: {},
+    focused: {},
+    hovered: {},
+
+    imageAvatar: {
+      zIndex: 0,
+    },
+
+    size: ({ size = 'small' }: Props) => {
+      const { dimensions } = SETTINGS[size]
+
+      return {
+        width: `${dimensions}em`,
+        height: `${dimensions}em`,
+        maxWidth: `${dimensions}em`,
+        maxHeight: `${dimensions}em`,
+      }
+    },
+
+    corner: ({ size = 'small' }: Props) => {
+      const { cornerSize } = SETTINGS[size]
+      const clipPath = `polygon(0 0, 100% 0, 100% 100%, ${cornerSize} 100%, 0 calc(100% - ${cornerSize}))`
+
+      return {
+        clipPath,
+        // we can remove this prefix as soon as this issue will
+        // be resolved - https://github.com/cssinjs/css-vendor/issues/74
+        '-webkit-clip-path': clipPath,
+      }
+    },
+
+    leftBottomCorner: ({ size = 'small', status, focused }: Props) => {
+      const { hypotenuse } = SETTINGS[size]
+      const error = status === 'error'
+
+      const borderAttributes = {
+        borderStyle: 'dashed',
+        borderColor: error ? palette.red.main : palette.blue.main,
+        borderWidth: sizes.borderWidth,
+      }
+
+      let borderCorrection = '0.5px'
+
+      if (focused) {
+        borderAttributes.borderStyle = 'solid'
+        borderAttributes.borderWidth = '3px'
+
+        borderCorrection = '2px'
+      }
+
+      return {
+        position: 'absolute',
+        left: 0,
+        bottom: 0,
+        width: `${hypotenuse}em`,
+        height: `${hypotenuse}em`,
+        ...borderAttributes,
+        zIndex: 1,
+        transform: `translate(calc(-50% + ${borderCorrection}), calc(50% - ${borderCorrection})) rotate(45deg)`,
+      }
+    },
+
+    warningIcon: {
+      position: 'absolute',
+      top: '-0.75em',
+      right: '-0.75em',
+      backgroundColor: palette.common.white,
+      borderRadius: '50%',
+      width: '1.5em',
+      height: '1.5em',
+      color: palette.yellow.main,
+      display: 'flex',
+      justifyContent: 'center',
+      alignItems: 'center',
+    },
+  })
+}

--- a/packages/picasso/src/AvatarUpload/test.tsx
+++ b/packages/picasso/src/AvatarUpload/test.tsx
@@ -1,0 +1,132 @@
+import React from 'react'
+import { render, fireEvent, act } from '@toptal/picasso/test-utils'
+
+import AvatarUpload, { Props } from './AvatarUpload'
+import { FileRejection } from './types'
+
+const renderAvatarUpload = (props: Props) => render(<AvatarUpload {...props} />)
+
+const dummyFile = new File(['image-string-content'], 'avatar.jpg', {
+  type: 'image/jpg',
+})
+const dummyFileData = {
+  dataTransfer: {
+    files: [dummyFile],
+    items: [
+      {
+        kind: 'file',
+        type: dummyFile.type,
+        getAsFile: () => dummyFile,
+      },
+    ],
+    types: ['Files'],
+  },
+}
+
+describe('AvatarUpload', () => {
+  it('renders', () => {
+    const { container } = renderAvatarUpload({})
+
+    expect(container).toMatchSnapshot()
+  })
+
+  describe('when a valid image dropped', () => {
+    it('calls onDrop and onDropAccepted for the parent with one file', async () => {
+      const mockOnDrop = jest.fn()
+      const mockOnDropAccepted = jest.fn()
+
+      const { getByTestId } = renderAvatarUpload({
+        onDrop: mockOnDrop,
+        onDropAccepted: mockOnDropAccepted,
+        'data-testid': 'avatar-upload',
+      })
+      const avatarUpload = getByTestId('avatar-upload')
+
+      await act(() => {
+        fireEvent.drop(avatarUpload, dummyFileData)
+      })
+
+      expect(mockOnDrop).toHaveBeenCalledWith(
+        dummyFile,
+        null,
+        expect.any(Object)
+      )
+      expect(mockOnDropAccepted).toHaveBeenCalledWith(
+        dummyFile,
+        expect.any(Object)
+      )
+
+      expect(mockOnDrop).toHaveBeenCalledTimes(1)
+      expect(mockOnDropAccepted).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('when an invalid image dropped', () => {
+    it('calls onDrop and onDropRejected for the parent with file rejection', async () => {
+      const mockOnDrop = jest.fn()
+      const mockOnDropRejected = jest.fn()
+
+      const fileMaxSize = 5
+
+      const { getByTestId } = renderAvatarUpload({
+        onDrop: mockOnDrop,
+        onDropRejected: mockOnDropRejected,
+        'data-testid': 'avatar-upload',
+        maxSize: fileMaxSize,
+      })
+
+      const avatarUpload = getByTestId('avatar-upload')
+
+      await act(() => {
+        fireEvent.drop(avatarUpload, dummyFileData)
+      })
+
+      const fileRejection: FileRejection = {
+        errors: [
+          {
+            code: 'file-too-large',
+            message: `File is larger than ${fileMaxSize} bytes`,
+          },
+        ],
+        file: dummyFile,
+      }
+
+      expect(mockOnDrop).toHaveBeenCalledWith(
+        null,
+        fileRejection,
+        expect.any(Object)
+      )
+      expect(mockOnDropRejected).toHaveBeenCalledWith(
+        fileRejection,
+        expect.any(Object)
+      )
+
+      expect(mockOnDrop).toHaveBeenCalledTimes(1)
+      expect(mockOnDropRejected).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('when image is already exist and file is being dragged on the component', () => {
+    it('hides existing image and show empty background', async () => {
+      const { getByTestId } = renderAvatarUpload({
+        src: 'https://example.com/avatar.jpg',
+        'data-testid': 'avatar-upload',
+        testIds: {
+          imageAvatar: 'image-avatar',
+        },
+      })
+
+      const imageAvatar = getByTestId('image-avatar')
+
+      expect(imageAvatar).toBeVisible()
+
+      const avatarUpload = getByTestId('avatar-upload')
+
+      await act(() => {
+        fireEvent.dragEnter(avatarUpload, dummyFileData)
+      })
+
+      expect(imageAvatar).not.toBeVisible()
+    })
+  })
+})

--- a/packages/picasso/src/AvatarUpload/types.ts
+++ b/packages/picasso/src/AvatarUpload/types.ts
@@ -1,0 +1,43 @@
+export interface FileUpload {
+  uploading?: boolean
+  progress?: number
+  error?: string
+  file: File
+}
+
+export type AvatarUploadOptions = {
+  accept?: string | string[]
+  onDrop?: <T extends File>(
+    acceptedFile: T | null,
+    fileRejection: FileRejection | null,
+    event: DropEvent
+  ) => void
+  onDropAccepted?: <T extends File>(files: T, event: DropEvent) => void
+  onDropRejected?: (fileRejection: FileRejection, event: DropEvent) => void
+  validator?: <T extends File>(file: T) => FileError | null
+}
+
+export type DropEvent =
+  | React.DragEvent<HTMLElement>
+  | React.ChangeEvent<HTMLInputElement>
+  | DragEvent
+  | Event
+
+export const ErrorCode = {
+  FileInvalidType: 'file-invalid-type',
+  FileTooLarge: 'file-too-large',
+  FileTooSmall: 'file-too-small',
+  TooManyFiles: 'too-many-files',
+} as const
+
+export type ErrorCodeType = typeof ErrorCode[keyof typeof ErrorCode]
+
+export interface FileError {
+  message: string
+  code: ErrorCodeType | string
+}
+
+export interface FileRejection {
+  file: File
+  errors: FileError[]
+}

--- a/packages/picasso/src/AvatarUpload/use-avatar-upload/index.ts
+++ b/packages/picasso/src/AvatarUpload/use-avatar-upload/index.ts
@@ -1,0 +1,1 @@
+export { default } from './use-avatar-upload'

--- a/packages/picasso/src/AvatarUpload/use-avatar-upload/test.tsx
+++ b/packages/picasso/src/AvatarUpload/use-avatar-upload/test.tsx
@@ -1,0 +1,63 @@
+import { renderHook } from '@testing-library/react-hooks'
+
+import useAvatarUpload from './use-avatar-upload'
+
+describe('useAvatarUpload', () => {
+  it('renders upload icon by default', () => {
+    const { result } = renderHook(() =>
+      useAvatarUpload({
+        isDragActive: false,
+      })
+    )
+    const { showLoadingIcon, showUploadIcon } = result.current
+
+    expect(showLoadingIcon).toBe(false)
+    expect(showUploadIcon).toBe(true)
+  })
+
+  describe('when source file exist without active dragging', () => {
+    it('shows image avatar', () => {
+      const { result } = renderHook(() =>
+        useAvatarUpload({
+          src: 'some-src',
+          isDragActive: false,
+        })
+      )
+
+      const { showImageAvatar } = result.current
+
+      expect(showImageAvatar).toBe(true)
+    })
+  })
+
+  describe('when source file exist while dragging is active', () => {
+    it('does not show image avatar', () => {
+      const { result } = renderHook(() =>
+        useAvatarUpload({
+          src: 'some-src',
+          isDragActive: true,
+        })
+      )
+
+      const { showImageAvatar } = result.current
+
+      expect(showImageAvatar).toBe(false)
+    })
+  })
+
+  describe('when uploading info provided', () => {
+    it('shows loading icon', () => {
+      const { result } = renderHook(() =>
+        useAvatarUpload({
+          uploading: true,
+          isDragActive: false,
+        })
+      )
+
+      const { showLoadingIcon, showUploadIcon } = result.current
+
+      expect(showLoadingIcon).toBe(true)
+      expect(showUploadIcon).toBe(false)
+    })
+  })
+})

--- a/packages/picasso/src/AvatarUpload/use-avatar-upload/use-avatar-upload.tsx
+++ b/packages/picasso/src/AvatarUpload/use-avatar-upload/use-avatar-upload.tsx
@@ -1,0 +1,60 @@
+import { useCallback, useState } from 'react'
+
+export interface Props {
+  isDragActive: boolean
+  focused?: boolean
+  hovered?: boolean
+  src?: string
+  uploading?: boolean
+}
+
+const useAvatarUpload = ({
+  isDragActive,
+  src,
+  focused: initiallyFocused,
+  hovered: initiallyHovered,
+  uploading,
+}: Props) => {
+  const [focused, setFocused] = useState(initiallyFocused)
+  const [hovered, setHovered] = useState(initiallyHovered)
+
+  const onFocus = useCallback(() => {
+    setFocused(true)
+  }, [])
+
+  const onBlur = useCallback(() => {
+    setFocused(false)
+  }, [])
+
+  const onMouseEnter = useCallback(() => {
+    setHovered(true)
+  }, [])
+
+  const onMouseLeave = useCallback(() => {
+    setHovered(false)
+  }, [])
+
+  const sourceFileExist = src !== undefined && src !== ''
+  const showImageAvatar = sourceFileExist && !isDragActive
+  const showUploadIcon =
+    ((sourceFileExist && hovered) || !sourceFileExist) && !uploading
+  const showLoadingIcon = !!uploading
+
+  return {
+    focused,
+    hovered,
+    sourceFileExist,
+    showImageAvatar,
+    showUploadIcon,
+    showLoadingIcon,
+
+    callbacks: {
+      onFocus,
+      onBlur,
+      onMouseEnter,
+      onMouseLeave,
+    },
+  }
+}
+
+export default useAvatarUpload

--- a/packages/picasso/src/index.ts
+++ b/packages/picasso/src/index.ts
@@ -198,6 +198,8 @@ export type {
   FieldRequirement,
 } from './FieldRequirements'
 export type { Status as OutlinedInputStatus } from './OutlinedInput'
+export { default as AvatarUpload } from './AvatarUpload'
+export type { AvatarUploadProps } from './AvatarUpload'
 
 // hygen code generator inserts export statements above this comment.
 export * from './Icon'


### PR DESCRIPTION
[FX-2889]

### Description

- implemented new component AvatarDropzone
- I decided to skip the title and file description parts for now. They can be introduced in another new component if needed.
- I solved the `focused` state differently than the designs to simplify the implementation.

### How to test

- you can use temploy to test the component. `Default` story is mimicking the uploading UX

### Screenshots

<img width="696" alt="Screen Shot 2022-08-11 at 15 15 19" src="https://user-images.githubusercontent.com/7733167/184131156-249e837e-dac8-4b22-80bf-dac49a1f799b.png">
<img width="696" alt="Screen Shot 2022-08-11 at 15 15 33" src="https://user-images.githubusercontent.com/7733167/184131163-6a327482-5451-4f44-8688-1a92ce829b76.png">
<img width="696" alt="Screen Shot 2022-08-11 at 15 15 37" src="https://user-images.githubusercontent.com/7733167/184131166-da7f465c-082f-416d-b605-d76067966b1f.png">

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests

**Breaking change**

- codemod is created and showcased in the changeset
- test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run all` - Run whole pipeline
- `@toptal-bot run build` - Check build
- `@toptal-bot run deploy:documentation` - Deploy documentation
- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-2889]: https://toptal-core.atlassian.net/browse/FX-2889?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ