### PR TITLE
chore: fix scroll to anchor in storybook

### DIFF
--- a/.storybook/addons/anchor-link-handler/index.js
+++ b/.storybook/addons/anchor-link-handler/index.js
@@ -8,8 +8,10 @@ const scrollTo = (section, container) => {
     return
   }
 
-  const scrollToPosition = sectionContainer.getBoundingClientRect().top
-  container.scrollTo(0, scrollToPosition)
+  setTimeout(() => {
+    const scrollToPosition = sectionContainer.getBoundingClientRect().top
+    container.scrollTo(0, scrollToPosition)
+  }, 0)
 }
 
 const highlightSection = section => {


### PR DESCRIPTION
[FX-NNNN]

### Description

With storybook using react@18 in the latest version 6.5.x, rendering stories changed a little bit and our custom `scroll to anchor` functionality stopped working because the calculation of the scroll position was calculated before the all stories were rendered. We hack it with `setTimeout` to move the calculation to the later tick.

### How to test

- check fixed [anchor](https://picasso.toptal.net/fix-anchor/?path=/story/components-dropdown--dropdown#custom-anchor)

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>
