### PR TITLE
fix: fix contributing markdown file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,14 +52,13 @@ We try to have everything inside `Picasso` synced with latest design proposal ca
 
 ## How can I contribute?
 
-1. Read [CONTRIBUTING.md](./CONTRIBUTING.md)
-2. Open a PR with your first contribution
-3. Make sure test pass by running `yarn test`
+- Make sure tests pass by running `yarn test`
 
-   - [Fixing broken visual tests](./docs/contribution/visual-testing.md#fixing-broken-visual-tests-inside-a-pr)
-   - [Project commands](./README.md#project-commands)
+- When your PR is opened, `contribution` label will be added and a ticket will be created automatically with high priority on `Frontend Experience` Kanban board. It will be reviewed by the team as soon as possible.
 
-4. Ask for a review in [#-frontend-exp-core](https://toptal-core.slack.com/archives/CERF5NHT3)
+- You can also use `@toptal-anvil ping reviewers` to ping the reviewers back to get their approvals after resolving the stated issues.
+
+- In case of an emergency, ask for review in [#-frontend-exp-core](https://toptal-core.slack.com/archives/CERF5NHT3)
 
 ### Your first contribution
 
@@ -83,21 +82,26 @@ We showcase how to use Picasso components via storybook. If you have new case an
 
 ### Alpha package release
 
-If you need to test the changes in your project, you can release an alpha package by adding this comment in PR: `@toptal-bot run package:alpha-release`.
+If you need to test the changes in your project, you can release an alpha package by adding this comment in the PR: `@toptal-bot run package:alpha-release`.
 
 ### Release
 
 We use [changesets](https://github.com/atlassian/changesets) to manage releases for Picasso packages.
 
-As a contributor, we expect you to create a "changeset" file for the changes you've made. You can do it, by running:
+As a contributor, we expect you to create a "changeset" file for the changes you've made. You can do it by running:
 
 ```
 yarn changeset
 ```
 
-"changeset" file should be committed together with the modified code to the PR branch. "changeset" file shoud follow [changeset guidelines](./docs/contribution/changeset-guidelines.md). You can also check [how to add changeset](https://github.com/atlassian/changesets/blob/main/docs/adding-a-changeset.md) for more details.
+The "changeset" file should:
 
-When the PR is merged, additional "Version Packages [skip ci]" PR is created with the version bump and changelogs generated. FX team member should merge this PR to make a release.
+- be committed together with the modified code to the PR branch
+- follow [changeset guidelines](./docs/contribution/changeset-guidelines.md)
+
+You can also check [how to add changeset](https://github.com/atlassian/changesets/blob/main/docs/adding-a-changeset.md) for more details.
+
+After the PR is merged, an additional "Version Packages [skip ci]" PR is created with the version bump, and changelogs are generated. An FX team member will merge this PR to make a release.
 
 #### Why my first PR is taking too long to merge?
 


### PR DESCRIPTION
[no-jira]

### Description

I updated the `CONTRIBUTING.md` markdown file with updated info with respect to Davinci version of it here: https://github.com/toptal/davinci/pull/1602

### How to test

- text review only

### Screenshots

no visual change

### Development checks

- Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- Make sure that additions and changes on design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- Annotate all `props` in component with documentation
- Create `examples` for component
- Ensure that deployed demo has expected results and good examples
- Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- Covered with tests

**Breaking change**

- codemod is created and showcased in the changeset
- test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>
