### PR TITLE
feat(SidebarItem): add `tag` prop

### DIFF
--- a/.changeset/few-wasps-sip.md
+++ b/.changeset/few-wasps-sip.md
@@ -1,0 +1,28 @@
+---
+'@toptal/picasso': major
+---
+
+---
+
+### Page.SidebarItem
+
+- add the new prop `tag` to display a new feature in the sidebar
+
+```jsx
+<Page.Sidebar.Item tag='New'>Label</Page.Sidebar.Item>
+<Page.Sidebar.Item tag={{ content: 'New', ...otherTagProps }}>Label</Page.Sidebar.Item>
+```
+
+- update `badge` prop to also support `number` as it is the most common way of the usage
+- the badge is now aligned to the right
+
+```jsx
+<Page.Sidebar.Item badge={5}>Label</Page.Sidebar.Item>
+```
+
+#### BREAKING CHANGES
+- sidebar item with a submenu (parent)
+  - will not display a `badge` or `tag` (**BREAKING CHANGE**)
+  - will display an indicator when any hidden child item has a `badge` or `tag`
+- submenu items will no longer display an icon (**BREAKING CHANGE**)
+

--- a/cypress/component/PageSidebar.spec.tsx
+++ b/cypress/component/PageSidebar.spec.tsx
@@ -60,17 +60,17 @@ const SidebarExample = (props: PageSidebarProps) => {
         >
           Team
         </Page.Sidebar.Item>
+        <Page.Sidebar.Item icon={<Team16 />} badge={10}>
+          Team
+        </Page.Sidebar.Item>
         <Page.Sidebar.Item
           icon={<Referral16 />}
           menu={
             <Page.Sidebar.Menu data-testid={TestIds.BASIC_MENU_INNER_MENU}>
-              <Page.Sidebar.Item>Foo </Page.Sidebar.Item>
-              <Page.Sidebar.Item>Bar </Page.Sidebar.Item>
+              <Page.Sidebar.Item badge={10}>Foo </Page.Sidebar.Item>
+              <Page.Sidebar.Item>Bar</Page.Sidebar.Item>
             </Page.Sidebar.Menu>
           }
-          badge={{
-            content: 10,
-          }}
         >
           Referral
         </Page.Sidebar.Item>
@@ -82,8 +82,25 @@ const SidebarExample = (props: PageSidebarProps) => {
             <Page.Sidebar.Menu
               data-testid={TestIds.COLLAPSIBLE_MENU_INNER_MENU}
             >
-              <Page.Sidebar.Item>Foo </Page.Sidebar.Item>
-              <Page.Sidebar.Item>Bar </Page.Sidebar.Item>
+              <Page.Sidebar.Item>Foo</Page.Sidebar.Item>
+              <Page.Sidebar.Item>Bar</Page.Sidebar.Item>
+            </Page.Sidebar.Menu>
+          }
+        >
+          Collapsible
+        </Page.Sidebar.Item>
+        <Page.Sidebar.Item
+          icon={<Referral16 />}
+          testIds={{ header: TestIds.COLLAPSIBLE_MENU_HEADER }}
+          collapsible
+          menu={
+            <Page.Sidebar.Menu
+              data-testid={TestIds.COLLAPSIBLE_MENU_INNER_MENU}
+            >
+              <Page.Sidebar.Item>Foo</Page.Sidebar.Item>
+              <Page.Sidebar.Item badge={10} tag='New'>
+                Bar
+              </Page.Sidebar.Item>
             </Page.Sidebar.Menu>
           }
         >
@@ -148,7 +165,7 @@ describe('Sidebar', () => {
   it('renders sidebar as dark and light variants', () => {
     cy.mount(<VariantsExample />)
 
-    cy.get('body').happoScreenshot({ component, variant: 'with-theme'})
+    cy.get('body').happoScreenshot({ component, variant: 'with-theme' })
   })
 
   describe('when the sidebar is collapsible', () => {
@@ -158,7 +175,10 @@ describe('Sidebar', () => {
       // Expand collapsible Menu
       cy.getByTestId(TestIds.COLLAPSIBLE_MENU_HEADER).realClick()
 
-      cy.get('body').happoScreenshot({ component, variant: 'expanded accordion menu' })
+      cy.get('body').happoScreenshot({
+        component,
+        variant: 'expanded accordion menu',
+      })
 
       // Collapse sidebar
       cy.getByTestId(TestIds.SIDEBAR_CONTAINER).realHover()
@@ -167,12 +187,18 @@ describe('Sidebar', () => {
       cy.getByTestId(TestIds.SIDEBAR_COLLAPSE_BUTTON).should('not.be.visible')
       cy.getByTestId(TestIds.SIDEBAR_CONTAINER).realHover()
 
-      cy.get('body').happoScreenshot({ component, variant: 'collapsed sidebar default' })
+      cy.get('body').happoScreenshot({
+        component,
+        variant: 'collapsed sidebar default',
+      })
 
       // Open collapsible Menu as dropdown
       cy.getByTestId(TestIds.COLLAPSIBLE_MENU_HEADER).realClick()
 
-      cy.get('body').happoScreenshot({ component, variant: 'open dropdown menu' })
+      cy.get('body').happoScreenshot({
+        component,
+        variant: 'open dropdown menu',
+      })
 
       // Expand collapsed sidebar
       cy.getByTestId(TestIds.SIDEBAR_CONTAINER).realHover()

--- a/packages/picasso/src/MenuItem/styles.ts
+++ b/packages/picasso/src/MenuItem/styles.ts
@@ -111,6 +111,7 @@ export default ({ typography, palette, shadows }: Theme) =>
     },
     itemWrapper: {
       flex: 1,
+      maxWidth: '100%',
     },
     content: {
       flex: 1,

--- a/packages/picasso/src/SidebarItem/ParentItemContextProvider.tsx
+++ b/packages/picasso/src/SidebarItem/ParentItemContextProvider.tsx
@@ -1,0 +1,46 @@
+import React, { createContext, useContext, ReactNode, useState } from 'react'
+
+export interface ContextProps {
+  /**
+   * Render indicator on the parent item
+   * when some of children has badge or tag rendered
+   */
+  isIndicatorVisible: boolean
+  /**
+   * When submenu item with badge or tag is mounted
+   */
+  handleDecoratedItemMount: () => void
+  /**
+   * When submenu item with badge or tag is unmounted
+   */
+  handleDecoratedItemUnmount: () => void
+}
+
+const Context = createContext<ContextProps>({
+  isIndicatorVisible: false,
+  handleDecoratedItemMount: () => {},
+  handleDecoratedItemUnmount: () => {},
+})
+
+export interface Props {
+  children?: ReactNode
+  isOpened: boolean
+}
+
+export const ParentItemContextProvider = ({ children, isOpened }: Props) => {
+  const [countItemsWithBadgeOrTag, updateCount] = useState(0)
+
+  const isIndicatorVisible = countItemsWithBadgeOrTag > 0 && !isOpened
+  const handleDecoratedItemMount = () => updateCount(count => count + 1)
+  const handleDecoratedItemUnmount = () => updateCount(count => count - 1)
+
+  const value = {
+    isIndicatorVisible,
+    handleDecoratedItemMount,
+    handleDecoratedItemUnmount,
+  }
+
+  return <Context.Provider value={value}>{children}</Context.Provider>
+}
+
+export const useParentItemContext = () => useContext(Context)

--- a/packages/picasso/src/SidebarItem/SidebarItemAccordion.tsx
+++ b/packages/picasso/src/SidebarItem/SidebarItemAccordion.tsx
@@ -6,6 +6,7 @@ import Accordion from '../Accordion'
 import { ArrowDownMinor16 } from '../Icon'
 import styles from './styles'
 import { SubMenuContextProvider } from './SubMenuContextProvider'
+import { ParentItemContextProvider } from './ParentItemContextProvider'
 import { Props } from './types'
 import { SidebarItemHeader } from './SidebarItemHeader'
 
@@ -25,16 +26,13 @@ export const SidebarItemAccordion = forwardRef<HTMLElement, Props>(
       icon,
       compact,
     } = props
-
     const classes = useStyles()
 
     const handleAccordionChange = useCallback(
       (event: ChangeEvent<{}>, isAccordionExpanded: boolean) => {
         event.stopPropagation()
 
-        if (isAccordionExpanded) {
-          expand?.(index ?? null)
-        }
+        expand?.((isAccordionExpanded && index) || null)
       },
       [index, expand]
     )
@@ -49,26 +47,32 @@ export const SidebarItemAccordion = forwardRef<HTMLElement, Props>(
     )
 
     return (
-      <Accordion
-        onChange={handleAccordionChange}
-        classes={{
-          summary: classes.collapsibleWrapper,
-          content: classes.content,
-        }}
-        content={content}
-        borders='none'
-        disabled={disabled}
-        expanded={isExpanded}
-        expandIcon={
-          <ArrowDownMinor16
-            className={cx(classes.expandIcon, classes[`${variant}ExpandIcon`], {
-              [classes.expandIconDisabled]: disabled,
-            })}
-          />
-        }
-      >
-        <SidebarItemHeader {...props} ref={ref} />
-      </Accordion>
+      <ParentItemContextProvider isOpened={isExpanded || false}>
+        <Accordion
+          onChange={handleAccordionChange}
+          classes={{
+            summary: classes.collapsibleWrapper,
+            content: classes.content,
+          }}
+          content={content}
+          borders='none'
+          disabled={disabled}
+          expanded={isExpanded}
+          expandIcon={
+            <ArrowDownMinor16
+              className={cx(
+                classes.expandIcon,
+                classes[`${variant}ExpandIcon`],
+                {
+                  [classes.expandIconDisabled]: disabled,
+                }
+              )}
+            />
+          }
+        >
+          <SidebarItemHeader {...props} ref={ref} />
+        </Accordion>
+      </ParentItemContextProvider>
     )
   }
 )

--- a/packages/picasso/src/SidebarItem/SidebarItemCompact.tsx
+++ b/packages/picasso/src/SidebarItem/SidebarItemCompact.tsx
@@ -7,6 +7,8 @@ import { SidebarItemHeader } from './SidebarItemHeader'
 import { SubMenuContextProvider } from './SubMenuContextProvider'
 import { Props } from './types'
 import styles from './styles'
+import { ParentItemContextProvider } from './ParentItemContextProvider'
+import useOpen from '../utils/useBoolean'
 
 const useStyles = makeStyles<Theme>(styles, {
   name: 'PicassoSidebarItemCompact',
@@ -15,7 +17,7 @@ const useStyles = makeStyles<Theme>(styles, {
 export const SidebarItemCompact = forwardRef<HTMLElement, Props>(
   function CompactSidebarItem(props: Props, ref) {
     const { menu, index, compact, icon } = props
-
+    const [isOpened, handleOpen, handleClose] = useOpen()
     const classes = useStyles()
 
     const subMenu = (
@@ -28,15 +30,23 @@ export const SidebarItemCompact = forwardRef<HTMLElement, Props>(
     )
 
     return (
-      <Container left='small' right='small'>
-        <Dropdown
-          classes={{ popper: classes.compactDropdown }}
-          placement='right-start'
-          content={subMenu}
-        >
-          <SidebarItemHeader {...props} ref={ref} />
-        </Dropdown>
-      </Container>
+      <ParentItemContextProvider isOpened={isOpened}>
+        <Container left='small' right='small'>
+          <Dropdown
+            classes={{ popper: classes.compactDropdown }}
+            placement='right-start'
+            content={subMenu}
+            keepMounted
+            onOpen={handleOpen}
+            onClose={handleClose}
+            popperProps={{
+              role: 'menu',
+            }}
+          >
+            <SidebarItemHeader {...props} ref={ref} />
+          </Dropdown>
+        </Container>
+      </ParentItemContextProvider>
     )
   }
 )

--- a/packages/picasso/src/SidebarItem/SidebarItemHeader.tsx
+++ b/packages/picasso/src/SidebarItem/SidebarItemHeader.tsx
@@ -7,6 +7,8 @@ import SidebarItemContent from '../SidebarItemContent'
 import styles from './styles'
 import { Props } from './types'
 import { useSubMenuContext } from './SubMenuContextProvider'
+import getBadgeProps from './utils/getBadgeProps/getBadgeProps'
+import getTagProps from './utils/getTagProps/getTagProps'
 
 const useStyles = makeStyles<Theme>(styles, {
   name: 'PicassoSidebarItemHeader',
@@ -29,6 +31,7 @@ export const SidebarItemHeader = forwardRef<HTMLElement, Props>(
       icon,
       isSubMenu,
       badge,
+      tag,
       isExpanded,
       expand,
       index,
@@ -82,7 +85,11 @@ export const SidebarItemHeader = forwardRef<HTMLElement, Props>(
         nonSelectable
         data-testid={testIds?.header}
       >
-        <SidebarItemContent {...props} />
+        <SidebarItemContent
+          {...props}
+          badge={getBadgeProps(badge)}
+          tag={getTagProps(tag)}
+        />
       </MenuItem>
     )
   }

--- a/packages/picasso/src/SidebarItem/__snapshots__/test.tsx.snap
+++ b/packages/picasso/src/SidebarItem/__snapshots__/test.tsx.snap
@@ -45,7 +45,7 @@ exports[`SidebarItem collapsible menu is expanded when one of the children is se
                       class="PicassoContainer-centerAlignItems PicassoContainer-flex"
                     >
                       <div
-                        class="PicassoContainer-centerAlignItems PicassoContainer-flex PicassoContainer-inline PicassoSidebarItemContent-noWrap"
+                        class="PicassoContainer-xsmallGap PicassoContainer-centerAlignItems PicassoContainer-flex PicassoContainer-inline PicassoSidebarItemContent-noWrap"
                       >
                         <div
                           class="PicassoContainer-centerAlignItems PicassoContainer-flex PicassoSidebarItemContent-noWrap"
@@ -109,7 +109,7 @@ exports[`SidebarItem collapsible menu is expanded when one of the children is se
                               class="PicassoContainer-centerAlignItems PicassoContainer-flex"
                             >
                               <div
-                                class="PicassoContainer-centerAlignItems PicassoContainer-flex PicassoContainer-inline PicassoSidebarItemContent-noWrap"
+                                class="PicassoContainer-xsmallGap PicassoContainer-centerAlignItems PicassoContainer-flex PicassoContainer-inline PicassoSidebarItemContent-noWrap"
                               >
                                 <div
                                   class="PicassoContainer-centerAlignItems PicassoContainer-flex PicassoSidebarItemContent-noWrap"
@@ -183,7 +183,7 @@ exports[`SidebarItem collapsible menu is expanded when one of the children is se
                       class="PicassoContainer-centerAlignItems PicassoContainer-flex"
                     >
                       <div
-                        class="PicassoContainer-centerAlignItems PicassoContainer-flex PicassoContainer-inline PicassoSidebarItemContent-noWrap"
+                        class="PicassoContainer-xsmallGap PicassoContainer-centerAlignItems PicassoContainer-flex PicassoContainer-inline PicassoSidebarItemContent-noWrap"
                       >
                         <div
                           class="PicassoContainer-centerAlignItems PicassoContainer-flex PicassoSidebarItemContent-noWrap"
@@ -247,7 +247,7 @@ exports[`SidebarItem collapsible menu is expanded when one of the children is se
                               class="PicassoContainer-centerAlignItems PicassoContainer-flex"
                             >
                               <div
-                                class="PicassoContainer-centerAlignItems PicassoContainer-flex PicassoContainer-inline PicassoSidebarItemContent-noWrap"
+                                class="PicassoContainer-xsmallGap PicassoContainer-centerAlignItems PicassoContainer-flex PicassoContainer-inline PicassoSidebarItemContent-noWrap"
                               >
                                 <div
                                   class="PicassoContainer-centerAlignItems PicassoContainer-flex PicassoSidebarItemContent-noWrap"
@@ -297,7 +297,7 @@ exports[`SidebarItem don't use accordion for non-collapsible with menu 1`] = `
             class="PicassoContainer-centerAlignItems PicassoContainer-flex"
           >
             <div
-              class="PicassoContainer-centerAlignItems PicassoContainer-flex PicassoContainer-inline PicassoSidebarItemContent-noWrap"
+              class="PicassoContainer-xsmallGap PicassoContainer-centerAlignItems PicassoContainer-flex PicassoContainer-inline PicassoSidebarItemContent-noWrap"
             >
               <svg
                 class="PicassoSvgCandidates16-root"
@@ -344,7 +344,7 @@ exports[`SidebarItem don't use accordion for non-collapsible with menu 1`] = `
                 class="PicassoContainer-centerAlignItems PicassoContainer-flex"
               >
                 <div
-                  class="PicassoContainer-centerAlignItems PicassoContainer-flex PicassoContainer-inline PicassoSidebarItemContent-noWrap"
+                  class="PicassoContainer-xsmallGap PicassoContainer-centerAlignItems PicassoContainer-flex PicassoContainer-inline PicassoSidebarItemContent-noWrap"
                 >
                   <div
                     class="PicassoContainer-centerAlignItems PicassoContainer-flex PicassoSidebarItemContent-noWrap"
@@ -387,7 +387,7 @@ exports[`SidebarItem is selected 1`] = `
             class="PicassoContainer-centerAlignItems PicassoContainer-flex"
           >
             <div
-              class="PicassoContainer-centerAlignItems PicassoContainer-flex PicassoContainer-inline PicassoSidebarItemContent-noWrap"
+              class="PicassoContainer-xsmallGap PicassoContainer-centerAlignItems PicassoContainer-flex PicassoContainer-inline PicassoSidebarItemContent-noWrap"
             >
               <svg
                 class="PicassoSvgCandidates16-root"
@@ -437,7 +437,7 @@ exports[`SidebarItem renders 1`] = `
             class="PicassoContainer-centerAlignItems PicassoContainer-flex"
           >
             <div
-              class="PicassoContainer-centerAlignItems PicassoContainer-flex PicassoContainer-inline PicassoSidebarItemContent-noWrap"
+              class="PicassoContainer-xsmallGap PicassoContainer-centerAlignItems PicassoContainer-flex PicassoContainer-inline PicassoSidebarItemContent-noWrap"
             >
               <div
                 class="PicassoContainer-centerAlignItems PicassoContainer-flex PicassoSidebarItemContent-noWrap"
@@ -491,7 +491,7 @@ exports[`SidebarItem use accordion for collapsible with menu 1`] = `
                   class="PicassoContainer-centerAlignItems PicassoContainer-flex"
                 >
                   <div
-                    class="PicassoContainer-centerAlignItems PicassoContainer-flex PicassoContainer-inline PicassoSidebarItemContent-noWrap"
+                    class="PicassoContainer-xsmallGap PicassoContainer-centerAlignItems PicassoContainer-flex PicassoContainer-inline PicassoSidebarItemContent-noWrap"
                   >
                     <svg
                       class="PicassoSvgCandidates16-root"
@@ -564,7 +564,7 @@ exports[`SidebarItem use accordion for collapsible with menu 1`] = `
                           class="PicassoContainer-centerAlignItems PicassoContainer-flex"
                         >
                           <div
-                            class="PicassoContainer-centerAlignItems PicassoContainer-flex PicassoContainer-inline PicassoSidebarItemContent-noWrap"
+                            class="PicassoContainer-xsmallGap PicassoContainer-centerAlignItems PicassoContainer-flex PicassoContainer-inline PicassoSidebarItemContent-noWrap"
                           >
                             <div
                               class="PicassoContainer-centerAlignItems PicassoContainer-flex PicassoSidebarItemContent-noWrap"
@@ -612,7 +612,7 @@ exports[`SidebarItem with icon 1`] = `
             class="PicassoContainer-centerAlignItems PicassoContainer-flex"
           >
             <div
-              class="PicassoContainer-centerAlignItems PicassoContainer-flex PicassoContainer-inline PicassoSidebarItemContent-noWrap"
+              class="PicassoContainer-xsmallGap PicassoContainer-centerAlignItems PicassoContainer-flex PicassoContainer-inline PicassoSidebarItemContent-noWrap"
             >
               <svg
                 class="PicassoSvgCandidates16-root"

--- a/packages/picasso/src/SidebarItem/story/WithBadgeAndTag.example.tsx
+++ b/packages/picasso/src/SidebarItem/story/WithBadgeAndTag.example.tsx
@@ -1,0 +1,81 @@
+import React from 'react'
+import { Page, Container } from '@toptal/picasso'
+import {
+  Referrals16,
+  Overview16,
+  AddDocument16,
+  Afternoon16,
+  Award16,
+  BankWire16,
+  Bell16,
+} from '@toptal/picasso/Icon'
+
+const Menu = () => (
+  <Page.Sidebar.Menu>
+    <Page.Sidebar.Item icon={<Award16 />}>Overview</Page.Sidebar.Item>
+    <Page.Sidebar.Item badge={5} icon={<BankWire16 />}>
+      Jobs
+    </Page.Sidebar.Item>
+    <Page.Sidebar.Item tag='New' icon={<Afternoon16 />}>
+      Team
+    </Page.Sidebar.Item>
+    <Page.Sidebar.Item badge={5} tag='New' icon={<Bell16 />}>
+      Users
+    </Page.Sidebar.Item>
+    <Page.Sidebar.Item badge={5} tag='New' icon={<Bell16 />}>
+      Users With Very Long Label
+    </Page.Sidebar.Item>
+    <Page.Sidebar.Item
+      collapsible
+      icon={<Referrals16 />}
+      menu={
+        <Page.Sidebar.Menu>
+          <Page.Sidebar.Item badge={5}>
+            Referrals
+          </Page.Sidebar.Item>
+        </Page.Sidebar.Menu>
+      }
+    >
+      Referrals
+    </Page.Sidebar.Item>
+    <Page.Sidebar.Item
+      collapsible
+      icon={<Overview16 />}
+      menu={
+        <Page.Sidebar.Menu>
+          <Page.Sidebar.Item tag='New'>
+            Share Online
+          </Page.Sidebar.Item>
+        </Page.Sidebar.Menu>
+      }
+    >
+      Share Online
+    </Page.Sidebar.Item>
+    <Page.Sidebar.Item
+      collapsible
+      icon={<AddDocument16 />}
+      menu={
+        <Page.Sidebar.Menu>
+          <Page.Sidebar.Item badge={5} tag='New'>
+            Legal Info
+          </Page.Sidebar.Item>
+        </Page.Sidebar.Menu>
+      }
+    >
+      Legal Info
+    </Page.Sidebar.Item>
+  </Page.Sidebar.Menu>
+)
+
+const Example = () => (
+  <Container flex gap='small'>
+    <Page.Sidebar size='large'>
+      <Menu />
+    </Page.Sidebar>
+    <Page.Sidebar size='large' defaultCollapsed collapsible>
+      <Menu />
+    </Page.Sidebar>
+  </Container>
+)
+
+export default Example

--- a/packages/picasso/src/SidebarItem/story/index.jsx
+++ b/packages/picasso/src/SidebarItem/story/index.jsx
@@ -42,6 +42,15 @@ const componentDocs = PicassoBook.createComponentDocs(
       },
       description: 'Callback when item is clicked',
     },
+    onMouseEnter: {
+      name: 'onClick',
+      type: {
+        name: 'function',
+        description:
+          '(event: React.MouseEvent<HTMLElement, MouseEvent>) => void',
+      },
+      description: 'Callback when item is hovered',
+    },
     as: {
       name: 'as',
       type: {
@@ -81,6 +90,24 @@ const componentDocs = PicassoBook.createComponentDocs(
       name: 'style',
       type: 'CSSProperties',
       description: 'Style applied to root element',
+    },
+    badge: {
+      name: 'badge',
+      type: {
+        name: 'number | BadgeProps',
+        description:
+          '{ content: number, variant?: "white" | "red", max?: number }',
+      },
+      description: 'Show number of unread messages',
+    },
+    tag: {
+      name: 'tag',
+      type: {
+        name: 'string | TagProps',
+        description:
+          '{ content: string, variant?: "red" | "yellow" | "dark-grey" | "light-grey" | "green" }',
+      },
+      description: 'Highlight new feature',
     },
   }
 )

--- a/packages/picasso/src/SidebarItem/story/index.jsx
+++ b/packages/picasso/src/SidebarItem/story/index.jsx
@@ -105,6 +105,10 @@ Most of the time you would use Sidebar.Item as a router Link. This is how to do 
       description:
         'When a nested Sidebar.Item is selected, it automatically expands the menu.',
     })
+    .addExample(
+      'SidebarItem/story/WithBadgeAndTag.example.tsx',
+      'With Badge and Tag'
+    )
     .addExample('SidebarItem/story/Disabled.example.tsx', 'Disabled')
 )
 

--- a/packages/picasso/src/SidebarItem/styles.ts
+++ b/packages/picasso/src/SidebarItem/styles.ts
@@ -58,11 +58,11 @@ export default ({ palette, sizes }: Theme) =>
       margin: '0 1rem',
     },
     nestedMenu: {
-      padding: '0 0 0 2rem',
+      padding: '0 1rem 0 2rem',
       marginRight: '1rem',
     },
     nestedMenuWithIcon: {
-      padding: '0 0 0 2.875rem',
+      padding: '0 1rem 0 2.875rem',
       marginRight: '1rem',
     },
     content: {

--- a/packages/picasso/src/SidebarItem/types.ts
+++ b/packages/picasso/src/SidebarItem/types.ts
@@ -4,7 +4,7 @@ import { MenuItemProps } from '@material-ui/core/MenuItem'
 
 import { MenuItemAttributes } from '../MenuItem'
 import { VariantType } from '../PageSidebar/types'
-import { BadgeProps } from '../Badge'
+import { SidebarTagProps, SidebarBadgeProps } from '../SidebarItemContent/types'
 
 export interface Props extends BaseProps, TextLabelProps, MenuItemAttributes {
   /** Pass icon to be used as part of item */
@@ -20,7 +20,9 @@ export interface Props extends BaseProps, TextLabelProps, MenuItemAttributes {
   /** Component name to render the menu item as */
   as?: ElementType<MenuItemProps>
   /** Definition of the embedded badge  */
-  badge?: Omit<BadgeProps, 'size' | 'children'>
+  badge?: number | SidebarBadgeProps
+  /** Render Tag.Rectangular */
+  tag?: string | SidebarTagProps
   /** Callback when item is clicked */
   onClick?: (event: React.MouseEvent<HTMLElement, MouseEvent>) => void
   /** Callback when item is hovered */

--- a/packages/picasso/src/SidebarItem/utils/getBadgeProps/getBadgeProps.ts
+++ b/packages/picasso/src/SidebarItem/utils/getBadgeProps/getBadgeProps.ts
@@ -1,0 +1,11 @@
+import { SidebarBadgeProps } from '../../../SidebarItemContent'
+
+const getBadgeProps = (badge?: number | SidebarBadgeProps) => {
+  if (typeof badge === 'number') {
+    return { content: badge }
+  }
+
+  return badge
+}
+
+export default getBadgeProps

--- a/packages/picasso/src/SidebarItem/utils/getBadgeProps/test.ts
+++ b/packages/picasso/src/SidebarItem/utils/getBadgeProps/test.ts
@@ -1,0 +1,35 @@
+import getBadgeProps from './getBadgeProps'
+import { SidebarBadgeProps } from '../../../SidebarItemContent'
+
+describe('getBadgeProps', () => {
+  describe('when number value is passed', () => {
+    it.each([0, 9, 50, 9999])(
+      'returns object with the value in content property',
+      value => {
+        const props = getBadgeProps(value)
+
+        expect(props).toEqual({ content: value })
+      }
+    )
+  })
+  describe('when falsy input is passed', () => {
+    it('returns the same value', () => {
+      const value = undefined
+      const props = getBadgeProps(value)
+
+      expect(props).toEqual(value)
+    })
+  })
+  describe('when badge props object is passed', () => {
+    const values: SidebarBadgeProps[] = [
+      { content: 5 },
+      { content: 0, max: 10, variant: 'white' },
+    ]
+
+    it.each(values)('returns the same object', value => {
+      const props = getBadgeProps(value)
+
+      expect(props).toStrictEqual(value)
+    })
+  })
+})

--- a/packages/picasso/src/SidebarItem/utils/getTagProps/getTagProps.ts
+++ b/packages/picasso/src/SidebarItem/utils/getTagProps/getTagProps.ts
@@ -1,0 +1,11 @@
+import { SidebarTagProps } from '../../../SidebarItemContent'
+
+const getTagProps = (tag?: string | SidebarTagProps) => {
+  if (typeof tag === 'string') {
+    return { content: tag }
+  }
+
+  return tag
+}
+
+export default getTagProps

--- a/packages/picasso/src/SidebarItem/utils/getTagProps/test.ts
+++ b/packages/picasso/src/SidebarItem/utils/getTagProps/test.ts
@@ -1,0 +1,35 @@
+import { SidebarTagProps } from '../../../SidebarItemContent'
+import getTagProps from './getTagProps'
+
+describe('getTagProps', () => {
+  describe('when string value is passed', () => {
+    it('returns object with the value in content property', () => {
+      const value = 'foobar'
+      const props = getTagProps(value)
+
+      expect(props).toEqual({ content: value })
+    })
+  })
+
+  describe('when falsy input is passed', () => {
+    it('returns the same value', () => {
+      const value = undefined
+      const props = getTagProps(value)
+
+      expect(props).toEqual(value)
+    })
+  })
+
+  describe('when tag props object is passed', () => {
+    const values: SidebarTagProps[] = [
+      { content: 'foobar' },
+      { content: 'foobar', variant: 'green' },
+    ]
+
+    it.each(values)('returns the same object', value => {
+      const props = getTagProps(value)
+
+      expect(props).toStrictEqual(value)
+    })
+  })
+})

--- a/packages/picasso/src/SidebarItemContent/SidebarItemContent.tsx
+++ b/packages/picasso/src/SidebarItemContent/SidebarItemContent.tsx
@@ -7,9 +7,10 @@ import Typography from '../Typography'
 import Tooltip from '../Tooltip'
 import Container from '../Container'
 import Badge from '../Badge'
+import TagRectangular from '../TagRectangular'
 import { getReactNodeTextContent } from '../utils'
 import styles from './styles'
-import { Props } from './types'
+import { Props, SidebarBadgeProps } from './types'
 
 const useStyles = makeStyles<Theme>(styles, {
   name: 'PicassoSidebarItemContent',
@@ -24,21 +25,14 @@ const resolveChildrenText = (text: ReactNode, titleCase: boolean) =>
     text
   )
 
-const ItemContentBadge = (props: Props['badge'] & { children?: ReactNode }) => {
+const ItemContentBadge = (
+  props: SidebarBadgeProps & { children?: ReactNode }
+) => {
   const { children, variant = 'red', ...rest } = props
-
-  const classes = useStyles()
   const isOverlay = React.Children.count(children) > 0
 
   return (
-    <Badge
-      className={cx({
-        [classes.staticBadge]: !isOverlay,
-      })}
-      variant={variant}
-      size={isOverlay ? 'small' : 'large'}
-      {...rest}
-    >
+    <Badge variant={variant} size={isOverlay ? 'small' : 'large'} {...rest}>
       {children}
     </Badge>
   )
@@ -79,15 +73,23 @@ const CompactItemContent = (props: Props) => {
 }
 
 const ExpandedItemContent = (props: Props) => {
-  const { icon, badge, children, testIds } = props
+  const { icon, badge, children, testIds, tag } = props
   const classes = useStyles()
 
   const hasIcon = icon != null
   const hasBadge = badge != null
+  const hasTag = tag != null
+  const hasSubItems = menu != null
 
   return (
-    <Container className={classes.noWrap} inline flex alignItems='center'>
-      {icon}
+    <Container
+      className={classes.noWrap}
+      inline
+      flex
+      alignItems='center'
+      gap='xsmall'
+    >
+      {!isSubMenu && icon}
 
       <Container
         className={cx(classes.noWrap, {
@@ -98,16 +100,18 @@ const ExpandedItemContent = (props: Props) => {
         data-testid={testIds?.content}
       >
         {children}
-
-        {hasBadge && <ItemContentBadge {...badge} />}
       </Container>
+      {hasTag && !hasSubItems && (
+        <TagRectangular variant={tag.variant || 'red'}>
+          {tag.content}
+        </TagRectangular>
+      )}
     </Container>
   )
 }
 
 const SidebarItemContent = (props: Props) => {
   const { children, titleCase: propsTitleCase, compact } = props
-
   const titleCase = useTitleCase(propsTitleCase)
   const resolvedChildren = resolveChildrenText(children, !!titleCase)
 

--- a/packages/picasso/src/SidebarItemContent/SidebarItemContent.tsx
+++ b/packages/picasso/src/SidebarItemContent/SidebarItemContent.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, ReactNode } from 'react'
+import React, { ReactNode } from 'react'
 import { useTitleCase } from '@toptal/picasso-shared'
 import cx from 'classnames'
 import { makeStyles, Theme } from '@material-ui/core'
@@ -6,20 +6,10 @@ import { makeStyles, Theme } from '@material-ui/core'
 import Typography from '../Typography'
 import Tooltip from '../Tooltip'
 import Container from '../Container'
-import Badge, { BadgeProps } from '../Badge'
+import Badge from '../Badge'
 import { getReactNodeTextContent } from '../utils'
 import styles from './styles'
-
-export interface Props {
-  compact?: boolean
-  icon?: ReactElement
-  badge?: Omit<BadgeProps, 'size' | 'children'>
-  children?: ReactNode
-  titleCase?: boolean
-  testIds?: {
-    content?: string
-  }
-}
+import { Props } from './types'
 
 const useStyles = makeStyles<Theme>(styles, {
   name: 'PicassoSidebarItemContent',
@@ -61,8 +51,10 @@ const CompactItemContent = (props: Props) => {
   const hasBadge = badge != null
 
   const wrappedIcon =
-    icon && hasBadge ? (
-      <ItemContentBadge content={badge.content}>{icon}</ItemContentBadge>
+    icon && hasBadge && !hasSubItems ? (
+      <ItemContentBadge content={badge.content} variant={badge.variant}>
+        {icon}
+      </ItemContentBadge>
     ) : (
       icon
     )

--- a/packages/picasso/src/SidebarItemContent/SidebarItemContent.tsx
+++ b/packages/picasso/src/SidebarItemContent/SidebarItemContent.tsx
@@ -85,11 +85,19 @@ const CompactItemContent = (props: Props & { isIndicatorVisible: boolean }) => {
 const ExpandedItemContent = (
   props: Props & { isIndicatorVisible: boolean }
 ) => {
-  const { icon, badge, children, testIds, tag, isIndicatorVisible, menu, isSubMenu } =
-    props
+  const {
+    icon,
+    badge,
+    children,
+    testIds,
+    tag,
+    isIndicatorVisible,
+    menu,
+    isSubMenu,
+  } = props
   const classes = useStyles()
 
-  const hasIcon = icon != null
+  const hasIcon = icon != null && !isSubMenu
   const hasBadge = badge != null
   const hasTag = tag != null
   const hasSubItems = menu != null

--- a/packages/picasso/src/SidebarItemContent/SidebarItemContent.tsx
+++ b/packages/picasso/src/SidebarItemContent/SidebarItemContent.tsx
@@ -11,6 +11,8 @@ import TagRectangular from '../TagRectangular'
 import { getReactNodeTextContent } from '../utils'
 import styles from './styles'
 import { Props, SidebarBadgeProps } from './types'
+import Indicator from '../Indicator'
+import useIndicatorOnParentItem from './useIndicatorOnParentItem'
 
 const useStyles = makeStyles<Theme>(styles, {
   name: 'PicassoSidebarItemContent',
@@ -38,11 +40,12 @@ const ItemContentBadge = (
   )
 }
 
-const CompactItemContent = (props: Props) => {
-  const { icon, children, badge } = props
+const CompactItemContent = (props: Props & { isIndicatorVisible: boolean }) => {
+  const { icon, children, badge, isIndicatorVisible, menu } = props
   const classes = useStyles()
 
   const hasBadge = badge != null
+  const hasSubItems = menu != null
 
   const wrappedIcon =
     icon && hasBadge && !hasSubItems ? (
@@ -66,14 +69,24 @@ const CompactItemContent = (props: Props) => {
         placement='right'
         content={getReactNodeTextContent(children)}
       >
-        <div className={classes.iconWrapper}>{wrappedIcon}</div>
+        <div className={classes.iconWrapper}>
+          {wrappedIcon}
+          {hasSubItems && isIndicatorVisible && (
+            <Container className={classes.compactIndicator}>
+              <Indicator color='red' />
+            </Container>
+          )}
+        </div>
       </Tooltip>
     </Container>
   )
 }
 
-const ExpandedItemContent = (props: Props) => {
-  const { icon, badge, children, testIds, tag } = props
+const ExpandedItemContent = (
+  props: Props & { isIndicatorVisible: boolean }
+) => {
+  const { icon, badge, children, testIds, tag, isIndicatorVisible, menu, isSubMenu } =
+    props
   const classes = useStyles()
 
   const hasIcon = icon != null
@@ -106,19 +119,44 @@ const ExpandedItemContent = (props: Props) => {
           {tag.content}
         </TagRectangular>
       )}
+      {hasBadge && !hasSubItems && <ItemContentBadge {...badge} />}
+      {isIndicatorVisible && hasSubItems && (
+        <Container className={classes.expandedIndicator}>
+          <Indicator color='red' />
+        </Container>
+      )}
     </Container>
   )
 }
 
 const SidebarItemContent = (props: Props) => {
-  const { children, titleCase: propsTitleCase, compact } = props
+  const {
+    children,
+    titleCase: propsTitleCase,
+    compact,
+    isSubMenu,
+    badge,
+    tag,
+  } = props
   const titleCase = useTitleCase(propsTitleCase)
   const resolvedChildren = resolveChildrenText(children, !!titleCase)
+  const hasBadge = badge != null
+  const hasTag = tag != null
+
+  const isIndicatorVisible = useIndicatorOnParentItem({
+    isSubMenu,
+    hasBadge,
+    hasTag,
+  })
 
   const ItemContentVariant = compact ? CompactItemContent : ExpandedItemContent
 
   return (
-    <ItemContentVariant {...props} titleCase={titleCase}>
+    <ItemContentVariant
+      {...props}
+      isIndicatorVisible={isIndicatorVisible}
+      titleCase={titleCase}
+    >
       {resolvedChildren}
     </ItemContentVariant>
   )

--- a/packages/picasso/src/SidebarItemContent/index.ts
+++ b/packages/picasso/src/SidebarItemContent/index.ts
@@ -1,6 +1,7 @@
 import { OmitInternalProps } from '@toptal/picasso-shared'
 
-import { Props } from './SidebarItemContent'
+import { Props } from './types'
 
+export type { SidebarTagProps, SidebarBadgeProps } from './types'
 export { default } from './SidebarItemContent'
 export type SidebarItemContentProps = OmitInternalProps<Props>

--- a/packages/picasso/src/SidebarItemContent/styles.ts
+++ b/packages/picasso/src/SidebarItemContent/styles.ts
@@ -1,4 +1,5 @@
 import { createStyles } from '@material-ui/core'
+import { rem } from '@toptal/picasso-shared'
 
 export default () =>
   createStyles({
@@ -7,7 +8,7 @@ export default () =>
       minWidth: 0,
     },
     withIcon: {
-      marginLeft: '0.875em',
+      marginLeft: rem('6px'),
     },
     hiddenContent: {
       visibility: 'hidden',
@@ -15,8 +16,5 @@ export default () =>
     iconWrapper: {
       width: '1em',
       height: '1em',
-    },
-    staticBadge: {
-      marginLeft: '0.5em',
     },
   })

--- a/packages/picasso/src/SidebarItemContent/styles.ts
+++ b/packages/picasso/src/SidebarItemContent/styles.ts
@@ -16,5 +16,15 @@ export default () =>
     iconWrapper: {
       width: '1em',
       height: '1em',
+      position: 'relative',
+    },
+    compactIndicator: {
+      position: 'absolute',
+      top: 0,
+      right: 0,
+      transform: 'translate(50%, -50%)',
+    },
+    expandedIndicator: {
+      marginRight: rem('6px'),
     },
   })

--- a/packages/picasso/src/SidebarItemContent/types.ts
+++ b/packages/picasso/src/SidebarItemContent/types.ts
@@ -1,0 +1,24 @@
+import { ReactElement, ReactNode } from 'react'
+
+import { BadgeProps } from '../Badge'
+import { VariantOnlyProps } from '../TagRectangular/types'
+
+/** Render Tag.Rectangular */
+export interface SidebarTagProps extends VariantOnlyProps {
+  content: string
+}
+
+/** Definition of the embedded badge  */
+export type SidebarBadgeProps = Omit<BadgeProps, 'size' | 'children'>
+
+export interface Props {
+  compact?: boolean
+  icon?: ReactElement
+  badge?: SidebarBadgeProps
+  tag?: SidebarTagProps
+  children?: ReactNode
+  titleCase?: boolean
+  testIds?: {
+    content?: string
+  }
+}

--- a/packages/picasso/src/SidebarItemContent/types.ts
+++ b/packages/picasso/src/SidebarItemContent/types.ts
@@ -21,4 +21,6 @@ export interface Props {
   testIds?: {
     content?: string
   }
+  isSubMenu?: boolean
+  menu?: ReactElement
 }

--- a/packages/picasso/src/SidebarItemContent/useIndicatorOnParentItem.ts
+++ b/packages/picasso/src/SidebarItemContent/useIndicatorOnParentItem.ts
@@ -1,0 +1,39 @@
+import { useEffect } from 'react'
+
+import { useParentItemContext } from '../SidebarItem/ParentItemContextProvider'
+
+type HookProps = {
+  isSubMenu?: boolean
+  hasBadge: boolean
+  hasTag: boolean
+}
+
+const useIndicatorOnParentItem = ({
+  isSubMenu,
+  hasBadge,
+  hasTag,
+}: HookProps) => {
+  const {
+    handleDecoratedItemMount,
+    handleDecoratedItemUnmount,
+    isIndicatorVisible,
+  } = useParentItemContext()
+
+  useEffect(() => {
+    if (isSubMenu && (hasBadge || hasTag)) {
+      handleDecoratedItemMount()
+
+      return handleDecoratedItemUnmount
+    }
+  }, [
+    isSubMenu,
+    hasBadge,
+    hasTag,
+    handleDecoratedItemMount,
+    handleDecoratedItemUnmount,
+  ])
+
+  return isIndicatorVisible
+}
+
+export default useIndicatorOnParentItem

--- a/packages/picasso/src/TagRectangular/TagRectangular.tsx
+++ b/packages/picasso/src/TagRectangular/TagRectangular.tsx
@@ -1,39 +1,13 @@
-import React, { forwardRef, HTMLAttributes, AnchorHTMLAttributes } from 'react'
+import React, { forwardRef } from 'react'
 import { makeStyles, Theme } from '@material-ui/core/styles'
 import cx from 'classnames'
-import { BaseProps, TextLabelProps, useTitleCase } from '@toptal/picasso-shared'
+import { useTitleCase } from '@toptal/picasso-shared'
 
-import Indicator, { IndicatorProps } from '../Indicator'
+import Indicator from '../Indicator'
 import Chip from '../Chip'
 import toTitleCase from '../utils/to-title-case'
 import styles from './styles'
-
-export type VariantType =
-  | 'red'
-  | 'yellow'
-  | 'dark-grey'
-  | 'light-grey'
-  | 'green'
-
-export type DivOrAnchorProps = AnchorHTMLAttributes<HTMLAnchorElement> &
-  HTMLAttributes<HTMLDivElement>
-
-interface VariantOnlyProps extends BaseProps, TextLabelProps, DivOrAnchorProps {
-  /** Variant of the rectangular `Tag`, can not be used with the `indicator` property at the same time. */
-  variant?: VariantType
-  /** Indicator color, can not be used with the `variant` property at the same time. The Tag's `variant` property is automatically set to `light` when indicator color is set. */
-  indicator?: never
-}
-
-interface IndicatorOnlyProps
-  extends BaseProps,
-    TextLabelProps,
-    DivOrAnchorProps {
-  variant?: never
-  indicator: IndicatorProps['color']
-}
-
-export type Props = VariantOnlyProps | IndicatorOnlyProps
+import { Props } from './types'
 
 const useStyles = makeStyles<Theme>(styles, {
   name: 'PicassoTagRectangular',

--- a/packages/picasso/src/TagRectangular/index.ts
+++ b/packages/picasso/src/TagRectangular/index.ts
@@ -1,6 +1,6 @@
 import { OmitInternalProps } from '@toptal/picasso-shared'
 
-import { Props } from './TagRectangular'
+import { Props } from './types'
 
 export { default } from './TagRectangular'
 export type TagRectangularProps = OmitInternalProps<Props>

--- a/packages/picasso/src/TagRectangular/test.tsx
+++ b/packages/picasso/src/TagRectangular/test.tsx
@@ -3,7 +3,8 @@ import { render, PicassoConfig } from '@toptal/picasso/test-utils'
 import { OmitInternalProps } from '@toptal/picasso-shared'
 import * as titleCaseModule from 'ap-style-title-case'
 
-import TagRectangular, { Props } from './TagRectangular'
+import TagRectangular from './TagRectangular'
+import { Props } from './types'
 
 jest.mock('ap-style-title-case')
 

--- a/packages/picasso/src/TagRectangular/types.ts
+++ b/packages/picasso/src/TagRectangular/types.ts
@@ -1,0 +1,34 @@
+import { HTMLAttributes, AnchorHTMLAttributes } from 'react'
+import { BaseProps, TextLabelProps } from '@toptal/picasso-shared'
+
+import { IndicatorProps } from '../Indicator'
+
+export type DivOrAnchorProps = AnchorHTMLAttributes<HTMLAnchorElement> &
+  HTMLAttributes<HTMLDivElement>
+
+export type VariantType =
+  | 'red'
+  | 'yellow'
+  | 'dark-grey'
+  | 'light-grey'
+  | 'green'
+
+export interface VariantOnlyProps
+  extends BaseProps,
+    TextLabelProps,
+    DivOrAnchorProps {
+  /** Variant of the rectangular `Tag`, can not be used with the `indicator` property at the same time. */
+  variant?: VariantType
+  /** Indicator color, can not be used with the `variant` property at the same time. The Tag's `variant` property is automatically set to `light` when indicator color is set. */
+  indicator?: never
+}
+
+export interface IndicatorOnlyProps
+  extends BaseProps,
+    TextLabelProps,
+    DivOrAnchorProps {
+  variant?: never
+  indicator: IndicatorProps['color']
+}
+
+export type Props = VariantOnlyProps | IndicatorOnlyProps


### PR DESCRIPTION
[FX-3279]

I have extracted some commits to different PRs
- https://github.com/toptal/picasso/pull/3257
- https://github.com/toptal/picasso/pull/3258

### Description

- [Design](https://www.figma.com/file/5SCTOPrCDcHuk5We091GBn/Product-Library?node-id=7071%3A20020&t=VkUIbNxY0CxmMmjY-0)

- We were discussing a lot this ticket with Matt, there might be still some inconsistencies in the Design since he is still working on it.

- 🔴 indicator should be visible for both variants of the sidebar only on closed parent items when children have a tag or badge
- badge and tag are aligned to the right
- parent item will not display the badge or tag
- long text should be overflowed by ellipsis
- collapsed sidebar's items (when only icon is visible) will not display tag

### How to test

- ⚠️ PR has quite a lot of changes, please try to review commit by commit 🙏 
- Play with [the new example](https://picasso.toptal.net/FX-3279-sidebar-item/?path=/story/components-pagesidebar--pagesidebar#sidebar-item-with-badge-and-tag) in the storybook

### Screenshots

![image](https://user-images.githubusercontent.com/6830426/205162212-83a39a64-52ac-4aeb-99d5-3457885f8b03.png)

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests

**Breaking change**

- [x] codemod is created and showcased in the changeset
- [x] test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-3279]: https://toptal-core.atlassian.net/browse/FX-3279?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ