### PR TITLE
fix(Tabs): fix alignment, shadow, and background color for vertical tabs

### DIFF
--- a/.changeset/wet-beans-pump.md
+++ b/.changeset/wet-beans-pump.md
@@ -1,0 +1,11 @@
+---
+'@toptal/picasso': minor
+---
+
+---
+
+### Tabs
+
+- fix vertical active tab has not background color
+- fix vertical tabs labels are center align instead of left aligned
+- fix active vertical tab's shadow is not visible on the left

--- a/packages/picasso/src/Tab/styles.ts
+++ b/packages/picasso/src/Tab/styles.ts
@@ -73,11 +73,13 @@ export default ({ sizes, palette, shadows }: Theme) =>
       '& $wrapper': {
         marginLeft: '1em',
         marginRight: '2em',
+        alignItems: 'flex-start',
       },
     },
     selected: {
       '&$vertical': {
         boxShadow: shadows[1],
+        backgroundColor: palette.grey.lightest,
 
         '&::before': {
           content: '""',

--- a/packages/picasso/src/Tabs/story/Vertical.example.tsx
+++ b/packages/picasso/src/Tabs/story/Vertical.example.tsx
@@ -11,9 +11,9 @@ const Example = () => {
   return (
     <Container flex>
       <Tabs value={value} orientation='vertical' onChange={handleChange}>
-        <Tabs.Tab label='Label' />
-        <Tabs.Tab label='Label' />
-        <Tabs.Tab label='Label' />
+        <Tabs.Tab label='Jobs' />
+        <Tabs.Tab label='Engagements' />
+        <Tabs.Tab label='Interviews' />
       </Tabs>
 
       {value === 0 && (

--- a/packages/picasso/src/Tabs/styles.ts
+++ b/packages/picasso/src/Tabs/styles.ts
@@ -8,6 +8,9 @@ PicassoProvider.override(({ palette }: Theme) => ({
       minHeight: 0,
     },
     vertical: {
+      // We need a bit of padding to allow active tab's shadow to be visible
+      paddingLeft: '0.25em',
+
       '& $indicator': {
         display: 'none',
       },

--- a/packages/picasso/src/Tabs/styles.ts
+++ b/packages/picasso/src/Tabs/styles.ts
@@ -8,8 +8,10 @@ PicassoProvider.override(({ palette }: Theme) => ({
       minHeight: 0,
     },
     vertical: {
-      // We need a bit of padding to allow active tab's shadow to be visible
-      paddingLeft: '0.25em',
+      '& $scroller': {
+        // We need a bit of padding to allow active tab's shadow to be visible
+        paddingLeft: '0.5em',
+      },
 
       '& $indicator': {
         display: 'none',


### PR DESCRIPTION
[TACO-1038]

### Description

This PR fixes few visual issues related to the newly introduced (by me :see_no_evil: ) vertical tabs:

1. The active tab has no background and according to the design it should have `#FCFCFC`  https://www.figma.com/file/5SCTOPrCDcHuk5We091GBn/Product-Library?node-id=1413%3A15705
2. The labels are center aligned and they should be left aligned. This one wasn't obvious because my example was using the same label :unamused: Now the example is using different labels
3. The active tab shadow gets trimmed on the left side because the `Tabs` scrollable container has a `overflow-x: hidden`. I've added a :pinching_hand: of `padding-left`

### How to test

- Use the example in storybook

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| ![image](https://user-images.githubusercontent.com/4757057/190425609-47b7c184-b173-4553-b556-1a183f4fb54b.png) | ![image](https://user-images.githubusercontent.com/4757057/190425702-56fc2349-2645-47dc-959d-5bb1887fe2f8.png) |

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests


> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
5. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
6. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[TACO-1038]: https://toptal-core.atlassian.net/browse/TACO-1038?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ