### PR TITLE
feat(AvatarUpload): add field wrapper

### DIFF
--- a/.changeset/cold-parrots-hide.md
+++ b/.changeset/cold-parrots-hide.md
@@ -1,0 +1,9 @@
+---
+'@toptal/picasso-forms': minor
+---
+
+---
+
+### AvatarUpload
+
+- add new component `AvatarUpload` as a field

--- a/.changeset/giant-shrimps-hope.md
+++ b/.changeset/giant-shrimps-hope.md
@@ -1,0 +1,8 @@
+---
+'@toptal/picasso': minor
+---
+
+---
+### AvatarUpload
+
+- add `value`, `onFocus` and `onBlur` props to be used in forms

--- a/packages/picasso-forms/src/AvatarUpload/AvatarUpload.tsx
+++ b/packages/picasso-forms/src/AvatarUpload/AvatarUpload.tsx
@@ -17,6 +17,8 @@ type FinalFormOnChangeType = FinalFieldInputProps<
 >['onChange']
 
 const AvatarUpload = (props: Props) => {
+  // dropping 'src' value here out from 'rest'. 'src' value should be provided via form context
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const { label, titleCase, src, ...rest } = props
 
   const handleDropAccepted = async ({
@@ -53,7 +55,7 @@ const AvatarUpload = (props: Props) => {
       {inputProps => (
         <PicassoAvatarUpload
           {...inputProps}
-          src={inputProps.value ? inputProps.value.src : src}
+          src={inputProps.value?.src}
           onDropAccepted={acceptedFile =>
             handleDropAccepted({
               acceptedFile,

--- a/packages/picasso-forms/src/AvatarUpload/AvatarUpload.tsx
+++ b/packages/picasso-forms/src/AvatarUpload/AvatarUpload.tsx
@@ -1,0 +1,73 @@
+import React from 'react'
+import {
+  AvatarUpload as PicassoAvatarUpload,
+  AvatarUploadProps,
+  AvatarUploadFileUpload,
+} from '@toptal/picasso'
+import { FieldInputProps as FinalFieldInputProps } from 'react-final-form'
+
+import { FieldProps } from '../Field'
+import FieldLabel from '../FieldLabel'
+import InputField from '../InputField'
+
+export type Props = AvatarUploadProps & FieldProps<AvatarUploadProps['value']>
+
+type FinalFormOnChangeType = FinalFieldInputProps<
+  AvatarUploadProps['value']
+>['onChange']
+
+const AvatarUpload = (props: Props) => {
+  const { label, titleCase, src, ...rest } = props
+
+  const handleDropAccepted = async ({
+    acceptedFile,
+    finalFormOnChange,
+  }: {
+    acceptedFile: File
+    finalFormOnChange: FinalFormOnChangeType
+  }) => {
+    const reader = new FileReader()
+
+    reader.readAsDataURL(acceptedFile)
+
+    reader.onload = () => {
+      // setting form value to the new file
+      finalFormOnChange({ file: acceptedFile, src: reader.result as string })
+    }
+  }
+
+  return (
+    <InputField<AvatarUploadProps, AvatarUploadFileUpload | undefined>
+      {...rest}
+      label={
+        label ? (
+          <FieldLabel
+            name={props.name}
+            required={props.required}
+            label={label}
+            titleCase={titleCase}
+          />
+        ) : null
+      }
+    >
+      {inputProps => (
+        <PicassoAvatarUpload
+          {...inputProps}
+          src={inputProps.value ? inputProps.value.src : src}
+          onDropAccepted={acceptedFile =>
+            handleDropAccepted({
+              acceptedFile,
+              finalFormOnChange: inputProps.onChange,
+            })
+          }
+        />
+      )}
+    </InputField>
+  )
+}
+
+AvatarUpload.defaultProps = {}
+
+AvatarUpload.displayName = 'AvatarUpload'
+
+export default AvatarUpload

--- a/packages/picasso-forms/src/AvatarUpload/AvatarUpload.tsx
+++ b/packages/picasso-forms/src/AvatarUpload/AvatarUpload.tsx
@@ -10,7 +10,7 @@ import { FieldProps } from '../Field'
 import FieldLabel from '../FieldLabel'
 import InputField from '../InputField'
 
-export type Props = AvatarUploadProps & FieldProps<AvatarUploadProps['value']>
+type Props = AvatarUploadProps & FieldProps<AvatarUploadProps['value']>
 
 type FinalFormOnChangeType = FinalFieldInputProps<
   AvatarUploadProps['value']

--- a/packages/picasso-forms/src/AvatarUpload/index.ts
+++ b/packages/picasso-forms/src/AvatarUpload/index.ts
@@ -1,0 +1,1 @@
+export { default } from './AvatarUpload'

--- a/packages/picasso-forms/src/FieldBase/types.ts
+++ b/packages/picasso-forms/src/FieldBase/types.ts
@@ -1,6 +1,7 @@
 import { DateOrDateRangeType } from '@toptal/picasso'
 import { Item } from '@toptal/picasso/Autocomplete'
 import { FileUpload } from '@toptal/picasso/FileInput'
+import { FileUpload as AvatarUploadFileUpload } from '@toptal/picasso/AvatarUpload'
 
 export type ValueType =
   | string
@@ -9,6 +10,7 @@ export type ValueType =
   | boolean
   | null
   | undefined
+  | AvatarUploadFileUpload
   | FileUpload[]
   | DateOrDateRangeType
   | Item

--- a/packages/picasso-forms/src/Form/story/AvatarUpload.example.tsx
+++ b/packages/picasso-forms/src/Form/story/AvatarUpload.example.tsx
@@ -1,0 +1,75 @@
+import React, { useState } from 'react'
+import {
+  AvatarUploadFileUpload,
+  AvatarUploadFileRejection,
+  Container,
+} from '@toptal/picasso'
+import { Form, useForm } from '@toptal/picasso-forms'
+
+type FormType = {
+  avatarUpload: AvatarUploadFileUpload
+}
+
+const FormRenderer = () => {
+  const { change } = useForm()
+  const [uploading, setUploading] = useState<boolean>(false)
+
+  const handleDrop = (
+    acceptedFile: File | null,
+    fileRejection: AvatarUploadFileRejection | null
+  ) => {
+    if (acceptedFile) {
+      // simulate upload with external upload service
+      const reader = new FileReader()
+
+      reader.readAsDataURL(acceptedFile)
+
+      reader.onload = () => {
+        setUploading(true)
+
+        setTimeout(() => {
+          setUploading(false)
+
+          // set result of upload to form
+          change('avatarUpload', { src: reader.result as string })
+        }, 1000)
+      }
+
+      reader.onerror = error => {
+        console.log('Error: upload failed, ', error)
+      }
+    } else if (fileRejection) {
+      // file rejected
+      console.log(fileRejection.errors.join(', '))
+    }
+  }
+
+  return (
+    <>
+      <Form.AvatarUpload
+        required
+        name='avatarUpload'
+        onDrop={handleDrop}
+        uploading={uploading}
+      />
+
+      <Container top='small'>
+        <Form.SubmitButton>Submit</Form.SubmitButton>
+      </Container>
+    </>
+  )
+}
+
+const Example = () => {
+  const handleSubmit = ({ avatarUpload }: FormType) => {
+    window.alert(`src: ${avatarUpload.src}`)
+  }
+
+  return (
+    <Form<FormType> autoComplete='off' onSubmit={handleSubmit}>
+      <FormRenderer />
+    </Form>
+  )
+}
+
+export default Example

--- a/packages/picasso-forms/src/Form/story/Default.example.tsx
+++ b/packages/picasso-forms/src/Form/story/Default.example.tsx
@@ -173,8 +173,8 @@ const Example = () => {
       />
       <Form.FileInput
         required
-        name='default-avatar'
-        label='Avatar'
+        name='default-resume'
+        label='Resume'
         status='No file selected.'
       />
       <Form.Dropzone label='Attachments' required name='default-attachments' />

--- a/packages/picasso-forms/src/Form/story/Default.example.tsx
+++ b/packages/picasso-forms/src/Form/story/Default.example.tsx
@@ -178,6 +178,11 @@ const Example = () => {
         status='No file selected.'
       />
       <Form.Dropzone label='Attachments' required name='default-attachments' />
+      <Form.AvatarUpload
+        label='Profile photo'
+        required
+        name='default-avatarUpload'
+      />
       <Form.Checkbox
         required
         name='default-legal'

--- a/packages/picasso-forms/src/Form/story/TitleCase.example.tsx
+++ b/packages/picasso-forms/src/Form/story/TitleCase.example.tsx
@@ -154,8 +154,8 @@ const Example = () => {
       <Form.FileInput
         titleCase
         required
-        name='titleCase-avatar'
-        label='Your avatar'
+        name='titleCase-resume'
+        label='Your resume'
         status='No file selected.'
       />
       <Form.Checkbox

--- a/packages/picasso-forms/src/Form/story/index.jsx
+++ b/packages/picasso-forms/src/Form/story/index.jsx
@@ -148,9 +148,9 @@ provides inside all the necessary input components types.
     {
       title: 'Default',
       description: `
-A general look of the form includes the examples of all the input
-types supported by picasso-forms.
-`,
+  A general look of the form includes the examples of all the input
+  types supported by picasso-forms.
+  `,
     },
     'picasso-form'
   )
@@ -159,9 +159,9 @@ types supported by picasso-forms.
     {
       title: 'Custom validator',
       description: `
-We have a 'required' validator included by default to each input type,
-however, you may need custom validators for more complex types of fields.
-`,
+  We have a 'required' validator included by default to each input type,
+  however, you may need custom validators for more complex types of fields.
+  `,
       takeScreenshot: false,
     },
     'picasso-form'
@@ -171,14 +171,14 @@ however, you may need custom validators for more complex types of fields.
     {
       title: 'Change form input value',
       description: `
-      When you use picasso-forms your form input components are no longer
-      completely controlled and they are controlled by final-form, which
-      gives you the opportunity to rely on it with displaying errors,
-      validations, etc.
+        When you use picasso-forms your form input components are no longer
+        completely controlled and they are controlled by final-form, which
+        gives you the opportunity to rely on it with displaying errors,
+        validations, etc.
 
-      However, sometimes you may need to be able to modify the form input
-      value.
-      `,
+        However, sometimes you may need to be able to modify the form input
+        value.
+        `,
       takeScreenshot: false,
     },
     'picasso-form'
@@ -188,10 +188,10 @@ however, you may need custom validators for more complex types of fields.
     {
       title: 'Backend communication',
       description: `
-        The form usually need to send data to backend, so we need to have
-        backend communication and display the process of submission and
-        the results. The form-level results are represented by notifications.
-        `,
+          The form usually need to send data to backend, so we need to have
+          backend communication and display the process of submission and
+          the results. The form-level results are represented by notifications.
+          `,
       takeScreenshot: false,
     },
     'picasso-form'
@@ -205,8 +205,8 @@ however, you may need custom validators for more complex types of fields.
     {
       title: 'Validate only on submit',
       description: `
-            All fields should not show any validation error messages until submission is made.
-            `,
+              All fields should not show any validation error messages until submission is made.
+              `,
       takeScreenshot: false,
     },
     'picasso-form'
@@ -246,5 +246,11 @@ however, you may need custom validators for more complex types of fields.
     title: 'Form Level Status Configuration',
     description:
       'Showcase how to enable success status via form configuration.',
+    takeScreenshot: false,
+  })
+  .addExample('Form/story/AvatarUpload.example.tsx', {
+    title: 'AvatarUpload',
+    description:
+      'Showcase how to handle avatar upload with external upload service.',
     takeScreenshot: false,
   })

--- a/packages/picasso-forms/src/Form/story/index.jsx
+++ b/packages/picasso-forms/src/Form/story/index.jsx
@@ -148,9 +148,9 @@ provides inside all the necessary input components types.
     {
       title: 'Default',
       description: `
-  A general look of the form includes the examples of all the input
-  types supported by picasso-forms.
-  `,
+A general look of the form includes the examples of all the input
+types supported by picasso-forms.
+`,
     },
     'picasso-form'
   )
@@ -159,9 +159,9 @@ provides inside all the necessary input components types.
     {
       title: 'Custom validator',
       description: `
-  We have a 'required' validator included by default to each input type,
-  however, you may need custom validators for more complex types of fields.
-  `,
+We have a 'required' validator included by default to each input type,
+however, you may need custom validators for more complex types of fields.
+`,
       takeScreenshot: false,
     },
     'picasso-form'
@@ -171,14 +171,14 @@ provides inside all the necessary input components types.
     {
       title: 'Change form input value',
       description: `
-        When you use picasso-forms your form input components are no longer
-        completely controlled and they are controlled by final-form, which
-        gives you the opportunity to rely on it with displaying errors,
-        validations, etc.
+      When you use picasso-forms your form input components are no longer
+      completely controlled and they are controlled by final-form, which
+      gives you the opportunity to rely on it with displaying errors,
+      validations, etc.
 
-        However, sometimes you may need to be able to modify the form input
-        value.
-        `,
+      However, sometimes you may need to be able to modify the form input
+      value.
+      `,
       takeScreenshot: false,
     },
     'picasso-form'
@@ -188,10 +188,10 @@ provides inside all the necessary input components types.
     {
       title: 'Backend communication',
       description: `
-          The form usually need to send data to backend, so we need to have
-          backend communication and display the process of submission and
-          the results. The form-level results are represented by notifications.
-          `,
+        The form usually need to send data to backend, so we need to have
+        backend communication and display the process of submission and
+        the results. The form-level results are represented by notifications.
+        `,
       takeScreenshot: false,
     },
     'picasso-form'
@@ -205,8 +205,8 @@ provides inside all the necessary input components types.
     {
       title: 'Validate only on submit',
       description: `
-              All fields should not show any validation error messages until submission is made.
-              `,
+            All fields should not show any validation error messages until submission is made.
+            `,
       takeScreenshot: false,
     },
     'picasso-form'

--- a/packages/picasso-forms/src/FormCompound/index.ts
+++ b/packages/picasso-forms/src/FormCompound/index.ts
@@ -22,6 +22,7 @@ import Dropzone from '../Dropzone'
 import RichTextEditor from '../RichTextEditor'
 import PasswordInput from '../PasswordInput'
 import { FormConfigContext } from '../FormConfig'
+import AvatarUpload from '../AvatarUpload'
 
 export const FormCompound = Object.assign(Form, {
   Autocomplete: Autocomplete,
@@ -46,4 +47,5 @@ export const FormCompound = Object.assign(Form, {
   PasswordInput: PasswordInput,
   FieldRequirements: FieldRequirements,
   RichTextEditor: RichTextEditor,
+  AvatarUpload: AvatarUpload,
 })

--- a/packages/picasso/src/AvatarUpload/AvatarUpload.tsx
+++ b/packages/picasso/src/AvatarUpload/AvatarUpload.tsx
@@ -12,7 +12,12 @@ import cx from 'classnames'
 
 import Avatar from '../Avatar'
 import styles from './styles'
-import { AvatarUploadOptions, DropEvent, FileRejection } from './types'
+import {
+  AvatarUploadOptions,
+  DropEvent,
+  FileRejection,
+  FileUpload,
+} from './types'
 import DropzoneSvg from './DropzoneSvg/DropzoneSvg'
 import Loader from '../Loader'
 import { Upload24 } from '../Icon'
@@ -59,6 +64,8 @@ export interface Props extends BaseProps {
    * (file: File) => FileError | FileError[] | null
    */
   validator?: AvatarUploadOptions['validator']
+  /** Value to be used for forms */
+  value?: FileUpload
   /** Indicate `AvatarUpload` is in `error` or `default` state */
   status?: Extract<Status, 'error' | 'default'>
   /** Indicate whether the selected file is being uploaded */

--- a/packages/picasso/src/AvatarUpload/AvatarUpload.tsx
+++ b/packages/picasso/src/AvatarUpload/AvatarUpload.tsx
@@ -1,4 +1,5 @@
 import React, {
+  FocusEvent,
   forwardRef,
   useCallback,
   useEffect,
@@ -40,10 +41,12 @@ export interface Props extends BaseProps {
   maxSize?: number
   /** Minimum file size (in bytes) */
   minSize?: number
-  /**
-   * Callback for when there is already a source and user clicks on the avatar.
-   */
+  /** Callback for when there is already a source and user clicks on the avatar. */
   onEdit?: AvatarUploadOptions['onEdit']
+  /** Callback for focusing */
+  onFocus?: (event: FocusEvent<HTMLElement, Element>) => void
+  /** Callback for losing focus */
+  onBlur?: (event: FocusEvent<HTMLElement, Element>) => void
   /**
    * Callback for when the drop event occurs. Note that if file is not accepted, this callback is not invoked.,
    * @type <T extends File>(files: T, event: DropEvent) => void
@@ -96,6 +99,8 @@ export const AvatarUpload = forwardRef<HTMLElement, Props>(
       uploading = false,
       size = 'small',
       onEdit,
+      onFocus,
+      onBlur,
       status,
       'data-testid': dataTestId,
       testIds,
@@ -246,9 +251,11 @@ export const AvatarUpload = forwardRef<HTMLElement, Props>(
             [classes.readonlyAvatar]: showAvatar,
           }),
           'data-testid': dataTestId,
+          onMouseEnter,
+          onMouseLeave,
+          onFocus,
+          onBlur,
         })}
-        onMouseEnter={onMouseEnter}
-        onMouseLeave={onMouseLeave}
       >
         <input {...getInputProps()} />
 

--- a/packages/picasso/src/AvatarUpload/types.ts
+++ b/packages/picasso/src/AvatarUpload/types.ts
@@ -1,8 +1,8 @@
 export interface FileUpload {
   uploading?: boolean
-  progress?: number
   error?: string
-  file: File
+  file?: File
+  src?: string
 }
 
 export type AvatarUploadOptions = {

--- a/packages/picasso/src/AvatarUpload/types.ts
+++ b/packages/picasso/src/AvatarUpload/types.ts
@@ -1,6 +1,4 @@
 export interface FileUpload {
-  uploading?: boolean
-  error?: string
   file?: File
   src?: string
 }


### PR DESCRIPTION
[FX-3072]

### Description

- I have added a new component into `picasso-forms` and wrapped `AvatarUpload` with `InputField`
- I have added `value`, `onFocus` and `onBlur` props for `picasso/AvatarUpload`

### How to test

- there are two different stories that include `AvatarUpload` examples:
https://picasso.toptal.net/fx-3072-avatarupload-form-wrapper/?path=/story/picasso-forms-form--form#default
https://picasso.toptal.net/fx-3072-avatarupload-form-wrapper/?path=/story/picasso-forms-form--form#avatarupload 

You can check them both and confirm that they are working as expected.

### Screenshots

<img width="531" alt="Screen Shot 2022-09-01 at 11 03 57" src="https://user-images.githubusercontent.com/7733167/187864078-94fc5790-b45d-4e20-9ad2-fd026d6381e0.png">

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- Covered with tests

**Breaking change**

- codemod is created and showcased in the changeset
- test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-3072]: https://toptal-core.atlassian.net/browse/FX-3072?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ