### PR TITLE
chore: remove run from happo command

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "generate:component": "davinci-code new component",
     "generate:example": "davinci-code new example",
     "generate:icons": "./bin/generate-icons",
-    "happo": "cross-env TEST_ENV=visual happo run",
+    "happo": "cross-env TEST_ENV=visual happo",
     "happo:storybook": "cross-env TEST_ENV=visual HAPPO_IS_ASYNC=false happo-ci-github-actions",
     "lint": "davinci-syntax lint code .",
     "release": "yarn build:package && changeset publish",


### PR DESCRIPTION
[no-jira]

### Description

This PR is about unblocking happo reports on master branch and removing `run` from the `happo` command to enable using `compare` like `yarn happo compare <sha1> <sha2>`

### How to test

- CI should be green except happo reports

### Screenshots

no visual changes
