### PR TITLE
chore(AvatarUpload): add sourcelink to AvatarUpload

### DIFF
--- a/.changeset/silent-mugs-peel.md
+++ b/.changeset/silent-mugs-peel.md
@@ -1,0 +1,7 @@
+---
+'@toptal/picasso': patch
+---
+
+---
+
+- add source link to storybook for AvatarUpload component

--- a/packages/picasso/src/AvatarUpload/story/index.jsx
+++ b/packages/picasso/src/AvatarUpload/story/index.jsx
@@ -3,7 +3,11 @@ import { AvatarUpload } from '../AvatarUpload'
 
 const page = PicassoBook.section('Components').createPage(
   'AvatarUpload',
-  `Gets the image from file input and displays it in the Avatar component.`
+  `
+    Gets the image from file input and displays it in the Avatar component.
+
+    ${PicassoBook.createSourceLink(__filename)}
+  `
 )
 
 page.createTabChapter('Props').addComponentDocs({


### PR DESCRIPTION
[no-jira]

### Description

Added source link to 

### How to test

- Go to [this link](https://picasso.toptal.net/add-sourcelink-to-avatarupload/?path=/story/components-avatarupload--avatarupload) (Visit AvatarUpload component (if not opened))
- Click on the link named `Source link`
- **Check:** Link should redirect you to the component's source code.

### Screenshots

<img width="1069" alt="Screen Shot 2022-09-16 at 11 34 04" src="https://user-images.githubusercontent.com/10911877/190594825-e3cdba4e-3964-4628-83c9-399e0754db47.png">


### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [N/A] Make sure that additions and changes on design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [N/A] Annotate all `props` in component with documentation
- [N/A] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [N/A] Covered with tests

**Breaking change**

- [N/A] codemod is created and showcased in the changeset
- [N/A] test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>
