### PR TITLE
fix: use `TypographyOverflow` to show file name inside `Dropzone`

### DIFF
--- a/.changeset/empty-bulldogs-sneeze.md
+++ b/.changeset/empty-bulldogs-sneeze.md
@@ -1,0 +1,7 @@
+---
+'@toptal/picasso': patch
+---
+
+---
+
+- use `TypographyOverflow` to display the file name inside `Dropzone`

--- a/packages/picasso/src/Dropzone/story/Multiple.example.tsx
+++ b/packages/picasso/src/Dropzone/story/Multiple.example.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Dropzone } from '@toptal/picasso'
+import { Container, Dropzone } from '@toptal/picasso'
 
 const value = [
   {
@@ -10,20 +10,25 @@ const value = [
   {
     uploading: false,
     progress: 0,
-    file: new File(['portfolio.pdf'], 'portfolio.pdf'),
+    file: new File(
+      ['portfolio.pdf'],
+      'lorem_ipsum_dolor_sit_amet_consectetur_adipisicing_elit_laborum_alias_fugiat_explicabo_unde_beatae_eaque_suscipit_ullam_eum_velit_pariatur_praesentium_sapiente_dicta_animi_iure_iste_quam_quae_labore_ullam.pdf'
+    ),
   },
 ]
 
 const Example = () => {
   return (
-    <Dropzone
-      value={value}
-      onDrop={() => alert('onDrop callback triggered')}
-      onRemove={() => alert('onRemove callback triggered')}
-      hint='Files allowed: 2. Max file size: 25MB'
-      accept='image/*'
-      disabled
-    />
+    <Container style={{ width: '600px' }}>
+      <Dropzone
+        value={value}
+        onDrop={() => alert('onDrop callback triggered')}
+        onRemove={() => alert('onRemove callback triggered')}
+        hint='Files allowed: 2. Max file size: 25MB'
+        accept='image/*'
+        disabled
+      />
+    </Container>
   )
 }
 

--- a/packages/picasso/src/FileList/__snapshots__/test.tsx.snap
+++ b/packages/picasso/src/FileList/__snapshots__/test.tsx.snap
@@ -12,7 +12,7 @@ exports[`FileList renders 1`] = `
         class="PicassoContainer-centerAlignItems PicassoContainer-spaceBetweenJustifyContent PicassoContainer-flex FileListItem-root"
       >
         <div
-          class="PicassoContainer-flex PicassoContainer-column"
+          class="PicassoContainer-flex PicassoContainer-column FileListItem-fileNodeContent"
         >
           <div
             class="PicassoContainer-flex"
@@ -32,7 +32,7 @@ exports[`FileList renders 1`] = `
               </svg>
             </div>
             <p
-              class="MuiTypography-root PicassoTypography-bodyMedium PicassoTypography-black FileListItem-label MuiTypography-body1"
+              class="MuiTypography-root PicassoTypography-bodyMedium PicassoTypography-black TypographyOverflow-wrapper TypographyOverflow-singleLine FileListItem-label MuiTypography-body1 MuiTypography-noWrap"
             >
               user-profile-picture.png
             </p>

--- a/packages/picasso/src/FileListItem/FileListItem.tsx
+++ b/packages/picasso/src/FileListItem/FileListItem.tsx
@@ -11,6 +11,7 @@ import ProgressBar from '../ProgressBar'
 import { Attachment16, Trash16, CloseMinor16 } from '../Icon'
 import { FileUpload } from '../FileInput/types'
 import styles from './styles'
+import TypographyOverflow from '../TypographyOverflow'
 
 export interface Props {
   file: FileUpload
@@ -60,21 +61,25 @@ const FileListItem = ({ file, index, disabled, onRemove, testIds }: Props) => {
 
   const fileNode = (
     <>
-      <Container flex direction='column'>
+      <Container
+        flex
+        direction='column'
+        className={cx(classes.fileNodeContent)}
+      >
         <Container flex direction='row'>
           {!error && (
             <Container right='xsmall'>
               <Attachment16 color='darkGrey' />
             </Container>
           )}
-          <Typography
+          <TypographyOverflow
             className={classes.label}
             variant='body'
             size='medium'
             color={error ? 'red' : 'black'}
           >
             {name}
-          </Typography>
+          </TypographyOverflow>
         </Container>
         <Typography
           className={classes.error}

--- a/packages/picasso/src/FileListItem/__snapshots__/test.tsx.snap
+++ b/packages/picasso/src/FileListItem/__snapshots__/test.tsx.snap
@@ -9,7 +9,7 @@ exports[`FileListItem renders 1`] = `
       class="PicassoContainer-centerAlignItems PicassoContainer-spaceBetweenJustifyContent PicassoContainer-flex FileListItem-root"
     >
       <div
-        class="PicassoContainer-flex PicassoContainer-column"
+        class="PicassoContainer-flex PicassoContainer-column FileListItem-fileNodeContent"
       >
         <div
           class="PicassoContainer-flex"
@@ -29,7 +29,7 @@ exports[`FileListItem renders 1`] = `
             </svg>
           </div>
           <p
-            class="MuiTypography-root PicassoTypography-bodyMedium PicassoTypography-black FileListItem-label MuiTypography-body1"
+            class="MuiTypography-root PicassoTypography-bodyMedium PicassoTypography-black TypographyOverflow-wrapper TypographyOverflow-singleLine FileListItem-label MuiTypography-body1 MuiTypography-noWrap"
           >
             user-profile-picture.png
           </p>

--- a/packages/picasso/src/FileListItem/styles.ts
+++ b/packages/picasso/src/FileListItem/styles.ts
@@ -14,4 +14,7 @@ export default ({ palette }: Theme) =>
     error: {
       lineHeight: rem('16px'),
     },
+    fileNodeContent: {
+      minWidth: 0,
+    },
   })


### PR DESCRIPTION
[SPT-2973](https://toptal-core.atlassian.net/browse/SPT-2973)

### Description

Fix showing the file name inside the Dropzone when the file name is long.
Use TypographyOverflow instead of Typography.

### How to test

- Navigate to https://picasso.toptal.net/SPT-2973-fix-showing-file-name-inside-dropzone/?path=/story/components-dropzone--dropzone#completed-multiple-files
- The long file name should contain ellipses.

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| ![Screenshot 2022-09-23 at 10 18 49](https://user-images.githubusercontent.com/2583281/191910108-8af53ac3-bfe0-49e4-bef6-200c2562c6a1.png) | ![Screenshot 2022-09-23 at 10 15 22](https://user-images.githubusercontent.com/2583281/191910139-e71fdaf1-2eb5-44a0-a04a-2bccdb7fad85.png) |

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests

**Breaking change**

- [x] codemod is created and showcased in the changeset
- [x] test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>
