### PR TITLE
chore: omit PasswordInput adornments

### DIFF
--- a/.changeset/lovely-forks-battle.md
+++ b/.changeset/lovely-forks-battle.md
@@ -1,0 +1,9 @@
+---
+'@toptal/picasso': patch
+---
+
+---
+
+### PasswordInput
+
+- remove `startAdornment` and `endAdornment` from PasswordInput's prop typings

--- a/packages/picasso/src/PasswordInput/PasswordInput.tsx
+++ b/packages/picasso/src/PasswordInput/PasswordInput.tsx
@@ -14,7 +14,13 @@ import { usePropDeprecationWarning } from '../utils/use-deprecation-warnings'
 export interface Props
   extends Omit<
       OmitInternalProps<OutlinedInputProps>,
-      'defaultValue' | 'type' | 'rows' | 'rowsMax' | 'multiline'
+      | 'defaultValue'
+      | 'type'
+      | 'rows'
+      | 'rowsMax'
+      | 'multiline'
+      | 'startAdornment'
+      | 'endAdornment'
     >,
     BaseProps {
   /** Value of the `input` element. */


### PR DESCRIPTION
### Description

PasswordInput exposes confusing `startAdornment` and `endAdornment` props which are ignored.

### How to test

Try using PasswordInput and you should not be able to pass adornments anymore

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| <img width="637" alt="Screenshot 2022-09-14 at 16 42 07" src="https://user-images.githubusercontent.com/9164266/190186357-dd6e1d8e-3de0-43b3-b0c1-3a9af168b29b.png"> | <img width="608" alt="Screenshot 2022-09-14 at 16 41 53" src="https://user-images.githubusercontent.com/9164266/190186347-28a0c00e-8213-4d58-b66e-99efdc943596.png"> | 

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests

**Breaking change**

- [x] codemod is created and showcased in the changeset
- [x] test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>
