### PR TITLE
style(ButtonAction): unify font-weight to semibold

### DIFF
--- a/.changeset/brave-hounds-travel.md
+++ b/.changeset/brave-hounds-travel.md
@@ -6,4 +6,4 @@
 
 ### ButtonAction
 
-- update font-weight in all variants to semibold to comply with BASE
+- update `font-weight` in all variants to `semibold` to comply with BASE

--- a/.changeset/brave-hounds-travel.md
+++ b/.changeset/brave-hounds-travel.md
@@ -1,0 +1,9 @@
+---
+'@toptal/picasso': patch
+---
+
+---
+
+### ButtonAction
+
+- update font-weight in all variants to semibold to comply with BASE

--- a/packages/picasso/src/ButtonAction/styles.ts
+++ b/packages/picasso/src/ButtonAction/styles.ts
@@ -23,7 +23,7 @@ export default ({ palette, typography }: Theme) =>
       },
     },
     content: {
-      fontWeight: 'normal',
+      fontWeight: typography.fontWeights.semibold,
       color: palette.blue.main,
     },
     small: {
@@ -36,11 +36,6 @@ export default ({ palette, typography }: Theme) =>
       },
       '& $iconRight': {
         marginRight: 0,
-      },
-    },
-    iconless: {
-      '&:not($loading) $content': {
-        fontWeight: typography.fontWeights.semibold,
       },
     },
     icon: {


### PR DESCRIPTION
[FX-3126]

### Description

Unify font-weight of action button.



### How to test
- compare [storybook examples](https://picasso.toptal.net/fx-3126-button-action-button/?path=/story/components-button--button#action-button-default) with [Figma](https://www.figma.com/file/5SCTOPrCDcHuk5We091GBn/Product-Library?node-id=109%3A297)
- All usages of action button needs to have `font-weight: 600`
- Check changes in Happo

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| ![image](https://user-images.githubusercontent.com/6830426/195335182-2fdd202c-2ef5-4b4c-b7c1-70cd981a6642.png) | ![image](https://user-images.githubusercontent.com/6830426/195335262-408ea382-bf45-46b2-ae2f-981cb3daf85c.png) |

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-3126]: https://toptal-core.atlassian.net/browse/FX-3126?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ