### PR TITLE
fix(CheckboxGroup): fix value type for form usage

### DIFF
--- a/.changeset/breezy-singers-compare.md
+++ b/.changeset/breezy-singers-compare.md
@@ -1,0 +1,9 @@
+---
+'@toptal/picasso-forms': patch
+---
+
+---
+
+### CheckboxGroup
+
+- fix type related to `value` and `initialValue` of the field

--- a/cypress/component/Form.spec.tsx
+++ b/cypress/component/Form.spec.tsx
@@ -212,7 +212,7 @@ const DisabledFieldsExample = () => {
       />
       <Form.CheckboxGroup
         disabled
-        value='freeDiving'
+        value={['freeDiving']}
         name='disabledHobbies'
         label='Hobbies'
       >

--- a/packages/picasso-forms/src/CheckboxGroup/CheckboxGroup.tsx
+++ b/packages/picasso-forms/src/CheckboxGroup/CheckboxGroup.tsx
@@ -2,7 +2,6 @@
 import React from 'react'
 import {
   Checkbox as PicassoCheckbox,
-  CheckboxProps,
   CheckboxGroupProps,
 } from '@toptal/picasso'
 
@@ -10,15 +9,17 @@ import PicassoField, { FieldProps } from '../Field'
 import FieldLabel from '../FieldLabel'
 import CheckboxGroupContext from './CheckboxGroupContext'
 
-export type Props = CheckboxGroupProps & FieldProps<CheckboxProps['value']>
+type ValueType = string[] | undefined
+export type Props = CheckboxGroupProps & FieldProps<ValueType>
 
 export const CheckboxGroup = (props: Props) => {
-  const { children, titleCase, label, ...rest } = props
+  const { children, titleCase, label, initialValue, ...rest } = props
 
   return (
     <CheckboxGroupContext.Provider value={props.name}>
       <PicassoField
         {...rest}
+        initialValue={initialValue}
         type='checkbox'
         label={
           label ? (

--- a/packages/picasso/src/Checkbox/Checkbox.tsx
+++ b/packages/picasso/src/Checkbox/Checkbox.tsx
@@ -19,7 +19,7 @@ export interface Props
   extends BaseProps,
     TextLabelProps,
     Omit<ButtonOrAnchorProps, 'onChange'> {
-  /** Show checkbox initially as checked */
+  /** Show checkbox as `checked` */
   checked?: boolean
   /** Disable changing `Checkbox` state */
   disabled?: boolean


### PR DESCRIPTION
[FX-3175]

### Description

This PR is about fixing the types of `value` and `initialValue` props for `Form.CheckboxGroup`. It was `string` before while the actual value type was `string[]` and it wasn't possible to pass inline `initialValue` to the component.

### How to test

- everything should work as expected before
- when you try to pass `value` or `initialValue` for a `Form.CheckboxGroup` component, you shouldn't see any type errors related to that.

### Screenshots

no visual changes

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- Make sure that additions and changes on design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [x] Annotate all `props` in component with documentation
- Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- Covered with tests

**Breaking change**

- codemod is created and showcased in the changeset
- test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-3175]: https://toptal-core.atlassian.net/browse/FX-3175?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ