### PR TITLE
chore: comply dropzone with base design

### DIFF
--- a/.changeset/old-pandas-tie.md
+++ b/.changeset/old-pandas-tie.md
@@ -1,0 +1,10 @@
+---
+'@toptal/picasso': patch
+---
+
+---
+
+### Dropzone
+
+- deprecate `errorMessages` prop
+- comply with BASE design

--- a/packages/picasso/src/Dropzone/Dropzone.tsx
+++ b/packages/picasso/src/Dropzone/Dropzone.tsx
@@ -44,7 +44,7 @@ export interface Props extends BaseProps {
   value?: FileUpload[]
   /**
    * @deprecated **Use value.error instead.**
-   * Provides reasons why files couldn't be dropped into dropzone
+   * Provide reasons why files couldn't be dropped into dropzone
    */
   errorMessages?: string[]
   focused?: boolean

--- a/packages/picasso/src/Dropzone/Dropzone.tsx
+++ b/packages/picasso/src/Dropzone/Dropzone.tsx
@@ -43,8 +43,8 @@ export interface Props extends BaseProps {
   /** Value uses the File interface. */
   value?: FileUpload[]
   /**
-   * @deprecated Use value.error instead
-   * Reasons why files couldn't be droped into dropzone
+   * @deprecated **Use value.error instead.**
+   * Provides reasons why files couldn't be dropped into dropzone
    */
   errorMessages?: string[]
   focused?: boolean

--- a/packages/picasso/src/Dropzone/Dropzone.tsx
+++ b/packages/picasso/src/Dropzone/Dropzone.tsx
@@ -11,6 +11,7 @@ import Container from '../Container'
 import FileList from '../FileList'
 import Typography from '../Typography'
 import { FileUpload, DropzoneOptions } from './types'
+import { usePropDeprecationWarning } from '../utils/use-deprecation-warnings'
 import styles from './styles'
 
 export interface Props extends BaseProps {
@@ -43,7 +44,7 @@ export interface Props extends BaseProps {
   /** Value uses the File interface. */
   value?: FileUpload[]
   /**
-   * @deprecated **Use value.error instead.**
+   * @deprecated **Use value[n].error instead.**
    * Provide reasons why files couldn't be dropped into dropzone
    */
   errorMessages?: string[]
@@ -98,6 +99,14 @@ export const Dropzone = forwardRef<HTMLInputElement, Props>(function Dropzone(
   })
 
   const classes = useStyles()
+
+  usePropDeprecationWarning({
+    props,
+    name: 'errorMessages',
+    componentName: 'Dropzone',
+    description:
+      'Use the `value[n].error` prop instead. `errorMessages` is deprecated and will be removed in the next major release.',
+  })
 
   return (
     <Container style={style} ref={ref} className={className}>

--- a/packages/picasso/src/Dropzone/Dropzone.tsx
+++ b/packages/picasso/src/Dropzone/Dropzone.tsx
@@ -42,7 +42,10 @@ export interface Props extends BaseProps {
   validator?: DropzoneOptions['validator']
   /** Value uses the File interface. */
   value?: FileUpload[]
-  /** Reasons why files couldn't be droped into dropzone */
+  /**
+   * @deprecated Use value.error instead
+   * Reasons why files couldn't be droped into dropzone
+   */
   errorMessages?: string[]
   focused?: boolean
   hovered?: boolean
@@ -119,9 +122,7 @@ export const Dropzone = forwardRef<HTMLInputElement, Props>(function Dropzone(
             Click or drag file to upload
           </Typography>
         )}
-        {hint && errorMessages.length === 0 && (
-          <FormHint className={cx(classes.hint)}>{hint}</FormHint>
-        )}
+        {hint && <FormHint className={cx(classes.hint)}>{hint}</FormHint>}
         {errorMessages.length > 0 &&
           errorMessages.map((error, index) => (
             <FormError

--- a/packages/picasso/src/Dropzone/story/Error.example.tsx
+++ b/packages/picasso/src/Dropzone/story/Error.example.tsx
@@ -1,14 +1,21 @@
 import React from 'react'
 import { Dropzone } from '@toptal/picasso'
 
-const errorMessages = ['resume.pdf: File is too large']
-
 const Example = () => {
   return (
     <Dropzone
-      hint='Max file size: 25MB'
+      hint='Files allowed: 2. Max file size: 25MB'
       accept='image/*'
-      errorMessages={errorMessages}
+      value={[
+        {
+          file: new File(['resume.pdf'], 'resume.pdf'),
+          error: 'File size exceeds the 25MB limit.',
+        },
+        {
+          file: new File(['portfolio.pdf'], 'portfolio.pdf'),
+        },
+      ]}
+      onRemove={() => undefined}
     />
   )
 }

--- a/packages/picasso/src/Dropzone/story/Uploader.example.tsx
+++ b/packages/picasso/src/Dropzone/story/Uploader.example.tsx
@@ -38,7 +38,6 @@ const useFiles = ({ maxFiles }: { maxFiles: number }) => {
     acceptedFiles: File[],
     rejectedFiles: DropzoneFileRejection[]
   ): void => {
-    console.log(files, acceptedFiles, rejectedFiles)
     if (files.length + acceptedFiles.length + rejectedFiles.length > maxFiles) {
       return setFiles(prevFiles => [
         ...prevFiles,

--- a/packages/picasso/src/Dropzone/story/Uploader.example.tsx
+++ b/packages/picasso/src/Dropzone/story/Uploader.example.tsx
@@ -42,7 +42,7 @@ const useFiles = ({ maxFiles }: { maxFiles: number }) => {
       return setFiles(prevFiles => [
         ...prevFiles,
         {
-          error: 'Too many files',
+          error: 'Upload failed due to number of files',
           file: new File([], ''),
         },
       ])

--- a/packages/picasso/src/Dropzone/test.tsx
+++ b/packages/picasso/src/Dropzone/test.tsx
@@ -21,7 +21,7 @@ describe('Dropzone', () => {
       hint: 'hint example',
     })
 
-    expect(queryByText('hint example')).not.toBeInTheDocument()
+    expect(queryByText('hint example')).toBeInTheDocument()
     expect(queryByText('error example')).toBeVisible()
   })
 


### PR DESCRIPTION
[FX-3177](https://toptal-core.atlassian.net/browse/FX-3177?atlOrigin=eyJpIjoiNmMzNDcwZjVmMDdhNDkwMmIyNjkyNjlhODJlZTllNTYiLCJwIjoiaiJ9)

### Description

- In **BASE** we have a different design of failed upload than we have implemented in Picasso.

### How to test

- `Dropzone`'s [Upload Failed example](https://picasso.toptal.net/fx-3177-dropzone-error-state/?path=/story/components-dropzone--dropzone#upload-failed) should be complied with the one in BASE design
- also: ![Screenshot from 2022-10-28 10-12-40](https://user-images.githubusercontent.com/72510037/198516121-6ea2aaca-69e8-46c2-bdd4-abb703672200.png), error will be shown this way, from now on, because we are deprecating `errorMessages` (I've commented below why)

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| Insert screenshots or screen recordings | Insert screenshots or screen recordings |

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- Covered with tests

**Breaking change**

- codemod is created and showcased in the changeset
- test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>
