### PR TITLE
feat(Avatar): add editable state

### DIFF
--- a/.changeset/strong-beans-perform.md
+++ b/.changeset/strong-beans-perform.md
@@ -6,4 +6,4 @@
 
 ### Avatar
 
-- add onEdit prop to Avatar
+- add `onEdit` prop to Avatar

--- a/.changeset/strong-beans-perform.md
+++ b/.changeset/strong-beans-perform.md
@@ -1,0 +1,9 @@
+---
+'@toptal/picasso': minor
+---
+
+---
+
+### Avatar
+
+- add onEdit prop to Avatar

--- a/packages/picasso/src/Avatar/Avatar.tsx
+++ b/packages/picasso/src/Avatar/Avatar.tsx
@@ -1,5 +1,6 @@
 import React, { HTMLAttributes, useCallback } from 'react'
 import { StandardProps, SizeType } from '@toptal/picasso-shared'
+import { makeStyles, Theme } from '@material-ui/core/styles'
 
 import { AVATAR_INITIALS_LIMIT } from '../utils/constants'
 import getNameInitials from '../utils/get-name-initials'
@@ -7,6 +8,8 @@ import ImageAvatar from './ImageAvatar/ImageAvatar'
 import TextAvatar from './TextAvatar/TextAvatar'
 import IconAvatar from './IconAvatar/IconAvatar'
 import AvatarWrapper from './AvatarWrapper/AvatarWrapper'
+import styles from './styles'
+import { Pencil16, Pencil24 } from '../Icon'
 
 export interface Props extends StandardProps, HTMLAttributes<HTMLDivElement> {
   /** Alt text */
@@ -19,25 +22,35 @@ export interface Props extends StandardProps, HTMLAttributes<HTMLDivElement> {
   src?: string
   /** Variant of the avatar shape */
   variant?: 'square' | 'portrait' | 'landscape'
+  /** Callback to show edit-on-hover and receive event */
+  onEdit?: (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => void
   testIds?: {
     wrapper?: string
     icon?: string
     image?: string
     text?: string
+    editContainer?: string
   }
 }
 
-export const Avatar = ({
-  alt,
-  src,
-  className,
-  name,
-  size,
-  style,
-  variant,
-  testIds,
-  ...rest
-}: Props) => {
+const useStyles = makeStyles<Theme, Props>(styles, {
+  name: 'PicassoAvatarWrapper',
+})
+
+export const Avatar = (props: Props) => {
+  const {
+    alt,
+    src,
+    className,
+    name,
+    size,
+    style,
+    variant,
+    testIds,
+    onEdit,
+    ...rest
+  } = props
+
   const renderAvatar = useCallback(() => {
     if (src) {
       return (
@@ -91,6 +104,12 @@ export const Avatar = ({
     style,
   ])
 
+  const classes = useStyles(props)
+  const isEditable = Boolean(onEdit)
+
+  const pencilIcon =
+    size === 'xxsmall' || size === 'xsmall' ? <Pencil16 /> : <Pencil24 />
+
   return (
     <AvatarWrapper
       /* eslint-disable-next-line @typescript-eslint/no-non-null-assertion */
@@ -100,6 +119,15 @@ export const Avatar = ({
       data-testid={testIds?.wrapper}
       {...rest}
     >
+      {isEditable && (
+        <div
+          data-testid={testIds?.editContainer}
+          className={classes.editContainer}
+          onClick={onEdit}
+        >
+          {pencilIcon}
+        </div>
+      )}
       {renderAvatar()}
     </AvatarWrapper>
   )

--- a/packages/picasso/src/Avatar/Avatar.tsx
+++ b/packages/picasso/src/Avatar/Avatar.tsx
@@ -22,7 +22,7 @@ export interface Props extends StandardProps, HTMLAttributes<HTMLDivElement> {
   src?: string
   /** Variant of the avatar shape */
   variant?: 'square' | 'portrait' | 'landscape'
-  /** Callback to show edit-on-hover and receive event */
+  /** Callback to show edit-on-click and receive event */
   onEdit?: (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => void
   testIds?: {
     wrapper?: string

--- a/packages/picasso/src/Avatar/story/Editable.example.tsx
+++ b/packages/picasso/src/Avatar/story/Editable.example.tsx
@@ -8,13 +8,14 @@ const Example = () => {
 
   return (
     <Container gap='medium' flex>
+      <Avatar name='Jacqueline Roque' onEdit={handleEdit} />
       <Avatar
         alt='Jacqueline Roque. Pablo Picasso, 1954'
         src='./jacqueline-with-flowers-1954-square.jpg'
         name='Jacqueline Roque'
+        size='medium'
         onEdit={handleEdit}
       />
-      <Avatar name='Jacqueline Roque' onEdit={handleEdit} size='medium' />
     </Container>
   )
 }

--- a/packages/picasso/src/Avatar/story/Editable.example.tsx
+++ b/packages/picasso/src/Avatar/story/Editable.example.tsx
@@ -1,0 +1,22 @@
+import React from 'react'
+import { Avatar, Container } from '@toptal/picasso'
+
+const Example = () => {
+  const handleEdit = () => {
+    window.alert('onEdit called')
+  }
+
+  return (
+    <Container gap='medium' flex>
+      <Avatar
+        alt='Jacqueline Roque. Pablo Picasso, 1954'
+        src='./jacqueline-with-flowers-1954-square.jpg'
+        name='Jacqueline Roque'
+        onEdit={handleEdit}
+      />
+      <Avatar name='Jacqueline Roque' onEdit={handleEdit} size='medium' />
+    </Container>
+  )
+}
+
+export default Example

--- a/packages/picasso/src/Avatar/story/index.jsx
+++ b/packages/picasso/src/Avatar/story/index.jsx
@@ -27,5 +27,6 @@ page
   .addExample('Avatar/story/Variants.example.tsx', 'Variants')
   .addExample('Avatar/story/Sizes.example.tsx', 'Sizes')
   .addExample('Avatar/story/LongName.example.tsx', 'Long Name')
+  .addExample('Avatar/story/Editable.example.tsx', 'Editable state')
 
 page.connect(AvatarGroupStory.chapter)

--- a/packages/picasso/src/Avatar/styles.ts
+++ b/packages/picasso/src/Avatar/styles.ts
@@ -1,0 +1,22 @@
+import { alpha } from '@toptal/picasso-shared'
+import { createStyles, Theme } from '@material-ui/core/styles'
+
+export default ({ palette }: Theme) => {
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+  const hoverColor = alpha(palette.grey.darker!, 0.7)
+
+  return createStyles({
+    editContainer: {
+      position: 'absolute',
+      width: '100%',
+      height: '100%',
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      backgroundColor: hoverColor,
+      zIndex: 1,
+      color: palette.common.white,
+      cursor: 'pointer',
+    },
+  })
+}

--- a/packages/picasso/src/Avatar/test.tsx
+++ b/packages/picasso/src/Avatar/test.tsx
@@ -1,14 +1,21 @@
 import React from 'react'
-import { render } from '@toptal/picasso/test-utils'
+import { render, fireEvent } from '@toptal/picasso/test-utils'
 import { OmitInternalProps } from '@toptal/picasso-shared'
 
 import Avatar, { Props } from './Avatar'
 
 const renderAvatar = (props: OmitInternalProps<Props>) => {
-  const { alt, name, src, size, testIds } = props
+  const { alt, name, src, size, onEdit, testIds } = props
 
   return render(
-    <Avatar alt={alt} name={name} src={src} size={size} testIds={testIds} />
+    <Avatar
+      alt={alt}
+      name={name}
+      src={src}
+      size={size}
+      testIds={testIds}
+      onEdit={onEdit}
+    />
   )
 }
 
@@ -59,5 +66,24 @@ describe('Avatar', () => {
     })
 
     expect(getByTestId('photo-placeholder')).toBeVisible()
+  })
+
+  describe('when edit state provided', () => {
+    it('renders with edit icon and backdrop', () => {
+      const mockOnEdit = jest.fn()
+
+      const { getByTestId } = renderAvatar({
+        onEdit: mockOnEdit,
+        testIds: { editContainer: 'edit-container' },
+      })
+
+      const editContainer = getByTestId('edit-container')
+
+      expect(editContainer).toBeVisible()
+
+      fireEvent.click(editContainer)
+
+      expect(mockOnEdit).toHaveBeenCalledTimes(1)
+    })
   })
 })


### PR DESCRIPTION
[FX-3062]

### Description

- according to designs, I have added a permanent(not on hover) editable state for Avatar

### How to test

- there is a separate story for this new state on storybook

### Screenshots

<img width="268" alt="Screen Shot 2022-08-23 at 11 57 25" src="https://user-images.githubusercontent.com/7733167/186122195-3a996831-b0e0-4c2d-9754-a6e209801619.png">

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests

**Breaking change**

- codemod is created and showcased in the changeset
- test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-3062]: https://toptal-core.atlassian.net/browse/FX-3062?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ