### PR TITLE
fix: fix MUI deprecation warnings

### DIFF
--- a/packages/picasso/src/Badge/Badge.tsx
+++ b/packages/picasso/src/Badge/Badge.tsx
@@ -65,6 +65,7 @@ export const Badge = forwardRef<HTMLDivElement, Props>(function Badge(
           [classes.static]: !hasChildren,
         }),
       }}
+      overlap='rectangular'
     >
       {children}
     </MuiBadge>

--- a/packages/picasso/src/Badge/__snapshots__/test.tsx.snap
+++ b/packages/picasso/src/Badge/__snapshots__/test.tsx.snap
@@ -9,7 +9,7 @@ exports[`Badge renders 1`] = `
       class="MuiBadge-root"
     >
       <span
-        class="MuiBadge-badge PicassoBadge-root PicassoBadge-white PicassoBadge-large PicassoBadge-static MuiBadge-anchorOriginTopRightRectangle"
+        class="MuiBadge-badge PicassoBadge-root PicassoBadge-white PicassoBadge-large PicassoBadge-static MuiBadge-anchorOriginTopRightRectangular"
       >
         5
       </span>
@@ -27,7 +27,7 @@ exports[`Badge renders in red variant 1`] = `
       class="MuiBadge-root"
     >
       <span
-        class="MuiBadge-badge PicassoBadge-root PicassoBadge-red PicassoBadge-large PicassoBadge-static MuiBadge-anchorOriginTopRightRectangle"
+        class="MuiBadge-badge PicassoBadge-root PicassoBadge-red PicassoBadge-large PicassoBadge-static MuiBadge-anchorOriginTopRightRectangular"
       >
         5
       </span>

--- a/packages/picasso/src/Modal/Modal.tsx
+++ b/packages/picasso/src/Modal/Modal.tsx
@@ -4,6 +4,7 @@ import React, {
   HTMLAttributes,
   useEffect,
   useRef,
+  useCallback,
 } from 'react'
 import { makeStyles, Theme } from '@material-ui/core/styles'
 import Dialog from '@material-ui/core/Dialog'
@@ -178,6 +179,16 @@ export const Modal = forwardRef<HTMLElement, Props>(function Modal(props, ref) {
 
   const isSmall = useBreakpoint('small')
 
+  const handleClose = useCallback(
+    (_event, reason: 'backdropClick' | 'escapeKeyDown') => {
+      // workaround for "disableBackdropClick" prop due to deprecation
+      if (reason !== 'backdropClick' && onClose) {
+        onClose()
+      }
+    },
+    [onClose]
+  )
+
   return (
     <Dialog
       {...rest}
@@ -196,13 +207,12 @@ export const Modal = forwardRef<HTMLElement, Props>(function Modal(props, ref) {
       PaperProps={{ ...paperProps, elevation: 2 }}
       hideBackdrop={hideBackdrop}
       onBackdropClick={onBackdropClick}
-      onClose={onClose}
+      onClose={handleClose}
       onEnter={onOpen}
       open={open}
       transitionDuration={transitionDuration}
       maxWidth={false}
       disableEnforceFocus // we need our own mechanism to keep focus inside the Modals
-      disableBackdropClick
       TransitionProps={transitionProps}
     >
       <ModalContext.Provider value>{children}</ModalContext.Provider>

--- a/packages/picasso/src/Modal/Modal.tsx
+++ b/packages/picasso/src/Modal/Modal.tsx
@@ -182,7 +182,7 @@ export const Modal = forwardRef<HTMLElement, Props>(function Modal(props, ref) {
   const handleClose = useCallback(
     (_event, reason: 'backdropClick' | 'escapeKeyDown') => {
       // workaround for "disableBackdropClick" prop due to deprecation
-      if (reason !== 'backdropClick' && onClose) {
+      if (reason === 'escapeKeyDown' && onClose) {
         onClose()
       }
     },


### PR DESCRIPTION
[FX-3059]

### Description

- fix for deprecation warnings for MUIv5:
- `disableBackdropClick` for Modal
- `overlap="rectangle"` for Badge component

### How to test

- there shouldn't be any errors related to Modal and Badge

### Screenshots

no visual changes

### Development checks

- Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- Make sure that additions and changes on design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- Annotate all `props` in component with documentation
- Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- Covered with tests

**Breaking change**

- codemod is created and showcased in the changeset
- test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-3059]: https://toptal-core.atlassian.net/browse/FX-3059?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ