### PR TITLE
feat(AutoSave): add form auto-save hook

### DIFF
--- a/.changeset/slimy-weeks-film.md
+++ b/.changeset/slimy-weeks-film.md
@@ -1,0 +1,7 @@
+---
+'@toptal/picasso-forms': minor
+---
+
+---
+
+- add form auto-save hook

--- a/packages/picasso-forms/package.json
+++ b/packages/picasso-forms/package.json
@@ -31,6 +31,7 @@
   },
   "dependencies": {
     "classnames": "^2.3.1",
+    "debounce": "^1.2.1",
     "detect-browser": "^5.3.0",
     "final-form": "^4.20.2",
     "final-form-arrays": "^3.0.2",

--- a/packages/picasso-forms/src/Form/story/AutoSave.example.tsx
+++ b/packages/picasso-forms/src/Form/story/AutoSave.example.tsx
@@ -1,41 +1,39 @@
-import React, { useCallback, useMemo, useState } from 'react'
+import React, { useCallback, useState } from 'react'
 import { Container, Typography } from '@toptal/picasso'
-import { Form, createFormValuesChangeDecorator } from '@toptal/picasso-forms'
+import { Form, ChangedFields, useFormAutoSave } from '@toptal/picasso-forms'
+
+// the emulation of the api call
+const saveWithDelay = async () =>
+  new Promise(resolve => setTimeout(() => resolve('success'), 2000))
 
 interface FormData {
   'autoSave-firstName'?: string
   'autoSave-lastName'?: string
-  'autoSave-age'?: string
+  'autoSave-bio'?: string
 }
 
-const autoSaveSubscribedFields: (keyof FormData)[] = ['autoSave-firstName']
+const autoSaveSubscribedFields: (keyof FormData)[] = ['autoSave-bio']
 
 const Example = () => {
   const [autoSaveValues, setAutoSaveValues] = useState<FormData>({
     'autoSave-firstName': undefined,
     'autoSave-lastName': undefined,
-    'autoSave-age': undefined,
+    'autoSave-bio': undefined,
   })
 
   const handleFormValuesChange = useCallback(
-    (
-      changedFields: Partial<Record<keyof FormData, boolean>>,
-      values: FormData
-    ) => {
-      console.log('changedFields', changedFields)
+    async (changedFields: ChangedFields<FormData>, values: FormData) => {
+      await saveWithDelay()
+
       setAutoSaveValues(values)
     },
     []
   )
 
-  const autoSaveDecorator = useMemo(
-    () =>
-      createFormValuesChangeDecorator<FormData>({
-        subscribedFields: autoSaveSubscribedFields,
-        onChange: handleFormValuesChange,
-      }),
-    [handleFormValuesChange]
-  )
+  const { autoSaveDecorator, savingFields } = useFormAutoSave({
+    subscribedFields: autoSaveSubscribedFields,
+    onFormValuesChange: handleFormValuesChange,
+  })
 
   return (
     <Form<FormData>
@@ -56,20 +54,24 @@ const Example = () => {
             label='Last name'
             placeholder='e.g. Wayne'
           />
-          <Form.NumberInput
-            enableReset
+          <Form.Input
             required
-            name='autoSave-age'
-            label="What's your age?"
-            placeholder='e.g. 25'
+            name='autoSave-bio'
+            multiline
+            rows={5}
+            label='Bio'
+            placeholder='Please tell us about yourself'
           />
+          {savingFields?.['autoSave-bio'] && (
+            <Typography align='right'>Saving</Typography>
+          )}
         </Container>
         <Container variant='grey' padded='medium'>
           <Typography size='small'>
-            Values should be updated only after subscribed fields changes
+            Values should be updated only after subscribed fields changes.
           </Typography>
           <pre style={{ width: 500 }}>
-            {JSON.stringify(autoSaveValues, undefined, 2)}
+            Saved values: {JSON.stringify(autoSaveValues, undefined, 2)}
           </pre>
         </Container>
       </Container>

--- a/packages/picasso-forms/src/index.ts
+++ b/packages/picasso-forms/src/index.ts
@@ -45,4 +45,6 @@ export { default as FieldWrapper } from './FieldWrapper'
 export type { FieldProps } from './Field'
 export type { FormConfigProps, RequiredVariant } from './FormConfig'
 export { default as createFormValuesChangeDecorator } from './utils/form-values-change-decorator'
+export type { ChangedFields } from './utils/form-values-change-decorator'
+export { default as useFormAutoSave } from './utils/use-form-auto-save/use-form-auto-save'
 // hygen code generator inserts export statements above this comment.

--- a/packages/picasso-forms/src/utils/form-values-change-decorator/form-values-change-decorator.ts
+++ b/packages/picasso-forms/src/utils/form-values-change-decorator/form-values-change-decorator.ts
@@ -1,6 +1,8 @@
 import { AnyObject, FormApi } from 'final-form'
 
-type ChangedFields<T extends AnyObject> = Partial<Record<keyof T, boolean>>
+export type ChangedFields<T extends AnyObject> = Partial<
+  Record<keyof T, boolean>
+>
 
 export const getChangedFields = <T extends AnyObject>(
   newValues: T,

--- a/packages/picasso-forms/src/utils/form-values-change-decorator/index.ts
+++ b/packages/picasso-forms/src/utils/form-values-change-decorator/index.ts
@@ -1,1 +1,3 @@
 export { default } from './form-values-change-decorator'
+
+export type { ChangedFields } from './form-values-change-decorator'

--- a/packages/picasso-forms/src/utils/index.ts
+++ b/packages/picasso-forms/src/utils/index.ts
@@ -1,5 +1,6 @@
 export { default as validators } from './validators'
 export { default as createScrollToErrorDecorator } from './scroll-to-error-decorator'
 export { default as createFormValuesChangeDecorator } from './form-values-change-decorator'
+export { default as useFormAutoSave } from './use-form-auto-save'
 export { default as flatMap } from './flat-map'
 export { default as useFieldValidation } from './use-field-validation'

--- a/packages/picasso-forms/src/utils/use-form-auto-save/index.ts
+++ b/packages/picasso-forms/src/utils/use-form-auto-save/index.ts
@@ -1,0 +1,1 @@
+export { default } from './use-form-auto-save'

--- a/packages/picasso-forms/src/utils/use-form-auto-save/use-form-auto-save.ts
+++ b/packages/picasso-forms/src/utils/use-form-auto-save/use-form-auto-save.ts
@@ -1,0 +1,60 @@
+import { AnyObject } from 'final-form'
+import { useCallback, useMemo, useState } from 'react'
+import { debounce } from 'debounce'
+
+import createFormValuesChangeDecorator, {
+  ChangedFields,
+} from '../form-values-change-decorator'
+
+interface Props<T extends AnyObject> {
+  subscribedFields?: (keyof T)[]
+  onFormValuesChange: (changedFields: ChangedFields<T>, values: T) => void
+  debounceDelay?: number
+}
+
+const useFormAutoSave = <T extends AnyObject>(props: Props<T>) => {
+  const [savingFields, setSavingFields] = useState<
+    ChangedFields<T> | undefined
+  >()
+
+  const {
+    onFormValuesChange,
+    subscribedFields,
+    debounceDelay: delay = 1000,
+  } = props
+
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  const handleValueChange = useCallback(
+    debounce(async (changedValues: ChangedFields<T>, debouncedValues: T) => {
+      await onFormValuesChange(changedValues, debouncedValues)
+
+      setSavingFields(undefined)
+    }, delay),
+    [delay, onFormValuesChange]
+  )
+
+  const handleFormValuesChange = useCallback(
+    (changedFields: ChangedFields<T>, values: T) => {
+      setSavingFields(changedFields)
+
+      handleValueChange(changedFields, values)
+    },
+    [handleValueChange]
+  )
+
+  const autoSaveDecorator = useMemo(
+    () =>
+      createFormValuesChangeDecorator({
+        subscribedFields,
+        onChange: handleFormValuesChange,
+      }),
+    [handleFormValuesChange, subscribedFields]
+  )
+
+  return {
+    savingFields,
+    autoSaveDecorator,
+  }
+}
+
+export default useFormAutoSave


### PR DESCRIPTION
[FX-3208]

### Description

This PR is about adding a new hook for utilizing the changed form values and hiding the part of the creation of form values change decorator.

I have just printed a `Saving` message for now but there will be a followup PR for introducing a new component for better UX.

https://user-images.githubusercontent.com/7733167/200324319-de8026d6-4e97-4c32-8aeb-1e6f77fc4cf4.mov

### How to test

- go to Form component's [auto-save story](https://picasso.toptal.net/fx-3208-add-auto-save-hook/?path=/story/picasso-forms-form--form#auto-save) and test the hook

### Screenshots

no visual changes

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- Make sure that additions and changes on design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- Covered with tests

**Breaking change**

- codemod is created and showcased in the changeset
- test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-3208]: https://toptal-core.atlassian.net/browse/FX-3208?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ