### PR TITLE
chore: automatically merge non-major changeset PRs

### DIFF
--- a/.github/workflows/automerge-release.yaml
+++ b/.github/workflows/automerge-release.yaml
@@ -1,0 +1,49 @@
+name: Automatically merge non-major release PR
+
+on:
+  pull_request:
+    branches:
+      - master
+
+    types:
+      - opened
+
+jobs:
+  merge-release-pr:
+    if: ${{ github.event.pull_request.head.ref == 'changeset-release/master' }}
+    name: Merge release PR
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+
+    steps:
+      - name: Merge pull request if the release is not major
+        uses: actions/github-script@v5
+        env:
+          PR_NUMBER: ${{ github.event.number }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+        with:
+          github-token: ${{ secrets.TOPTAL_DEVBOT_TOKEN }}
+          script: |
+            const { PR_NUMBER, PR_BODY } = process.env
+            const repository = context.repo
+
+            const isMajorRelease = PR_BODY.includes("### Major Changes")
+            const commentBody = isMajorRelease ?
+              "This pull request seems to be a **major** release and will **not** be merged automatically"
+              : "This pull request seems to be a **non-major** release and will be merged automatically"
+
+            await github.rest.issues.createComment({
+              owner: repository.owner,
+              issue_number: PR_NUMBER,
+              repo: repository.repo,
+              body: commentBody,
+            })
+
+            if (!isMajorRelease) {
+              await github.rest.pulls.merge({
+                merge_method: "squash",
+                owner: repository.owner,
+                pull_number: PR_NUMBER,
+                repo: repository.repo,
+              })
+            }


### PR DESCRIPTION
[FX-3025](https://toptal-core.atlassian.net/browse/FX-3025)

### Description

Non-major release PRs (only containing minor and patch changes) generated by changeset should be automatically merged.

### How to test

- See if the code looks good
- Checkout the testing branch of picasso `git checkout changeset-release/test-automerge` (the only [difference](https://github.com/toptal/picasso/commit/bfdca11c707476e5a65ae7c7511bfc344c84bd1e) from this PR is branch names to avoid testing on master)
- Push any change to the branch
- Create a pull request against `test/FX-3025-automerge-release` ([link](https://github.com/toptal/picasso/compare/test/FX-3025-automerge-release...changeset-release/test-automerge?expand=1))
- Test different PR body variations from existing Picasso changeset PRs ([minor/patch example](https://github.com/toptal/picasso/pull/3085) / [major example](https://github.com/toptal/picasso/pull/3052))
- Depending on the PR body, the PR should be automatically merged and the comment from the toptal-devbot should be posted.

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests

**Breaking change**

- [ ] codemod is created and showcased in the changeset
- [ ] test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>
