### PR TITLE
fix: move resize handle same row as multiline input adornment

### DIFF
--- a/.changeset/thin-mails-kiss.md
+++ b/.changeset/thin-mails-kiss.md
@@ -1,0 +1,10 @@
+---
+'@toptal/picasso': patch
+'@toptal/picasso-forms': patch
+---
+
+---
+
+### Input
+
+- move resize handle to bottom bar

--- a/packages/picasso/src/Input/Input.tsx
+++ b/packages/picasso/src/Input/Input.tsx
@@ -264,12 +264,6 @@ export const Input = forwardRef<HTMLInputElement, Props>(function Input(
   const charsLength = value ? value.length : 0
 
   const classes = useStyles()
-  const showAdornment = hasMultilineAdornment({
-    multiline,
-    status,
-    limit,
-    counter,
-  })
 
   return (
     <OutlinedInput
@@ -280,11 +274,15 @@ export const Input = forwardRef<HTMLInputElement, Props>(function Input(
       classes={{
         root: cx(classes.root, {
           [classes.rootMultiline]: multiline,
-          [classes.rootMultilineLimiter]: showAdornment,
         }),
         input: cx(classes.input, {
           [classes.inputMultiline]: multiline,
-          [classes.inputMultilineWithAdornment]: showAdornment,
+          [classes.inputMultilineWithAdornment]: hasMultilineAdornment({
+            multiline,
+            status,
+            limit,
+            counter,
+          }),
           [classes.inputMultilineResizable]: multiline && multilineResizable,
         }),
       }}

--- a/packages/picasso/src/Input/Input.tsx
+++ b/packages/picasso/src/Input/Input.tsx
@@ -283,6 +283,12 @@ export const Input = forwardRef<HTMLInputElement, Props>(function Input(
         }),
         input: cx(classes.input, {
           [classes.inputMultiline]: multiline,
+          [classes.inputMultilineWithAdornment]: hasMultilineAdornment({
+            multiline,
+            status,
+            limit,
+            counter,
+          }),
           [classes.inputMultilineResizable]: multiline && multilineResizable,
         }),
       }}

--- a/packages/picasso/src/Input/Input.tsx
+++ b/packages/picasso/src/Input/Input.tsx
@@ -105,6 +105,7 @@ type EndAdornmentProps = Pick<
   | 'multiline'
   | 'limit'
   | 'counter'
+  | 'size'
   | 'status'
   | 'testIds'
 > & { charsLength?: number }
@@ -154,6 +155,7 @@ const EndAdornment = (props: EndAdornmentProps) => {
     testIds,
     counter,
     status,
+    size,
   } = props
 
   if (icon && iconPosition === 'end') {
@@ -178,7 +180,7 @@ const EndAdornment = (props: EndAdornmentProps) => {
 
   if (hasMultilineAdornment({ multiline, status, counter, limit })) {
     return (
-      <InputMultilineAdornment status={status} testIds={testIds}>
+      <InputMultilineAdornment status={status} testIds={testIds} size={size}>
         {showCounter && (
           <InputLimitAdornment
             charsLength={charsLength}
@@ -277,6 +279,7 @@ export const Input = forwardRef<HTMLInputElement, Props>(function Input(
         }),
         input: cx(classes.input, {
           [classes.inputMultiline]: multiline,
+          [classes.inputLarge]: size === 'large',
           [classes.inputMultilineWithAdornment]: hasMultilineAdornment({
             multiline,
             status,
@@ -327,6 +330,7 @@ export const Input = forwardRef<HTMLInputElement, Props>(function Input(
             counter={counter}
             status={status}
             testIds={testIds}
+            size={size}
           />
         )
       }

--- a/packages/picasso/src/Input/Input.tsx
+++ b/packages/picasso/src/Input/Input.tsx
@@ -264,6 +264,12 @@ export const Input = forwardRef<HTMLInputElement, Props>(function Input(
   const charsLength = value ? value.length : 0
 
   const classes = useStyles()
+  const showAdornment = hasMultilineAdornment({
+    multiline,
+    status,
+    limit,
+    counter,
+  })
 
   return (
     <OutlinedInput
@@ -274,21 +280,11 @@ export const Input = forwardRef<HTMLInputElement, Props>(function Input(
       classes={{
         root: cx(classes.root, {
           [classes.rootMultiline]: multiline,
-          [classes.rootMultilineLimiter]: hasMultilineAdornment({
-            multiline,
-            status,
-            limit,
-            counter,
-          }),
+          [classes.rootMultilineLimiter]: showAdornment,
         }),
         input: cx(classes.input, {
           [classes.inputMultiline]: multiline,
-          [classes.inputMultilineWithAdornment]: hasMultilineAdornment({
-            multiline,
-            status,
-            limit,
-            counter,
-          }),
+          [classes.inputMultilineWithAdornment]: showAdornment,
           [classes.inputMultilineResizable]: multiline && multilineResizable,
         }),
       }}

--- a/packages/picasso/src/Input/Input.tsx
+++ b/packages/picasso/src/Input/Input.tsx
@@ -282,6 +282,7 @@ export const Input = forwardRef<HTMLInputElement, Props>(function Input(
           }),
         }),
         input: cx(classes.input, {
+          [classes.inputMultiline]: multiline,
           [classes.inputMultilineResizable]: multiline && multilineResizable,
         }),
       }}

--- a/packages/picasso/src/Input/__snapshots__/test.tsx.snap
+++ b/packages/picasso/src/Input/__snapshots__/test.tsx.snap
@@ -105,7 +105,7 @@ exports[`Input should show manual resize handler 1`] = `
       <textarea
         aria-invalid="false"
         autocomplete="none"
-        class="MuiInputBase-input MuiOutlinedInput-input PicassoOutlinedInput-input PicassoInput-inputMultilineResizable PicassoOutlinedInput-inputMedium MuiInputBase-inputMultiline MuiOutlinedInput-inputMultiline PicassoOutlinedInput-inputMultiline MuiInputBase-inputAdornedStart MuiOutlinedInput-inputAdornedStart MuiInputBase-inputAdornedEnd MuiOutlinedInput-inputAdornedEnd"
+        class="MuiInputBase-input MuiOutlinedInput-input PicassoOutlinedInput-input PicassoInput-inputMultiline PicassoInput-inputMultilineResizable PicassoOutlinedInput-inputMedium MuiInputBase-inputMultiline MuiOutlinedInput-inputMultiline PicassoOutlinedInput-inputMultiline MuiInputBase-inputAdornedStart MuiOutlinedInput-inputAdornedStart MuiInputBase-inputAdornedEnd MuiOutlinedInput-inputAdornedEnd"
         rows="4"
         style="height: 0px; overflow: hidden;"
       >
@@ -113,7 +113,7 @@ exports[`Input should show manual resize handler 1`] = `
       </textarea>
       <textarea
         aria-hidden="true"
-        class="MuiInputBase-input MuiOutlinedInput-input PicassoOutlinedInput-input PicassoInput-inputMultilineResizable PicassoOutlinedInput-inputMedium MuiInputBase-inputMultiline MuiOutlinedInput-inputMultiline PicassoOutlinedInput-inputMultiline MuiInputBase-inputAdornedStart MuiOutlinedInput-inputAdornedStart MuiInputBase-inputAdornedEnd MuiOutlinedInput-inputAdornedEnd"
+        class="MuiInputBase-input MuiOutlinedInput-input PicassoOutlinedInput-input PicassoInput-inputMultiline PicassoInput-inputMultilineResizable PicassoOutlinedInput-inputMedium MuiInputBase-inputMultiline MuiOutlinedInput-inputMultiline PicassoOutlinedInput-inputMultiline MuiInputBase-inputAdornedStart MuiOutlinedInput-inputAdornedStart MuiInputBase-inputAdornedEnd MuiOutlinedInput-inputAdornedEnd"
         readonly=""
         style="visibility: hidden; position: absolute; overflow: hidden; height: 0px; top: 0px; left: 0px; transform: translateZ(0); width: 100%;"
         tabindex="-1"
@@ -203,18 +203,18 @@ exports[`Input shows counter for multiline input 1`] = `
     class="Picasso-root"
   >
     <div
-      class="MuiInputBase-root MuiOutlinedInput-root PicassoOutlinedInput-root PicassoInput-root PicassoInput-rootMultiline PicassoInput-rootMultilineLimiter PicassoOutlinedInput-rootAuto PicassoOutlinedInput-rootMedium MuiInputBase-multiline MuiOutlinedInput-multiline MuiInputBase-adornedStart MuiOutlinedInput-adornedStart MuiInputBase-adornedEnd MuiOutlinedInput-adornedEnd"
+      class="MuiInputBase-root MuiOutlinedInput-root PicassoOutlinedInput-root PicassoInput-root PicassoInput-rootMultiline undefined PicassoOutlinedInput-rootAuto PicassoOutlinedInput-rootMedium MuiInputBase-multiline MuiOutlinedInput-multiline MuiInputBase-adornedStart MuiOutlinedInput-adornedStart MuiInputBase-adornedEnd MuiOutlinedInput-adornedEnd"
     >
       <textarea
         aria-invalid="false"
         autocomplete="none"
-        class="MuiInputBase-input MuiOutlinedInput-input PicassoOutlinedInput-input PicassoOutlinedInput-inputMedium MuiInputBase-inputMultiline MuiOutlinedInput-inputMultiline PicassoOutlinedInput-inputMultiline MuiInputBase-inputAdornedStart MuiOutlinedInput-inputAdornedStart MuiInputBase-inputAdornedEnd MuiOutlinedInput-inputAdornedEnd"
+        class="MuiInputBase-input MuiOutlinedInput-input PicassoOutlinedInput-input PicassoInput-inputMultiline PicassoOutlinedInput-inputMedium MuiInputBase-inputMultiline MuiOutlinedInput-inputMultiline PicassoOutlinedInput-inputMultiline MuiInputBase-inputAdornedStart MuiOutlinedInput-inputAdornedStart MuiInputBase-inputAdornedEnd MuiOutlinedInput-inputAdornedEnd"
         rows="4"
         style="height: 0px; overflow: hidden;"
       />
       <textarea
         aria-hidden="true"
-        class="MuiInputBase-input MuiOutlinedInput-input PicassoOutlinedInput-input PicassoOutlinedInput-inputMedium MuiInputBase-inputMultiline MuiOutlinedInput-inputMultiline PicassoOutlinedInput-inputMultiline MuiInputBase-inputAdornedStart MuiOutlinedInput-inputAdornedStart MuiInputBase-inputAdornedEnd MuiOutlinedInput-inputAdornedEnd"
+        class="MuiInputBase-input MuiOutlinedInput-input PicassoOutlinedInput-input PicassoInput-inputMultiline PicassoOutlinedInput-inputMedium MuiInputBase-inputMultiline MuiOutlinedInput-inputMultiline PicassoOutlinedInput-inputMultiline MuiInputBase-inputAdornedStart MuiOutlinedInput-inputAdornedStart MuiInputBase-inputAdornedEnd MuiOutlinedInput-inputAdornedEnd"
         readonly=""
         style="visibility: hidden; position: absolute; overflow: hidden; height: 0px; top: 0px; left: 0px; transform: translateZ(0); width: 100%;"
         tabindex="-1"

--- a/packages/picasso/src/Input/__snapshots__/test.tsx.snap
+++ b/packages/picasso/src/Input/__snapshots__/test.tsx.snap
@@ -203,7 +203,7 @@ exports[`Input shows counter for multiline input 1`] = `
     class="Picasso-root"
   >
     <div
-      class="MuiInputBase-root MuiOutlinedInput-root PicassoOutlinedInput-root PicassoInput-root PicassoInput-rootMultiline PicassoInput-rootMultilineLimiter PicassoOutlinedInput-rootAuto PicassoOutlinedInput-rootMedium MuiInputBase-multiline MuiOutlinedInput-multiline MuiInputBase-adornedStart MuiOutlinedInput-adornedStart MuiInputBase-adornedEnd MuiOutlinedInput-adornedEnd"
+      class="MuiInputBase-root MuiOutlinedInput-root PicassoOutlinedInput-root PicassoInput-root PicassoInput-rootMultiline PicassoOutlinedInput-rootAuto PicassoOutlinedInput-rootMedium MuiInputBase-multiline MuiOutlinedInput-multiline MuiInputBase-adornedStart MuiOutlinedInput-adornedStart MuiInputBase-adornedEnd MuiOutlinedInput-adornedEnd"
     >
       <textarea
         aria-invalid="false"

--- a/packages/picasso/src/Input/__snapshots__/test.tsx.snap
+++ b/packages/picasso/src/Input/__snapshots__/test.tsx.snap
@@ -203,18 +203,18 @@ exports[`Input shows counter for multiline input 1`] = `
     class="Picasso-root"
   >
     <div
-      class="MuiInputBase-root MuiOutlinedInput-root PicassoOutlinedInput-root PicassoInput-root PicassoInput-rootMultiline undefined PicassoOutlinedInput-rootAuto PicassoOutlinedInput-rootMedium MuiInputBase-multiline MuiOutlinedInput-multiline MuiInputBase-adornedStart MuiOutlinedInput-adornedStart MuiInputBase-adornedEnd MuiOutlinedInput-adornedEnd"
+      class="MuiInputBase-root MuiOutlinedInput-root PicassoOutlinedInput-root PicassoInput-root PicassoInput-rootMultiline PicassoInput-rootMultilineLimiter PicassoOutlinedInput-rootAuto PicassoOutlinedInput-rootMedium MuiInputBase-multiline MuiOutlinedInput-multiline MuiInputBase-adornedStart MuiOutlinedInput-adornedStart MuiInputBase-adornedEnd MuiOutlinedInput-adornedEnd"
     >
       <textarea
         aria-invalid="false"
         autocomplete="none"
-        class="MuiInputBase-input MuiOutlinedInput-input PicassoOutlinedInput-input PicassoInput-inputMultiline PicassoOutlinedInput-inputMedium MuiInputBase-inputMultiline MuiOutlinedInput-inputMultiline PicassoOutlinedInput-inputMultiline MuiInputBase-inputAdornedStart MuiOutlinedInput-inputAdornedStart MuiInputBase-inputAdornedEnd MuiOutlinedInput-inputAdornedEnd"
+        class="MuiInputBase-input MuiOutlinedInput-input PicassoOutlinedInput-input PicassoInput-inputMultiline PicassoInput-inputMultilineWithAdornment PicassoOutlinedInput-inputMedium MuiInputBase-inputMultiline MuiOutlinedInput-inputMultiline PicassoOutlinedInput-inputMultiline MuiInputBase-inputAdornedStart MuiOutlinedInput-inputAdornedStart MuiInputBase-inputAdornedEnd MuiOutlinedInput-inputAdornedEnd"
         rows="4"
         style="height: 0px; overflow: hidden;"
       />
       <textarea
         aria-hidden="true"
-        class="MuiInputBase-input MuiOutlinedInput-input PicassoOutlinedInput-input PicassoInput-inputMultiline PicassoOutlinedInput-inputMedium MuiInputBase-inputMultiline MuiOutlinedInput-inputMultiline PicassoOutlinedInput-inputMultiline MuiInputBase-inputAdornedStart MuiOutlinedInput-inputAdornedStart MuiInputBase-inputAdornedEnd MuiOutlinedInput-inputAdornedEnd"
+        class="MuiInputBase-input MuiOutlinedInput-input PicassoOutlinedInput-input PicassoInput-inputMultiline PicassoInput-inputMultilineWithAdornment PicassoOutlinedInput-inputMedium MuiInputBase-inputMultiline MuiOutlinedInput-inputMultiline PicassoOutlinedInput-inputMultiline MuiInputBase-inputAdornedStart MuiOutlinedInput-inputAdornedStart MuiInputBase-inputAdornedEnd MuiOutlinedInput-inputAdornedEnd"
         readonly=""
         style="visibility: hidden; position: absolute; overflow: hidden; height: 0px; top: 0px; left: 0px; transform: translateZ(0); width: 100%;"
         tabindex="-1"

--- a/packages/picasso/src/Input/story/Status.example.tsx
+++ b/packages/picasso/src/Input/story/Status.example.tsx
@@ -18,7 +18,14 @@ const Example = () => {
       </Form.Field>
       <Form.Field>
         <Form.Label>Multiline Success</Form.Label>
-        <Input value='Ukraine' multiline rows={4} status='success' />
+        <Input
+          value='Ukraine'
+          multiline
+          multilineResizable
+          limit={5}
+          rows={2}
+          status='success'
+        />
       </Form.Field>
     </Form>
   )

--- a/packages/picasso/src/Input/story/Status.example.tsx
+++ b/packages/picasso/src/Input/story/Status.example.tsx
@@ -27,6 +27,22 @@ const Example = () => {
           status='success'
         />
       </Form.Field>
+      <Form.Field>
+        <Form.Label>Success</Form.Label>
+        <Input size='large' value='Ukraine' status='success' />
+      </Form.Field>
+      <Form.Field>
+        <Form.Label>Multiline Success</Form.Label>
+        <Input
+          value='Ukraine'
+          multiline
+          size='large'
+          multilineResizable
+          limit={5}
+          rows={2}
+          status='success'
+        />
+      </Form.Field>
     </Form>
   )
 }

--- a/packages/picasso/src/Input/styles.ts
+++ b/packages/picasso/src/Input/styles.ts
@@ -16,10 +16,14 @@ export default ({ palette }: Theme) =>
       height: 'auto',
       padding: '0.15em',
     },
-    inputMultiline: {
+    rootMultilineLimiter: {
       minHeight: '4em',
-      paddingBottom: '1.25em',
+    },
+    inputMultiline: {
       padding: '0.5em',
+    },
+    inputMultilineWithAdornment: {
+      paddingBottom: '1.25em',
     },
     inputMultilineResizable: {
       resize: 'vertical',

--- a/packages/picasso/src/Input/styles.ts
+++ b/packages/picasso/src/Input/styles.ts
@@ -1,4 +1,5 @@
 import { Theme, createStyles } from '@material-ui/core/styles'
+import { rem } from '@toptal/picasso-shared'
 
 import '../InputBase/styles'
 import '../InputLabel/styles'
@@ -14,12 +15,18 @@ export default ({ palette }: Theme) =>
     },
     rootMultiline: {
       height: 'auto',
-      padding: '0.15em',
+      padding: rem('2px'),
     },
     inputMultiline: {
-      // 1rem line + top and bottom 0.5rem padding
-      minHeight: '2rem',
-      padding: '0.5rem',
+      // 1rem line + top and bottom 0.375rem padding
+      minHeight: '1.75rem',
+      padding: '0.375rem',
+
+      '&$inputLarge': {
+        // 1rem line + top and bottom 0.625rem
+        minHeight: '2.25rem',
+        padding: '0.625rem',
+      },
 
       // after manually lowering height of the textarea,
       // the input receives inline overflow:hidden and
@@ -28,11 +35,18 @@ export default ({ palette }: Theme) =>
       overflow: 'auto !important',
     },
     inputMultilineWithAdornment: {
-      // 1rem line + top 0.5rem + bottom 1.25rem padding
-      minHeight: '2.75rem',
-      paddingBottom: '1.25rem',
+      // 1rem line + top 0.375rem + bottom 1.5rem padding
+      minHeight: '2.875rem',
+      paddingBottom: '1.5rem',
+
+      '&$inputLarge': {
+        // 1rem line + top 0.625rem + bottom 2.125rem padding
+        minHeight: '3.75rem',
+        paddingBottom: '2.125rem',
+      },
     },
     inputMultilineResizable: {
       resize: 'vertical',
     },
+    inputLarge: {},
   })

--- a/packages/picasso/src/Input/styles.ts
+++ b/packages/picasso/src/Input/styles.ts
@@ -16,14 +16,21 @@ export default ({ palette }: Theme) =>
       height: 'auto',
       padding: '0.15em',
     },
-    rootMultilineLimiter: {
-      minHeight: '4em',
-    },
     inputMultiline: {
-      padding: '0.5em',
+      // 1rem line + top and bottom 0.5rem padding
+      minHeight: '2rem',
+      padding: '0.5rem',
+
+      // after manually lowering height of the textarea,
+      // the input receives inline overflow:hidden and
+      // it is very hard to navigate inside the textarea
+      // showing scrollbar is much better experience
+      overflow: 'auto !important',
     },
     inputMultilineWithAdornment: {
-      paddingBottom: '1.25em',
+      // 1rem line + top 0.5rem + bottom 1.25rem padding
+      minHeight: '2.75rem',
+      paddingBottom: '1.25rem',
     },
     inputMultilineResizable: {
       resize: 'vertical',

--- a/packages/picasso/src/Input/styles.ts
+++ b/packages/picasso/src/Input/styles.ts
@@ -8,16 +8,18 @@ import '../InputAdornment/styles'
 export default ({ palette }: Theme) =>
   createStyles({
     root: {
-      fontSize: '1rem',
+      fontSize: '1em',
       backgroundColor: palette.common.white,
       cursor: 'text',
     },
     rootMultiline: {
       height: 'auto',
+      padding: '0.15em',
     },
-    rootMultilineLimiter: {
-      minHeight: '3.75rem',
-      paddingBottom: '1.875rem',
+    inputMultiline: {
+      minHeight: '4em',
+      paddingBottom: '1.25em',
+      padding: '0.5em',
     },
     inputMultilineResizable: {
       resize: 'vertical',

--- a/packages/picasso/src/InputMultilineAdornment/InputMultilineAdornment.tsx
+++ b/packages/picasso/src/InputMultilineAdornment/InputMultilineAdornment.tsx
@@ -1,5 +1,6 @@
 import React, { ReactNode } from 'react'
 import { makeStyles, Theme } from '@material-ui/core/styles'
+import cx from 'classnames'
 
 import styles from './styles'
 import InputAdornment from '../InputAdornment'
@@ -9,6 +10,7 @@ import InputValidIconAdornment from '../InputValidIconAdornment'
 export interface Props {
   children: ReactNode
   status?: Status
+  size?: 'small' | 'medium' | 'large'
   testIds?: {
     inputAdornment?: string
   }
@@ -19,14 +21,16 @@ const useStyles = makeStyles<Theme>(styles, {
 })
 
 const InputMultilineAdornment = (props: Props) => {
-  const { children, status, testIds } = props
+  const { children, status, testIds, size } = props
   const classes = useStyles()
 
   return (
     <InputAdornment
       data-testid={testIds?.inputAdornment}
       position='end'
-      className={classes.multilineAdornment}
+      className={cx(classes.multilineAdornment, {
+        [classes.large]: size === 'large',
+      })}
       disablePointerEvents
     >
       {children}

--- a/packages/picasso/src/InputMultilineAdornment/styles.ts
+++ b/packages/picasso/src/InputMultilineAdornment/styles.ts
@@ -5,6 +5,9 @@ export default ({ palette }: Theme) => {
 
   return createStyles({
     multilineAdornment: {
+      // we cover the input when resizing, but keep the resize handle visible
+      background:
+        'linear-gradient(90deg, white 0%, white calc(100% - 20px), transparent calc(100% - 19px))',
       position: 'absolute',
       bottom: 0,
       left: 0,

--- a/packages/picasso/src/InputMultilineAdornment/styles.ts
+++ b/packages/picasso/src/InputMultilineAdornment/styles.ts
@@ -1,15 +1,26 @@
 import { Theme, createStyles } from '@material-ui/core/styles'
 
-export default ({ palette }: Theme) =>
-  createStyles({
+export default ({ palette }: Theme) => {
+  const bottomBarSpacingPx = 9
+
+  return createStyles({
     multilineAdornment: {
       position: 'absolute',
       bottom: 0,
-      width: 'calc(100% - 1.25rem)',
+      left: 0,
+      width: '100%',
       height: '1.25rem',
       justifyContent: 'space-between',
       margin: 0,
-      padding: '0.25rem 0',
-      borderTop: `1px solid ${palette.grey.lighter2}`,
+      padding: `0.25rem ${bottomBarSpacingPx}px`,
+      '&::after': {
+        content: '""',
+        position: 'absolute',
+        top: 0,
+        left: `${bottomBarSpacingPx}px`,
+        width: `calc(100% - ${bottomBarSpacingPx * 2}px)`,
+        borderTop: `1px solid ${palette.grey.lighter2}`,
+      },
     },
   })
+}

--- a/packages/picasso/src/InputMultilineAdornment/styles.ts
+++ b/packages/picasso/src/InputMultilineAdornment/styles.ts
@@ -1,7 +1,8 @@
 import { Theme, createStyles } from '@material-ui/core/styles'
 
 export default ({ palette }: Theme) => {
-  const bottomBarSpacingPx = 9
+  const bottomBarSpacingPx = 8
+  const bottomBarSpacingLargePx = 12
 
   return createStyles({
     multilineAdornment: {
@@ -12,18 +13,30 @@ export default ({ palette }: Theme) => {
       bottom: 0,
       left: 0,
       width: '100%',
-      height: '1.25rem',
+      height: '1.75rem',
       justifyContent: 'space-between',
       margin: 0,
-      padding: `0.25rem ${bottomBarSpacingPx}px`,
+      padding: `0.75rem ${bottomBarSpacingPx}px 0.25rem`,
       '&::after': {
         content: '""',
         position: 'absolute',
-        top: 0,
+        top: bottomBarSpacingPx,
         left: `${bottomBarSpacingPx}px`,
         width: `calc(100% - ${bottomBarSpacingPx * 2}px)`,
         borderTop: `1px solid ${palette.grey.lighter2}`,
       },
+
+      '&$large': {
+        padding: `1rem ${bottomBarSpacingLargePx}px 0.25rem`,
+        height: '2.25rem',
+        maxHeight: '2.25rem',
+        '&::after': {
+          top: bottomBarSpacingLargePx,
+          left: `${bottomBarSpacingLargePx}px`,
+          width: `calc(100% - ${bottomBarSpacingLargePx * 2}px)`,
+        },
+      },
     },
+    large: {},
   })
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -19112,15 +19112,10 @@ regenerator-runtime@^0.11.0:
   version "0.11.1"
   resolved "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz"
 
-regenerator-runtime@^0.13.10:
+regenerator-runtime@^0.13.10, regenerator-runtime@^0.13.4, regenerator-runtime@^0.13.7, regenerator-runtime@^0.13.9:
   version "0.13.10"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.10.tgz#ed07b19616bcbec5da6274ebc75ae95634bfc2ee"
   integrity sha512-KepLsg4dU12hryUO7bp/axHAKvwGOCV0sGloQtpagJ12ai+ojVDqkeGSiRX1zlq+kjIMZ1t7gpze+26QqtdGqw==
-
-regenerator-runtime@^0.13.4, regenerator-runtime@^0.13.7, regenerator-runtime@^0.13.9:
-  version "0.13.9"
-  resolved "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz"
-  integrity sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==
 
 regenerator-transform@^0.15.0:
   version "0.15.0"


### PR DESCRIPTION
[FX-3144]

### Description

Move the resize handle for multiline Input to the bottom bar.

### How to test

- Check demo and Happo

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| ![image](https://user-images.githubusercontent.com/5845160/200454518-6deb661d-3785-46f5-9f3e-b7657af127ca.png) | ![image](https://user-images.githubusercontent.com/5845160/200454547-a2d46e91-c476-40f2-ad2f-09243ecac172.png) |

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests


> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-3144]: https://toptal-core.atlassian.net/browse/FX-3144?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ