### PR TITLE
chore(PasswordInput): update error message for invalid password

### DIFF
--- a/.changeset/unlucky-vans-study.md
+++ b/.changeset/unlucky-vans-study.md
@@ -1,0 +1,9 @@
+---
+'@toptal/picasso-forms': patch
+---
+
+---
+
+### PasswordInput
+
+- update error message for invalid password value

--- a/packages/picasso-forms/src/PasswordInput/PasswordInput.tsx
+++ b/packages/picasso-forms/src/PasswordInput/PasswordInput.tsx
@@ -30,7 +30,7 @@ const validatePassword: FieldValidator<PasswordInputProps['value']> = (
     passwordValidators.atLeastOneLowerCaseCharacter(value) &&
     passwordValidators.atLeastOneSpecialCharacter(value)
 
-  return isValidPassword ? undefined : 'Invalid password'
+  return isValidPassword ? undefined : 'Please enter a valid password.'
 }
 
 export const PasswordInput = ({


### PR DESCRIPTION
[FX-3088]
[TACO-1515]

### Description

- Change the error message of `PasswordInput` so it has the same phrasing as the error message of [the required validator](https://github.com/toptal/picasso/blob/master/packages/picasso-forms/src/utils/validators.ts#L15)

The change is approved by Matt Vella (designer of the BASE)

### How to test

- Open https://picasso.toptal.net/taco-1515-fix-password-input/?path=/story/picasso-forms-form--form#field-requirements
- Enter "Password" in the password field and click outside
- You should see `Please enter a valid password.` instead of `Invalid password`

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| ![image](https://user-images.githubusercontent.com/3861498/189599680-6579070d-3008-49f7-9f92-572d7e038687.png) | ![image](https://user-images.githubusercontent.com/3861498/189599160-a5737ed7-d837-4b3f-90c8-142cb17679e4.png) |

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests

**Breaking change**

- codemod is created and showcased in the changeset
- test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[TACO-1515]: https://toptal-core.atlassian.net/browse/TACO-1515?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[FX-3088]: https://toptal-core.atlassian.net/browse/FX-3088?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ