### PR TITLE
test: poc of hamburger menu

### DIFF
--- a/packages/picasso/src/Page/Page.tsx
+++ b/packages/picasso/src/Page/Page.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, ReactNode, HTMLAttributes } from 'react'
+import React, { forwardRef, ReactNode, HTMLAttributes, useState } from 'react'
 import { makeStyles, Theme } from '@material-ui/core/styles'
 import cx from 'classnames'
 import { BaseProps } from '@toptal/picasso-shared'
@@ -29,6 +29,7 @@ export const Page = forwardRef<HTMLDivElement, Props>(function Page(
   ref
 ) {
   const { children, className, style, width, fullWidth, ...rest } = props
+  const [showHamburger, setShowHamburger] = useState(false)
   const classes = useStyles()
 
   return (
@@ -38,7 +39,9 @@ export const Page = forwardRef<HTMLDivElement, Props>(function Page(
       className={cx(classes.root, className)}
       style={style}
     >
-      <PageContext.Provider value={{ width, fullWidth }}>
+      <PageContext.Provider
+        value={{ width, fullWidth, showHamburger, setShowHamburger }}
+      >
         {children}
       </PageContext.Provider>
     </div>

--- a/packages/picasso/src/Page/story/Default.example.tsx
+++ b/packages/picasso/src/Page/story/Default.example.tsx
@@ -5,7 +5,11 @@ import { Globe16, Profile16, PortfolioDesigner16 } from '@toptal/picasso/Icon'
 const Example = () => (
   <div style={{ height: '30rem' }}>
     <Page>
-      <Page.TopBar rightContent={<RightContent />} title='Default example' />
+      <Page.TopBar
+        rightContent={<RightContent />}
+        centerContent={<CenterContent />}
+        title='Default example'
+      />
       <Page.Content>
         <SidebarMenu />
         <Page.Article>
@@ -29,6 +33,13 @@ const SidebarMenu = () => (
       <Page.Sidebar.Item icon={<Globe16 />}>Team</Page.Sidebar.Item>
     </Page.Sidebar.Menu>
   </Page.Sidebar>
+)
+
+const CenterContent = () => (
+  <Page.TopBar.Menu>
+    <Page.TopBar.Item icon={<Globe16 />}>Foo</Page.TopBar.Item>
+    <Page.TopBar.Item icon={<Profile16 />}>Bar</Page.TopBar.Item>
+  </Page.TopBar.Menu>
 )
 
 const RightContent = () => (

--- a/packages/picasso/src/Page/story/index.jsx
+++ b/packages/picasso/src/Page/story/index.jsx
@@ -58,7 +58,7 @@ page.connect(pageHelmetStory.chapter)
 
 page.connect(pageContentStory.chapter)
 
-page.connect(pageArticleStory.chapter)
+// page.connect(pageArticleStory.chapter)
 
 page.connect(pageFooterStory.chapter)
 

--- a/packages/picasso/src/Page/types.ts
+++ b/packages/picasso/src/Page/types.ts
@@ -3,4 +3,6 @@ export type ViewportWidthType = 'wide' | 'full'
 export interface PageContextProps {
   fullWidth?: boolean
   width?: ViewportWidthType
+  showHamburger?: boolean
+  setShowHamburger?: (showHamburger: boolean) => void
 }

--- a/packages/picasso/src/PageHamburger/PageHamburger.tsx
+++ b/packages/picasso/src/PageHamburger/PageHamburger.tsx
@@ -1,0 +1,64 @@
+import React, { useContext, useState } from 'react'
+import { makeStyles, Theme } from '@material-ui/core/styles'
+import cx from 'classnames'
+
+import ButtonCircular from '../ButtonCircular'
+import { PageContext } from '../Page'
+import { PageContextProps } from '../Page/types'
+import Dropdown from '../Dropdown'
+import { Close16, Overview16 } from '../Icon'
+import { useBreakpoint } from '../utils'
+import styles from './styles'
+
+const useStyles = makeStyles<Theme>(styles, {
+  name: 'PageHamburger',
+})
+
+const PageHamburgerContent = () => {
+  return <div id='hamburger' />
+}
+
+const PageHamburger = () => {
+  const { showHamburger } = useContext<PageContextProps>(PageContext)
+  const [showContent, setShowContent] = useState<boolean>(false)
+  const classes = useStyles()
+  const isCompactLayout = useBreakpoint(['small', 'medium'])
+
+  const handleShowContent = () => setShowContent(true)
+  const handleHideContent = () => setShowContent(false)
+
+  return (
+    <Dropdown
+      content={<PageHamburgerContent />}
+      className={cx(classes.responsiveWrapper, {
+        [classes.hidden]: !isCompactLayout || !showHamburger,
+      })}
+      classes={{ content: classes.responsiveWrapperContent }}
+      offset={{ top: 0.4 }}
+      popperOptions={{
+        modifiers: {
+          flip: { enabled: false },
+          preventOverflow: {
+            padding: 0,
+          },
+        },
+      }}
+      onOpen={handleShowContent}
+      onClose={handleHideContent}
+      keepMounted
+    >
+      <ButtonCircular
+        icon={
+          showContent ? (
+            <Close16 />
+          ) : (
+            <Overview16 style={{ pointerEvents: 'none' }} />
+          )
+        }
+        variant='transparent'
+      />
+    </Dropdown>
+  )
+}
+
+export default PageHamburger

--- a/packages/picasso/src/PageHamburger/index.ts
+++ b/packages/picasso/src/PageHamburger/index.ts
@@ -1,0 +1,2 @@
+export { default } from './PageHamburger'
+export { getHamburgerContainer } from './utils'

--- a/packages/picasso/src/PageHamburger/styles.ts
+++ b/packages/picasso/src/PageHamburger/styles.ts
@@ -1,0 +1,31 @@
+import { Theme, createStyles } from '@material-ui/core/styles'
+
+export default ({ screens, zIndex }: Theme) =>
+  createStyles({
+    responsiveWrapper: {
+      position: 'fixed',
+      top: '0.75em',
+      left: '0.75em',
+      zIndex: zIndex.appBar,
+    },
+    hidden: {
+      display: 'none',
+    },
+    responsiveWrapperContent: {
+      maxHeight: 'calc(100vh - 4.5rem)', // viewport minus header height
+
+      [screens('small', 'medium')]: {
+        maxHeight: 'calc(100vh - 3rem)', // viewport minus header height
+      },
+
+      // height under which maxHeight menu starts to overflow
+      // and needs to reduce height dynamically to avoid overflow
+      '@media screen and (max-height: 585px)': {
+        maxHeight: 'calc(100vh - 4.5rem)', // viewport minus header height
+
+        [screens('small', 'medium')]: {
+          maxHeight: 'calc(100vh - 3rem)', // viewport minus header height
+        },
+      },
+    },
+  })

--- a/packages/picasso/src/PageHamburger/utils.ts
+++ b/packages/picasso/src/PageHamburger/utils.ts
@@ -1,0 +1,7 @@
+export const getHamburgerContainer = () => {
+  if (typeof document === 'undefined') {
+    return null
+  }
+
+  return document.getElementById('hamburger')
+}

--- a/packages/picasso/src/PageSidebar/PageSidebar.tsx
+++ b/packages/picasso/src/PageSidebar/PageSidebar.tsx
@@ -1,19 +1,23 @@
 import { makeStyles, Theme } from '@material-ui/core/styles'
+import Portal from '@material-ui/core/Portal'
 import { useSidebar } from '@toptal/picasso-provider'
-import { BaseProps, StandardProps } from '@toptal/picasso-shared'
+import { BaseProps } from '@toptal/picasso-shared'
 import cx from 'classnames'
 import React, {
   forwardRef,
   ReactNode,
   useCallback,
+  useContext,
   useEffect,
   useState,
 } from 'react'
 
 import ButtonCircular from '../ButtonCircular'
 import Container from '../Container'
-import Dropdown from '../Dropdown'
-import { BackMinor16, ChevronRight16, Close16, Overview16 } from '../Icon'
+import { BackMinor16, ChevronRight16 } from '../Icon'
+import { PageContext } from '../Page'
+import { PageContextProps } from '../Page/types'
+import { getHamburgerContainer } from '../PageHamburger'
 import SidebarItem from '../SidebarItem'
 import SidebarLogo from '../SidebarLogo'
 import SidebarMenu from '../SidebarMenu'
@@ -21,44 +25,6 @@ import { noop, useBreakpoint } from '../utils'
 import { SidebarContextProvider } from './SidebarContextProvider'
 import styles from './styles'
 import { VariantType } from './types'
-
-export interface SmallScreenSidebarWrapperProps extends StandardProps {
-  children?: ReactNode
-}
-
-const SmallScreenSidebarWrapper = ({
-  classes,
-  children,
-}: SmallScreenSidebarWrapperProps) => {
-  const [showSidebar, setShowSidebar] = useState<boolean>(false)
-
-  const handleShowSidebar = () => setShowSidebar(true)
-  const handleHideSidebar = () => setShowSidebar(false)
-
-  return (
-    <Dropdown
-      content={children}
-      className={classes?.responsiveWrapper}
-      classes={{ content: classes?.responsiveWrapperContent ?? '' }}
-      offset={{ top: 0.4 }}
-      popperOptions={{
-        modifiers: {
-          flip: { enabled: false },
-          preventOverflow: {
-            padding: 0,
-          },
-        },
-      }}
-      onOpen={handleShowSidebar}
-      onClose={handleHideSidebar}
-    >
-      <ButtonCircular
-        icon={showSidebar ? <Close16 /> : <Overview16 />}
-        variant='transparent'
-      />
-    </Dropdown>
-  )
-}
 
 export interface Props extends BaseProps {
   /** Style variant of Sidebar and subcomponents */
@@ -98,6 +64,7 @@ export const PageSidebar = forwardRef<HTMLDivElement, Props>(function Sidebar(
   const [isCollapsed, setIsCollapsed] = useState(!!defaultCollapsed)
   const [isHovered, setIsHovered] = useState(false)
   const [expandedItemKey, setExpandedItemKey] = useState<number | null>(null)
+  const { setShowHamburger } = useContext<PageContextProps>(PageContext)
 
   useEffect(() => {
     // Clear expanded submenu on sidebar collapse
@@ -113,6 +80,10 @@ export const PageSidebar = forwardRef<HTMLDivElement, Props>(function Sidebar(
       setHasSidebar(false)
     }
   }, [setHasSidebar])
+
+  useEffect(() => {
+    setShowHamburger?.(true)
+  }, [])
 
   const isCompactLayout = useBreakpoint(['small', 'medium'])
 
@@ -159,9 +130,7 @@ export const PageSidebar = forwardRef<HTMLDivElement, Props>(function Sidebar(
   )
 
   return isCompactLayout ? (
-    <SmallScreenSidebarWrapper classes={classes}>
-      {sidebar}
-    </SmallScreenSidebarWrapper>
+    <Portal container={getHamburgerContainer}>{children}</Portal>
   ) : (
     sidebar
   )

--- a/packages/picasso/src/PageTopBar/PageTopBar.tsx
+++ b/packages/picasso/src/PageTopBar/PageTopBar.tsx
@@ -10,9 +10,13 @@ import cx from 'classnames'
 import { BaseProps } from '@toptal/picasso-shared'
 import { usePageTopBar } from '@toptal/picasso-provider'
 import { makeStyles, Theme } from '@material-ui/core/styles'
+import Portal from '@material-ui/core/Portal'
 
 import Logo from '../Logo'
 import Container from '../Container'
+import PageHamburger, { getHamburgerContainer } from '../PageHamburger'
+import TopBarMenu from '../TopBarMenu'
+import TopBarItem from '../TopBarItem'
 import Typography from '../Typography'
 import { PageContext } from '../Page'
 import { PageContextProps } from '../Page/types'
@@ -28,6 +32,8 @@ export interface Props extends BaseProps, HTMLAttributes<HTMLElement> {
   logoLink?: ReactElement
   /** Logo to display */
   logo?: ReactNode
+  /** Content for the center of the `Header`  */
+  centerContent?: ReactNode
   /** Content for the left side of the `Header`  */
   leftContent?: ReactNode
   /** Content for the right side of the `Header`  */
@@ -52,6 +58,7 @@ export const PageTopBar = forwardRef<HTMLElement, Props>(function PageTopBar(
     title,
     logoLink,
     logo,
+    centerContent,
     leftContent,
     rightContent,
     actionItems,
@@ -127,12 +134,19 @@ export const PageTopBar = forwardRef<HTMLElement, Props>(function PageTopBar(
             {leftContent}
           </div>
 
+          {isCompactLayout ? (
+            <Portal container={getHamburgerContainer}>{centerContent}</Portal>
+          ) : (
+            <div className={classes.center}>{centerContent}</div>
+          )}
+
           <div className={classes.right}>
             {!isCompactLayout && actionItems}
             {rightContent}
           </div>
         </div>
       </header>
+      <PageHamburger />
     </div>
   )
 })
@@ -143,4 +157,7 @@ PageTopBar.defaultProps = {
 
 PageTopBar.displayName = 'PageTopBar'
 
-export default PageTopBar
+export default Object.assign(PageTopBar, {
+  Menu: TopBarMenu,
+  Item: TopBarItem,
+})

--- a/packages/picasso/src/PageTopBar/__snapshots__/test.tsx.snap
+++ b/packages/picasso/src/PageTopBar/__snapshots__/test.tsx.snap
@@ -42,10 +42,57 @@ exports[`Page.TopBar render with custom logo 1`] = `
             </div>
           </div>
           <div
+            class="PicassoTopBar-center"
+          />
+          <div
             class="PicassoTopBar-right"
           />
         </div>
       </header>
+      <div
+        class="PicassoDropdown-root PageHamburger-responsiveWrapper PageHamburger-hidden"
+      >
+        <div
+          class="PicassoDropdown-anchor"
+        >
+          <button
+            class="MuiButtonBase-root PicassoButton-small PicassoButton-primary PicassoButton-root PicassoButtonCircular-transparent PicassoButtonCircular-root"
+            data-component-type="button"
+            tabindex="0"
+            type="button"
+          >
+            <span
+              class="PicassoContainer-centerAlignItems PicassoContainer-flex PicassoContainer-inline PicassoButton-content"
+            >
+              <svg
+                class="PicassoSvgOverview16-root PicassoButton-icon"
+                style="min-width: 16px; min-height: 16px; pointer-events: none;"
+                viewBox="0 0 16 16"
+              >
+                <path
+                  d="M0 13h16v1H0v-1Zm0-5h16v1H0V8Zm0-5h16v1H0V3Z"
+                />
+              </svg>
+            </span>
+          </button>
+        </div>
+      </div>
+    </div>
+    <div
+      class="PicassoPopper-root PicassoDropdown-popper"
+      role="tooltip"
+      style="position: fixed; top: 0px; left: 0px; display: none; margin-top: 0.4rem;"
+    >
+      <div>
+        <div
+          class="MuiPaper-root PicassoDropdown-content PageHamburger-responsiveWrapperContent MuiPaper-elevation2"
+          style="opacity: 0; transform: scale(0.75, 0.5625); visibility: hidden;"
+        >
+          <div
+            id="hamburger"
+          />
+        </div>
+      </div>
     </div>
   </div>
 </div>
@@ -109,10 +156,57 @@ exports[`Page.TopBar render with link 1`] = `
             </div>
           </div>
           <div
+            class="PicassoTopBar-center"
+          />
+          <div
             class="PicassoTopBar-right"
           />
         </div>
       </header>
+      <div
+        class="PicassoDropdown-root PageHamburger-responsiveWrapper PageHamburger-hidden"
+      >
+        <div
+          class="PicassoDropdown-anchor"
+        >
+          <button
+            class="MuiButtonBase-root PicassoButton-small PicassoButton-primary PicassoButton-root PicassoButtonCircular-transparent PicassoButtonCircular-root"
+            data-component-type="button"
+            tabindex="0"
+            type="button"
+          >
+            <span
+              class="PicassoContainer-centerAlignItems PicassoContainer-flex PicassoContainer-inline PicassoButton-content"
+            >
+              <svg
+                class="PicassoSvgOverview16-root PicassoButton-icon"
+                style="min-width: 16px; min-height: 16px; pointer-events: none;"
+                viewBox="0 0 16 16"
+              >
+                <path
+                  d="M0 13h16v1H0v-1Zm0-5h16v1H0V8Zm0-5h16v1H0V3Z"
+                />
+              </svg>
+            </span>
+          </button>
+        </div>
+      </div>
+    </div>
+    <div
+      class="PicassoPopper-root PicassoDropdown-popper"
+      role="tooltip"
+      style="position: fixed; top: 0px; left: 0px; display: none; margin-top: 0.4rem;"
+    >
+      <div>
+        <div
+          class="MuiPaper-root PicassoDropdown-content PageHamburger-responsiveWrapperContent MuiPaper-elevation2"
+          style="opacity: 0; transform: scale(0.75, 0.5625); visibility: hidden;"
+        >
+          <div
+            id="hamburger"
+          />
+        </div>
+      </div>
     </div>
   </div>
 </div>
@@ -171,10 +265,57 @@ exports[`Page.TopBar renders 1`] = `
             </div>
           </div>
           <div
+            class="PicassoTopBar-center"
+          />
+          <div
             class="PicassoTopBar-right"
           />
         </div>
       </header>
+      <div
+        class="PicassoDropdown-root PageHamburger-responsiveWrapper PageHamburger-hidden"
+      >
+        <div
+          class="PicassoDropdown-anchor"
+        >
+          <button
+            class="MuiButtonBase-root PicassoButton-small PicassoButton-primary PicassoButton-root PicassoButtonCircular-transparent PicassoButtonCircular-root"
+            data-component-type="button"
+            tabindex="0"
+            type="button"
+          >
+            <span
+              class="PicassoContainer-centerAlignItems PicassoContainer-flex PicassoContainer-inline PicassoButton-content"
+            >
+              <svg
+                class="PicassoSvgOverview16-root PicassoButton-icon"
+                style="min-width: 16px; min-height: 16px; pointer-events: none;"
+                viewBox="0 0 16 16"
+              >
+                <path
+                  d="M0 13h16v1H0v-1Zm0-5h16v1H0V8Zm0-5h16v1H0V3Z"
+                />
+              </svg>
+            </span>
+          </button>
+        </div>
+      </div>
+    </div>
+    <div
+      class="PicassoPopper-root PicassoDropdown-popper"
+      role="tooltip"
+      style="position: fixed; top: 0px; left: 0px; display: none; margin-top: 0.4rem;"
+    >
+      <div>
+        <div
+          class="MuiPaper-root PicassoDropdown-content PageHamburger-responsiveWrapperContent MuiPaper-elevation2"
+          style="opacity: 0; transform: scale(0.75, 0.5625); visibility: hidden;"
+        >
+          <div
+            id="hamburger"
+          />
+        </div>
+      </div>
     </div>
   </div>
 </div>

--- a/packages/picasso/src/PageTopBar/styles.ts
+++ b/packages/picasso/src/PageTopBar/styles.ts
@@ -45,6 +45,10 @@ export default ({ palette, layout, zIndex, screens }: Theme) =>
     fullWidth: {
       maxWidth: '100%',
     },
+    center: {
+      display: 'flex',
+      alignItems: 'center',
+    },
     left: {
       display: 'flex',
       alignItems: 'center',

--- a/packages/picasso/src/Portal/Portal.tsx
+++ b/packages/picasso/src/Portal/Portal.tsx
@@ -1,0 +1,33 @@
+import { memo, ReactNode, useEffect, useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
+
+type Props = {
+  id: string
+  children: ReactNode
+}
+
+const Portal = ({ id, children }: Props) => {
+  const el = useRef(
+    document.getElementById(id) || document.createElement('div')
+  )
+  const [dynamic] = useState(!el.current.parentElement)
+
+  useEffect(() => {
+    console.log('render portal', dynamic, id, children)
+
+    if (dynamic) {
+      el.current.id = id
+      document.body.appendChild(el.current)
+    }
+
+    return () => {
+      if (dynamic && el.current.parentElement) {
+        el.current.parentElement.removeChild(el.current)
+      }
+    }
+  }, [id])
+
+  return createPortal(children, el.current)
+}
+
+export default memo(Portal)

--- a/packages/picasso/src/Portal/index.ts
+++ b/packages/picasso/src/Portal/index.ts
@@ -1,0 +1,1 @@
+export { default } from './Portal'

--- a/packages/picasso/src/TopBarItem/TopBarItem.tsx
+++ b/packages/picasso/src/TopBarItem/TopBarItem.tsx
@@ -1,0 +1,53 @@
+import {
+  BaseProps,
+  TextLabelProps,
+  OverridableComponent,
+} from '@toptal/picasso-shared'
+import React, { forwardRef, memo, ElementType, ReactElement } from 'react'
+import { MenuItemProps } from '@material-ui/core/MenuItem'
+
+import Link from '../Link'
+import MenuItem from '../MenuItem'
+import { useBreakpoint, noop } from '../utils'
+
+export interface Props extends BaseProps, TextLabelProps {
+  /** Pass icon to be used as part of item */
+  icon?: ReactElement
+  /** Highlights the item as selected */
+  selected?: boolean
+  /** Whether to render disabled item */
+  disabled?: boolean
+  /** Component name to render the menu item as */
+  as?: ElementType<MenuItemProps>
+  /** Callback when item is clicked */
+  onClick?: (event: React.MouseEvent<HTMLElement, MouseEvent>) => void
+  /** Callback when item is hovered */
+  onMouseEnter?: (event: React.MouseEvent<HTMLElement, MouseEvent>) => void
+  /** Should it be shown as a compact variant. It becomes a single icon, content becomes a tooltip and badges become overlaid */
+  index?: number | null
+  testIds?: {
+    content?: string
+    header?: string
+  }
+}
+
+export const TopBarItem: OverridableComponent<Props> = memo(
+  forwardRef<HTMLElement, Props>(function TopBarItem(props, ref) {
+    const isCompactLayout = useBreakpoint(['small', 'medium'])
+
+    return isCompactLayout ? (
+      <MenuItem ref={ref} {...props} />
+    ) : (
+      <Link {...props} color='white' ref={ref} />
+    )
+  })
+)
+
+TopBarItem.defaultProps = {
+  onClick: noop,
+  selected: false,
+}
+
+TopBarItem.displayName = 'TopBarItem'
+
+export default TopBarItem

--- a/packages/picasso/src/TopBarItem/index.ts
+++ b/packages/picasso/src/TopBarItem/index.ts
@@ -1,0 +1,1 @@
+export { default } from './TopBarItem'

--- a/packages/picasso/src/TopBarMenu/TopBarMenu.tsx
+++ b/packages/picasso/src/TopBarMenu/TopBarMenu.tsx
@@ -1,0 +1,29 @@
+import { BaseProps } from '@toptal/picasso-shared'
+import React, { forwardRef, HTMLAttributes, useEffect, useContext } from 'react'
+
+import Menu from '../Menu'
+import { PageContext } from '../Page'
+import { PageContextProps } from '../Page/types'
+
+export interface Props extends BaseProps, HTMLAttributes<HTMLUListElement> {}
+
+export const TopBarMenu = forwardRef<HTMLUListElement, Props>(
+  function TopBarMenu(props, ref) {
+    const { style, children, ...rest } = props
+    const { setShowHamburger } = useContext<PageContextProps>(PageContext)
+
+    useEffect(() => {
+      setShowHamburger?.(true)
+    }, [])
+
+    return (
+      <Menu {...rest} allowNestedNavigation={false} ref={ref} style={style}>
+        {children}
+      </Menu>
+    )
+  }
+)
+
+TopBarMenu.displayName = 'TopBarMenu'
+
+export default TopBarMenu

--- a/packages/picasso/src/TopBarMenu/index.ts
+++ b/packages/picasso/src/TopBarMenu/index.ts
@@ -1,0 +1,1 @@
+export { default } from './TopBarMenu'


### PR DESCRIPTION
[FX-3212]

### Description

Finding a way to display menu items from Sidebar and Topbar in a Hamburger menu for small screens.

In order to make [TopBar centered items](https://toptal-core.atlassian.net/browse/FX-3139) work, there needs to be following changes:

1. create `TopBarMenu` and `TopBarItem` components
2. change looks of `TopBarItem`s based on screen size
3. create `PageHamburger` component
4. use portal to display `TopBarMenu` and `SidebarMenu` in `PageHamburger`
5. create context for displaying `PageHamburger` - whenever there is either `SidebarMenu` or `TopBarMenu`

Dont mind the styling for now, just the idea.

This is very raw POC so feel free to suggest better ways to improve it 🙏 


### How to test

- check [temploy example](https://picasso.toptal.net/testing-hamburger/?path=/story/layout-page--page#default)
- see that there are menu items in sidebar and in topbar center
- resize to see hamburger menu and open it - there should be items from both topbar and sidebar

### Screenshots

![image](https://user-images.githubusercontent.com/22159416/198579572-cb5431cb-add3-4a20-af33-fb26a0b8e171.png)

### Development checks

- [ ] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [ ] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [ ] Make sure that additions and changes on design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [ ] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [ ] Self reviewed
- [ ] Covered with tests

**Breaking change**

- [ ] codemod is created and showcased in the changeset
- [ ] test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
6. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
7. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-3212]: https://toptal-core.atlassian.net/browse/FX-3212?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ