### PR TITLE
fix: test for root containers on hast to html

### DIFF
--- a/.changeset/light-cats-argue.md
+++ b/.changeset/light-cats-argue.md
@@ -1,0 +1,9 @@
+---
+'@toptal/picasso': patch
+---
+
+---
+
+### RichText
+
+- fix losing single root containers in html to ast parsing

--- a/packages/picasso/src/utils/__tests__/html-to-hast.test.tsx
+++ b/packages/picasso/src/utils/__tests__/html-to-hast.test.tsx
@@ -1,0 +1,101 @@
+import { htmlToHast } from '..'
+
+describe('html-to-hast', () => {
+  describe('valid HTML string', () => {
+    it('returns valid Picasso components', () => {
+      const html = '<h3>heading</h3><p>normal</p>'
+      const result = htmlToHast(html)
+
+      expect(result).toEqual({
+        type: 'root',
+        children: [
+          {
+            type: 'element',
+            tagName: 'h3',
+            properties: {},
+            children: [{ type: 'text', value: 'heading' }],
+          },
+          {
+            type: 'element',
+            tagName: 'p',
+            properties: {},
+            children: [{ type: 'text', value: 'normal' }],
+          },
+        ],
+      })
+    })
+
+    it('strips script tags', () => {
+      const html = `
+        <script>alert(2)</script>
+        <p><em>Foo</em></p>`
+      const ast = htmlToHast(html)
+
+      expect(ast).toEqual({
+        type: 'root',
+        children: [
+          {
+            type: 'element',
+            tagName: 'p',
+            properties: {},
+            children: [
+              {
+                type: 'element',
+                tagName: 'em',
+                properties: {},
+                children: [{ type: 'text', value: 'Foo' }],
+              },
+            ],
+          },
+        ],
+      })
+    })
+  })
+
+  describe('when parsing HTML with a single container', () => {
+    it('returns an single starting node AST for a single paragraph', () => {
+      const html = '<p>Container</p>'
+
+      expect(htmlToHast(html)).toEqual({
+        type: 'root',
+        children: [
+          {
+            type: 'element',
+            tagName: 'p',
+            properties: {},
+            children: [{ type: 'text', value: 'Container' }],
+          },
+        ],
+      })
+    })
+
+    it('returns an single starting node AST for lists', () => {
+      const html = '<ul><li>Item 1</li><li>Item 2</li></ul>'
+
+      expect(htmlToHast(html)).toEqual({
+        type: 'root',
+        children: [
+          {
+            type: 'element',
+            tagName: 'ul',
+            properties: {},
+            children: [
+              {
+                type: 'element',
+                tagName: 'li',
+                properties: {},
+                children: [{ type: 'text', value: 'Item 1' }],
+              },
+              {
+                type: 'element',
+                tagName: 'li',
+                properties: {},
+                children: [{ type: 'text', value: 'Item 2' }],
+              },
+            ],
+          },
+        ],
+      })
+    })
+  })
+})

--- a/packages/picasso/src/utils/html-to-hast.ts
+++ b/packages/picasso/src/utils/html-to-hast.ts
@@ -1,7 +1,7 @@
 import hastSanitize, { Schema } from 'hast-util-sanitize'
 import hastFromDom from 'hast-util-from-dom'
 
-import { ElementType, ASTType } from '../RichText/types'
+import { ASTType, ASTChildType } from '../RichText/types'
 
 export const hastSanitizeSchema: Schema = {
   allowComments: false,
@@ -19,14 +19,13 @@ export const hastSanitizeSchema: Schema = {
 
 const htmlToAst = (html: string) => {
   const dom = new DOMParser().parseFromString(html, 'text/html')
-  const domHast = hastSanitize(
-    hastFromDom(dom.body),
-    hastSanitizeSchema
-  ) as ElementType
+  const domHast = hastSanitize(hastFromDom(dom.body), hastSanitizeSchema) as
+    | ASTType
+    | ASTChildType
 
   const ast: ASTType = {
     type: 'root',
-    children: domHast.children,
+    children: domHast.type === 'root' ? domHast.children : [domHast],
   }
 
   return ast

--- a/packages/picasso/src/utils/test.tsx
+++ b/packages/picasso/src/utils/test.tsx
@@ -18,7 +18,6 @@ import {
   documentable,
   disableUnsupportedProps,
   sum,
-  htmlToHast,
   getReactNodeTextContent,
   isBrowser,
 } from './index'
@@ -308,42 +307,6 @@ describe('isBrowser', () => {
     windowSpy.mockImplementation(() => ({}))
 
     expect(isBrowser()).toBe(true)
-  })
-})
-
-describe('htmlToHast', () => {
-  describe('invalid HTML string', () => {
-    it('returns null', () => {
-      const html = 'foobar'
-      const result = htmlToHast(html)
-
-      expect(result).toEqual({ type: 'root', children: undefined })
-    })
-  })
-
-  describe('valid HTML string', () => {
-    it('returns valid Picasso components', () => {
-      const html = '<h3>heading</h3><p>normal</p>'
-      const result = htmlToHast(html)
-
-      expect(result).toEqual({
-        type: 'root',
-        children: [
-          {
-            type: 'element',
-            tagName: 'h3',
-            properties: {},
-            children: [{ type: 'text', value: 'heading' }],
-          },
-          {
-            type: 'element',
-            tagName: 'p',
-            properties: {},
-            children: [{ type: 'text', value: 'normal' }],
-          },
-        ],
-      })
-    })
   })
 })
 


### PR DESCRIPTION
### Description

Previously on `htmlToHast` we were always getting the children of the resulting AST and returning them as a root. That would work greatly when the input HTML had multiples elements and no single root HTML element. The problem is when the input HTML would already have a single root element, we would take the children of it anyway, and ignore the element itself. Example:

``` javascript
/*
  Because there are multiple elements without an wrapping container, hast would
  return an AST with the first node being `type: root` and the children being the elements:

  { type: 'root', children: [ { type: 'element', tagName: 'p' }, { type: 'element', tagName: 'p' } ]}
  
  Only in this scenario should we take the children and the returning AST
*/
htmlToAst(`<p></p>  <p></p>`)

/*
  In this case, because the HTML already has a single root element, hast would return 
  that element as the first node, without wrapping it on a `type: root` node

  { type: 'element', tagName: 'p' children: [ { type: 'element', tagName: 'em', ... }, { type: 'element', tagName: 'h3', ... } ]}
  
  In this scenario, we should return the element itself instead of it's children
*/
htmlToAst(`
  <p>
    <em>Foo</em>
    <h3>Bar</h3>
  </p>`)
```

### How to test

- Tests should be green

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests

**Breaking change**

- [-] codemod is created and showcased in the changeset
- [-] test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>
