### PR TITLE
feat(Tabs): introduce `orientation` prop

### DIFF
--- a/.changeset/tame-zebras-accept.md
+++ b/.changeset/tame-zebras-accept.md
@@ -1,0 +1,9 @@
+---
+'@toptal/picasso': patch
+---
+
+---
+
+### Tabs
+
+- introduce `orientation` prop. possible values are `horizontal` and `vertical`

--- a/packages/picasso/src/Tab/Tab.tsx
+++ b/packages/picasso/src/Tab/Tab.tsx
@@ -8,6 +8,7 @@ import React, {
 import { makeStyles, Theme } from '@material-ui/core/styles'
 import MUITab, { TabProps } from '@material-ui/core/Tab'
 import { BaseProps, TextLabelProps, useTitleCase } from '@toptal/picasso-shared'
+import cx from 'classnames'
 
 import Typography from '../Typography'
 import styles from './styles'
@@ -75,8 +76,14 @@ export const Tab = forwardRef<HTMLDivElement, Props>(function Tab(props, ref) {
       selected={selected}
       onChange={onChange}
       onClick={onClick}
-      classes={classes}
-      className={`PicassoTab-${orientation}`}
+      classes={{
+        root: cx({
+          [classes.horizontal]: orientation === 'horizontal',
+          [classes.vertical]: orientation === 'vertical',
+        }),
+        selected: classes.selected,
+        wrapper: classes.wrapper,
+      }}
     />
   )
 })

--- a/packages/picasso/src/Tab/Tab.tsx
+++ b/packages/picasso/src/Tab/Tab.tsx
@@ -8,7 +8,6 @@ import React, {
 import { makeStyles, Theme } from '@material-ui/core/styles'
 import MUITab, { TabProps } from '@material-ui/core/Tab'
 import { BaseProps, TextLabelProps, useTitleCase } from '@toptal/picasso-shared'
-import cx from 'classnames'
 
 import Typography from '../Typography'
 import styles from './styles'
@@ -77,10 +76,7 @@ export const Tab = forwardRef<HTMLDivElement, Props>(function Tab(props, ref) {
       onChange={onChange}
       onClick={onClick}
       classes={{
-        root: cx({
-          [classes.horizontal]: orientation === 'horizontal',
-          [classes.vertical]: orientation === 'vertical',
-        }),
+        root: classes[orientation],
         selected: classes.selected,
         wrapper: classes.wrapper,
       }}

--- a/packages/picasso/src/Tab/Tab.tsx
+++ b/packages/picasso/src/Tab/Tab.tsx
@@ -61,7 +61,7 @@ export const Tab = forwardRef<HTMLDivElement, Props>(function Tab(props, ref) {
       {titleCase ? toTitleCase(label) : label}
     </Typography>
   )
-  const orientation = useContext(TabsOrientationContext) || 'horizontal'
+  const orientation = useContext(TabsOrientationContext)
 
   return (
     <MUITab

--- a/packages/picasso/src/Tab/Tab.tsx
+++ b/packages/picasso/src/Tab/Tab.tsx
@@ -3,6 +3,7 @@ import React, {
   ReactNode,
   HTMLAttributes,
   ReactElement,
+  useContext,
 } from 'react'
 import { makeStyles, Theme } from '@material-ui/core/styles'
 import MUITab, { TabProps } from '@material-ui/core/Tab'
@@ -11,6 +12,7 @@ import { BaseProps, TextLabelProps, useTitleCase } from '@toptal/picasso-shared'
 import Typography from '../Typography'
 import styles from './styles'
 import toTitleCase from '../utils/to-title-case'
+import { TabsOrientationContext } from '../Tabs/Tabs'
 
 export interface Props
   extends BaseProps,
@@ -59,6 +61,7 @@ export const Tab = forwardRef<HTMLDivElement, Props>(function Tab(props, ref) {
       {titleCase ? toTitleCase(label) : label}
     </Typography>
   )
+  const orientation = useContext(TabsOrientationContext) || 'horizontal'
 
   return (
     <MUITab
@@ -73,6 +76,7 @@ export const Tab = forwardRef<HTMLDivElement, Props>(function Tab(props, ref) {
       onChange={onChange}
       onClick={onClick}
       classes={classes}
+      className={`PicassoTab-${orientation}`}
     />
   )
 })

--- a/packages/picasso/src/Tab/__snapshots__/test.tsx.snap
+++ b/packages/picasso/src/Tab/__snapshots__/test.tsx.snap
@@ -6,14 +6,14 @@ exports[`Tab Tab disabled tab 1`] = `
     class="Picasso-root"
   >
     <button
-      class="MuiButtonBase-root MuiTab-root MuiTab-textColorInherit PicassoTab-horizontal Mui-disabled Mui-disabled"
+      class="MuiButtonBase-root MuiTab-root PicassoTab-horizontal MuiTab-textColorInherit Mui-disabled Mui-disabled"
       disabled=""
       role="tab"
       tabindex="-1"
       type="button"
     >
       <span
-        class="MuiTab-wrapper"
+        class="MuiTab-wrapper PicassoTab-wrapper"
       >
         <div
           class="MuiTypography-root PicassoTypography-bodySmall PicassoTypography-inherit PicassoTypography-semibold MuiTypography-body1"
@@ -32,13 +32,13 @@ exports[`Tab Tab renders 1`] = `
     class="Picasso-root"
   >
     <button
-      class="MuiButtonBase-root MuiTab-root MuiTab-textColorInherit PicassoTab-horizontal"
+      class="MuiButtonBase-root MuiTab-root PicassoTab-horizontal MuiTab-textColorInherit"
       role="tab"
       tabindex="0"
       type="button"
     >
       <span
-        class="MuiTab-wrapper"
+        class="MuiTab-wrapper PicassoTab-wrapper"
       >
         <div
           class="MuiTypography-root PicassoTypography-bodySmall PicassoTypography-inherit PicassoTypography-semibold MuiTypography-body1"
@@ -57,13 +57,13 @@ exports[`Tab Tab tab with icon 1`] = `
     class="Picasso-root"
   >
     <button
-      class="MuiButtonBase-root MuiTab-root MuiTab-textColorInherit PicassoTab-horizontal MuiTab-labelIcon"
+      class="MuiButtonBase-root MuiTab-root PicassoTab-horizontal MuiTab-textColorInherit MuiTab-labelIcon"
       role="tab"
       tabindex="0"
       type="button"
     >
       <span
-        class="MuiTab-wrapper"
+        class="MuiTab-wrapper PicassoTab-wrapper"
       >
         <div
           id="Icon"

--- a/packages/picasso/src/Tab/__snapshots__/test.tsx.snap
+++ b/packages/picasso/src/Tab/__snapshots__/test.tsx.snap
@@ -6,7 +6,7 @@ exports[`Tab Tab disabled tab 1`] = `
     class="Picasso-root"
   >
     <button
-      class="MuiButtonBase-root MuiTab-root MuiTab-textColorInherit Mui-disabled Mui-disabled"
+      class="MuiButtonBase-root MuiTab-root MuiTab-textColorInherit PicassoTab-horizontal Mui-disabled Mui-disabled"
       disabled=""
       role="tab"
       tabindex="-1"
@@ -32,7 +32,7 @@ exports[`Tab Tab renders 1`] = `
     class="Picasso-root"
   >
     <button
-      class="MuiButtonBase-root MuiTab-root MuiTab-textColorInherit"
+      class="MuiButtonBase-root MuiTab-root MuiTab-textColorInherit PicassoTab-horizontal"
       role="tab"
       tabindex="0"
       type="button"
@@ -57,7 +57,7 @@ exports[`Tab Tab tab with icon 1`] = `
     class="Picasso-root"
   >
     <button
-      class="MuiButtonBase-root MuiTab-root MuiTab-textColorInherit MuiTab-labelIcon"
+      class="MuiButtonBase-root MuiTab-root MuiTab-textColorInherit PicassoTab-horizontal MuiTab-labelIcon"
       role="tab"
       tabindex="0"
       type="button"

--- a/packages/picasso/src/Tab/styles.ts
+++ b/packages/picasso/src/Tab/styles.ts
@@ -1,10 +1,8 @@
 import { Theme, createStyles } from '@material-ui/core/styles'
 import { rem } from '@toptal/picasso-shared'
-import { PicassoProvider, palette } from '@toptal/picasso-provider'
+import { PicassoProvider } from '@toptal/picasso-provider'
 
-const ACTIVE_SHADOW = `4px 0 0 ${palette.grey.lightest}, 0 0 4px rgba(0, 0, 0, 0.08)`
-
-PicassoProvider.override(({ breakpoints }: Theme) => ({
+PicassoProvider.override(({ breakpoints, palette }: Theme) => ({
   MuiTab: {
     root: {
       minHeight: 0,
@@ -47,7 +45,7 @@ PicassoProvider.override(({ breakpoints }: Theme) => ({
   },
 }))
 
-export default ({ sizes }: Theme) =>
+export default ({ sizes, palette, shadows }: Theme) =>
   createStyles({
     horizontal: {
       '&:not(:last-child)': {
@@ -79,7 +77,7 @@ export default ({ sizes }: Theme) =>
     },
     selected: {
       '&$vertical': {
-        boxShadow: ACTIVE_SHADOW,
+        boxShadow: shadows[1],
 
         '&::before': {
           content: '""',

--- a/packages/picasso/src/Tab/styles.ts
+++ b/packages/picasso/src/Tab/styles.ts
@@ -2,7 +2,7 @@ import { Theme, createStyles } from '@material-ui/core/styles'
 import { rem } from '@toptal/picasso-shared'
 import { PicassoProvider } from '@toptal/picasso-provider'
 
-PicassoProvider.override(({ breakpoints, palette }: Theme) => ({
+PicassoProvider.override(({ breakpoints, palette, sizes }: Theme) => ({
   MuiTab: {
     root: {
       minHeight: 0,
@@ -18,17 +18,15 @@ PicassoProvider.override(({ breakpoints, palette }: Theme) => ({
 
       color: palette.grey.dark,
 
-      '&.PicassoTab-horizontal': {
-        '&:not(:last-child)': {
-          marginRight: '2em',
-        },
+      '&.PicassoTab-horizontal:not(:last-child)': {
+        marginRight: '2em',
       },
 
       '&.PicassoTab-vertical': {
-        borderRadius: '0.5rem 0 0 0.5rem',
+        borderRadius: `${sizes.borderRadius.medium} 0 0 ${sizes.borderRadius.medium}`,
         margin: '0.125rem 0',
         overflow: 'hidden',
-        padding: `${rem('8px')} 0 ${rem('8px')}`,
+        padding: `0.5rem 0 0.5rem`,
       },
 
       [breakpoints.up('md')]: {

--- a/packages/picasso/src/Tab/styles.ts
+++ b/packages/picasso/src/Tab/styles.ts
@@ -58,7 +58,7 @@ export default ({ sizes }: Theme) =>
       borderRadius: `${sizes.borderRadius.medium} 0 0 ${sizes.borderRadius.medium}`,
       margin: '0.5rem 0',
       overflow: 'hidden',
-      padding: `${rem('9px')} 0 ${rem('9px')}`,
+      padding: '0.5625em 0 0.5625em',
 
       '&:first-child': {
         marginTop: '0.125rem',
@@ -70,6 +70,11 @@ export default ({ sizes }: Theme) =>
 
       '&:hover:not($selected)': {
         backgroundColor: palette.grey.lighter2,
+      },
+
+      '& $wrapper': {
+        marginLeft: '1rem',
+        marginRight: '2rem',
       },
     },
     selected: {
@@ -87,10 +92,5 @@ export default ({ sizes }: Theme) =>
         },
       },
     },
-    wrapper: {
-      '$vertical &': {
-        marginLeft: '1rem',
-        marginRight: '2rem',
-      },
-    },
+    wrapper: {},
   })

--- a/packages/picasso/src/Tab/styles.ts
+++ b/packages/picasso/src/Tab/styles.ts
@@ -52,14 +52,26 @@ export default ({ palette, sizes }: Theme) =>
         marginRight: '2em',
       },
     },
-
     vertical: {
       borderRadius: `${sizes.borderRadius.medium} 0 0 ${sizes.borderRadius.medium}`,
-      margin: '0.125rem 0',
+      margin: '0.5rem 0',
       overflow: 'hidden',
-      padding: `0.5rem 0 0.5rem`,
+      padding: `${rem('9px')} 0 ${rem('9px')}`,
 
-      '&$selected': {
+      '&:first-child': {
+        marginTop: '0.125rem',
+      },
+
+      '&:last-child': {
+        marginBottom: '0.125rem',
+      },
+
+      '&:hover:not($selected)': {
+        backgroundColor: palette.grey.lighter2,
+      },
+    },
+    selected: {
+      '&$vertical': {
         boxShadow: `0.25rem 0 0 ${palette.grey.lightest}, 0 0 0.25rem rgba(0, 0, 0, 0.08)`,
 
         '&::before': {
@@ -72,13 +84,11 @@ export default ({ palette, sizes }: Theme) =>
           width: '3px',
         },
       },
-
-      '& $wrapper': {
+    },
+    wrapper: {
+      '$vertical &': {
         marginLeft: '1rem',
         marginRight: '2rem',
       },
     },
-
-    selected: {},
-    wrapper: {},
   })

--- a/packages/picasso/src/Tab/styles.ts
+++ b/packages/picasso/src/Tab/styles.ts
@@ -1,8 +1,10 @@
 import { Theme, createStyles } from '@material-ui/core/styles'
 import { rem } from '@toptal/picasso-shared'
-import { PicassoProvider } from '@toptal/picasso-provider'
+import { PicassoProvider, palette } from '@toptal/picasso-provider'
 
-PicassoProvider.override(({ breakpoints, palette }: Theme) => ({
+const ACTIVE_SHADOW = `4px 0 0 ${palette.grey.lightest}, 0 0 4px rgba(0, 0, 0, 0.08)`
+
+PicassoProvider.override(({ breakpoints }: Theme) => ({
   MuiTab: {
     root: {
       minHeight: 0,
@@ -45,7 +47,7 @@ PicassoProvider.override(({ breakpoints, palette }: Theme) => ({
   },
 }))
 
-export default ({ palette, sizes }: Theme) =>
+export default ({ sizes }: Theme) =>
   createStyles({
     horizontal: {
       '&:not(:last-child)': {
@@ -72,7 +74,7 @@ export default ({ palette, sizes }: Theme) =>
     },
     selected: {
       '&$vertical': {
-        boxShadow: `0.25rem 0 0 ${palette.grey.lightest}, 0 0 0.25rem rgba(0, 0, 0, 0.08)`,
+        boxShadow: ACTIVE_SHADOW,
 
         '&::before': {
           content: '""',

--- a/packages/picasso/src/Tab/styles.ts
+++ b/packages/picasso/src/Tab/styles.ts
@@ -18,8 +18,17 @@ PicassoProvider.override(({ breakpoints, palette }: Theme) => ({
 
       color: palette.grey.dark,
 
-      '&:not(:last-child)': {
-        marginRight: '2em',
+      '&.PicassoTab-horizontal': {
+        '&:not(:last-child)': {
+          marginRight: '2em',
+        },
+      },
+
+      '&.PicassoTab-vertical': {
+        borderRadius: '0.5rem 0 0 0.5rem',
+        margin: '0.125rem 0',
+        overflow: 'hidden',
+        padding: `${rem('8px')} 0 ${rem('8px')}`,
       },
 
       [breakpoints.up('md')]: {
@@ -39,6 +48,20 @@ PicassoProvider.override(({ breakpoints, palette }: Theme) => ({
     },
     selected: {
       color: palette.common.black,
+
+      '&.PicassoTab-vertical': {
+        boxShadow: `0.25rem 0 0 ${palette.grey.lightest}, 0 0 0.25rem rgba(0, 0, 0, 0.08)`,
+
+        '&::before': {
+          content: '""',
+          background: palette.blue.main,
+          position: 'absolute',
+          left: 0,
+          top: 0,
+          bottom: 0,
+          width: '3px',
+        },
+      },
     },
     textColorInherit: {
       '&$disabled': {
@@ -48,6 +71,11 @@ PicassoProvider.override(({ breakpoints, palette }: Theme) => ({
     disabled: {},
     wrapper: {
       width: 'auto',
+
+      '.PicassoTab-vertical &': {
+        marginLeft: '1rem',
+        marginRight: '2rem',
+      },
     },
   },
 }))

--- a/packages/picasso/src/Tab/styles.ts
+++ b/packages/picasso/src/Tab/styles.ts
@@ -54,16 +54,16 @@ export default ({ sizes, palette, shadows }: Theme) =>
     },
     vertical: {
       borderRadius: `${sizes.borderRadius.medium} 0 0 ${sizes.borderRadius.medium}`,
-      margin: '0.5rem 0',
+      margin: '0.5em 0',
       overflow: 'hidden',
       padding: '0.5625em 0 0.5625em',
 
       '&:first-child': {
-        marginTop: '0.125rem',
+        marginTop: '0.125em',
       },
 
       '&:last-child': {
-        marginBottom: '0.125rem',
+        marginBottom: '0.125em',
       },
 
       '&:hover:not($selected)': {
@@ -71,8 +71,8 @@ export default ({ sizes, palette, shadows }: Theme) =>
       },
 
       '& $wrapper': {
-        marginLeft: '1rem',
-        marginRight: '2rem',
+        marginLeft: '1em',
+        marginRight: '2em',
       },
     },
     selected: {

--- a/packages/picasso/src/Tab/styles.ts
+++ b/packages/picasso/src/Tab/styles.ts
@@ -2,7 +2,7 @@ import { Theme, createStyles } from '@material-ui/core/styles'
 import { rem } from '@toptal/picasso-shared'
 import { PicassoProvider } from '@toptal/picasso-provider'
 
-PicassoProvider.override(({ breakpoints, palette, sizes }: Theme) => ({
+PicassoProvider.override(({ breakpoints, palette }: Theme) => ({
   MuiTab: {
     root: {
       minHeight: 0,
@@ -17,17 +17,6 @@ PicassoProvider.override(({ breakpoints, palette, sizes }: Theme) => ({
       },
 
       color: palette.grey.dark,
-
-      '&.PicassoTab-horizontal:not(:last-child)': {
-        marginRight: '2em',
-      },
-
-      '&.PicassoTab-vertical': {
-        borderRadius: `${sizes.borderRadius.medium} 0 0 ${sizes.borderRadius.medium}`,
-        margin: '0.125rem 0',
-        overflow: 'hidden',
-        padding: `0.5rem 0 0.5rem`,
-      },
 
       [breakpoints.up('md')]: {
         minWidth: 'auto',
@@ -46,8 +35,31 @@ PicassoProvider.override(({ breakpoints, palette, sizes }: Theme) => ({
     },
     selected: {
       color: palette.common.black,
+    },
+    textColorInherit: {
+      '&$disabled': {
+        color: palette.grey.main,
+      },
+    },
+    disabled: {},
+  },
+}))
 
-      '&.PicassoTab-vertical': {
+export default ({ palette, sizes }: Theme) =>
+  createStyles({
+    horizontal: {
+      '&:not(:last-child)': {
+        marginRight: '2em',
+      },
+    },
+
+    vertical: {
+      borderRadius: `${sizes.borderRadius.medium} 0 0 ${sizes.borderRadius.medium}`,
+      margin: '0.125rem 0',
+      overflow: 'hidden',
+      padding: `0.5rem 0 0.5rem`,
+
+      '&$selected': {
         boxShadow: `0.25rem 0 0 ${palette.grey.lightest}, 0 0 0.25rem rgba(0, 0, 0, 0.08)`,
 
         '&::before': {
@@ -60,22 +72,13 @@ PicassoProvider.override(({ breakpoints, palette, sizes }: Theme) => ({
           width: '3px',
         },
       },
-    },
-    textColorInherit: {
-      '&$disabled': {
-        color: palette.grey.main,
-      },
-    },
-    disabled: {},
-    wrapper: {
-      width: 'auto',
 
-      '.PicassoTab-vertical &': {
+      '& $wrapper': {
         marginLeft: '1rem',
         marginRight: '2rem',
       },
     },
-  },
-}))
 
-export default () => createStyles({})
+    selected: {},
+    wrapper: {},
+  })

--- a/packages/picasso/src/Tabs/Tabs.tsx
+++ b/packages/picasso/src/Tabs/Tabs.tsx
@@ -41,7 +41,7 @@ export const Tabs = forwardRef<HTMLButtonElement, Props>(function Tabs(
   const action = useTabAction()
 
   return (
-    <TabsOrientationContext.Provider value={orientation || 'horizontal'}>
+    <TabsOrientationContext.Provider value={orientation!}>
       <MUITabs
         {...rest}
         classes={classes}

--- a/packages/picasso/src/Tabs/Tabs.tsx
+++ b/packages/picasso/src/Tabs/Tabs.tsx
@@ -18,38 +18,51 @@ export interface Props
 
   /** The value of the currently selected Tab. If you don't want any selected Tab, you can set this property to false. */
   value: TabsProps['value']
+
+  /** The tabs orientation (layout flow direction). */
+  orientation?: 'horizontal' | 'vertical'
 }
 
 const useStyles = makeStyles<Theme>(styles, {
   name: 'Tabs',
 })
 
+export const TabsOrientationContext = React.createContext<
+  'horizontal' | 'vertical'
+>('horizontal')
+
 // eslint-disable-next-line react/display-name
 export const Tabs = forwardRef<HTMLButtonElement, Props>(function Tabs(
   props,
   ref
 ) {
-  const { children, onChange, value, ...rest } = props
-  const classes = useStyles()
+  const { children, orientation, onChange, value, ...rest } = props
+  const classes = useStyles(props)
   const action = useTabAction()
 
   return (
-    <MUITabs
-      {...rest}
-      classes={classes}
-      ref={ref}
-      onChange={onChange}
-      value={value}
-      variant='scrollable'
-      action={action}
-      scrollButtons='auto'
-      ScrollButtonComponent={TabScrollButton}
-    >
-      {children}
-    </MUITabs>
+    <TabsOrientationContext.Provider value={orientation || 'horizontal'}>
+      <MUITabs
+        {...rest}
+        classes={classes}
+        ref={ref}
+        onChange={onChange}
+        value={value}
+        variant='scrollable'
+        action={action}
+        scrollButtons='auto'
+        ScrollButtonComponent={TabScrollButton}
+        orientation={orientation}
+      >
+        {children}
+      </MUITabs>
+    </TabsOrientationContext.Provider>
   )
 })
 
 Tabs.displayName = 'Tabs'
+Tabs.defaultProps = {
+  orientation: 'horizontal',
+}
 
 export default Tabs

--- a/packages/picasso/src/Tabs/Tabs.tsx
+++ b/packages/picasso/src/Tabs/Tabs.tsx
@@ -44,7 +44,7 @@ export const Tabs = forwardRef<HTMLButtonElement, Props>(function Tabs(
     <TabsOrientationContext.Provider value={orientation!}>
       <MUITabs
         {...rest}
-        classes={classes}
+        classes={{ root: classes[orientation!] }}
         ref={ref}
         onChange={onChange}
         value={value}

--- a/packages/picasso/src/Tabs/__snapshots__/test.tsx.snap
+++ b/packages/picasso/src/Tabs/__snapshots__/test.tsx.snap
@@ -22,7 +22,7 @@ exports[`Tabs renders 1`] = `
         >
           <button
             aria-selected="false"
-            class="MuiButtonBase-root MuiTab-root MuiTab-textColorInherit"
+            class="MuiButtonBase-root MuiTab-root MuiTab-textColorInherit PicassoTab-horizontal"
             data-testid="tab-1"
             role="tab"
             tabindex="0"
@@ -40,7 +40,7 @@ exports[`Tabs renders 1`] = `
           </button>
           <button
             aria-selected="false"
-            class="MuiButtonBase-root MuiTab-root MuiTab-textColorInherit"
+            class="MuiButtonBase-root MuiTab-root MuiTab-textColorInherit PicassoTab-horizontal"
             data-testid="tab-2"
             role="tab"
             tabindex="0"
@@ -60,6 +60,73 @@ exports[`Tabs renders 1`] = `
         <span
           class="PrivateTabIndicator-root PrivateTabIndicator-colorSecondary MuiTabs-indicator"
           style="left: 0px; width: 0px;"
+        />
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Tabs renders in vertical orientation 1`] = `
+<div>
+  <div
+    class="Picasso-root"
+  >
+    <div
+      class="MuiTabs-root MuiTabs-vertical"
+    >
+      <div
+        class="MuiTabs-scrollable"
+        style="width: 99px; height: 99px; position: absolute; top: -9999px; overflow: scroll;"
+      />
+      <div
+        class="MuiTabs-scroller MuiTabs-scrollable"
+        style="margin-bottom: 0px;"
+      >
+        <div
+          class="MuiTabs-flexContainer MuiTabs-flexContainerVertical"
+          role="tablist"
+        >
+          <button
+            aria-selected="false"
+            class="MuiButtonBase-root MuiTab-root MuiTab-textColorInherit PicassoTab-vertical"
+            data-testid="tab-1"
+            role="tab"
+            tabindex="0"
+            type="button"
+          >
+            <span
+              class="MuiTab-wrapper"
+            >
+              <div
+                class="MuiTypography-root PicassoTypography-bodySmall PicassoTypography-inherit PicassoTypography-semibold MuiTypography-body1"
+              >
+                Tab 1
+              </div>
+            </span>
+          </button>
+          <button
+            aria-selected="false"
+            class="MuiButtonBase-root MuiTab-root MuiTab-textColorInherit PicassoTab-vertical"
+            data-testid="tab-2"
+            role="tab"
+            tabindex="0"
+            type="button"
+          >
+            <span
+              class="MuiTab-wrapper"
+            >
+              <div
+                class="MuiTypography-root PicassoTypography-bodySmall PicassoTypography-inherit PicassoTypography-semibold MuiTypography-body1"
+              >
+                Tab 2
+              </div>
+            </span>
+          </button>
+        </div>
+        <span
+          class="PrivateTabIndicator-root PrivateTabIndicator-colorSecondary MuiTabs-indicator PrivateTabIndicator-vertical"
+          style="top: 0px; height: 0px;"
         />
       </div>
     </div>
@@ -89,7 +156,7 @@ exports[`Tabs renders with a pre-selected option 1`] = `
         >
           <button
             aria-selected="false"
-            class="MuiButtonBase-root MuiTab-root MuiTab-textColorInherit"
+            class="MuiButtonBase-root MuiTab-root MuiTab-textColorInherit PicassoTab-horizontal"
             data-testid="tab-1"
             role="tab"
             tabindex="0"
@@ -107,7 +174,7 @@ exports[`Tabs renders with a pre-selected option 1`] = `
           </button>
           <button
             aria-selected="true"
-            class="MuiButtonBase-root MuiTab-root MuiTab-textColorInherit Mui-selected"
+            class="MuiButtonBase-root MuiTab-root MuiTab-textColorInherit PicassoTab-horizontal Mui-selected"
             data-testid="tab-2"
             role="tab"
             tabindex="0"
@@ -163,7 +230,7 @@ exports[`Tabs renders with a pre-selected option using custom value 1`] = `
         >
           <button
             aria-selected="true"
-            class="MuiButtonBase-root MuiTab-root MuiTab-textColorInherit Mui-selected"
+            class="MuiButtonBase-root MuiTab-root MuiTab-textColorInherit PicassoTab-horizontal Mui-selected"
             data-testid="tab-1"
             role="tab"
             tabindex="0"
@@ -181,7 +248,7 @@ exports[`Tabs renders with a pre-selected option using custom value 1`] = `
           </button>
           <button
             aria-selected="false"
-            class="MuiButtonBase-root MuiTab-root MuiTab-textColorInherit"
+            class="MuiButtonBase-root MuiTab-root MuiTab-textColorInherit PicassoTab-horizontal"
             data-testid="tab-2"
             role="tab"
             tabindex="0"

--- a/packages/picasso/src/Tabs/__snapshots__/test.tsx.snap
+++ b/packages/picasso/src/Tabs/__snapshots__/test.tsx.snap
@@ -6,7 +6,7 @@ exports[`Tabs renders 1`] = `
     class="Picasso-root"
   >
     <div
-      class="MuiTabs-root"
+      class="MuiTabs-root Tabs-horizontal"
     >
       <div
         class="MuiTabs-scrollable"
@@ -73,7 +73,7 @@ exports[`Tabs renders in vertical orientation 1`] = `
     class="Picasso-root"
   >
     <div
-      class="MuiTabs-root MuiTabs-vertical"
+      class="MuiTabs-root Tabs-vertical MuiTabs-vertical"
     >
       <div
         class="MuiTabs-scrollable"
@@ -140,7 +140,7 @@ exports[`Tabs renders with a pre-selected option 1`] = `
     class="Picasso-root"
   >
     <div
-      class="MuiTabs-root"
+      class="MuiTabs-root Tabs-horizontal"
     >
       <div
         class="MuiTabs-scrollable"
@@ -214,7 +214,7 @@ exports[`Tabs renders with a pre-selected option using custom value 1`] = `
     class="Picasso-root"
   >
     <div
-      class="MuiTabs-root"
+      class="MuiTabs-root Tabs-horizontal"
     >
       <div
         class="MuiTabs-scrollable"

--- a/packages/picasso/src/Tabs/__snapshots__/test.tsx.snap
+++ b/packages/picasso/src/Tabs/__snapshots__/test.tsx.snap
@@ -22,14 +22,14 @@ exports[`Tabs renders 1`] = `
         >
           <button
             aria-selected="false"
-            class="MuiButtonBase-root MuiTab-root MuiTab-textColorInherit PicassoTab-horizontal"
+            class="MuiButtonBase-root MuiTab-root PicassoTab-horizontal MuiTab-textColorInherit"
             data-testid="tab-1"
             role="tab"
             tabindex="0"
             type="button"
           >
             <span
-              class="MuiTab-wrapper"
+              class="MuiTab-wrapper PicassoTab-wrapper"
             >
               <div
                 class="MuiTypography-root PicassoTypography-bodySmall PicassoTypography-inherit PicassoTypography-semibold MuiTypography-body1"
@@ -40,14 +40,14 @@ exports[`Tabs renders 1`] = `
           </button>
           <button
             aria-selected="false"
-            class="MuiButtonBase-root MuiTab-root MuiTab-textColorInherit PicassoTab-horizontal"
+            class="MuiButtonBase-root MuiTab-root PicassoTab-horizontal MuiTab-textColorInherit"
             data-testid="tab-2"
             role="tab"
             tabindex="0"
             type="button"
           >
             <span
-              class="MuiTab-wrapper"
+              class="MuiTab-wrapper PicassoTab-wrapper"
             >
               <div
                 class="MuiTypography-root PicassoTypography-bodySmall PicassoTypography-inherit PicassoTypography-semibold MuiTypography-body1"
@@ -89,14 +89,14 @@ exports[`Tabs renders in vertical orientation 1`] = `
         >
           <button
             aria-selected="false"
-            class="MuiButtonBase-root MuiTab-root MuiTab-textColorInherit PicassoTab-vertical"
+            class="MuiButtonBase-root MuiTab-root PicassoTab-vertical MuiTab-textColorInherit"
             data-testid="tab-1"
             role="tab"
             tabindex="0"
             type="button"
           >
             <span
-              class="MuiTab-wrapper"
+              class="MuiTab-wrapper PicassoTab-wrapper"
             >
               <div
                 class="MuiTypography-root PicassoTypography-bodySmall PicassoTypography-inherit PicassoTypography-semibold MuiTypography-body1"
@@ -107,14 +107,14 @@ exports[`Tabs renders in vertical orientation 1`] = `
           </button>
           <button
             aria-selected="false"
-            class="MuiButtonBase-root MuiTab-root MuiTab-textColorInherit PicassoTab-vertical"
+            class="MuiButtonBase-root MuiTab-root PicassoTab-vertical MuiTab-textColorInherit"
             data-testid="tab-2"
             role="tab"
             tabindex="0"
             type="button"
           >
             <span
-              class="MuiTab-wrapper"
+              class="MuiTab-wrapper PicassoTab-wrapper"
             >
               <div
                 class="MuiTypography-root PicassoTypography-bodySmall PicassoTypography-inherit PicassoTypography-semibold MuiTypography-body1"
@@ -156,14 +156,14 @@ exports[`Tabs renders with a pre-selected option 1`] = `
         >
           <button
             aria-selected="false"
-            class="MuiButtonBase-root MuiTab-root MuiTab-textColorInherit PicassoTab-horizontal"
+            class="MuiButtonBase-root MuiTab-root PicassoTab-horizontal MuiTab-textColorInherit"
             data-testid="tab-1"
             role="tab"
             tabindex="0"
             type="button"
           >
             <span
-              class="MuiTab-wrapper"
+              class="MuiTab-wrapper PicassoTab-wrapper"
             >
               <div
                 class="MuiTypography-root PicassoTypography-bodySmall PicassoTypography-inherit PicassoTypography-semibold MuiTypography-body1"
@@ -174,14 +174,14 @@ exports[`Tabs renders with a pre-selected option 1`] = `
           </button>
           <button
             aria-selected="true"
-            class="MuiButtonBase-root MuiTab-root MuiTab-textColorInherit PicassoTab-horizontal Mui-selected"
+            class="MuiButtonBase-root MuiTab-root PicassoTab-horizontal MuiTab-textColorInherit Mui-selected PicassoTab-selected"
             data-testid="tab-2"
             role="tab"
             tabindex="0"
             type="button"
           >
             <span
-              class="MuiTab-wrapper"
+              class="MuiTab-wrapper PicassoTab-wrapper"
             >
               <div
                 class="MuiTypography-root PicassoTypography-bodySmall PicassoTypography-inherit PicassoTypography-semibold MuiTypography-body1"
@@ -230,14 +230,14 @@ exports[`Tabs renders with a pre-selected option using custom value 1`] = `
         >
           <button
             aria-selected="true"
-            class="MuiButtonBase-root MuiTab-root MuiTab-textColorInherit PicassoTab-horizontal Mui-selected"
+            class="MuiButtonBase-root MuiTab-root PicassoTab-horizontal MuiTab-textColorInherit Mui-selected PicassoTab-selected"
             data-testid="tab-1"
             role="tab"
             tabindex="0"
             type="button"
           >
             <span
-              class="MuiTab-wrapper"
+              class="MuiTab-wrapper PicassoTab-wrapper"
             >
               <div
                 class="MuiTypography-root PicassoTypography-bodySmall PicassoTypography-inherit PicassoTypography-semibold MuiTypography-body1"
@@ -248,14 +248,14 @@ exports[`Tabs renders with a pre-selected option using custom value 1`] = `
           </button>
           <button
             aria-selected="false"
-            class="MuiButtonBase-root MuiTab-root MuiTab-textColorInherit PicassoTab-horizontal"
+            class="MuiButtonBase-root MuiTab-root PicassoTab-horizontal MuiTab-textColorInherit"
             data-testid="tab-2"
             role="tab"
             tabindex="0"
             type="button"
           >
             <span
-              class="MuiTab-wrapper"
+              class="MuiTab-wrapper PicassoTab-wrapper"
             >
               <div
                 class="MuiTypography-root PicassoTypography-bodySmall PicassoTypography-inherit PicassoTypography-semibold MuiTypography-body1"

--- a/packages/picasso/src/Tabs/story/Vertical.example.tsx
+++ b/packages/picasso/src/Tabs/story/Vertical.example.tsx
@@ -1,0 +1,32 @@
+import React from 'react'
+import { Container, Tabs } from '@toptal/picasso'
+
+const Example = () => {
+  const [value, setValue] = React.useState(0)
+
+  const handleChange = (_: React.ChangeEvent<{}>, newValue: number) => {
+    setValue(newValue)
+  }
+
+  return (
+    <Container flex>
+      <Tabs value={value} orientation='vertical' onChange={handleChange}>
+        <Tabs.Tab label='Label' />
+        <Tabs.Tab label='Label' />
+        <Tabs.Tab label='Label' />
+      </Tabs>
+
+      {value === 0 && (
+        <Container left='small'>Content of the first tab</Container>
+      )}
+      {value === 1 && (
+        <Container left='small'>Content of the second tab</Container>
+      )}
+      {value === 2 && (
+        <Container left='small'>Content of the third tab</Container>
+      )}
+    </Container>
+  )
+}
+
+export default Example

--- a/packages/picasso/src/Tabs/story/index.jsx
+++ b/packages/picasso/src/Tabs/story/index.jsx
@@ -28,7 +28,7 @@ page
   })
   .addExample('Tabs/story/Vertical.example.tsx', {
     title: 'Vertical',
-    takeScreenshot: false,
+    takeScreenshot: true,
   })
   .addExample('Tabs/story/ScrollButtons.example.tsx', {
     title: 'Scroll buttons',

--- a/packages/picasso/src/Tabs/story/index.jsx
+++ b/packages/picasso/src/Tabs/story/index.jsx
@@ -26,6 +26,10 @@ page
     title: 'Default',
     takeScreenshot: false,
   })
+  .addExample('Tabs/story/Vertical.example.tsx', {
+    title: 'Vertical',
+    takeScreenshot: false,
+  })
   .addExample('Tabs/story/ScrollButtons.example.tsx', {
     title: 'Scroll buttons',
     takeScreenshot: false,

--- a/packages/picasso/src/Tabs/styles.ts
+++ b/packages/picasso/src/Tabs/styles.ts
@@ -6,23 +6,8 @@ PicassoProvider.override(({ palette }: Theme) => ({
     root: {
       position: 'relative',
       minHeight: 0,
-
-      '&::after': {
-        position: 'absolute',
-        content: '""',
-        bottom: 0,
-        left: 0,
-        right: 0,
-        height: 1,
-        backgroundColor: palette.grey.main,
-        zIndex: 0,
-      },
     },
     vertical: {
-      '&::after': {
-        display: 'none',
-      },
-
       '& $indicator': {
         display: 'none',
       },
@@ -34,4 +19,19 @@ PicassoProvider.override(({ palette }: Theme) => ({
   },
 }))
 
-export default () => createStyles({})
+export default ({ palette }: Theme) =>
+  createStyles({
+    horizontal: {
+      '&::after': {
+        position: 'absolute',
+        content: '""',
+        bottom: 0,
+        left: 0,
+        right: 0,
+        height: 1,
+        backgroundColor: palette.grey.main,
+        zIndex: 0,
+      },
+    },
+    vertical: {},
+  })

--- a/packages/picasso/src/Tabs/styles.ts
+++ b/packages/picasso/src/Tabs/styles.ts
@@ -18,6 +18,15 @@ PicassoProvider.override(({ palette }: Theme) => ({
         zIndex: 0,
       },
     },
+    vertical: {
+      '&::after': {
+        display: 'none',
+      },
+
+      '& $indicator': {
+        display: 'none',
+      },
+    },
     indicator: {
       backgroundColor: palette.blue.main,
       zIndex: 1,

--- a/packages/picasso/src/Tabs/test.tsx
+++ b/packages/picasso/src/Tabs/test.tsx
@@ -63,16 +63,11 @@ describe('Tabs', () => {
   })
 
   it('renders in vertical orientation', () => {
-    const { container, queryByTestId } = renderTabs(
+    const { container } = renderTabs(
       [{ label: 'Tab 1' }, { label: 'Tab 2' }],
-      {
-        value: false,
-      },
+      { value: false },
       'vertical'
     )
-
-    expect(queryByTestId('tab-1-content')).not.toBeInTheDocument()
-    expect(queryByTestId('tab-2-content')).not.toBeInTheDocument()
 
     expect(container).toMatchSnapshot()
   })

--- a/packages/picasso/src/Tabs/test.tsx
+++ b/packages/picasso/src/Tabs/test.tsx
@@ -25,11 +25,12 @@ const renderTabContent = (tab: TabProps, index: number, value: any) => {
 
 const renderTabs = (
   tabs: TabProps[],
-  { value, onChange }: OmitInternalProps<Props, 'children'>
+  { value, onChange }: OmitInternalProps<Props, 'children'>,
+  orientation: 'horizontal' | 'vertical' = 'horizontal'
 ) => {
   return render(
     <TestingPicasso>
-      <Tabs onChange={onChange} value={value}>
+      <Tabs onChange={onChange} value={value} orientation={orientation}>
         {tabs.map((tab, index) => (
           <Tabs.Tab
             key={index}
@@ -53,6 +54,21 @@ describe('Tabs', () => {
       {
         value: false,
       }
+    )
+
+    expect(queryByTestId('tab-1-content')).not.toBeInTheDocument()
+    expect(queryByTestId('tab-2-content')).not.toBeInTheDocument()
+
+    expect(container).toMatchSnapshot()
+  })
+
+  it('renders in vertical orientation', () => {
+    const { container, queryByTestId } = renderTabs(
+      [{ label: 'Tab 1' }, { label: 'Tab 2' }],
+      {
+        value: false,
+      },
+      'vertical'
     )
 
     expect(queryByTestId('tab-1-content')).not.toBeInTheDocument()


### PR DESCRIPTION
[TACO-1038]

### Description

This introduces the `orientation` prop on `Tabs`. This is already supported by MUI itself so I just had to expose it and style the varient.

I bounced this off BASE already - https://toptal-core.slack.com/archives/CCC3GP6CC/p1662703900679159

### How to test

- Check the new vertical tabs example in storybook

### Screenshots

![image](https://user-images.githubusercontent.com/4757057/189835003-396c3ca7-176f-4e1e-8728-9fffb894aaa6.png)


### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests

**Breaking change**

- n/a ~~codemod is created and showcased in the changeset~~
- n/a ~~test alpha package of Picasso in StaffPortal~~

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[TACO-1038]: https://toptal-core.atlassian.net/browse/TACO-1038?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ