### PR TITLE
feat(AvatarUpload): add size variant

### DIFF
--- a/.changeset/blue-eels-compete.md
+++ b/.changeset/blue-eels-compete.md
@@ -7,3 +7,4 @@
 ### AvatarUpload
 
 - add new component for avatar uploads
+- add `size` prop and large variant for the component

--- a/cypress/component/AvatarUpload.spec.tsx
+++ b/cypress/component/AvatarUpload.spec.tsx
@@ -18,8 +18,9 @@ describe('AvatarUpload', () => {
 
     it('renders upload icon over image avatar', () => {
       cy.mount(
-        <Container padded='small'>
+        <Container padded='small' gap='small'>
           <AvatarUpload src={src} alt='avatar' />
+          <AvatarUpload src={src} alt='avatar' size='large' />
         </Container>
       )
 

--- a/packages/picasso/src/AvatarUpload/AvatarUpload.tsx
+++ b/packages/picasso/src/AvatarUpload/AvatarUpload.tsx
@@ -1,6 +1,6 @@
 import React, { forwardRef, useCallback } from 'react'
-import { makeStyles, Theme } from '@material-ui/core'
-import { BaseProps } from '@toptal/picasso-shared'
+import { capitalize, makeStyles, Theme } from '@material-ui/core'
+import { BaseProps, SizeType } from '@toptal/picasso-shared'
 import { useDropzone } from 'react-dropzone'
 import cx from 'classnames'
 
@@ -20,6 +20,8 @@ export interface Props extends BaseProps {
   alt?: string
   /** Image URL */
   src?: string
+  /** Size of the avatar */
+  size?: SizeType<'small' | 'large'>
   /** Enable/disable the dropzone */
   disabled?: boolean
   /** Maximum file size (in bytes) */
@@ -68,6 +70,7 @@ export const AvatarUpload = forwardRef<HTMLDivElement, Props>(
   function AvatarUpload(props, ref) {
     const {
       uploading,
+      size = 'small',
       onEdit,
       'data-testid': dataTestId,
       testIds,
@@ -157,13 +160,17 @@ export const AvatarUpload = forwardRef<HTMLDivElement, Props>(
       onDropAccepted: handleDropAccepted,
       onDropRejected: handleDropRejected,
       validator,
+      noClick: showAvatar && !showEditIcon,
+      // after showing avatar, only way to change the avatar is to use 'onEdit'
+      noDrag: showAvatar,
+      noKeyboard: showAvatar,
     })
 
     return (
       <div
         {...getRootProps({
           ref,
-          className: cx(classes.root, classes.size),
+          className: cx(classes.root, classes[`size${capitalize(size)}`]),
           'data-testid': dataTestId,
         })}
       >
@@ -171,7 +178,7 @@ export const AvatarUpload = forwardRef<HTMLDivElement, Props>(
 
         {showAvatar ? (
           <Avatar
-            size='small'
+            size={size}
             onEdit={showEditIcon ? handleEdit : undefined}
             // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             src={src!}
@@ -181,7 +188,7 @@ export const AvatarUpload = forwardRef<HTMLDivElement, Props>(
           />
         ) : (
           <>
-            <DropzoneSvg data-testid={testIds?.dropzoneSvg} />
+            <DropzoneSvg size={size} data-testid={testIds?.dropzoneSvg} />
             {loadingIcon}
             {uploadIcon}
           </>
@@ -194,6 +201,7 @@ export const AvatarUpload = forwardRef<HTMLDivElement, Props>(
 AvatarUpload.displayName = 'AvatarUpload'
 
 AvatarUpload.defaultProps = {
+  size: 'small',
   disabled: false,
   maxSize: 104857600, // 100MB in bytes (100 * 1024 * 1024)
   minSize: 0,

--- a/packages/picasso/src/AvatarUpload/AvatarUpload.tsx
+++ b/packages/picasso/src/AvatarUpload/AvatarUpload.tsx
@@ -136,6 +136,10 @@ export const AvatarUpload = forwardRef<HTMLDivElement, Props>(
     const showUploadIcon = !showAvatar && !showLoader
     const showEditIcon = Boolean(onEdit)
 
+    // after showing avatar, only way to change the file selection is to use 'onEdit'
+    const disableDropzoneClick = showAvatar && !showEditIcon
+    const disableDropzoneDragAndKeyboard = showAvatar
+
     const classes = useStyles()
 
     const loadingIcon = showLoader && (
@@ -160,10 +164,9 @@ export const AvatarUpload = forwardRef<HTMLDivElement, Props>(
       onDropAccepted: handleDropAccepted,
       onDropRejected: handleDropRejected,
       validator,
-      noClick: showAvatar && !showEditIcon,
-      // after showing avatar, only way to change the avatar is to use 'onEdit'
-      noDrag: showAvatar,
-      noKeyboard: showAvatar,
+      noClick: disableDropzoneClick,
+      noDrag: disableDropzoneDragAndKeyboard,
+      noKeyboard: disableDropzoneDragAndKeyboard,
     })
 
     return (

--- a/packages/picasso/src/AvatarUpload/DropzoneSvg/DropzoneSvg.tsx
+++ b/packages/picasso/src/AvatarUpload/DropzoneSvg/DropzoneSvg.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
-import { makeStyles, Theme } from '@material-ui/core'
-import { BaseProps } from '@toptal/picasso-shared'
+import { capitalize, makeStyles, Theme } from '@material-ui/core'
+import { BaseProps, SizeType } from '@toptal/picasso-shared'
+import cx from 'classnames'
 
 import styles from './styles'
 import { getBackgroundShape, getBordersShape, getOutlineShape } from './utils'
@@ -9,29 +10,53 @@ import { getBackgroundShape, getBordersShape, getOutlineShape } from './utils'
  * For measuring, pixel values are used because SVG's "d" attribute works with percentages and pixels only
  */
 const BASE_FONT_SIZE = 16
+const SETTINGS = {
+  small: {
+    dimensions: 5 * BASE_FONT_SIZE,
+    cornerSize: 1 * BASE_FONT_SIZE,
+  },
+  large: {
+    dimensions: 10 * BASE_FONT_SIZE,
+    cornerSize: 1.5 * BASE_FONT_SIZE,
+  },
+} as const
 
-const dimensions = 5 * BASE_FONT_SIZE
-const cornerSize = BASE_FONT_SIZE
+const SHAPES = {
+  small: {
+    backgroundShape: getBackgroundShape(SETTINGS.small),
+    outlineShape: getOutlineShape(SETTINGS.small),
+    bordersShape: getBordersShape(SETTINGS.small),
+  },
+  large: {
+    backgroundShape: getBackgroundShape(SETTINGS.large),
+    outlineShape: getOutlineShape(SETTINGS.large),
+    bordersShape: getBordersShape(SETTINGS.large),
+  },
+} as const
 
-const backgroundShape = getBackgroundShape(dimensions, cornerSize)
-const bordersShape = getBordersShape(dimensions, cornerSize)
-const outlineShape = getOutlineShape(dimensions, cornerSize)
-
-export interface Props extends BaseProps {}
+export interface Props extends BaseProps {
+  size?: SizeType<'small' | 'large'>
+}
 
 const useStyles = makeStyles<Theme>(styles, {
   name: 'PicassoDropzoneSvg',
 })
 
 export const DropzoneSvg = (props: Props) => {
-  const { 'data-testid': dataTestId } = props
+  const { size = 'small', 'data-testid': dataTestId } = props
+
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+  const shapes = SHAPES[size!]
 
   const classes = useStyles()
 
   return (
-    <div className={classes.root} data-testid={dataTestId}>
+    <div
+      className={cx(classes.root, classes[`root${capitalize(size)}`])}
+      data-testid={dataTestId}
+    >
       <svg
-        className={classes.svg}
+        className={cx(classes.svg, classes[`svg${capitalize(size)}`])}
         fill='none'
         xmlns='http://www.w3.org/2000/svg'
       >
@@ -39,13 +64,13 @@ export const DropzoneSvg = (props: Props) => {
           className={classes.background}
           fillRule='evenodd'
           clipRule='evenodd'
-          d={backgroundShape}
+          d={shapes.backgroundShape}
         />
         <path
           className={classes.outline}
           fillRule='evenodd'
           clipRule='evenodd'
-          d={outlineShape}
+          d={shapes.outlineShape}
           strokeOpacity='.48'
           strokeWidth='3'
           strokeLinejoin='round'
@@ -54,7 +79,7 @@ export const DropzoneSvg = (props: Props) => {
           className={classes.border}
           fillRule='evenodd'
           clipRule='evenodd'
-          d={bordersShape}
+          d={shapes.bordersShape}
           strokeDasharray='3 3'
         />
       </svg>

--- a/packages/picasso/src/AvatarUpload/DropzoneSvg/styles.ts
+++ b/packages/picasso/src/AvatarUpload/DropzoneSvg/styles.ts
@@ -4,15 +4,27 @@ export default ({ palette, transitions }: Theme) =>
   createStyles({
     root: {
       position: 'relative',
+      background: 'transparent',
+    },
+    rootSmall: {
       width: '80px',
       height: '80px',
-      background: 'transparent',
+    },
+    rootLarge: {
+      width: '160px',
+      height: '160px',
     },
 
     svg: {
+      margin: '-3px', // to center the svg
+    },
+    svgSmall: {
       width: '86px', // 6px for the outline stroke
       height: '86px', // 6px for the outline stroke
-      margin: '-3px', // to center the svg
+    },
+    svgLarge: {
+      width: '166px', // 6px for the outline stroke
+      height: '166px', // 6px for the outline stroke
     },
 
     background: {

--- a/packages/picasso/src/AvatarUpload/DropzoneSvg/utils.ts
+++ b/packages/picasso/src/AvatarUpload/DropzoneSvg/utils.ts
@@ -34,9 +34,15 @@ const getAvatarShape = ({
 
 /**
  * Returns the shape of the background of the avatar.
- * it should be 80x80(px)
+ * For small variant, it should be 80x80(px), for large - 160x160(px).
  */
-export const getBackgroundShape = (dimensions: number, cornerSize: number) => {
+export const getBackgroundShape = ({
+  dimensions,
+  cornerSize,
+}: {
+  dimensions: number
+  cornerSize: number
+}) => {
   const centerShift = 3 // shift for the outline stroke
 
   return getAvatarShape({
@@ -51,10 +57,16 @@ export const getBackgroundShape = (dimensions: number, cornerSize: number) => {
 
 /**
  * Returns the shape of the outline when field is focused.
- * it should be 82x82(px)
+ * For small variant, it should be 82x82(px), for large - 162x162(px).
  * it is 2px bigger than the background because of the outline stroke width.
  */
-export const getOutlineShape = (dimensions: number, cornerSize: number) => {
+export const getOutlineShape = ({
+  dimensions,
+  cornerSize,
+}: {
+  dimensions: number
+  cornerSize: number
+}) => {
   const centerShift = 2 // shift for the outline stroke
   const outlineStrokeWidth = 2 // width of the outline stroke
 
@@ -70,10 +82,16 @@ export const getOutlineShape = (dimensions: number, cornerSize: number) => {
 
 /**
  * Returns the shape of the borders.
- * it should be 78x78(px)
+ * For small variant, it should be 78x78(px), for large - 158x158(px).
  * it is 1px smaller than the background because of the border stroke width.
  */
-export const getBordersShape = (dimensions: number, cornerSize: number) => {
+export const getBordersShape = ({
+  dimensions,
+  cornerSize,
+}: {
+  dimensions: number
+  cornerSize: number
+}) => {
   const centerShift = 4 // shift for the outline stroke and border stroke
   const outlineStrokeWidth = 2 // width of the outline stroke
 

--- a/packages/picasso/src/AvatarUpload/__snapshots__/test.tsx.snap
+++ b/packages/picasso/src/AvatarUpload/__snapshots__/test.tsx.snap
@@ -6,7 +6,7 @@ exports[`AvatarUpload renders 1`] = `
     class="Picasso-root"
   >
     <div
-      class="PicassoAvatarUpload-root PicassoAvatarUpload-size"
+      class="PicassoAvatarUpload-root PicassoAvatarUpload-sizeSmall"
       tabindex="0"
     >
       <input
@@ -17,10 +17,10 @@ exports[`AvatarUpload renders 1`] = `
         type="file"
       />
       <div
-        class="PicassoDropzoneSvg-root"
+        class="PicassoDropzoneSvg-root PicassoDropzoneSvg-rootSmall"
       >
         <svg
-          class="PicassoDropzoneSvg-svg"
+          class="PicassoDropzoneSvg-svg PicassoDropzoneSvg-svgSmall"
           fill="none"
           xmlns="http://www.w3.org/2000/svg"
         >

--- a/packages/picasso/src/AvatarUpload/story/Sizes.example.tsx
+++ b/packages/picasso/src/AvatarUpload/story/Sizes.example.tsx
@@ -1,0 +1,32 @@
+import React from 'react'
+import { AvatarUpload, Container } from '@toptal/picasso'
+
+const SmallSizeExample = () => <AvatarUpload size='small' />
+const SmallSizeWithSrcExample = () => (
+  <AvatarUpload
+    size='small'
+    alt='Jacqueline Roque. Pablo Picasso, 1954'
+    src='./jacqueline-with-flowers-1954-square.jpg'
+  />
+)
+const LargeSizeExample = () => <AvatarUpload size='large' />
+const LargeSizeWithSrcExample = () => (
+  <AvatarUpload
+    size='large'
+    alt='Jacqueline Roque. Pablo Picasso, 1954'
+    src='./jacqueline-with-flowers-1954-square.jpg'
+  />
+)
+
+const Example = () => {
+  return (
+    <Container flex gap='medium' padded='medium'>
+      <SmallSizeExample />
+      <SmallSizeWithSrcExample />
+      <LargeSizeExample />
+      <LargeSizeWithSrcExample />
+    </Container>
+  )
+}
+
+export default Example

--- a/packages/picasso/src/AvatarUpload/story/Sizes.example.tsx
+++ b/packages/picasso/src/AvatarUpload/story/Sizes.example.tsx
@@ -2,29 +2,14 @@ import React from 'react'
 import { AvatarUpload, Container } from '@toptal/picasso'
 
 const SmallSizeExample = () => <AvatarUpload size='small' />
-const SmallSizeWithSrcExample = () => (
-  <AvatarUpload
-    size='small'
-    alt='Jacqueline Roque. Pablo Picasso, 1954'
-    src='./jacqueline-with-flowers-1954-square.jpg'
-  />
-)
+
 const LargeSizeExample = () => <AvatarUpload size='large' />
-const LargeSizeWithSrcExample = () => (
-  <AvatarUpload
-    size='large'
-    alt='Jacqueline Roque. Pablo Picasso, 1954'
-    src='./jacqueline-with-flowers-1954-square.jpg'
-  />
-)
 
 const Example = () => {
   return (
     <Container flex gap='medium' padded='medium'>
       <SmallSizeExample />
-      <SmallSizeWithSrcExample />
       <LargeSizeExample />
-      <LargeSizeWithSrcExample />
     </Container>
   )
 }

--- a/packages/picasso/src/AvatarUpload/story/WithUpload.example.tsx
+++ b/packages/picasso/src/AvatarUpload/story/WithUpload.example.tsx
@@ -1,9 +1,8 @@
-import React, { useRef, useState } from 'react'
+import React, { useState } from 'react'
 import { AvatarUpload, Container } from '@toptal/picasso'
 import { FileRejection } from '@toptal/picasso/AvatarUpload'
 
 const Example = () => {
-  const avatarUploadRef = useRef<HTMLDivElement>(null)
   const [uploading, setUploading] = useState<boolean>(false)
   const [src, setSrc] = useState<string | undefined>()
 
@@ -40,7 +39,6 @@ const Example = () => {
   return (
     <Container padded='medium'>
       <AvatarUpload
-        ref={avatarUploadRef}
         alt='Jacqueline Roque. Pablo Picasso, 1954'
         onDrop={handleDrop}
         src={src}

--- a/packages/picasso/src/AvatarUpload/story/index.jsx
+++ b/packages/picasso/src/AvatarUpload/story/index.jsx
@@ -20,3 +20,4 @@ page
       'Shows how the component can be used with FileReader to upload a file',
     takeScreenshot: false,
   })
+  .addExample('AvatarUpload/story/Sizes.example.tsx', 'Sizes')

--- a/packages/picasso/src/AvatarUpload/styles.ts
+++ b/packages/picasso/src/AvatarUpload/styles.ts
@@ -11,9 +11,14 @@ export default ({ palette }: Theme) =>
       outline: 'none',
     },
 
-    size: {
+    sizeSmall: {
       width: '5rem',
       height: '5rem',
+    },
+
+    sizeLarge: {
+      width: '10rem',
+      height: '10rem',
     },
 
     icon: {


### PR DESCRIPTION
[FX-2889]

### Description

- `size` prop added with following values `small`, `large`
- disabled keyboard and drag functionality while `onEdit` functionality

### How to test

- go to [component page](https://picasso.toptal.net/fx-2889-implement-basic-avatar-upload/?path=/story/components-avatarupload--avatarupload)
- you can see the new story for sizes.
- HOVERING state of the component will be handled in upcoming PR

### Screenshots

<img width="685" alt="Screen Shot 2022-08-29 at 12 34 09" src="https://user-images.githubusercontent.com/7733167/187171309-a21cb16a-a350-45e1-a45d-c836b42e473f.png">

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- Covered with tests

**Breaking change**

- codemod is created and showcased in the changeset
- test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-2889]: https://toptal-core.atlassian.net/browse/FX-2889?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ