### PR TITLE
fix(Select): remove internal value state

### DIFF
--- a/.changeset/hip-yaks-move.md
+++ b/.changeset/hip-yaks-move.md
@@ -1,0 +1,9 @@
+---
+'@toptal/picasso': major
+---
+
+---
+
+### Select
+
+- remove internal value state and make component controlled only

--- a/packages/picasso/src/NonNativeSelect/test.tsx
+++ b/packages/picasso/src/NonNativeSelect/test.tsx
@@ -445,6 +445,28 @@ describe('NonNativeSelect', () => {
     expect(highlightedOption).not.toBeNull()
     expect(highlightedOption?.textContent).toEqual(OPTIONS[2].text)
   })
+
+  describe('when value prop is not updated after onChange', () => {
+    it("doesn't change value", () => {
+      const onChange = jest.fn(event => event.target.value)
+      const placeholder = 'choose'
+
+      const { getByPlaceholderText, getByText } = renderSelect({
+        options: OPTIONS,
+        placeholder,
+        onChange,
+        value: OPTIONS[0].value,
+      })
+
+      const selectInput = getByPlaceholderText(placeholder) as HTMLInputElement
+
+      fireEvent.click(getByPlaceholderText(placeholder))
+      fireEvent.click(getByText(OPTIONS[1].text))
+
+      // expect value didn't change because value prop didn't change
+      expect(selectInput.value).toBe(OPTIONS[0].text)
+    })
+  })
 })
 
 describe('NonNativeSelect (multiple)', () => {

--- a/packages/picasso/src/SelectBase/hooks/use-select-props/mocks.ts
+++ b/packages/picasso/src/SelectBase/hooks/use-select-props/mocks.ts
@@ -50,7 +50,6 @@ export const getUseSelectPropsMock = (): UseSelectProps => {
       filteredOptions: [],
       emptySelectValue: '',
       selectedOptions: [],
-      setValue: jest.fn(),
     },
   }
 }

--- a/packages/picasso/src/SelectBase/hooks/use-select-props/use-select-handler/test.ts
+++ b/packages/picasso/src/SelectBase/hooks/use-select-props/use-select-handler/test.ts
@@ -32,7 +32,6 @@ describe('useSelectHandler', () => {
       result.current(event, OPTIONS[1])
 
       expect(props.selectState.setFilterOptionsValue).toHaveBeenCalledTimes(1)
-      expect(props.selectState.setValue).toHaveBeenCalledWith(OPTIONS[1].value)
       expect(props.selectProps.onChange).toHaveBeenCalledWith({
         ...event,
         target: { name: undefined, value: OPTIONS[1].value },
@@ -54,7 +53,6 @@ describe('useSelectHandler', () => {
       result.current(event, null)
 
       expect(props.selectState.setFilterOptionsValue).toHaveBeenCalledTimes(1)
-      expect(props.selectState.setValue).toHaveBeenCalledWith('')
       expect(props.selectProps.onChange).toHaveBeenCalledWith({
         ...event,
         target: {
@@ -81,9 +79,6 @@ describe('useSelectHandler', () => {
       result.current(event, OPTIONS[1])
 
       expect(props.selectState.setFilterOptionsValue).toHaveBeenCalledTimes(1)
-      expect(props.selectState.setValue).toHaveBeenCalledWith([
-        OPTIONS[1].value,
-      ])
       expect(props.selectProps.onChange).toHaveBeenCalledWith({
         ...event,
         target: {
@@ -109,7 +104,6 @@ describe('useSelectHandler', () => {
       result.current(event, OPTIONS[0])
 
       expect(props.selectState.setFilterOptionsValue).toHaveBeenCalledTimes(1)
-      expect(props.selectState.setValue).toHaveBeenCalledWith([])
       expect(props.selectProps.onChange).toHaveBeenCalledWith({
         ...event,
         target: {

--- a/packages/picasso/src/SelectBase/hooks/use-select-props/use-select-handler/use-select-handler.ts
+++ b/packages/picasso/src/SelectBase/hooks/use-select-props/use-select-handler/use-select-handler.ts
@@ -10,7 +10,7 @@ import {
 } from '../../../utils'
 
 const useSelectHandler = <T extends ValueType, M extends boolean = false>({
-  selectState: { emptySelectValue, setValue, setFilterOptionsValue },
+  selectState: { emptySelectValue, setFilterOptionsValue },
   selectProps: { multiple, value, name, onChange },
   selectRef,
 }: UseSelectProps<T, M>) =>
@@ -29,8 +29,6 @@ const useSelectHandler = <T extends ValueType, M extends boolean = false>({
         newValue = option.value
       }
 
-      setValue(newValue)
-
       fireOnChangeEvent({ event, value: newValue, name, onChange })
       setFilterOptionsValue(EMPTY_INPUT_VALUE)
 
@@ -44,7 +42,6 @@ const useSelectHandler = <T extends ValueType, M extends boolean = false>({
       multiple,
       value,
       selectRef,
-      setValue,
     ]
   )
 

--- a/packages/picasso/src/SelectBase/hooks/use-select-state/use-select-state.ts
+++ b/packages/picasso/src/SelectBase/hooks/use-select-state/use-select-state.ts
@@ -46,10 +46,9 @@ const useSelectState = (props: Props): UseSelectStateOutput => {
     () => flattenOptions(options),
     [options]
   )
-  const [value, setValue] = useState(valueProp)
   const selectedOptions = useMemo(
-    () => getSelectedOptions(flatOptions, value),
-    [flatOptions, value]
+    () => getSelectedOptions(flatOptions, valueProp),
+    [flatOptions, valueProp]
   )
   const selection = useMemo(
     () =>
@@ -97,10 +96,6 @@ const useSelectState = (props: Props): UseSelectStateOutput => {
     isOpen,
   })
 
-  useEffect(() => {
-    setValue(valueProp)
-  }, [valueProp])
-
   const close = useCallback(() => {
     setOpen(false)
   }, [])
@@ -117,7 +112,6 @@ const useSelectState = (props: Props): UseSelectStateOutput => {
 
   return {
     ...props,
-    setValue,
     selectedOptions,
     // TODO: keep consistent naming
     filteredOptions: filteredLimitedOptions,

--- a/packages/picasso/src/SelectBase/types.ts
+++ b/packages/picasso/src/SelectBase/types.ts
@@ -155,7 +155,6 @@ export type UseSelectStateOutput = {
   filteredOptions: Option[] | OptionGroups
   emptySelectValue: string | string[]
   selectedOptions: Option[]
-  setValue: (value: ValueType | ValueType[]) => void
 }
 
 export interface UseSelectProps<


### PR DESCRIPTION
[no-jira]

### Description

A reported bug shows that the `Select` component changes its internal value even without changing the `value` prop from outside. This is the opposite of being a `controlled` component so I got rid of the internal value state.

### How to test

- All stories of the `Select` component should be working as are. 

### Screenshots

no visual change

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- Make sure that additions and changes on design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- Annotate all `props` in component with documentation
- Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests

**Breaking change**

- codemod is created and showcased in the changeset
- test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>
