### PR TITLE
chore(Switch): add type for switch field

### DIFF
--- a/.changeset/proud-bobcats-hunt.md
+++ b/.changeset/proud-bobcats-hunt.md
@@ -1,0 +1,9 @@
+---
+'@toptal/picasso-forms': patch
+---
+
+---
+
+### Switch
+
+- add `type=checkbox` for Switch field

--- a/packages/picasso-forms/src/Field/Field.tsx
+++ b/packages/picasso-forms/src/Field/Field.tsx
@@ -29,7 +29,6 @@ export type Props<
     name: string
     type?: string
     label?: React.ReactNode
-    fieldType?: string
     status?: OutlinedInputStatus
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     children: (props: any) => React.ReactNode

--- a/packages/picasso-forms/src/Switch/Switch.tsx
+++ b/packages/picasso-forms/src/Switch/Switch.tsx
@@ -15,6 +15,7 @@ export type Props = FormSwitchProps & FieldProps<SwitchProps['value']>
 export const Switch = (props: Props) => (
   <PicassoField<FormSwitchProps>
     {...props}
+    type='checkbox'
     label={
       props.label ? (
         <PicassoForm.Label htmlFor={props.id} titleCase={props.titleCase}>

--- a/packages/picasso/src/Switch/Switch.tsx
+++ b/packages/picasso/src/Switch/Switch.tsx
@@ -11,7 +11,7 @@ const useStyles = makeStyles<Theme>(styles, { name: 'PicassoSwitch' })
 export interface Props
   extends BaseProps,
     TextLabelProps,
-    Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'onChange'> {
+    Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'onChange' | 'type'> {
   /** Show Switch initially as checked */
   checked?: boolean
   /** Disable changing `Switch` state */


### PR DESCRIPTION
[FX-3116]

### Description

There was a warning related to missing `Switch`'s field type in `picasso-forms`:
![image (2)](https://user-images.githubusercontent.com/7733167/193252767-780cc1df-a15d-46e4-a547-658b9892e1e0.png)

To fix that, I had to omit HTMLButtonElement's `type` prop for Switch. The reason for this is that TS was arguing about providing `type='checkbox'` to the Switch field because the `type` could be `button | submit | reset` which doesn't make any sense since MUISwitch underneath is still input and these values are not convenient for an input.

### How to test

- checkout master locally and run storybook (warning only visible in dev environment)
- go to http://localhost:9001/?path=/story/picasso-forms-form--form
- click any Switch component and see the warning in console

### Screenshots

no visual changes

### Development checks

- [no-need] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [no-need] Make sure that additions and changes on design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [x] Annotate all `props` in component with documentation
- [no-need] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [no-need] Covered with tests

**Breaking change**

- [no-need] codemod is created and showcased in the changeset
- [no-need] test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-3116]: https://toptal-core.atlassian.net/browse/FX-3116?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ