### PR TITLE
chore(AvatarUpload): add remaining size variants

### DIFF
--- a/.changeset/mighty-radios-sniff.md
+++ b/.changeset/mighty-radios-sniff.md
@@ -1,0 +1,10 @@
+---
+'@toptal/picasso': minor
+---
+
+---
+
+### AvatarUpload
+
+- add `xxsmall`, `xsmall`, and `medium` size variants
+- pixel perfect the border and outline of the component

--- a/packages/picasso/src/AvatarUpload/AvatarUpload.tsx
+++ b/packages/picasso/src/AvatarUpload/AvatarUpload.tsx
@@ -21,7 +21,7 @@ import {
 } from './types'
 import DropzoneSvg from './DropzoneSvg/DropzoneSvg'
 import Loader from '../Loader'
-import { Upload24 } from '../Icon'
+import { Upload16, Upload24 } from '../Icon'
 import { Status } from '../OutlinedInput'
 
 export interface Props extends BaseProps {
@@ -34,7 +34,7 @@ export interface Props extends BaseProps {
   /** Image URL */
   src?: string
   /** Size of the avatar */
-  size?: SizeType<'small' | 'large'>
+  size?: SizeType<'xxsmall' | 'xsmall' | 'small' | 'medium' | 'large'>
   /** Enable/disable the dropzone */
   disabled?: boolean
   /** Maximum file size (in bytes) */
@@ -90,7 +90,7 @@ const useStyles = makeStyles<Theme>(styles, {
 })
 
 export const AvatarUpload = forwardRef<HTMLElement, Props>(
-  // eslint-disable-next-line complexity
+  // eslint-disable-next-line complexity, max-statements
   function AvatarUpload(props, ref) {
     const {
       autoFocus,
@@ -200,8 +200,11 @@ export const AvatarUpload = forwardRef<HTMLElement, Props>(
         data-testid={testIds?.loader}
       />
     )
+
+    const UploadIconComponent =
+      size === 'xxsmall' || size === 'xsmall' ? Upload16 : Upload24
     const uploadIcon = showUploadIcon && (
-      <Upload24
+      <UploadIconComponent
         className={cx(classes.icon, {
           [classes.hovered]: hovered,
           [classes.error]: status === 'error',

--- a/packages/picasso/src/AvatarUpload/DropzoneSvg/DropzoneSvg.tsx
+++ b/packages/picasso/src/AvatarUpload/DropzoneSvg/DropzoneSvg.tsx
@@ -4,16 +4,29 @@ import { BaseProps, SizeType } from '@toptal/picasso-shared'
 import cx from 'classnames'
 
 import styles from './styles'
-import { getBackgroundShape, getBordersShape, getOutlineShape } from './utils'
+import { getShapes } from './utils'
 
 /**
  * For measuring, pixel values are used because SVG's "d" attribute works with percentages and pixels only
  */
 const BASE_FONT_SIZE = 16
+
 const SETTINGS = {
+  xxsmall: {
+    dimensions: 2 * BASE_FONT_SIZE,
+    cornerSize: 0.5 * BASE_FONT_SIZE,
+  },
+  xsmall: {
+    dimensions: 2.5 * BASE_FONT_SIZE,
+    cornerSize: 0.5 * BASE_FONT_SIZE,
+  },
   small: {
     dimensions: 5 * BASE_FONT_SIZE,
     cornerSize: 1 * BASE_FONT_SIZE,
+  },
+  medium: {
+    dimensions: 7.5 * BASE_FONT_SIZE,
+    cornerSize: 1.5 * BASE_FONT_SIZE,
   },
   large: {
     dimensions: 10 * BASE_FONT_SIZE,
@@ -22,20 +35,15 @@ const SETTINGS = {
 } as const
 
 const SHAPES = {
-  small: {
-    backgroundShape: getBackgroundShape(SETTINGS.small),
-    outlineShape: getOutlineShape(SETTINGS.small),
-    bordersShape: getBordersShape(SETTINGS.small),
-  },
-  large: {
-    backgroundShape: getBackgroundShape(SETTINGS.large),
-    outlineShape: getOutlineShape(SETTINGS.large),
-    bordersShape: getBordersShape(SETTINGS.large),
-  },
+  xxsmall: getShapes(SETTINGS.xxsmall),
+  xsmall: getShapes(SETTINGS.xsmall),
+  small: getShapes(SETTINGS.small),
+  medium: getShapes(SETTINGS.medium),
+  large: getShapes(SETTINGS.large),
 } as const
 
 export interface Props extends BaseProps {
-  size?: SizeType<'small' | 'large'>
+  size?: SizeType<'xxsmall' | 'xsmall' | 'small' | 'medium' | 'large'>
   isDragActive?: boolean
   disabled?: boolean
   error?: boolean
@@ -83,7 +91,7 @@ export const DropzoneSvg = (props: Props) => {
           })}
           fillRule='evenodd'
           clipRule='evenodd'
-          d={shapes.backgroundShape}
+          d={shapes.background}
         />
         <path
           className={cx(classes.outline, {
@@ -92,7 +100,7 @@ export const DropzoneSvg = (props: Props) => {
           })}
           fillRule='evenodd'
           clipRule='evenodd'
-          d={shapes.outlineShape}
+          d={shapes.outline}
           strokeOpacity='.48'
           strokeWidth='3'
           strokeLinejoin='round'
@@ -105,7 +113,7 @@ export const DropzoneSvg = (props: Props) => {
           })}
           fillRule='evenodd'
           clipRule='evenodd'
-          d={shapes.bordersShape}
+          d={shapes.borders}
           strokeDasharray='3 3'
         />
       </svg>

--- a/packages/picasso/src/AvatarUpload/DropzoneSvg/styles.ts
+++ b/packages/picasso/src/AvatarUpload/DropzoneSvg/styles.ts
@@ -13,9 +13,21 @@ export default ({ palette, transitions }: Theme) => {
       position: 'relative',
       background: 'transparent',
     },
+    rootXxsmall: {
+      width: '32px',
+      height: '32px',
+    },
+    rootXsmall: {
+      width: '40px',
+      height: '40px',
+    },
     rootSmall: {
       width: '80px',
       height: '80px',
+    },
+    rootMedium: {
+      width: '120px',
+      height: '120px',
     },
     rootLarge: {
       width: '160px',
@@ -25,18 +37,30 @@ export default ({ palette, transitions }: Theme) => {
     svg: {
       margin: '-3px', // to center the svg
     },
+    svgXxsmall: {
+      width: '38px', // +6px for outline
+      height: '38px', // +6px for outline
+    },
+    svgXsmall: {
+      width: '46px', // +6px for outline
+      height: '46px', // +6px for outline
+    },
     svgSmall: {
-      width: '86px', // 6px for the outline stroke
-      height: '86px', // 6px for the outline stroke
+      width: '86px', // +6px for outline
+      height: '86px', // +6px for outline
+    },
+    svgMedium: {
+      width: '126px', // +6px for outline
+      height: '126px', // +6px for outline
     },
     svgLarge: {
-      width: '166px', // 6px for the outline stroke
-      height: '166px', // 6px for the outline stroke
+      width: '166px', // +6px for outline
+      height: '166px', // +6px for outline
     },
 
     background: {
       fill: palette.blue.lighter,
-      transition: `all ${transitions.duration.short}ms ${transitions.easing.easeOut}`,
+      transition: `all ${transitions.duration.short}ms ${transitions.easing.easeOut}ms`,
       transitionProperty: 'fill',
 
       '&$hovered': {
@@ -56,7 +80,7 @@ export default ({ palette, transitions }: Theme) => {
     },
     border: {
       stroke: palette.blue.main,
-      transition: `stroke ${transitions.duration.short}`,
+      transition: `stroke ${transitions.duration.short}ms`,
 
       '&$hovered': {
         stroke: hoverBorderColor,

--- a/packages/picasso/src/AvatarUpload/DropzoneSvg/utils.ts
+++ b/packages/picasso/src/AvatarUpload/DropzoneSvg/utils.ts
@@ -1,17 +1,29 @@
 /**
  * Returns the shape of the Avatar component in SVG path's format.
  * SVG's "path" works for the function like this:
- * M x1 y1 - move to point x, y (start point)
- * H x2 - horizontal line to x1 (top edge)
- * V y3 - vertical line to y2 (right edge)
- * H x4 - horizontal line to x3 (bottom edge)
- * L x1 y5 - close path to point x4, y4
+ * M x1 y1 => move to point (x1,y1) (startPoint)
+ * H x2 => horizontal line from (x1,y1) to (x2,y1) (topEdgeLength)
+ * V y2 => vertical line from (x2,y1) to (x2,y2) (rightEdgeLength)
+ * H x3 => horizontal line from (x2,y2) to (x3,y2) (bottomEdgeStartPoint)
+ * L x1 y3 => line from (x1,y3) to (x3,y2) (leftCornerEndPoint)
  * Z - draw path back to starting point (x1 y1)
+ *
+ *   x1,y1 ----------------- x2,y1
+ *     |                       |
+ *     |                       |
+ *     |                       |
+ *     |                       |
+ *     |                       |
+ *   x1,y3                     |
+ *      \                      |
+ *       \                     |
+ *       x3,y2-------------- x2,y2
+ *
  */
 const getAvatarShape = ({
-  bottomEdgeLength,
+  bottomEdgeStartPoint,
   startPoint,
-  leftCornerPoint,
+  leftCornerEndPoint,
   rightEdgeLength,
   topEdgeLength,
   drawBackToStart,
@@ -19,54 +31,40 @@ const getAvatarShape = ({
   startPoint: number
   topEdgeLength: number
   rightEdgeLength: number
-  bottomEdgeLength: number
-  leftCornerPoint: number
+  bottomEdgeStartPoint: number
+  leftCornerEndPoint: number
   drawBackToStart: boolean
 }) => {
   return `
     M ${startPoint} ${startPoint}
     H ${topEdgeLength} 
     V ${rightEdgeLength} 
-    H ${bottomEdgeLength} 
-    L ${startPoint} ${leftCornerPoint}${drawBackToStart ? ' Z' : ''}
+    H ${bottomEdgeStartPoint} 
+    L ${startPoint} ${leftCornerEndPoint}${drawBackToStart ? ' Z' : ''}
   `
 }
 
 /**
  * Returns the shape of the background of the avatar.
- * For small variant, it should be 80x80(px), for large - 160x160(px).
  */
-export const getBackgroundShape = ({
-  dimensions,
-  cornerSize,
-}: {
-  dimensions: number
-  cornerSize: number
-}) => {
+export const getBackgroundShape = (dimensions: number, cornerSize: number) => {
   const centerShift = 3 // shift for the outline stroke
 
   return getAvatarShape({
     startPoint: centerShift,
     topEdgeLength: dimensions + centerShift,
     rightEdgeLength: dimensions + centerShift,
-    bottomEdgeLength: cornerSize + centerShift,
-    leftCornerPoint: dimensions - cornerSize + centerShift,
+    bottomEdgeStartPoint: cornerSize + centerShift,
+    leftCornerEndPoint: dimensions - cornerSize + centerShift,
     drawBackToStart: false,
   })
 }
 
 /**
  * Returns the shape of the outline when field is focused.
- * For small variant, it should be 82x82(px), for large - 162x162(px).
  * it is 2px bigger than the background because of the outline stroke width.
  */
-export const getOutlineShape = ({
-  dimensions,
-  cornerSize,
-}: {
-  dimensions: number
-  cornerSize: number
-}) => {
+export const getOutlineShape = (dimensions: number, cornerSize: number) => {
   const centerShift = 2 // shift for the outline stroke
   const outlineStrokeWidth = 2 // width of the outline stroke
 
@@ -74,24 +72,18 @@ export const getOutlineShape = ({
     startPoint: centerShift,
     topEdgeLength: dimensions + centerShift + outlineStrokeWidth,
     rightEdgeLength: dimensions + centerShift + outlineStrokeWidth,
-    bottomEdgeLength: cornerSize + 1,
-    leftCornerPoint: dimensions - cornerSize + centerShift,
+    bottomEdgeStartPoint: cornerSize + centerShift,
+    leftCornerEndPoint:
+      dimensions - cornerSize + centerShift + outlineStrokeWidth, // fine tuning for the outline stroke
     drawBackToStart: true,
   })
 }
 
 /**
  * Returns the shape of the borders.
- * For small variant, it should be 78x78(px), for large - 158x158(px).
- * it is 1px smaller than the background because of the border stroke width.
+ * it is 2px smaller than the background because of the border stroke width.
  */
-export const getBordersShape = ({
-  dimensions,
-  cornerSize,
-}: {
-  dimensions: number
-  cornerSize: number
-}) => {
+export const getBordersShape = (dimensions: number, cornerSize: number) => {
   const centerShift = 4 // shift for the outline stroke and border stroke
   const outlineStrokeWidth = 2 // width of the outline stroke
 
@@ -99,8 +91,22 @@ export const getBordersShape = ({
     startPoint: centerShift,
     topEdgeLength: dimensions + outlineStrokeWidth,
     rightEdgeLength: dimensions + outlineStrokeWidth,
-    bottomEdgeLength: cornerSize + outlineStrokeWidth,
-    leftCornerPoint: dimensions - cornerSize + outlineStrokeWidth,
+    bottomEdgeStartPoint: cornerSize + outlineStrokeWidth + 1, // fine tuning for the border stroke
+    leftCornerEndPoint: dimensions - cornerSize + outlineStrokeWidth + 1, // fine tuning for the border stroke
     drawBackToStart: true,
   })
+}
+
+export const getShapes = ({
+  dimensions,
+  cornerSize,
+}: {
+  dimensions: number
+  cornerSize: number
+}) => {
+  return {
+    background: getBackgroundShape(dimensions, cornerSize),
+    outline: getOutlineShape(dimensions, cornerSize),
+    borders: getBordersShape(dimensions, cornerSize),
+  }
 }

--- a/packages/picasso/src/AvatarUpload/__snapshots__/test.tsx.snap
+++ b/packages/picasso/src/AvatarUpload/__snapshots__/test.tsx.snap
@@ -43,8 +43,8 @@ exports[`AvatarUpload renders 1`] = `
     M 2 2
     H 84 
     V 84 
-    H 17 
-    L 2 66 Z
+    H 18 
+    L 2 68 Z
   "
             fill-rule="evenodd"
             stroke-linejoin="round"
@@ -58,8 +58,8 @@ exports[`AvatarUpload renders 1`] = `
     M 4 4
     H 82 
     V 82 
-    H 18 
-    L 4 66 Z
+    H 19 
+    L 4 67 Z
   "
             fill-rule="evenodd"
             stroke-dasharray="3 3"

--- a/packages/picasso/src/AvatarUpload/story/Sizes.example.tsx
+++ b/packages/picasso/src/AvatarUpload/story/Sizes.example.tsx
@@ -1,15 +1,14 @@
 import React from 'react'
 import { AvatarUpload, Container } from '@toptal/picasso'
 
-const SmallSizeExample = () => <AvatarUpload size='small' />
-
-const LargeSizeExample = () => <AvatarUpload size='large' />
-
 const Example = () => {
   return (
-    <Container flex gap='medium' padded='medium'>
-      <SmallSizeExample />
-      <LargeSizeExample />
+    <Container flex gap='medium' padded='medium' alignItems='flex-end'>
+      <AvatarUpload size='xxsmall' />
+      <AvatarUpload size='xsmall' />
+      <AvatarUpload size='small' />
+      <AvatarUpload size='medium' />
+      <AvatarUpload size='large' />
     </Container>
   )
 }

--- a/packages/picasso/src/AvatarUpload/styles.ts
+++ b/packages/picasso/src/AvatarUpload/styles.ts
@@ -24,11 +24,22 @@ export default ({ palette }: Theme) => {
       },
     },
 
+    sizeXxsmall: {
+      width: '2rem',
+      height: '2rem',
+    },
+    sizeXsmall: {
+      width: '2.5rem',
+      height: '2.5rem',
+    },
     sizeSmall: {
       width: '5rem',
       height: '5rem',
     },
-
+    sizeMedium: {
+      width: '7.5rem',
+      height: '7.5rem',
+    },
     sizeLarge: {
       width: '10rem',
       height: '10rem',


### PR DESCRIPTION
[FX-3074]

### Description

- added remaining size variants from Avatar: `xxsmall`, `xsmall`, and `medium`
- fine-tuned AvatarUpload's border and outline shapes
- provide some more comments to ease understanding how DropzoneSvg works

### How to test

- go and check the sizes story https://picasso.toptal.net/fx-3073-avatar-upload-remaining-size-variants/?path=/story/components-avatarupload--avatarupload#sizes

### Screenshots

<img width="911" alt="Screen Shot 2022-09-02 at 15 31 02" src="https://user-images.githubusercontent.com/7733167/188143219-50e45d1e-8023-47b7-ae6e-c460d5de4ba2.png">

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- Covered with tests

**Breaking change**

- codemod is created and showcased in the changeset
- test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-3074]: https://toptal-core.atlassian.net/browse/FX-3074?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ