### PR TITLE
fix: [FX-3151] bold and italic interaction in typography

### DIFF
--- a/.changeset/nervous-goats-hunt.md
+++ b/.changeset/nervous-goats-hunt.md
@@ -1,0 +1,17 @@
+---
+'@toptal/picasso': patch
+---
+
+---
+
+### Typography
+
+- inherits font-weight correctly when taken as italic component.
+
+**Example**
+
+```jsx
+<Typograhy as='strong' weight='semibold'>
+  <Typograhy as='em'>Should be both bold and italic</Typograhy>
+</Typograhy>
+```

--- a/.changeset/nervous-goats-hunt.md
+++ b/.changeset/nervous-goats-hunt.md
@@ -11,7 +11,7 @@
 **Example**
 
 ```jsx
-<Typograhy as='strong' weight='semibold'>
-  <Typograhy as='em'>Should be both bold and italic</Typograhy>
-</Typograhy>
+<Typography as='strong' weight='semibold'>
+  <Typography as='em'>Should be both bold and italic</Typography>
+</Typography>
 ```

--- a/packages/picasso/src/Typography/Typography.tsx
+++ b/packages/picasso/src/Typography/Typography.tsx
@@ -89,6 +89,7 @@ export const Typography = forwardRef<HTMLElement, Props>(function Typography(
           underline,
           invert,
           lineThrough,
+          as,
         }),
       }}
       style={style}

--- a/packages/picasso/src/Typography/utils/get-typography-class-name/get-typography-class-name.ts
+++ b/packages/picasso/src/Typography/utils/get-typography-class-name/get-typography-class-name.ts
@@ -13,6 +13,7 @@ const getTypographyClassName = (
     underline,
     invert,
     lineThrough,
+    as,
   }: {
     variant: 'heading' | 'body'
     size:
@@ -23,6 +24,7 @@ const getTypographyClassName = (
     underline?: 'solid' | 'dashed'
     invert?: boolean
     lineThrough?: boolean
+    as?: React.ElementType<React.HTMLAttributes<HTMLElement>>
   }
 ) => {
   const variantClassName = kebabToCamelCase(`${variant}-${size}`)
@@ -30,7 +32,9 @@ const getTypographyClassName = (
 
   const weightVariantClass = weight ? classes[weight] : undefined
   const weightClass =
-    weight === 'inherit' ? classes.inheritWeight : weightVariantClass
+    weight === 'inherit' || as === 'em'
+      ? classes.inheritWeight
+      : weightVariantClass
 
   const underlineClass = underline ? classes[underline] : undefined
 


### PR DESCRIPTION
[FX-3151](https://toptal-core.atlassian.net/browse/FX-3151?atlOrigin=eyJpIjoiNDhlZDkyZTFlZDc5NGY0MjgxMWNiZTU2YjkxN2VlNTciLCJwIjoiaiJ9)

### Description

- `Italic` `Typography` does not inherit `font-weight` when placed inside `bold` `Typography`



### How to test

- Visit [demo](https://picasso.toptal.net/fx-3151-typography-component-does-not-render-italic-bold-text-correctly/?path=/story/components-typography--typography#normal-text)
- Update example to:
```jsx
import React from 'react'
import { Typography } from '@toptal/picasso'

const Example = () => (
  <div>
    <Typography as='strong' weight='semibold'>
      <Typography as='em'>Just text</Typography>
    </Typography>
  </div>
)

export default Example
```
- We should see **_Just text_** (bold + italic) in generated example

### Screenshots

|                                  |                                   |
| --------------------------------------- | --------------------------------------- |
| ![Screenshot from 2022-10-06 12-30-36](https://user-images.githubusercontent.com/72510037/194269490-0bc14f7d-adac-4f34-9c78-0736b1e200f2.png) | ![Screenshot from 2022-10-06 12-29-51](https://user-images.githubusercontent.com/72510037/194269516-7383f204-fa17-4684-a9b0-c1169b18c6a7.png) |

In both cases, `Just text` should be `Italic` and `Bold`: **_Just text_**

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- Annotate all `props` in component with documentation
- Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- Covered with tests

**Breaking change**

- codemod is created and showcased in the changeset
- test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>
