### PR TITLE
chore: add parameter to remove content text of dropzone

### DIFF
--- a/.changeset/rude-cameras-shake.md
+++ b/.changeset/rude-cameras-shake.md
@@ -1,0 +1,7 @@
+---
+'@toptal/picasso': minor
+---
+
+---
+
+- added `hideContentText` property to the Dropzone to not put the default text in Dropzone

--- a/.changeset/rude-cameras-shake.md
+++ b/.changeset/rude-cameras-shake.md
@@ -4,4 +4,6 @@
 
 ---
 
-- added `hideContentText` property to the Dropzone to not put the default text in Dropzone
+### Dropzone
+
+- add `hideContentText` property for hiding default text

--- a/packages/picasso/src/Dropzone/Dropzone.tsx
+++ b/packages/picasso/src/Dropzone/Dropzone.tsx
@@ -28,6 +28,8 @@ export interface Props extends BaseProps {
   multiple?: boolean
   /** The text of the hint */
   hint?: string
+  /** Hide/Show the content text */
+  hideContentText?: boolean
   /** Callback invoked when a file item is removed */
   onRemove?: (fileName: string, index: number) => void
   /** Callback for when the drop event occurs */
@@ -54,6 +56,7 @@ export const Dropzone = forwardRef<HTMLInputElement, Props>(function Dropzone(
 ) {
   const {
     hint,
+    hideContentText,
     onRemove,
     value,
     className,
@@ -111,9 +114,11 @@ export const Dropzone = forwardRef<HTMLInputElement, Props>(function Dropzone(
       >
         <input {...getInputProps({ className: classes.nativeInput })} />
         <Upload24 color='darkGrey' />
-        <Typography size='medium' color='black' weight='semibold'>
-          Click or drag file to upload
-        </Typography>
+        {!hideContentText && (
+          <Typography size='medium' color='black' weight='semibold'>
+            Click or drag file to upload
+          </Typography>
+        )}
         {hint && errorMessages.length === 0 && (
           <FormHint className={cx(classes.hint)}>{hint}</FormHint>
         )}

--- a/packages/picasso/src/Dropzone/test.tsx
+++ b/packages/picasso/src/Dropzone/test.tsx
@@ -49,4 +49,22 @@ describe('Dropzone', () => {
       expect(getByTestId('dropzone').className).toContain('disabled')
     })
   })
+
+  describe('when hideContentText is not provided', () => {
+    it('render contentText', () => {
+      const { queryByText } = renderDropzone({})
+
+      expect(queryByText('Click or drag file to upload')).toBeInTheDocument()
+    })
+  })
+
+  describe('when hideContentText is provided', () => {
+    it('render contentText', () => {
+      const { queryByText } = renderDropzone({ hideContentText: true })
+
+      expect(
+        queryByText('Click or drag file to upload')
+      ).not.toBeInTheDocument()
+    })
+  })
 })


### PR DESCRIPTION
[no-jira]

### Description

Added `hideContentText` property to the Dropzone to not put the default text in Dropzone

### How to test

- Check out this branch
- Apply [this diff](https://github.com/toptal/picasso/files/9682102/story-to-test.txt) in your local
- Run storybook 
- Go to the storybook, `dropzone` component
- **Check:** The last example on the page doesn't have any content text. (See `Screenshots` sections.)


### Screenshots

<img width="1458" alt="Screen Shot 2022-09-30 at 11 09 39" src="https://user-images.githubusercontent.com/10911877/193223921-c990acb5-a3a1-44b2-927d-e132d7afa3c2.png">


### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [x] Annotate all `props` in component with documentation
- [N/A] Create `examples` for property **(I didn't want to add this property to the examples, as it is not that much important. You can check the diff.)**
- [N/A] Ensure that deployed demo has expected results and good examples **(I didn't want to add this property to the examples, as it is not that much important. You can check the diff.)**
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [X] Covered with tests

**Breaking change**

- [N/A] codemod is created and showcased in the changeset
- [N/A] test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>
