### PR TITLE
feat(AutoSave): add indicator component

### DIFF
--- a/.changeset/great-boxes-design.md
+++ b/.changeset/great-boxes-design.md
@@ -1,0 +1,9 @@
+---
+'@toptal/picasso': minor
+---
+
+---
+
+### FormAutoSaveIndicator
+
+- add a new component to be used inside forms to show the auto-saving state

--- a/packages/picasso-forms/src/Form/story/AutoSave.example.tsx
+++ b/packages/picasso-forms/src/Form/story/AutoSave.example.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useState } from 'react'
-import { Container, Typography } from '@toptal/picasso'
+import { Container, FormAutoSaveIndicator, Typography } from '@toptal/picasso'
 import { Form, ChangedFields, useFormAutoSave } from '@toptal/picasso-forms'
 
 // the emulation of the api call
@@ -62,9 +62,7 @@ const Example = () => {
             label='Bio'
             placeholder='Please tell us about yourself'
           />
-          {savingFields?.['autoSave-bio'] && (
-            <Typography align='right'>Saving</Typography>
-          )}
+          <FormAutoSaveIndicator saving={savingFields?.['autoSave-bio']} />
         </Container>
         <Container variant='grey' padded='medium'>
           <Typography size='small'>
@@ -73,6 +71,9 @@ const Example = () => {
           <pre style={{ width: 500 }}>
             Saved values: {JSON.stringify(autoSaveValues, undefined, 2)}
           </pre>
+          {savingFields?.['autoSave-bio'] && (
+            <Typography size='medium'>Saving...</Typography>
+          )}
         </Container>
       </Container>
 

--- a/packages/picasso/src/FormAutoSaveIndicator/FormAutoSaveIndicator.tsx
+++ b/packages/picasso/src/FormAutoSaveIndicator/FormAutoSaveIndicator.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react'
+import React, { useEffect, useState } from 'react'
 import debounce from 'debounce'
 import { makeStyles, Theme } from '@material-ui/core/styles'
 import cx from 'classnames'
@@ -8,8 +8,11 @@ import Typography from '../Typography'
 import Container from '../Container'
 
 export interface Props {
+  /** Indicates that form values are being saved */
   saving?: boolean
+  /** Duration for the delay before hiding 'Saved' text */
   duration?: number
+  /** The text of the label, default is 'Saved' */
   label?: string
 }
 
@@ -22,37 +25,37 @@ const FormAutoSaveIndicator = ({
   label = 'Saved',
   duration = 1000,
 }: Props) => {
-  const [show, setShow] = React.useState<'initial' | 'saving' | 'saved'>(
-    'initial'
-  )
+  const [visibilityState, setVisibilityState] = useState<
+    'initial' | 'saving' | 'saved'
+  >('initial')
   const classes = useStyles()
 
   useEffect(() => {
     if (saving) {
-      setShow('saving')
-    } else if (show === 'saving') {
-      setShow('saved')
+      setVisibilityState('saving')
+    } else if (visibilityState === 'saving') {
+      setVisibilityState('saved')
     }
-  }, [saving, show])
+  }, [saving, visibilityState])
 
   useEffect(() => {
     const hideIndicator = debounce(() => {
-      setShow('initial')
+      setVisibilityState('initial')
     }, duration)
 
-    if (show === 'saved') {
+    if (visibilityState === 'saved') {
       hideIndicator()
     }
 
     return () => {
       hideIndicator.clear()
     }
-  }, [show, duration])
+  }, [visibilityState, duration])
 
   return (
     <Container
       className={cx(classes.root, {
-        [classes.visible]: show === 'saved',
+        [classes.visible]: visibilityState === 'saved',
       })}
       align='right'
     >

--- a/packages/picasso/src/FormAutoSaveIndicator/FormAutoSaveIndicator.tsx
+++ b/packages/picasso/src/FormAutoSaveIndicator/FormAutoSaveIndicator.tsx
@@ -16,6 +16,12 @@ export interface Props {
   label?: string
 }
 
+enum SavingState {
+  Initial,
+  Saving,
+  Saved,
+}
+
 const useStyles = makeStyles<Theme>(styles, {
   name: 'PicassoAutoSaveIndicator',
 })
@@ -25,25 +31,25 @@ const FormAutoSaveIndicator = ({
   label = 'Saved',
   duration = 1000,
 }: Props) => {
-  const [savingState, setSavingState] = useState<
-    'initial' | 'saving' | 'saved'
-  >('initial')
+  const [savingState, setSavingState] = useState<SavingState>(
+    SavingState.Initial
+  )
   const classes = useStyles()
 
   useEffect(() => {
     if (saving) {
-      setSavingState('saving')
-    } else if (savingState === 'saving') {
-      setSavingState('saved')
+      setSavingState(SavingState.Saving)
+    } else if (savingState === SavingState.Saving) {
+      setSavingState(SavingState.Saved)
     }
   }, [saving, savingState])
 
   useEffect(() => {
     const hideIndicator = debounce(() => {
-      setSavingState('initial')
+      setSavingState(SavingState.Initial)
     }, duration)
 
-    if (savingState === 'saved') {
+    if (savingState === SavingState.Saved) {
       hideIndicator()
     }
 
@@ -55,7 +61,7 @@ const FormAutoSaveIndicator = ({
   return (
     <Container
       className={cx(classes.root, {
-        [classes.visible]: savingState === 'saved',
+        [classes.visible]: savingState === SavingState.Saved,
       })}
       align='right'
     >

--- a/packages/picasso/src/FormAutoSaveIndicator/FormAutoSaveIndicator.tsx
+++ b/packages/picasso/src/FormAutoSaveIndicator/FormAutoSaveIndicator.tsx
@@ -25,37 +25,37 @@ const FormAutoSaveIndicator = ({
   label = 'Saved',
   duration = 1000,
 }: Props) => {
-  const [visibilityState, setVisibilityState] = useState<
+  const [savingState, setSavingState] = useState<
     'initial' | 'saving' | 'saved'
   >('initial')
   const classes = useStyles()
 
   useEffect(() => {
     if (saving) {
-      setVisibilityState('saving')
-    } else if (visibilityState === 'saving') {
-      setVisibilityState('saved')
+      setSavingState('saving')
+    } else if (savingState === 'saving') {
+      setSavingState('saved')
     }
-  }, [saving, visibilityState])
+  }, [saving, savingState])
 
   useEffect(() => {
     const hideIndicator = debounce(() => {
-      setVisibilityState('initial')
+      setSavingState('initial')
     }, duration)
 
-    if (visibilityState === 'saved') {
+    if (savingState === 'saved') {
       hideIndicator()
     }
 
     return () => {
       hideIndicator.clear()
     }
-  }, [visibilityState, duration])
+  }, [savingState, duration])
 
   return (
     <Container
       className={cx(classes.root, {
-        [classes.visible]: visibilityState === 'saved',
+        [classes.visible]: savingState === 'saved',
       })}
       align='right'
     >

--- a/packages/picasso/src/FormAutoSaveIndicator/FormAutoSaveIndicator.tsx
+++ b/packages/picasso/src/FormAutoSaveIndicator/FormAutoSaveIndicator.tsx
@@ -1,0 +1,64 @@
+import React, { useEffect } from 'react'
+import debounce from 'debounce'
+import { makeStyles, Theme } from '@material-ui/core/styles'
+import cx from 'classnames'
+
+import styles from './styles'
+import Typography from '../Typography'
+import Container from '../Container'
+
+export interface Props {
+  saving?: boolean
+  duration?: number
+  label?: string
+}
+
+const useStyles = makeStyles<Theme>(styles, {
+  name: 'PicassoAutoSaveIndicator',
+})
+
+const FormAutoSaveIndicator = ({
+  saving,
+  label = 'Saved',
+  duration = 1000,
+}: Props) => {
+  const [show, setShow] = React.useState<'initial' | 'saving' | 'saved'>(
+    'initial'
+  )
+  const classes = useStyles()
+
+  useEffect(() => {
+    if (saving) {
+      setShow('saving')
+    } else if (show === 'saving') {
+      setShow('saved')
+    }
+  }, [saving, show])
+
+  useEffect(() => {
+    const hideIndicator = debounce(() => {
+      setShow('initial')
+    }, duration)
+
+    if (show === 'saved') {
+      hideIndicator()
+    }
+
+    return () => {
+      hideIndicator.clear()
+    }
+  }, [show, duration])
+
+  return (
+    <Container
+      className={cx(classes.root, {
+        [classes.visible]: show === 'saved',
+      })}
+      align='right'
+    >
+      <Typography size='xxsmall'>{label}</Typography>
+    </Container>
+  )
+}
+
+export default FormAutoSaveIndicator

--- a/packages/picasso/src/FormAutoSaveIndicator/FormAutoSaveIndicator.tsx
+++ b/packages/picasso/src/FormAutoSaveIndicator/FormAutoSaveIndicator.tsx
@@ -10,8 +10,8 @@ import Container from '../Container'
 export interface Props {
   /** Indicates that form values are being saved */
   saving?: boolean
-  /** Duration for the delay before hiding 'Saved' text */
-  duration?: number
+  /** Timeout duration for the delay before hiding 'Saved' text */
+  hideTimeout?: number
   /** The text of the label, default is 'Saved' */
   label?: string
 }
@@ -29,7 +29,7 @@ const useStyles = makeStyles<Theme>(styles, {
 const FormAutoSaveIndicator = ({
   saving,
   label = 'Saved',
-  duration = 1000,
+  hideTimeout = 1000,
 }: Props) => {
   const [savingState, setSavingState] = useState<SavingState>(
     SavingState.Initial
@@ -47,7 +47,7 @@ const FormAutoSaveIndicator = ({
   useEffect(() => {
     const hideIndicator = debounce(() => {
       setSavingState(SavingState.Initial)
-    }, duration)
+    }, hideTimeout)
 
     if (savingState === SavingState.Saved) {
       hideIndicator()
@@ -56,7 +56,7 @@ const FormAutoSaveIndicator = ({
     return () => {
       hideIndicator.clear()
     }
-  }, [savingState, duration])
+  }, [savingState, hideTimeout])
 
   return (
     <Container

--- a/packages/picasso/src/FormAutoSaveIndicator/index.ts
+++ b/packages/picasso/src/FormAutoSaveIndicator/index.ts
@@ -1,0 +1,6 @@
+import { OmitInternalProps } from '@toptal/picasso-shared'
+
+import { Props } from './FormAutoSaveIndicator'
+
+export { default } from './FormAutoSaveIndicator'
+export type FormAutoSaveIndicatorProps = OmitInternalProps<Props>

--- a/packages/picasso/src/FormAutoSaveIndicator/styles.ts
+++ b/packages/picasso/src/FormAutoSaveIndicator/styles.ts
@@ -1,0 +1,13 @@
+import { createStyles } from '@material-ui/core/styles'
+
+export default () =>
+  createStyles({
+    root: {
+      visibility: 'hidden',
+      marginTop: '0.25em',
+      marginBottom: '0.25em',
+    },
+    visible: {
+      visibility: 'visible',
+    },
+  })

--- a/packages/picasso/src/FormAutoSaveIndicator/test.tsx
+++ b/packages/picasso/src/FormAutoSaveIndicator/test.tsx
@@ -24,8 +24,6 @@ describe('FormAutoSaveIndicator', () => {
     it('should show label', () => {
       const { queryByText, rerender } = render(<FormAutoSaveIndicator saving />)
 
-      expect(queryByText('Saved')).not.toBeVisible()
-
       rerender(<FormAutoSaveIndicator />)
 
       expect(queryByText('Saved')).toBeVisible()

--- a/packages/picasso/src/FormAutoSaveIndicator/test.tsx
+++ b/packages/picasso/src/FormAutoSaveIndicator/test.tsx
@@ -1,0 +1,34 @@
+import React from 'react'
+import { render } from '@toptal/picasso/test-utils'
+
+import FormAutoSaveIndicator from './FormAutoSaveIndicator'
+
+describe('FormAutoSaveIndicator', () => {
+  describe('in initial state', () => {
+    it('hides label', () => {
+      const { queryByText } = render(<FormAutoSaveIndicator />)
+
+      expect(queryByText('Saved')).not.toBeVisible()
+    })
+  })
+
+  describe('when saving', () => {
+    it('hides label', () => {
+      const { queryByText } = render(<FormAutoSaveIndicator saving />)
+
+      expect(queryByText('Saved')).not.toBeVisible()
+    })
+  })
+
+  describe('when saved', () => {
+    it('should show label', () => {
+      const { queryByText, rerender } = render(<FormAutoSaveIndicator saving />)
+
+      expect(queryByText('Saved')).not.toBeVisible()
+
+      rerender(<FormAutoSaveIndicator />)
+
+      expect(queryByText('Saved')).toBeVisible()
+    })
+  })
+})

--- a/packages/picasso/src/index.ts
+++ b/packages/picasso/src/index.ts
@@ -11,6 +11,8 @@ export type {
   AutocompleteProps,
   Item as AutocompleteItem,
 } from './Autocomplete'
+export { default as FormAutoSaveIndicator } from './FormAutoSaveIndicator'
+export type { FormAutoSaveIndicatorProps } from './FormAutoSaveIndicator'
 export { AvatarCompound as Avatar } from './AvatarCompound'
 export type { AvatarProps } from './Avatar'
 export { ButtonCompound as Button } from './ButtonCompound'


### PR DESCRIPTION
[FX-3209]

### Description

This PR is about adding an indicator component for auto-save functionality.
I'm totally up for different opinions and refactoring 🙇‍♂️ 

### How to test

- go to [auto-save story](https://picasso.toptal.net/fx-3209-add-autosave-indicator/?path=/story/picasso-forms-form--form#auto-save) and test the component 

### Screenshots

https://user-images.githubusercontent.com/7733167/200835695-156b2437-f361-4a54-aced-2b4395b72287.mov

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests

**Breaking change**

- codemod is created and showcased in the changeset
- test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-3209]: https://toptal-core.atlassian.net/browse/FX-3209?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ