### PR TITLE
fix: pass missing props to children when mapping

### DIFF
--- a/.changeset/five-comics-care.md
+++ b/.changeset/five-comics-care.md
@@ -2,4 +2,6 @@
 '@toptal/picasso': patch
 ---
 
-Fix useRichText hook and make it pass props down properly so Links can work fine
+### RichText
+
+- fix useRichText hook and make it pass props down properly so Links can work fine

--- a/.changeset/five-comics-care.md
+++ b/.changeset/five-comics-care.md
@@ -1,0 +1,5 @@
+---
+'@toptal/picasso': patch
+---
+
+Fix useRichText hook and make it pass props down properly so Links can work fine

--- a/packages/picasso/src/RichText/hooks/useRichText/useRichText.tsx
+++ b/packages/picasso/src/RichText/hooks/useRichText/useRichText.tsx
@@ -70,7 +70,7 @@ const picassoMapper = (child: ReactNode): ReactNode => {
 
   const mappedChildren = child.props.children?.map(picassoMapper) ?? null
 
-  return createElement(type, { key: child.key }, mappedChildren)
+  return createElement(type, { ...child.props, key: child.key }, mappedChildren)
 }
 
 const useRichText = (value: ASTType): ReactNode[] | ReactNode => {

--- a/packages/picasso/src/utils/html-to-hast.ts
+++ b/packages/picasso/src/utils/html-to-hast.ts
@@ -11,6 +11,7 @@ export const hastSanitizeSchema: Schema = {
   },
   attributes: {
     '*': [],
+    a: ['href'],
   },
   tagNames: ['h3', 'p', 'br', 'strong', 'em', 'ul', 'ol', 'li', 'a'],
   strip: ['script'],


### PR DESCRIPTION
[NO-JIRA]

### Description

`picassoMapper` was not implemented correctly and it wasn't passing `child.props` when creating the React Element and therefore, links were not working as they were loosing `href` since it wasn't being passed down to the `Link` component

### How to test

- `RichText` component should be working as expected and links also have their `href` and redirecting to the appropriate URL
- CI should be 💚 

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests

**Breaking change**

- [x] codemod is created and showcased in the changeset
- [x] test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>
