### PR TITLE
feat(TabItem): add `description` and `image`

### DIFF
--- a/.changeset/good-carpets-change.md
+++ b/.changeset/good-carpets-change.md
@@ -1,0 +1,11 @@
+---
+'@toptal/picasso': minor
+---
+
+---
+
+### Tabs
+
+- update styles of the vertical variant to comply with BASE
+- add `description` and `avatar` props to `Tabs.Tab` in the vertical variant
+- add [new examples](https://picasso.toptal.net/?path=/story/layout-tabs--tabs#tabs-tab-vertical-tab) in the storybook

--- a/cypress/component/Tabs.spec.tsx
+++ b/cypress/component/Tabs.spec.tsx
@@ -67,28 +67,136 @@ const renderTabs = ({
 const component = 'Tabs'
 
 describe('Tabs', () => {
-  it('navigates with scroll buttons', () => {
-    cy.mount(renderTabs({ width: '13rem' }))
+  describe('with horizontal orientation', () => {
+    it('navigates with scroll buttons', () => {
+      cy.mount(renderTabs({ width: '13rem' }))
 
-    cy.get(getTabSelector(0)).should('be.visible')
-    cy.get(getTabSelector(4)).should('not.be.visible')
-    cy.get(getScrollButtonSelector('left')).should('not.exist')
-    cy.get(getScrollButtonSelector('right')).should('be.visible')
-    cy.get('body').happoScreenshot({
-      component,
-      variant: 'with-scroll-buttons',
+      cy.get('body').happoScreenshot({
+        component,
+        variant: 'with-scroll-buttons',
+      })
+
+      cy.get(getScrollButtonSelector('right')).click()
+      cy.get(getTabSelector(0)).should('not.be.visible')
+      cy.get(getTabSelector(4)).should('be.visible')
+      cy.get(getScrollButtonSelector('left')).should('be.visible')
+      cy.get(getScrollButtonSelector('right')).should('not.exist')
+
+      cy.get(getScrollButtonSelector('left')).click()
+      cy.get(getTabSelector(0)).should('be.visible')
+      cy.get(getTabSelector(4)).should('not.be.visible')
+      cy.get(getScrollButtonSelector('left')).should('not.exist')
+      cy.get(getScrollButtonSelector('right')).should('be.visible')
+    })
+  })
+  describe('with vertical orientation', () => {
+    let src: string | null = null
+
+    before(() => {
+      // eslint-disable-next-line max-nested-callbacks, promise/catch-or-return
+      cy.fixture('pablo.jpg').then(image => {
+        src = 'data:image/jpg;base64,' + image
+
+        return image
+      })
+    })
+    it('renders with label', () => {
+      cy.mount(
+        <Tabs value={0} orientation='vertical'>
+          <Tabs.Tab label='Label' />
+          <Tabs.Tab label='Label' disabled />
+          <Tabs.Tab label='Label' />
+          <Tabs.Tab data-testid='to-be-hovered' label='Label' />
+          <Tabs.Tab label='Truncated very long label' />
+        </Tabs>
+      )
+
+      cy.getByTestId('to-be-hovered').hoverAndTakeHappoScreenshot({
+        component,
+        variant: 'vertical-with-label/after-hovered',
+      })
+
+      cy.contains('Truncated').realHover()
+      cy.getByRole('tooltip')
+        .should('contain.text', 'Truncated very long label')
+        .should('be.visible')
     })
 
-    cy.get(getScrollButtonSelector('right')).click()
-    cy.get(getTabSelector(0)).should('not.be.visible')
-    cy.get(getTabSelector(4)).should('be.visible')
-    cy.get(getScrollButtonSelector('left')).should('be.visible')
-    cy.get(getScrollButtonSelector('right')).should('not.exist')
+    it('renders with label and description', () => {
+      cy.mount(
+        <Tabs value={0} orientation='vertical'>
+          <Tabs.Tab description='Description' label='Label' />
+          <Tabs.Tab description='Description' disabled label='Label' />
+          <Tabs.Tab description='Description' label='Label' />
+          <Tabs.Tab
+            data-testid='to-be-hovered'
+            description='Description'
+            label='Label'
+          />
+          <Tabs.Tab
+            data-testid='truncated'
+            description='Truncated very very long description'
+            label='Label'
+          />
+        </Tabs>
+      )
 
-    cy.get(getScrollButtonSelector('left')).click()
-    cy.get(getTabSelector(0)).should('be.visible')
-    cy.get(getTabSelector(4)).should('not.be.visible')
-    cy.get(getScrollButtonSelector('left')).should('not.exist')
-    cy.get(getScrollButtonSelector('right')).should('be.visible')
+      cy.getByTestId('to-be-hovered').hoverAndTakeHappoScreenshot({
+        component,
+        variant: 'vertical-with-description/after-hovered',
+      })
+
+      cy.getByTestId('truncated').contains('Truncated').realHover()
+      cy.getByRole('tooltip')
+        .should('contain.text', 'Truncated very very long description')
+        .should('be.visible')
+    })
+
+    it('renders with user badge', () => {
+      cy.mount(
+        <Tabs value={0} orientation='vertical'>
+          <Tabs.Tab avatar={src} description='Description' label='Label' />
+          <Tabs.Tab avatar={src} description='Description' label='Label' />
+          <Tabs.Tab
+            avatar={src}
+            disabled
+            description='Description'
+            label='Label'
+          />
+          <Tabs.Tab avatar={src} label='Label' />
+
+          <Tabs.Tab avatar={null} description='Description' label='Label' />
+          <Tabs.Tab avatar='' description='Description' label='Label' />
+
+          <Tabs.Tab
+            avatar={src}
+            data-testid='to-be-hovered'
+            description='Description'
+            label='Label'
+          />
+        </Tabs>
+      )
+
+      cy.getByTestId('to-be-hovered').hoverAndTakeHappoScreenshot({
+        component,
+        variant: 'vertical-with-user-badge/after-hovered',
+      })
+    })
+    describe('does not render avatar', () => {
+      // eslint-disable-next-line max-nested-callbacks
+      it('when avatar is undefined', () => {
+        cy.mount(
+          <Tabs value={0} orientation='vertical'>
+            <Tabs.Tab
+              avatar={undefined}
+              description='Description'
+              label='Label'
+            />
+          </Tabs>
+        )
+
+        cy.get('img').should('not.exist')
+      })
+    })
   })
 })

--- a/packages/picasso/src/Tab/Tab.tsx
+++ b/packages/picasso/src/Tab/Tab.tsx
@@ -9,10 +9,11 @@ import { makeStyles, Theme } from '@material-ui/core/styles'
 import MUITab, { TabProps } from '@material-ui/core/Tab'
 import { BaseProps, TextLabelProps, useTitleCase } from '@toptal/picasso-shared'
 
-import Typography from '../Typography'
+import UserBadge from '../UserBadge'
 import styles from './styles'
-import toTitleCase from '../utils/to-title-case'
 import { TabsOrientationContext } from '../Tabs/Tabs'
+import TabLabel from '../TabLabel'
+import TabDescription from '../TabDescription'
 
 export interface Props
   extends BaseProps,
@@ -33,6 +34,12 @@ export interface Props
   /** The Icon element */
   icon?: ReactElement
 
+  /** Image URL */
+  avatar?: string | null
+
+  /** Description */
+  description?: string
+
   // Properties below are managed by Tabs component
 
   selected?: boolean
@@ -52,16 +59,22 @@ export const Tab = forwardRef<HTMLDivElement, Props>(function Tab(props, ref) {
     onChange,
     onClick,
     titleCase: propsTitleCase,
+    description,
+    avatar,
     ...rest
   } = props
   const classes = useStyles()
   const titleCase = useTitleCase(propsTitleCase)
-  const labelComponent = (
-    <Typography as='div' size='small' weight='semibold' color='inherit'>
-      {titleCase ? toTitleCase(label) : label}
-    </Typography>
-  )
   const orientation = useContext(TabsOrientationContext)
+
+  const labelComponent = getLabelComponent({
+    avatar,
+    description,
+    disabled,
+    label,
+    orientation,
+    titleCase,
+  })
 
   return (
     <MUITab
@@ -87,5 +100,56 @@ export const Tab = forwardRef<HTMLDivElement, Props>(function Tab(props, ref) {
 Tab.defaultProps = {}
 
 Tab.displayName = 'Tab'
+
+type GetLabelComponentProps = {
+  avatar?: string | null
+  description?: string
+  disabled?: boolean
+  label?: React.ReactNode
+  orientation: 'horizontal' | 'vertical'
+  titleCase?: boolean
+}
+const getLabelComponent = ({
+  avatar,
+  description,
+  disabled,
+  label,
+  orientation,
+  titleCase,
+}: GetLabelComponentProps): React.ReactNode => {
+  if (!label) {
+    return null
+  }
+
+  const isHorizontal = orientation === 'horizontal'
+  const isCustomLabel = typeof label !== 'string'
+
+  const Label = () => (
+    <TabLabel titleCase={titleCase} label={label} orientation={orientation} />
+  )
+
+  if (isHorizontal || isCustomLabel) {
+    return <Label />
+  }
+
+  if (typeof avatar === 'undefined') {
+    return (
+      <>
+        <Label />
+        {description && (
+          <TabDescription disabled={disabled}>{description}</TabDescription>
+        )}
+      </>
+    )
+  }
+
+  return (
+    <UserBadge renderName={Label} name={label} avatar={avatar}>
+      {description && (
+        <TabDescription disabled={disabled}>{description}</TabDescription>
+      )}
+    </UserBadge>
+  )
+}
 
 export default Tab

--- a/packages/picasso/src/Tab/story/Vertical.example.tsx
+++ b/packages/picasso/src/Tab/story/Vertical.example.tsx
@@ -1,0 +1,83 @@
+import React from 'react'
+import { Container, Tabs, Typography } from '@toptal/picasso'
+import { palette } from '@toptal/picasso/utils'
+
+const Example = () => {
+  return (
+    <Container flex gap='large' padded='small'>
+      <ExampleDecorator title='With Title'>
+        <Tabs value={0} orientation='vertical'>
+          <Tabs.Tab label='Label' />
+          <Tabs.Tab label='Label' disabled />
+          <Tabs.Tab label='Label' />
+          <Tabs.Tab label='Very long label that truncated' />
+        </Tabs>
+      </ExampleDecorator>
+      <ExampleDecorator title='With Title & Description'>
+        <Tabs value={0} orientation='vertical'>
+          <Tabs.Tab label='Label' description='Description' />
+          <Tabs.Tab label='Label' description='Description' disabled />
+          <Tabs.Tab label='Label' description='Description' />
+          <Tabs.Tab
+            label='Very long label that truncated'
+            description='Description'
+          />
+          <Tabs.Tab
+            label='Label'
+            description='Very long description that truncated'
+          />
+        </Tabs>
+      </ExampleDecorator>
+      <ExampleDecorator title='With UserBadge'>
+        <Tabs value={0} orientation='vertical'>
+          <Tabs.Tab label='Label' description='Description' avatar={null} />
+          <Tabs.Tab
+            label='Label'
+            disabled
+            description='Description'
+            avatar='./jacqueline-with-flowers-1954-square.jpg'
+          />
+          <Tabs.Tab
+            label='Label'
+            description='Description'
+            avatar='./jacqueline-with-flowers-1954-square.jpg'
+          />
+          <Tabs.Tab
+            label='Very long label that truncated'
+            description='Description'
+            avatar='./jacqueline-with-flowers-1954-square.jpg'
+          />
+          <Tabs.Tab
+            label='Label'
+            description='Very long description that truncated'
+            avatar='./jacqueline-with-flowers-1954-square.jpg'
+          />
+          <Tabs.Tab
+            label='Label'
+            avatar='./jacqueline-with-flowers-1954-square.jpg'
+          />
+        </Tabs>
+      </ExampleDecorator>
+    </Container>
+  )
+}
+
+type Props = {
+  children: React.ReactNode
+  title: string
+}
+
+const ExampleDecorator = ({ children, title }: Props) => {
+  const style: React.CSSProperties = { backgroundColor: palette.grey.lighter }
+
+  return (
+    <Container>
+      <Typography variant='heading' size='small'>
+        {title}
+      </Typography>
+      <Container style={style}>{children}</Container>
+    </Container>
+  )
+}
+
+export default Example

--- a/packages/picasso/src/Tab/story/index.jsx
+++ b/packages/picasso/src/Tab/story/index.jsx
@@ -6,6 +6,10 @@ const componentDocs = PicassoBook.createComponentDocs(Tab, 'Tabs.Tab')
 const chapter = PicassoBook.connectToPage(page => {
   page
     .createChapter('Tabs.Tab')
+    .addExample('Tab/story/Vertical.example.tsx', {
+      title: 'Vertical tab',
+      takeScreenshot: false,
+    })
     .addExample('Tab/story/Disabled.example.tsx', 'Disabled tab')
     .addExample('Tab/story/CustomValue.example.tsx', 'Using custom value')
     .addExample('Tab/story/Icon.example.tsx', 'With Icon')

--- a/packages/picasso/src/Tab/styles.ts
+++ b/packages/picasso/src/Tab/styles.ts
@@ -45,7 +45,7 @@ PicassoProvider.override(({ breakpoints, palette }: Theme) => ({
   },
 }))
 
-export default ({ sizes, palette, shadows }: Theme) =>
+export default ({ sizes, palette, shadows, transitions }: Theme) =>
   createStyles({
     horizontal: {
       '&:not(:last-child)': {
@@ -53,17 +53,27 @@ export default ({ sizes, palette, shadows }: Theme) =>
       },
     },
     vertical: {
-      borderRadius: `${sizes.borderRadius.medium} 0 0 ${sizes.borderRadius.medium}`,
-      margin: '0.5em 0',
+      width: '100%',
+      borderRadius: `${sizes.borderRadius.small} 0 0 ${sizes.borderRadius.small}`,
+      margin: '0.25rem 0',
       overflow: 'hidden',
-      padding: '0.5625em 0 0.5625em',
+      padding: '0.5rem 1rem',
+      transition: `all ${transitions.duration.short}ms ${transitions.easing.easeInOut}`,
+      textAlign: 'left',
+      backgroundColor: palette.grey.lighter,
+      opacity: 1,
+      color: palette.grey.dark,
 
       '&:first-child': {
-        marginTop: '0.125em',
+        marginTop: '1rem',
       },
 
       '&:last-child': {
-        marginBottom: '0.125em',
+        marginBottom: '1rem',
+      },
+
+      '&:hover': {
+        color: palette.common.black,
       },
 
       '&:hover:not($selected)': {
@@ -71,13 +81,12 @@ export default ({ sizes, palette, shadows }: Theme) =>
       },
 
       '& $wrapper': {
-        marginLeft: '1em',
-        marginRight: '2em',
-        alignItems: 'flex-start',
+        display: 'block',
       },
     },
     selected: {
       '&$vertical': {
+        color: palette.common.black,
         boxShadow: shadows[1],
         backgroundColor: palette.grey.lightest,
 

--- a/packages/picasso/src/TabDescription/TabDescription.tsx
+++ b/packages/picasso/src/TabDescription/TabDescription.tsx
@@ -1,0 +1,30 @@
+import React from 'react'
+import { makeStyles, Theme } from '@material-ui/core/styles'
+
+import TypographyOverflow from '../TypographyOverflow'
+import styles from './styles'
+
+interface Props {
+  children: string
+  disabled?: boolean
+}
+
+const useStyles = makeStyles<Theme>(styles, { name: 'PicassoTabDescription' })
+
+const TabDescription = ({ children, disabled }: Props) => {
+  const classes = useStyles()
+  const color = disabled ? 'inherit' : undefined
+
+  return (
+    <TypographyOverflow
+      className={classes.root}
+      size='xxsmall'
+      inline
+      color={color}
+    >
+      {children}
+    </TypographyOverflow>
+  )
+}
+
+export default TabDescription

--- a/packages/picasso/src/TabDescription/index.ts
+++ b/packages/picasso/src/TabDescription/index.ts
@@ -1,0 +1,1 @@
+export { default } from './TabDescription'

--- a/packages/picasso/src/TabDescription/styles.ts
+++ b/packages/picasso/src/TabDescription/styles.ts
@@ -1,0 +1,7 @@
+import { rem } from '@toptal/picasso-shared'
+
+export default {
+  root: {
+    marginTop: rem('2px'),
+  },
+}

--- a/packages/picasso/src/TabLabel/TabLabel.tsx
+++ b/packages/picasso/src/TabLabel/TabLabel.tsx
@@ -1,0 +1,35 @@
+import React from 'react'
+
+import TypographyOverflow from '../TypographyOverflow'
+import Typography from '../Typography'
+import toTitleCase from '../utils/to-title-case'
+
+interface Props {
+  label?: React.ReactNode
+  orientation: 'horizontal' | 'vertical'
+  titleCase?: boolean
+}
+
+const TabLabel = ({ label, orientation, titleCase }: Props) => {
+  if (orientation === 'horizontal') {
+    return (
+      <Typography as='div' size='small' weight='semibold' color='inherit'>
+        {titleCase ? toTitleCase(label) : label}
+      </Typography>
+    )
+  }
+
+  return (
+    <TypographyOverflow
+      variant='body'
+      size='medium'
+      weight='semibold'
+      inline
+      color='inherit'
+    >
+      {titleCase ? toTitleCase(label) : label}
+    </TypographyOverflow>
+  )
+}
+
+export default TabLabel

--- a/packages/picasso/src/TabLabel/TabLabel.tsx
+++ b/packages/picasso/src/TabLabel/TabLabel.tsx
@@ -21,11 +21,12 @@ const TabLabel = ({ label, orientation, titleCase }: Props) => {
 
   return (
     <TypographyOverflow
-      variant='body'
-      size='medium'
-      weight='semibold'
-      inline
+      as='div'
       color='inherit'
+      inline
+      size='medium'
+      variant='body'
+      weight='semibold'
     >
       {titleCase ? toTitleCase(label) : label}
     </TypographyOverflow>

--- a/packages/picasso/src/TabLabel/index.ts
+++ b/packages/picasso/src/TabLabel/index.ts
@@ -1,0 +1,1 @@
+export { default } from './TabLabel'

--- a/packages/picasso/src/Tabs/__snapshots__/test.tsx.snap
+++ b/packages/picasso/src/Tabs/__snapshots__/test.tsx.snap
@@ -99,7 +99,7 @@ exports[`Tabs renders in vertical orientation 1`] = `
               class="MuiTab-wrapper PicassoTab-wrapper"
             >
               <div
-                class="MuiTypography-root PicassoTypography-bodySmall PicassoTypography-inherit PicassoTypography-semibold MuiTypography-body1"
+                class="MuiTypography-root PicassoTypography-bodyMedium PicassoTypography-inherit PicassoTypography-semibold TypographyOverflow-wrapper TypographyOverflow-singleLine MuiTypography-body1 MuiTypography-noWrap MuiTypography-displayInline"
               >
                 Tab 1
               </div>
@@ -117,7 +117,7 @@ exports[`Tabs renders in vertical orientation 1`] = `
               class="MuiTab-wrapper PicassoTab-wrapper"
             >
               <div
-                class="MuiTypography-root PicassoTypography-bodySmall PicassoTypography-inherit PicassoTypography-semibold MuiTypography-body1"
+                class="MuiTypography-root PicassoTypography-bodyMedium PicassoTypography-inherit PicassoTypography-semibold TypographyOverflow-wrapper TypographyOverflow-singleLine MuiTypography-body1 MuiTypography-noWrap MuiTypography-displayInline"
               >
                 Tab 2
               </div>

--- a/packages/picasso/src/Tabs/story/Vertical.example.tsx
+++ b/packages/picasso/src/Tabs/story/Vertical.example.tsx
@@ -1,5 +1,34 @@
 import React from 'react'
 import { Container, Tabs } from '@toptal/picasso'
+import { shadows, sizes, palette } from '@toptal/picasso/utils'
+
+type TabPanelProps = {
+  children: React.ReactNode
+  value: number
+  index: number
+}
+const TabPanel = ({ children, value, index }: TabPanelProps) => (
+  <Container role='tabpanel' hidden={value !== index}>
+    {children}
+  </Container>
+)
+
+// This component is not from BASE, just an example how it can be used
+const TabsContent = ({ children }: { children: React.ReactNode }) => {
+  return (
+    <Container
+      style={{
+        flex: '1 1 auto',
+        backgroundColor: palette.grey.lightest,
+        boxShadow: shadows[1],
+        borderRadius: sizes.borderRadius.medium,
+      }}
+      padded='small'
+    >
+      {children}
+    </Container>
+  )
+}
 
 const Example = () => {
   const [value, setValue] = React.useState(0)
@@ -9,22 +38,45 @@ const Example = () => {
   }
 
   return (
-    <Container flex>
-      <Tabs value={value} orientation='vertical' onChange={handleChange}>
-        <Tabs.Tab label='Jobs' />
-        <Tabs.Tab label='Engagements' />
-        <Tabs.Tab label='Interviews' />
+    <Container
+      style={{
+        backgroundColor: palette.grey.lighter,
+      }}
+      padded='small'
+      flex
+    >
+      <Tabs onChange={handleChange} orientation='vertical' value={value}>
+        <Tabs.Tab
+          avatar='./jacqueline-with-flowers-1954-square.jpg'
+          description='UI specialist'
+          label='Jacqueline Roque'
+        />
+        <Tabs.Tab
+          avatar='./jacqueline-with-flowers-1954-square.jpg'
+          description='UI specialist'
+          label='Jacqueline Roque'
+        />
+        <Tabs.Tab
+          avatar=''
+          description='UI specialist'
+          label='Jacqueline Roque'
+        />
+        <Tabs.Tab avatar={null} description='UI specialist' label='John Doe' />
       </Tabs>
-
-      {value === 0 && (
-        <Container left='small'>Content of the first tab</Container>
-      )}
-      {value === 1 && (
-        <Container left='small'>Content of the second tab</Container>
-      )}
-      {value === 2 && (
-        <Container left='small'>Content of the third tab</Container>
-      )}
+      <TabsContent>
+        <TabPanel value={value} index={0}>
+          Content of the first tab
+        </TabPanel>
+        <TabPanel value={value} index={1}>
+          Content of the second tab
+        </TabPanel>
+        <TabPanel value={value} index={2}>
+          Content of the third tab
+        </TabPanel>
+        <TabPanel value={value} index={3}>
+          Content of the third tab
+        </TabPanel>
+      </TabsContent>
     </Container>
   )
 }

--- a/packages/picasso/src/Tabs/story/index.jsx
+++ b/packages/picasso/src/Tabs/story/index.jsx
@@ -1,3 +1,4 @@
+import { Tabs } from '../Tabs'
 import tabStory from '../../Tab/story'
 import PicassoBook from '~/.storybook/components/PicassoBook'
 

--- a/packages/picasso/src/Tabs/story/index.jsx
+++ b/packages/picasso/src/Tabs/story/index.jsx
@@ -1,4 +1,3 @@
-import { Tabs } from '../Tabs'
 import tabStory from '../../Tab/story'
 import PicassoBook from '~/.storybook/components/PicassoBook'
 
@@ -8,17 +7,17 @@ const page = PicassoBook.section('Layout').createPage(
   Tabs allow to switch between content sections
 
   ${PicassoBook.createBaseDocsLink(
-    'https://share.goabstract.com/7263b996-174b-4d0c-b5aa-22344bfba249?mode=build&sha=baf4205fe8e730f6bc50c064446103ccc8c988f1'
+    'https://www.figma.com/file/5SCTOPrCDcHuk5We091GBn/Product-Library?node-id=246%3A11213'
   )}
 
   ${PicassoBook.createSourceLink(__filename)}
   `
 )
 
-page
-  .createTabChapter('Props')
-  .addComponentDocs({ component: Tabs, name: 'Tabs' })
-  .addComponentDocs(tabStory.componentDocs)
+// page
+//   .createTabChapter('Props')
+//   .addComponentDocs({ component: Tabs, name: 'Tabs' })
+//   .addComponentDocs(tabStory.componentDocs)
 
 page
   .createChapter()
@@ -28,7 +27,8 @@ page
   })
   .addExample('Tabs/story/Vertical.example.tsx', {
     title: 'Vertical',
-    takeScreenshot: true,
+    takeScreenshot: false,
+    description: '⚠️ Not responsive',
   })
   .addExample('Tabs/story/ScrollButtons.example.tsx', {
     title: 'Scroll buttons',

--- a/packages/picasso/src/Tabs/story/index.jsx
+++ b/packages/picasso/src/Tabs/story/index.jsx
@@ -14,10 +14,10 @@ const page = PicassoBook.section('Layout').createPage(
   `
 )
 
-// page
-//   .createTabChapter('Props')
-//   .addComponentDocs({ component: Tabs, name: 'Tabs' })
-//   .addComponentDocs(tabStory.componentDocs)
+page
+  .createTabChapter('Props')
+  .addComponentDocs({ component: Tabs, name: 'Tabs' })
+  .addComponentDocs(tabStory.componentDocs)
 
 page
   .createChapter()

--- a/packages/picasso/src/Tabs/styles.ts
+++ b/packages/picasso/src/Tabs/styles.ts
@@ -8,6 +8,8 @@ PicassoProvider.override(({ palette }: Theme) => ({
       minHeight: 0,
     },
     vertical: {
+      width: 200,
+      margin: 0,
       '& $scroller': {
         // We need a bit of padding to allow active tab's shadow to be visible
         paddingLeft: '0.5em',

--- a/packages/picasso/src/utils/index.ts
+++ b/packages/picasso/src/utils/index.ts
@@ -20,6 +20,7 @@ export {
   colors as palette,
   generateRandomString,
   generateRandomStringOrGetEmptyInTest,
+  sizes,
 } from '@toptal/picasso-provider'
 export { useIsomorphicLayoutEffect, isBrowser } from '@toptal/picasso-shared'
 


### PR DESCRIPTION
[FX-3140]

### Description

- enhance `Tabs.Tab` with `description` and `avatar` as we agreed in [the RFC](https://github.com/toptal/picasso/blob/master/docs/decisions/12-vertical-tabs.md)
- update styles to comply with [BASE](https://www.figma.com/file/5SCTOPrCDcHuk5We091GBn/Product-Library?node-id=238%3A10918&t=9yzEloERLafMAVal-0)
- showcase all possible states [in the storybook](https://picasso.toptal.net/fx-3220-vertical-tab-item/?path=/story/layout-tabs--tabs#tabs-tab-vertical-tab)
- showcase possible real usage example [in the storybook](https://picasso.toptal.net/fx-3220-vertical-tab-item/?path=/story/layout-tabs--tabs#vertical) (It is just an example, it will not be in BASE)

### How to test

- I tried to use atomic commits, if you find the PR too big, try to review commit by commit 🙇 
- compare examples in the storybook with the design
- check Happo screenshots

![image](https://user-images.githubusercontent.com/6830426/202293385-5c9ec22c-f5e1-4611-a067-b9d2ebac5407.png)

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-3140]: https://toptal-core.atlassian.net/browse/FX-3140?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ