### PR TITLE
feat(NotificationsProvider): provide maxNotifications props

### DIFF
--- a/.changeset/warm-berries-sleep.md
+++ b/.changeset/warm-berries-sleep.md
@@ -1,0 +1,7 @@
+---
+'@toptal/picasso-provider': minor
+---
+
+### NotificationsProvider
+
+- Add `maxNotifications` prop

--- a/packages/picasso-provider/src/Picasso/NotificationsProvider/NotificationsProvider.tsx
+++ b/packages/picasso-provider/src/Picasso/NotificationsProvider/NotificationsProvider.tsx
@@ -9,15 +9,20 @@ const useStyles = makeStyles<Theme>(styles, {
   name: 'PicassoNotificationsProvider',
 })
 
-const MAX_NOTIFICATION_MESSAGES = 5
-
-interface Props {
+export interface NotificationsProviderProps {
   /** Notification DOMNode for createPortal */
   children: React.ReactNode
+  /** Valid HTML Node element, used to target `ReactDOM.createPortal`.*/
   container?: HTMLElement
+  /** Maximum notifications that can be stacked on top of one another.   */
+  maxNotifications?: 1 | 2 | 3 | 4 | 5
 }
 
-const NotificationsProvider = ({ children, container }: Props) => {
+const NotificationsProvider = ({
+  children,
+  container,
+  maxNotifications = 5,
+}: NotificationsProviderProps) => {
   const { hasTopBar } = usePageTopBar()
   const classes = useStyles()
 
@@ -27,7 +32,7 @@ const NotificationsProvider = ({ children, container }: Props) => {
 
   return (
     <SnackbarProvider
-      maxSnack={MAX_NOTIFICATION_MESSAGES}
+      maxSnack={maxNotifications}
       domRoot={container}
       classes={{
         containerRoot: classes.root,

--- a/packages/picasso-provider/src/Picasso/NotificationsProvider/index.ts
+++ b/packages/picasso-provider/src/Picasso/NotificationsProvider/index.ts
@@ -1,1 +1,1 @@
-export { default } from './NotificationsProvider'
+export { default, NotificationsProviderProps } from './NotificationsProvider'

--- a/packages/picasso-provider/src/Picasso/NotificationsProvider/test.tsx
+++ b/packages/picasso-provider/src/Picasso/NotificationsProvider/test.tsx
@@ -1,0 +1,54 @@
+import React, { PropsWithChildren } from 'react'
+import { render, screen, fireEvent } from '@toptal/picasso/test-utils'
+import { useNotifications } from '@toptal/picasso/utils'
+import { Button } from '@material-ui/core'
+
+import NotificationsProvider from './'
+import type { NotificationsProviderProps } from './'
+
+const App = ({ children }: PropsWithChildren<{}>) => {
+  const { showInfo } = useNotifications()
+  const handleClick = () => {
+    for (let index = 0; index < 6; index++) {
+      showInfo('Notification')
+    }
+  }
+
+  return (
+    <>
+      {children}
+      <Button onClick={handleClick}>Open notification</Button>
+    </>
+  )
+}
+
+const renderNotificationsProvider = ({
+  children,
+  ...restProps
+}: NotificationsProviderProps) => {
+  return render(
+    <NotificationsProvider {...restProps}>
+      <App>{children}</App>
+    </NotificationsProvider>
+  )
+}
+
+describe('NotificationsProvider', () => {
+  it('default number of max notifications', () => {
+    renderNotificationsProvider({ children: 'children' })
+    fireEvent.click(screen.getByRole('button'))
+
+    const notifications = screen.getAllByText('Notification')
+
+    expect(notifications).toHaveLength(5)
+  })
+
+  it('show custom number of max notifications', () => {
+    renderNotificationsProvider({ children: 'children', maxNotifications: 2 })
+    fireEvent.click(screen.getByRole('button'))
+
+    const notifications = screen.getAllByText('Notification')
+
+    expect(notifications).toHaveLength(2)
+  })
+})

--- a/packages/picasso-provider/src/Picasso/index.ts
+++ b/packages/picasso-provider/src/Picasso/index.ts
@@ -2,4 +2,7 @@ export { default } from './Picasso'
 export { default as PicassoLight } from './PicassoLight'
 export { default as FontsLoader } from './FontsLoader'
 export { default as FixViewport } from './FixViewport'
-export { default as NotificationsProvider } from './NotificationsProvider'
+export {
+  default as NotificationsProvider,
+  NotificationsProviderProps,
+} from './NotificationsProvider'

--- a/packages/picasso-provider/src/index.ts
+++ b/packages/picasso-provider/src/index.ts
@@ -3,6 +3,7 @@ export {
   FixViewport,
   FontsLoader,
   NotificationsProvider,
+  NotificationsProviderProps,
   PicassoLight,
 } from './Picasso'
 

--- a/packages/picasso/src/utils/Notifications/story/CustomPosition.example.tsx
+++ b/packages/picasso/src/utils/Notifications/story/CustomPosition.example.tsx
@@ -1,0 +1,31 @@
+import React from 'react'
+import { Button, Notification } from '@toptal/picasso'
+import { useNotifications } from '@toptal/picasso/utils'
+
+const Example = () => {
+  const { showCustom } = useNotifications()
+
+  const customNotification = (
+    <Notification elevated variant='white'>
+      Message
+    </Notification>
+  )
+
+  return (
+    <Button
+      variant='secondary'
+      onClick={() =>
+        showCustom(customNotification, {
+          anchorOrigin: {
+            vertical: 'bottom',
+            horizontal: 'center',
+          },
+        })
+      }
+    >
+      Show custom notification
+    </Button>
+  )
+}
+
+export default Example

--- a/packages/picasso/src/utils/Notifications/story/MaxNotifications.example.tsx
+++ b/packages/picasso/src/utils/Notifications/story/MaxNotifications.example.tsx
@@ -1,0 +1,64 @@
+import React, { useState } from 'react'
+import { NotificationsProvider } from '@toptal/picasso-provider'
+import type { NotificationsProviderProps } from '@toptal/picasso-provider'
+import { Button, Slider, Typography, Container } from '@toptal/picasso'
+import { useNotifications } from '@toptal/picasso/utils'
+
+const App = () => {
+  const { showInfo } = useNotifications()
+  const handleClick = () => {
+    showInfo('Message')
+  }
+
+  return <Button onClick={handleClick}>Open notification</Button>
+}
+
+const Example = () => {
+  const [maxNotifications, setMaxNotifications] =
+    useState<NotificationsProviderProps['maxNotifications']>(1)
+  const [notificationContainer, setNotificationContainer] =
+    useState<HTMLDivElement | null>(null)
+
+  const handleChange = (
+    _: React.ChangeEvent<{}>,
+    newValue: number | number[]
+  ) => {
+    setMaxNotifications(
+      Number(newValue) as NotificationsProviderProps['maxNotifications']
+    )
+  }
+
+  return (
+    <div style={{ width: 500 }}>
+      <Container bottom={2}>
+        <Container bottom={2}>
+          <Typography variant='heading' size='small'>
+            maxNotifications
+          </Typography>
+        </Container>
+
+        <Slider
+          defaultValue={maxNotifications}
+          min={1}
+          max={5}
+          tooltip='on'
+          compact
+          marks
+          onChange={handleChange}
+        />
+      </Container>
+
+      {notificationContainer && (
+        <NotificationsProvider
+          maxNotifications={maxNotifications}
+          container={notificationContainer}
+        >
+          <App />
+        </NotificationsProvider>
+      )}
+      <div data-testid='notifications' ref={setNotificationContainer} />
+    </div>
+  )
+}
+
+export default Example

--- a/packages/picasso/src/utils/Notifications/story/index.jsx
+++ b/packages/picasso/src/utils/Notifications/story/index.jsx
@@ -69,6 +69,14 @@ Each of them has this list of props:
       title: 'Custom',
       takeScreenshot: false,
     })
+    .addExample('utils/Notifications/story/CustomPosition.example.tsx', {
+      title: 'Custom Position',
+      takeScreenshot: false,
+    })
+    .addExample('utils/Notifications/story/MaxNotifications.example.tsx', {
+      title: 'MaxNotifications',
+      takeScreenshot: false,
+    })
 )
 
 export default {


### PR DESCRIPTION
[TDESKAPP-967]

### Description

Expose `maxSnack` from internal `SnackbarProvider` as `maxNotifications`.

More details https://toptal-core.slack.com/archives/CERF5NHT3/p1668017294156079.

### How to test

- run `yarn start`
- got to http://localhost:9001/?path=/story/components-notificationsprovider--notificationsprovider
 
### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
|  | ![image](https://user-images.githubusercontent.com/3688905/202464782-7a9e0ea5-0e47-4f0b-978a-84315a09d728.png) |


### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests

**Breaking change**

- [x] codemod is created and showcased in the changeset
- [x] test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[TDESKAPP-967]: https://toptal-core.atlassian.net/browse/TDESKAPP-967?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ