### PR TITLE
chore: run danger check when PR title changes

### DIFF
--- a/.github/workflows/danger.yaml
+++ b/.github/workflows/danger.yaml
@@ -1,0 +1,28 @@
+name: Danger
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited]
+    branches: [master]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  danger:
+    name: Check
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.TOPTAL_DEVBOT_TOKEN }}
+    if: ${{ github.event.pull_request.head.ref != 'changeset-release/master' }}
+    steps:
+      - name: Checkout project
+        uses: actions/checkout@v3
+
+      - name: Setup node
+        uses: actions/setup-node@v3
+
+      - uses: toptal/davinci-github-actions/yarn-install@v4.4.1
+
+      - uses: toptal/davinci-github-actions/danger@v4.4.1

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -62,11 +62,6 @@ jobs:
 
       - uses: toptal/davinci-github-actions/yarn-install@v4.4.1
 
-      - name: Danger
-        env:
-          GITHUB_TOKEN: ${{ env.TOPTAL_DEVBOT_TOKEN }}
-        run: yarn davinci-ci danger
-
       - name: Syncpack check
         run: yarn syncpack:list
 


### PR DESCRIPTION
### Description

This change was [introduced in davinci](https://github.com/toptal/davinci/pull/1669) some time back, its time to move it [also to picasso](https://github.com/toptal/davinci/pull/1669#pullrequestreview-1144088998)

> Sometimes you generate your PR with incorrect title. But because Danger was until now part of PR checks workflow, which runs only when PR new changes are pushed into the PR, changing the title wouldn't resolve the danger failure.
This PR yanks the danger job into separate PR that runs even when PR is edited.

### How to test

- CI should be green
- You can try to edit title of this PR

### Development checks

- Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- Make sure that additions and changes on design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- Annotate all `props` in component with documentation
- Create `examples` for component
- Ensure that deployed demo has expected results and good examples
- Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- Covered with tests

**Breaking change**

- codemod is created and showcased in the changeset
- test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>
