### PR TITLE
feat(AvatarUpload): add visual states

### DIFF
--- a/.changeset/quiet-cameras-carry.md
+++ b/.changeset/quiet-cameras-carry.md
@@ -1,0 +1,9 @@
+---
+'@toptal/picasso': minor
+---
+
+---
+
+### AvatarUpload
+
+- add `focused`, `hovered`, `active` and `error` states for the component

--- a/packages/picasso/src/AvatarUpload/AvatarUpload.tsx
+++ b/packages/picasso/src/AvatarUpload/AvatarUpload.tsx
@@ -63,12 +63,10 @@ export interface Props extends BaseProps {
   status?: Extract<Status, 'error' | 'default'>
   /** Indicate whether the selected file is being uploaded */
   uploading?: boolean
-  /** Indicate whether component has focused state */
-  focused?: boolean
-  /** Indicate whether component has hovered state */
-  hovered?: boolean
-  /** Indicate whether component has active state */
-  active?: boolean
+  /** Indicate whether component has focused state as default */
+  autoFocus?: boolean
+  autoHover?: boolean
+  defaultActive?: boolean
   testIds?: {
     avatar?: string
     dropzoneSvg?: string
@@ -85,9 +83,9 @@ export const AvatarUpload = forwardRef<HTMLElement, Props>(
   // eslint-disable-next-line complexity
   function AvatarUpload(props, ref) {
     const {
-      focused: focusedProp,
-      hovered: hoveredProp,
-      active: activeProp,
+      autoFocus,
+      autoHover,
+      defaultActive,
       uploading = false,
       size = 'small',
       onEdit,
@@ -114,9 +112,9 @@ export const AvatarUpload = forwardRef<HTMLElement, Props>(
         initiallyFocused?: boolean
         initiallyActive?: boolean
       }>({
-        hovered: hoveredProp,
-        initiallyFocused: focusedProp,
-        initiallyActive: activeProp,
+        hovered: autoHover,
+        initiallyFocused: autoFocus,
+        initiallyActive: defaultActive,
       })
 
     // callback overrides to return only one file to the parent component

--- a/packages/picasso/src/AvatarUpload/AvatarUpload.tsx
+++ b/packages/picasso/src/AvatarUpload/AvatarUpload.tsx
@@ -174,6 +174,7 @@ export const AvatarUpload = forwardRef<HTMLElement, Props>(
     const showAvatar = !showLoader && Boolean(src)
     const showUploadIcon = !showAvatar && !showLoader
     const showEditIcon = Boolean(onEdit)
+    const error = status === 'error'
 
     // after showing avatar, only way to change the file selection is to use 'onEdit' by clicking
     const disableDropzoneClick = showAvatar && !showEditIcon
@@ -184,6 +185,7 @@ export const AvatarUpload = forwardRef<HTMLElement, Props>(
       <Loader
         className={cx(classes.icon, {
           [classes.hovered]: hovered,
+          [classes.error]: error,
         })}
         size='small'
         variant='inherit'
@@ -194,6 +196,7 @@ export const AvatarUpload = forwardRef<HTMLElement, Props>(
       <Upload24
         className={cx(classes.icon, {
           [classes.hovered]: hovered,
+          [classes.error]: error,
         })}
         data-testid={testIds?.uploadIcon}
       />
@@ -236,7 +239,6 @@ export const AvatarUpload = forwardRef<HTMLElement, Props>(
       <div
         {...getRootProps({
           className: cx(classes.root, classes[`size${capitalize(size)}`], {
-            [classes.error]: status === 'error',
             [classes.disabled]: disabled,
           }),
           'data-testid': dataTestId,

--- a/packages/picasso/src/AvatarUpload/DropzoneSvg/DropzoneSvg.tsx
+++ b/packages/picasso/src/AvatarUpload/DropzoneSvg/DropzoneSvg.tsx
@@ -88,6 +88,7 @@ export const DropzoneSvg = (props: Props) => {
         <path
           className={cx(classes.outline, {
             [classes.focused]: focused,
+            [classes.error]: error,
           })}
           fillRule='evenodd'
           clipRule='evenodd'
@@ -100,6 +101,7 @@ export const DropzoneSvg = (props: Props) => {
           className={cx(classes.border, {
             [classes.error]: error,
             [classes.focused]: focused,
+            [classes.hovered]: hovered,
           })}
           fillRule='evenodd'
           clipRule='evenodd'

--- a/packages/picasso/src/AvatarUpload/DropzoneSvg/DropzoneSvg.tsx
+++ b/packages/picasso/src/AvatarUpload/DropzoneSvg/DropzoneSvg.tsx
@@ -36,6 +36,11 @@ const SHAPES = {
 
 export interface Props extends BaseProps {
   size?: SizeType<'small' | 'large'>
+  isDragActive?: boolean
+  disabled?: boolean
+  error?: boolean
+  focused?: boolean
+  hovered?: boolean
 }
 
 const useStyles = makeStyles<Theme>(styles, {
@@ -43,7 +48,15 @@ const useStyles = makeStyles<Theme>(styles, {
 })
 
 export const DropzoneSvg = (props: Props) => {
-  const { size = 'small', 'data-testid': dataTestId } = props
+  const {
+    size = 'small',
+    disabled,
+    error,
+    focused,
+    hovered,
+    isDragActive,
+    'data-testid': dataTestId,
+  } = props
 
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   const shapes = SHAPES[size!]
@@ -61,13 +74,21 @@ export const DropzoneSvg = (props: Props) => {
         xmlns='http://www.w3.org/2000/svg'
       >
         <path
-          className={classes.background}
+          className={cx(classes.background, {
+            [classes.dragActive]: isDragActive,
+            [classes.disabled]: disabled,
+            [classes.error]: error,
+            [classes.focused]: focused,
+            [classes.hovered]: hovered,
+          })}
           fillRule='evenodd'
           clipRule='evenodd'
           d={shapes.backgroundShape}
         />
         <path
-          className={classes.outline}
+          className={cx(classes.outline, {
+            [classes.focused]: focused,
+          })}
           fillRule='evenodd'
           clipRule='evenodd'
           d={shapes.outlineShape}
@@ -76,7 +97,10 @@ export const DropzoneSvg = (props: Props) => {
           strokeLinejoin='round'
         />
         <path
-          className={classes.border}
+          className={cx(classes.border, {
+            [classes.error]: error,
+            [classes.focused]: focused,
+          })}
           fillRule='evenodd'
           clipRule='evenodd'
           d={shapes.bordersShape}

--- a/packages/picasso/src/AvatarUpload/DropzoneSvg/styles.ts
+++ b/packages/picasso/src/AvatarUpload/DropzoneSvg/styles.ts
@@ -1,7 +1,12 @@
 import { createStyles, Theme } from '@material-ui/core/styles'
+import { alpha } from '@toptal/picasso-shared'
 
-export default ({ palette, transitions }: Theme) =>
-  createStyles({
+export default ({ palette, transitions }: Theme) => {
+  const dragActiveColor = alpha(palette.blue.main, 0.24)
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+  const hoverColor = alpha(palette.blue.lighter!, 0.84)
+
+  return createStyles({
     root: {
       position: 'relative',
       background: 'transparent',
@@ -31,13 +36,49 @@ export default ({ palette, transitions }: Theme) =>
       fill: palette.blue.lighter,
       transition: `all ${transitions.duration.short}ms ${transitions.easing.easeOut}`,
       transitionProperty: 'fill',
+
+      '&$hovered': {
+        cursor: 'pointer',
+        fill: hoverColor,
+      },
+
+      '&$dragActive,&:active': {
+        fill: dragActiveColor,
+      },
+
+      '&$disabled': {
+        fill: palette.grey.lighter,
+        '&$hovered': {
+          cursor: 'no-drop',
+          fill: palette.grey.light2,
+        },
+      },
     },
     border: {
       stroke: palette.blue.main,
       transition: `stroke ${transitions.duration.short}`,
+
+      '&$error': {
+        stroke: palette.red.main,
+
+        '&$focused': {
+          stroke: palette.blue.main,
+        },
+      },
     },
     outline: {
       display: 'none',
       stroke: palette.blue.main,
+
+      '&$focused:not($dragActive)': {
+        display: 'initial',
+      },
     },
+
+    dragActive: {},
+    disabled: {},
+    error: {},
+    focused: {},
+    hovered: {},
   })
+}

--- a/packages/picasso/src/AvatarUpload/DropzoneSvg/styles.ts
+++ b/packages/picasso/src/AvatarUpload/DropzoneSvg/styles.ts
@@ -4,10 +4,12 @@ import { alpha } from '@toptal/picasso-shared'
 export default ({ palette, transitions }: Theme) => {
   const dragActiveColor = alpha(palette.blue.main, 0.24)
   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-  const hoverColor = alpha(palette.blue.lighter!, 0.84)
+  const hoverBackgroundColor = alpha(palette.blue.lighter!, 0.84)
+  const hoverBorderColor = alpha(palette.blue.main, 0.84)
 
   return createStyles({
     root: {
+      pointerEvents: 'unset',
       position: 'relative',
       background: 'transparent',
     },
@@ -38,8 +40,7 @@ export default ({ palette, transitions }: Theme) => {
       transitionProperty: 'fill',
 
       '&$hovered': {
-        cursor: 'pointer',
-        fill: hoverColor,
+        fill: hoverBackgroundColor,
       },
 
       '&$dragActive,&:active': {
@@ -49,7 +50,6 @@ export default ({ palette, transitions }: Theme) => {
       '&$disabled': {
         fill: palette.grey.lighter,
         '&$hovered': {
-          cursor: 'no-drop',
           fill: palette.grey.light2,
         },
       },
@@ -58,12 +58,12 @@ export default ({ palette, transitions }: Theme) => {
       stroke: palette.blue.main,
       transition: `stroke ${transitions.duration.short}`,
 
+      '&$hovered': {
+        stroke: hoverBorderColor,
+      },
+
       '&$error': {
         stroke: palette.red.main,
-
-        '&$focused': {
-          stroke: palette.blue.main,
-        },
       },
     },
     outline: {
@@ -72,6 +72,10 @@ export default ({ palette, transitions }: Theme) => {
 
       '&$focused:not($dragActive)': {
         display: 'initial',
+      },
+
+      '&$error': {
+        stroke: palette.red.main,
       },
     },
 

--- a/packages/picasso/src/AvatarUpload/story/States.example.tsx
+++ b/packages/picasso/src/AvatarUpload/story/States.example.tsx
@@ -51,7 +51,7 @@ const ActiveExample = () => (
     <Typography variant='heading' size='small'>
       Active
     </Typography>
-    <AvatarUpload alt='avatar-upload' autoActive />
+    <AvatarUpload alt='avatar-upload' defaultActive />
   </Container>
 )
 

--- a/packages/picasso/src/AvatarUpload/story/States.example.tsx
+++ b/packages/picasso/src/AvatarUpload/story/States.example.tsx
@@ -1,12 +1,21 @@
 import React from 'react'
 import { AvatarUpload, Container, Typography } from '@toptal/picasso'
 
+const HoveredExample = () => (
+  <Container flex direction='column' alignItems='center'>
+    <Typography variant='heading' size='small'>
+      Hovered
+    </Typography>
+    <AvatarUpload alt='avatar-upload' hovered />
+  </Container>
+)
+
 const FocusedExample = () => (
   <Container flex direction='column' alignItems='center'>
     <Typography variant='heading' size='small'>
       Focused
     </Typography>
-    <AvatarUpload alt='Jacqueline Roque. Pablo Picasso, 1954' focused />
+    <AvatarUpload alt='avatar-upload' focused />
   </Container>
 )
 
@@ -15,7 +24,7 @@ const ErrorExample = () => (
     <Typography variant='heading' size='small'>
       Error
     </Typography>
-    <AvatarUpload alt='Jacqueline Roque. Pablo Picasso, 1954' status='error' />
+    <AvatarUpload alt='avatar-upload' status='error' />
   </Container>
 )
 
@@ -24,11 +33,7 @@ const FocusedAndErrorExample = () => (
     <Typography variant='heading' size='small'>
       Focused & Error
     </Typography>
-    <AvatarUpload
-      alt='Jacqueline Roque. Pablo Picasso, 1954'
-      status='error'
-      focused
-    />
+    <AvatarUpload alt='avatar-upload' status='error' focused />
   </Container>
 )
 
@@ -37,16 +42,27 @@ const LoadingExample = () => (
     <Typography variant='heading' size='small'>
       Loading
     </Typography>
-    <AvatarUpload alt='Jacqueline Roque. Pablo Picasso, 1954' uploading />
+    <AvatarUpload alt='avatar-upload' uploading />
+  </Container>
+)
+
+const ActiveExample = () => (
+  <Container flex direction='column' alignItems='center'>
+    <Typography variant='heading' size='small'>
+      Active & Drag
+    </Typography>
+    <AvatarUpload alt='avatar-upload' active />
   </Container>
 )
 
 const Example = () => (
   <Container flex padded='medium' gap='medium'>
+    <HoveredExample />
     <FocusedExample />
     <ErrorExample />
     <FocusedAndErrorExample />
     <LoadingExample />
+    <ActiveExample />
   </Container>
 )
 

--- a/packages/picasso/src/AvatarUpload/story/States.example.tsx
+++ b/packages/picasso/src/AvatarUpload/story/States.example.tsx
@@ -1,0 +1,53 @@
+import React from 'react'
+import { AvatarUpload, Container, Typography } from '@toptal/picasso'
+
+const FocusedExample = () => (
+  <Container flex direction='column' alignItems='center'>
+    <Typography variant='heading' size='small'>
+      Focused
+    </Typography>
+    <AvatarUpload alt='Jacqueline Roque. Pablo Picasso, 1954' focused />
+  </Container>
+)
+
+const ErrorExample = () => (
+  <Container flex direction='column' alignItems='center'>
+    <Typography variant='heading' size='small'>
+      Error
+    </Typography>
+    <AvatarUpload alt='Jacqueline Roque. Pablo Picasso, 1954' status='error' />
+  </Container>
+)
+
+const FocusedAndErrorExample = () => (
+  <Container flex direction='column' alignItems='center'>
+    <Typography variant='heading' size='small'>
+      Focused & Error
+    </Typography>
+    <AvatarUpload
+      alt='Jacqueline Roque. Pablo Picasso, 1954'
+      status='error'
+      focused
+    />
+  </Container>
+)
+
+const LoadingExample = () => (
+  <Container flex direction='column' alignItems='center'>
+    <Typography variant='heading' size='small'>
+      Loading
+    </Typography>
+    <AvatarUpload alt='Jacqueline Roque. Pablo Picasso, 1954' uploading />
+  </Container>
+)
+
+const Example = () => (
+  <Container flex padded='medium' gap='medium'>
+    <FocusedExample />
+    <ErrorExample />
+    <FocusedAndErrorExample />
+    <LoadingExample />
+  </Container>
+)
+
+export default Example

--- a/packages/picasso/src/AvatarUpload/story/States.example.tsx
+++ b/packages/picasso/src/AvatarUpload/story/States.example.tsx
@@ -49,7 +49,7 @@ const LoadingExample = () => (
 const ActiveExample = () => (
   <Container flex direction='column' alignItems='center'>
     <Typography variant='heading' size='small'>
-      Active & Drag
+      Active
     </Typography>
     <AvatarUpload alt='avatar-upload' active />
   </Container>

--- a/packages/picasso/src/AvatarUpload/story/States.example.tsx
+++ b/packages/picasso/src/AvatarUpload/story/States.example.tsx
@@ -6,7 +6,7 @@ const HoveredExample = () => (
     <Typography variant='heading' size='small'>
       Hovered
     </Typography>
-    <AvatarUpload alt='avatar-upload' hovered />
+    <AvatarUpload alt='avatar-upload' autoHover />
   </Container>
 )
 
@@ -15,7 +15,7 @@ const FocusedExample = () => (
     <Typography variant='heading' size='small'>
       Focused
     </Typography>
-    <AvatarUpload alt='avatar-upload' focused />
+    <AvatarUpload alt='avatar-upload' autoFocus />
   </Container>
 )
 
@@ -33,7 +33,7 @@ const FocusedAndErrorExample = () => (
     <Typography variant='heading' size='small'>
       Focused & Error
     </Typography>
-    <AvatarUpload alt='avatar-upload' status='error' focused />
+    <AvatarUpload alt='avatar-upload' status='error' autoFocus />
   </Container>
 )
 
@@ -51,7 +51,7 @@ const ActiveExample = () => (
     <Typography variant='heading' size='small'>
       Active
     </Typography>
-    <AvatarUpload alt='avatar-upload' active />
+    <AvatarUpload alt='avatar-upload' autoActive />
   </Container>
 )
 

--- a/packages/picasso/src/AvatarUpload/story/index.jsx
+++ b/packages/picasso/src/AvatarUpload/story/index.jsx
@@ -21,3 +21,4 @@ page
     takeScreenshot: false,
   })
   .addExample('AvatarUpload/story/Sizes.example.tsx', 'Sizes')
+  .addExample('AvatarUpload/story/States.example.tsx', 'States')

--- a/packages/picasso/src/AvatarUpload/styles.ts
+++ b/packages/picasso/src/AvatarUpload/styles.ts
@@ -2,7 +2,8 @@ import { createStyles, Theme } from '@material-ui/core/styles'
 import { alpha } from '@toptal/picasso-shared'
 
 export default ({ palette }: Theme) => {
-  const hoverIconColor = alpha(palette.blue.main, 0.84)
+  const iconHoverColor = alpha(palette.blue.main, 0.84)
+  const iconHoverErrorColor = alpha(palette.red.main, 0.84)
 
   return createStyles({
     root: {
@@ -13,10 +14,6 @@ export default ({ palette }: Theme) => {
       color: palette.blue.main,
       outline: 'none',
       cursor: 'pointer',
-
-      '&$error': {
-        color: palette.red.main,
-      },
 
       '&$disabled': {
         cursor: 'no-drop',
@@ -37,8 +34,16 @@ export default ({ palette }: Theme) => {
       position: 'absolute',
       pointerEvents: 'none',
 
+      '&$error': {
+        color: palette.red.main,
+      },
+
       '&$hovered': {
-        color: hoverIconColor,
+        color: iconHoverColor,
+
+        '&$error': {
+          color: iconHoverErrorColor,
+        },
       },
     },
 

--- a/packages/picasso/src/AvatarUpload/styles.ts
+++ b/packages/picasso/src/AvatarUpload/styles.ts
@@ -9,6 +9,10 @@ export default ({ palette }: Theme) =>
       alignItems: 'center',
       color: palette.blue.main,
       outline: 'none',
+
+      '&$error': {
+        color: palette.red.main,
+      },
     },
 
     sizeSmall: {
@@ -23,6 +27,8 @@ export default ({ palette }: Theme) =>
 
     icon: {
       position: 'absolute',
-      cursor: 'pointer',
+      pointerEvents: 'none',
     },
+
+    error: {},
   })

--- a/packages/picasso/src/AvatarUpload/styles.ts
+++ b/packages/picasso/src/AvatarUpload/styles.ts
@@ -18,6 +18,10 @@ export default ({ palette }: Theme) => {
       '&$disabled': {
         cursor: 'no-drop',
       },
+
+      '&$readonlyAvatar': {
+        cursor: 'default',
+      },
     },
 
     sizeSmall: {
@@ -50,5 +54,6 @@ export default ({ palette }: Theme) => {
     error: {},
     disabled: {},
     hovered: {},
+    readonlyAvatar: {},
   })
 }

--- a/packages/picasso/src/AvatarUpload/styles.ts
+++ b/packages/picasso/src/AvatarUpload/styles.ts
@@ -1,7 +1,10 @@
 import { createStyles, Theme } from '@material-ui/core/styles'
+import { alpha } from '@toptal/picasso-shared'
 
-export default ({ palette }: Theme) =>
-  createStyles({
+export default ({ palette }: Theme) => {
+  const hoverIconColor = alpha(palette.blue.main, 0.84)
+
+  return createStyles({
     root: {
       position: 'relative',
       display: 'flex',
@@ -9,9 +12,14 @@ export default ({ palette }: Theme) =>
       alignItems: 'center',
       color: palette.blue.main,
       outline: 'none',
+      cursor: 'pointer',
 
       '&$error': {
         color: palette.red.main,
+      },
+
+      '&$disabled': {
+        cursor: 'no-drop',
       },
     },
 
@@ -28,7 +36,14 @@ export default ({ palette }: Theme) =>
     icon: {
       position: 'absolute',
       pointerEvents: 'none',
+
+      '&$hovered': {
+        color: hoverIconColor,
+      },
     },
 
     error: {},
+    disabled: {},
+    hovered: {},
   })
+}


### PR DESCRIPTION
[FX-2889]

### Description

- added focused, hovered, active (also dragActive) and error states to the AvatarUpload

figma designs for this component: https://www.figma.com/file/q2nvjiyO2CLqBv4DeJnU3i/Product-Library-Documentation?node-id=2599%3A18280

### How to test

- go to [component page and check new story](https://picasso.toptal.net/fx-2889-add-visual-states-avatar-upload/?path=/story/components-avatarupload--avatarupload#states)

### Screenshots

<img width="714" alt="Screen Shot 2022-08-30 at 13 37 59" src="https://user-images.githubusercontent.com/7733167/187416120-08b115a8-fac6-4522-be3d-6b18632e3102.png">

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests

**Breaking change**

- codemod is created and showcased in the changeset
- test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-2889]: https://toptal-core.atlassian.net/browse/FX-2889?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ