### PR TITLE
feat(MenuItem): add new prop icon

### DIFF
--- a/.changeset/slow-spies-refuse.md
+++ b/.changeset/slow-spies-refuse.md
@@ -1,0 +1,9 @@
+---
+'@toptal/picasso': minor
+---
+
+---
+
+### Menu.Item
+
+- add new prop `icon` to render any Icon. Check [example](https://picasso.toptal.net/?path=/story/components-dropdown--dropdown#dropdown-menu) for more info.

--- a/packages/picasso/src/Menu/story/Default.example.tsx
+++ b/packages/picasso/src/Menu/story/Default.example.tsx
@@ -1,5 +1,12 @@
 import React from 'react'
-import { Menu, Container, Typography } from '@toptal/picasso'
+import {
+  Menu,
+  Container,
+  Typography,
+  Afternoon16,
+  Company16,
+  Component16,
+} from '@toptal/picasso'
 
 const handleClick = () => window.alert('Item clicked')
 
@@ -30,6 +37,53 @@ const Example = () => (
           Label
         </Menu.Item>
         <Menu.Item description='Description' onClick={handleClick}>
+          Label
+        </Menu.Item>
+      </Menu>
+    </Container>
+
+    <Container flex gap='small' direction='column'>
+      <Typography variant='heading' size='small'>
+        With Icon
+      </Typography>
+      <Menu data-testid='menu'>
+        <Menu.Item icon={<Afternoon16 />} onClick={handleClick}>
+          Label
+        </Menu.Item>
+        <Menu.Item disabled icon={<Company16 />} onClick={handleClick}>
+          Label
+        </Menu.Item>
+        <Menu.Item icon={<Component16 />} onClick={handleClick}>
+          Label
+        </Menu.Item>
+      </Menu>
+    </Container>
+
+    <Container flex gap='small' direction='column'>
+      <Typography variant='heading' size='small'>
+        With Description and Icon
+      </Typography>
+      <Menu data-testid='menu'>
+        <Menu.Item
+          description='Description'
+          icon={<Afternoon16 />}
+          onClick={handleClick}
+        >
+          Label
+        </Menu.Item>
+        <Menu.Item
+          disabled
+          description='Description'
+          icon={<Company16 />}
+          onClick={handleClick}
+        >
+          Label
+        </Menu.Item>
+        <Menu.Item
+          description='Description'
+          icon={<Component16 />}
+          onClick={handleClick}
+        >
           Label
         </Menu.Item>
       </Menu>

--- a/packages/picasso/src/Menu/story/Multilevel.example.tsx
+++ b/packages/picasso/src/Menu/story/Multilevel.example.tsx
@@ -8,127 +8,148 @@ import {
   Typography,
 } from '@toptal/picasso'
 
+const SlideMenu = () => (
+  <Menu>
+    <Menu.Item>Label</Menu.Item>
+    <Menu.Item
+      menu={
+        <Menu>
+          <Menu.Item>Label inner</Menu.Item>
+          <Menu.Item
+            menu={
+              <Menu>
+                <Menu.Item>Label inner</Menu.Item>
+              </Menu>
+            }
+          >
+            Label inner
+          </Menu.Item>
+        </Menu>
+      }
+    >
+      Label
+    </Menu.Item>
+  </Menu>
+)
+
+const DrilldownMenu = () => (
+  <Menu variant='drilldown'>
+    <Menu.Item>Label</Menu.Item>
+    <Menu.Item
+      menu={
+        <Menu variant='drilldown'>
+          <Menu.Item>Label inner</Menu.Item>
+          <Menu.Item
+            menu={
+              <Menu variant='drilldown'>
+                <Menu.Item>Label inner</Menu.Item>
+              </Menu>
+            }
+          >
+            Label inner
+          </Menu.Item>
+        </Menu>
+      }
+    >
+      Label
+    </Menu.Item>
+  </Menu>
+)
+
+const SlideMenuWithIcon = () => (
+  <Menu>
+    <Menu.Item icon={<Afternoon16 />}>Label</Menu.Item>
+    <Menu.Item
+      icon={<Company16 />}
+      menu={
+        <Menu>
+          <Menu.Item icon={<Afternoon16 />}>Label inner</Menu.Item>
+          <Menu.Item
+            icon={<Company16 />}
+            menu={
+              <Menu>
+                <Menu.Item icon={<Component16 />}>Label inner</Menu.Item>
+              </Menu>
+            }
+          >
+            Label inner
+          </Menu.Item>
+        </Menu>
+      }
+    >
+      Label
+    </Menu.Item>
+  </Menu>
+)
+const DrilldownMenuWithDescIcon = () => (
+  <Menu variant='drilldown'>
+    <Menu.Item description='Description' icon={<Afternoon16 />}>
+      Label
+    </Menu.Item>
+    <Menu.Item
+      description='Description'
+      icon={<Company16 />}
+      menu={
+        <Menu variant='drilldown'>
+          <Menu.Item description='Description' icon={<Afternoon16 />}>
+            Label inner
+          </Menu.Item>
+          <Menu.Item
+            description='Description'
+            icon={<Company16 />}
+            menu={
+              <Menu variant='drilldown'>
+                <Menu.Item description='Description' icon={<Component16 />}>
+                  Label inner
+                </Menu.Item>
+              </Menu>
+            }
+          >
+            Label inner
+          </Menu.Item>
+        </Menu>
+      }
+    >
+      Label
+    </Menu.Item>
+  </Menu>
+)
+
 const Example = () => {
-  const menuForItemB1 = (
-    <Menu>
-      <Menu.Item>Item B1-1</Menu.Item>
-      <Menu.Item>Item B1-2</Menu.Item>
-    </Menu>
-  )
-
-  const menuForItemB2 = (
-    <Menu>
-      <Menu.Item>Item B2-1</Menu.Item>
-      <Menu.Item>Item B2-2</Menu.Item>
-    </Menu>
-  )
-
-  const menuForItemB = (
-    <Menu>
-      <Menu.Item menu={menuForItemB1}>Item B1</Menu.Item>
-      <Menu.Item menu={menuForItemB2}>Item B2</Menu.Item>
-    </Menu>
-  )
-
-  const sliderMenu = (
-    <Menu>
-      <Menu.Item>Item A</Menu.Item>
-      <Menu.Item menu={menuForItemB}>Item B</Menu.Item>
-      <Menu.Item description='Description' menu={menuForItemB}>
-        Item B
-      </Menu.Item>
-      <Menu.Item description='Description' disabled menu={menuForItemB}>
-        Item B
-      </Menu.Item>
-    </Menu>
-  )
-
-  const drilldownMenu = (
-    <Menu variant='drilldown'>
-      <Menu.Item>Item A</Menu.Item>
-      <Menu.Item menu={menuForItemB}>Item B</Menu.Item>
-      <Menu.Item description='Description' menu={menuForItemB}>
-        Item B
-      </Menu.Item>
-      <Menu.Item description='Description' disabled menu={menuForItemB}>
-        Item B
-      </Menu.Item>
-    </Menu>
-  )
-
-  type Options = { variant?: 'slide' | 'drilldown'; description?: string }
-
-  const iconMenu = ({ variant, description }: Options) => (
-    <Menu variant={variant}>
-      <Menu.Item icon={<Component16 />} description={description}>
-        Label
-      </Menu.Item>
-      <Menu.Item icon={<Company16 />} description={description}>
-        Label
-      </Menu.Item>
-      <Menu.Item disabled icon={<Afternoon16 />} description={description}>
-        Label
-      </Menu.Item>
-    </Menu>
-  )
-
-  const multiIconMenu = (options: Options) => (
-    <Menu variant={options.variant}>
-      <Menu.Item
-        description={options.description}
-        menu={iconMenu(options)}
-        icon={<Component16 />}
-      >
-        Label
-      </Menu.Item>
-      <Menu.Item
-        description={options.description}
-        menu={iconMenu(options)}
-        icon={<Company16 />}
-      >
-        Label
-      </Menu.Item>
-      <Menu.Item
-        description={options.description}
-        disabled
-        menu={iconMenu(options)}
-        icon={<Afternoon16 />}
-      >
-        Label
-      </Menu.Item>
-    </Menu>
-  )
-
   return (
     <Container flex gap='medium'>
-      <Container flex gap='small' direction='column'>
-        <Typography variant='heading' size='small'>
-          Slide (default)
-        </Typography>
-        <Container>{sliderMenu}</Container>
-      </Container>
-      <Container flex gap='small' direction='column'>
-        <Typography variant='heading' size='small'>
-          Drilldown
-        </Typography>
-        <Container>{drilldownMenu}</Container>
-      </Container>
+      <ExampleContainer title='Slide (default)'>
+        <SlideMenu />
+      </ExampleContainer>
 
-      <Container flex gap='small' direction='column'>
-        <Typography variant='heading' size='small'>
-          With Icon
-        </Typography>
-        <Container>{multiIconMenu({})}</Container>
-      </Container>
+      <ExampleContainer title='Drilldown'>
+        <DrilldownMenu />
+      </ExampleContainer>
 
-      <Container flex gap='small' direction='column'>
-        <Typography variant='heading' size='small'>
-          With Description and Icon
-        </Typography>
-        <Container>
-          {multiIconMenu({ variant: 'drilldown', description: 'Description' })}
-        </Container>
-      </Container>
+      <ExampleContainer title='Slide with Icon'>
+        <SlideMenuWithIcon />
+      </ExampleContainer>
+
+      <ExampleContainer title='Drilldown with Description and Icon'>
+        <DrilldownMenuWithDescIcon />
+      </ExampleContainer>
+    </Container>
+  )
+}
+
+const ExampleContainer = ({
+  title,
+  children,
+}: {
+  title: string
+  children: React.ReactNode
+}) => {
+  return (
+    <Container flex gap='small' direction='column'>
+      <Typography variant='heading' size='small'>
+        {title}
+      </Typography>
+      <Container>{children}</Container>
     </Container>
   )
 }

--- a/packages/picasso/src/Menu/story/Multilevel.example.tsx
+++ b/packages/picasso/src/Menu/story/Multilevel.example.tsx
@@ -1,5 +1,12 @@
 import React from 'react'
-import { Container, Typography, Menu } from '@toptal/picasso'
+import {
+  Afternoon16,
+  Company16,
+  Component16,
+  Container,
+  Menu,
+  Typography,
+} from '@toptal/picasso'
 
 const Example = () => {
   const menuForItemB1 = (
@@ -49,6 +56,49 @@ const Example = () => {
     </Menu>
   )
 
+  type Options = { variant?: 'slide' | 'drilldown'; description?: string }
+
+  const iconMenu = ({ variant, description }: Options) => (
+    <Menu variant={variant}>
+      <Menu.Item icon={<Component16 />} description={description}>
+        Label
+      </Menu.Item>
+      <Menu.Item icon={<Company16 />} description={description}>
+        Label
+      </Menu.Item>
+      <Menu.Item disabled icon={<Afternoon16 />} description={description}>
+        Label
+      </Menu.Item>
+    </Menu>
+  )
+
+  const multiIconMenu = (options: Options) => (
+    <Menu variant={options.variant}>
+      <Menu.Item
+        description={options.description}
+        menu={iconMenu(options)}
+        icon={<Component16 />}
+      >
+        Label
+      </Menu.Item>
+      <Menu.Item
+        description={options.description}
+        menu={iconMenu(options)}
+        icon={<Company16 />}
+      >
+        Label
+      </Menu.Item>
+      <Menu.Item
+        description={options.description}
+        disabled
+        menu={iconMenu(options)}
+        icon={<Afternoon16 />}
+      >
+        Label
+      </Menu.Item>
+    </Menu>
+  )
+
   return (
     <Container flex gap='medium'>
       <Container flex gap='small' direction='column'>
@@ -62,6 +112,22 @@ const Example = () => {
           Drilldown
         </Typography>
         <Container>{drilldownMenu}</Container>
+      </Container>
+
+      <Container flex gap='small' direction='column'>
+        <Typography variant='heading' size='small'>
+          With Icon
+        </Typography>
+        <Container>{multiIconMenu({})}</Container>
+      </Container>
+
+      <Container flex gap='small' direction='column'>
+        <Typography variant='heading' size='small'>
+          With Description and Icon
+        </Typography>
+        <Container>
+          {multiIconMenu({ variant: 'drilldown', description: 'Description' })}
+        </Container>
       </Container>
     </Container>
   )

--- a/packages/picasso/src/MenuItem/MenuItem.tsx
+++ b/packages/picasso/src/MenuItem/MenuItem.tsx
@@ -56,6 +56,8 @@ export interface Props extends BaseProps, TextLabelProps, MenuItemAttributes {
   children?: ReactNode
   /** The additional description */
   description?: ReactNode
+  /** Render an `<Icon />` */
+  icon?: ReactElement
   /** Callback when item is clicked */
   onClick?: (event: React.MouseEvent<HTMLElement, MouseEvent>) => void
   /** Callback when item is hovered */
@@ -88,6 +90,7 @@ export const MenuItem: OverridableComponent<Props> = forwardRef<
     nonSelectable,
     onClick,
     onMouseEnter,
+    icon,
     ...rest
   } = props
 
@@ -132,14 +135,14 @@ export const MenuItem: OverridableComponent<Props> = forwardRef<
           className={classes.content}
         >
           <Container flex alignItems='center'>
-            {checkmarked !== undefined && (
+            {(checkmarked !== undefined || icon) && (
               <Container
                 className={classes.iconContainer}
                 flex
                 inline
                 right='xsmall'
               >
-                {checkmarked && <CheckMinor16 />}
+                {checkmarked ? <CheckMinor16 /> : icon}
               </Container>
             )}
             {typeof children === 'string' ? (
@@ -165,7 +168,7 @@ export const MenuItem: OverridableComponent<Props> = forwardRef<
               className={cx(classes.description, {
                 [classes.descriptionDisabled]: disabled,
               })}
-              left={checkmarked === undefined ? undefined : 'medium'}
+              left={checkmarked === undefined && !icon ? undefined : 'medium'}
               top={0.25}
             >
               {description}

--- a/packages/picasso/src/MenuItem/MenuItem.tsx
+++ b/packages/picasso/src/MenuItem/MenuItem.tsx
@@ -103,6 +103,7 @@ export const MenuItem: OverridableComponent<Props> = forwardRef<
     onMouseEnter,
   })
   const isLink = as === Link && rest.href
+  const isIconWrapperVisible = checkmarked !== undefined || icon
 
   return (
     <>
@@ -135,7 +136,7 @@ export const MenuItem: OverridableComponent<Props> = forwardRef<
           className={classes.content}
         >
           <Container flex alignItems='center'>
-            {(checkmarked !== undefined || icon) && (
+            {isIconWrapperVisible && (
               <Container
                 className={classes.iconContainer}
                 flex
@@ -168,7 +169,7 @@ export const MenuItem: OverridableComponent<Props> = forwardRef<
               className={cx(classes.description, {
                 [classes.descriptionDisabled]: disabled,
               })}
-              left={checkmarked === undefined && !icon ? undefined : 'medium'}
+              left={isIconWrapperVisible ? 'medium' : undefined}
               top={0.25}
             >
               {description}


### PR DESCRIPTION
[FX-3128]

### Description

Add new prop `icon` to `Menu.Item` to allow rendering any icon inside the Dropdown menu

### How to test

- check [temploy](https://picasso.toptal.net/fx-3128-dropdown-with-icon/?path=/story/components-dropdown--dropdown#dropdown-menu) and compare with [design](https://www.figma.com/file/5SCTOPrCDcHuk5We091GBn/Product-Library?node-id=191%3A2806)
- check Happo changes

### Screenshots

![image](https://user-images.githubusercontent.com/6830426/197488370-a809b082-d2cc-4550-8651-27ef3e940d60.png)

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-3128]: https://toptal-core.atlassian.net/browse/FX-3128?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ