### PR TITLE
feat: add `size` prop to Sidebar

### DIFF
--- a/.changeset/tasty-snails-prove.md
+++ b/.changeset/tasty-snails-prove.md
@@ -1,0 +1,12 @@
+---
+'@toptal/picasso': minor
+---
+
+---
+
+### Page.Sidebar
+
+- add `size` prop to support different widths
+  - **small** for `212px`
+  - **medium** for `236px`
+  - **large** for `280px`

--- a/packages/picasso/src/PageSidebar/PageSidebar.tsx
+++ b/packages/picasso/src/PageSidebar/PageSidebar.tsx
@@ -1,6 +1,6 @@
 import { makeStyles, Theme } from '@material-ui/core/styles'
 import { useSidebar } from '@toptal/picasso-provider'
-import { BaseProps } from '@toptal/picasso-shared'
+import { BaseProps, SizeType } from '@toptal/picasso-shared'
 import cx from 'classnames'
 import React, {
   forwardRef,
@@ -36,6 +36,8 @@ export interface Props extends BaseProps {
     collapseButton?: string
     container?: string
   }
+  /** Different width of sidebar */
+  size?: SizeType<'small' | 'medium' | 'large'>
 }
 
 const useStyles = makeStyles<Theme>(styles, {
@@ -54,6 +56,7 @@ export const PageSidebar = forwardRef<HTMLDivElement, Props>(function Sidebar(
     collapsible,
     defaultCollapsed,
     testIds,
+    size = 'medium',
   } = props
   const classes = useStyles()
   const { setHasSidebar } = useSidebar()
@@ -90,7 +93,7 @@ export const PageSidebar = forwardRef<HTMLDivElement, Props>(function Sidebar(
       flex
       direction='column'
       style={style}
-      className={cx(classes.root, className, classes[variant], {
+      className={cx(classes.root, className, classes[variant], classes[size], {
         [classes.rootCollapsed]: collapsible && isCollapsed,
       })}
       data-testid={testIds?.container}
@@ -131,6 +134,7 @@ export const PageSidebar = forwardRef<HTMLDivElement, Props>(function Sidebar(
 
 PageSidebar.defaultProps = {
   variant: 'light',
+  size: 'medium',
 }
 
 PageSidebar.displayName = 'PageSidebar'

--- a/packages/picasso/src/PageSidebar/__snapshots__/test.tsx.snap
+++ b/packages/picasso/src/PageSidebar/__snapshots__/test.tsx.snap
@@ -6,7 +6,7 @@ exports[`PageSidebar renders 1`] = `
     class="Picasso-root"
   >
     <div
-      class="PicassoContainer-flex PicassoContainer-column PageSidebar-root PageSidebar-light"
+      class="PicassoContainer-flex PicassoContainer-column PageSidebar-root PageSidebar-light PageSidebar-medium"
     >
       <div
         class="PageSidebar-spacer"
@@ -22,7 +22,7 @@ exports[`PageSidebar with menu 1`] = `
     class="Picasso-root"
   >
     <div
-      class="PicassoContainer-flex PicassoContainer-column PageSidebar-root PageSidebar-light"
+      class="PicassoContainer-flex PicassoContainer-column PageSidebar-root PageSidebar-light PageSidebar-medium"
     >
       <div
         class="PageSidebar-spacer"
@@ -43,7 +43,7 @@ exports[`PageSidebar with one normal and one bottom menu 1`] = `
     class="Picasso-root"
   >
     <div
-      class="PicassoContainer-flex PicassoContainer-column PageSidebar-root PageSidebar-light"
+      class="PicassoContainer-flex PicassoContainer-column PageSidebar-root PageSidebar-light PageSidebar-medium"
     >
       <div
         class="PageSidebar-spacer"

--- a/packages/picasso/src/PageSidebar/story/Size.example.tsx
+++ b/packages/picasso/src/PageSidebar/story/Size.example.tsx
@@ -1,0 +1,51 @@
+import React from 'react'
+import { Page, Logo, Typography, Container } from '@toptal/picasso'
+import {
+  Jobs16,
+  Overview16,
+  Candidates16,
+  Team16,
+  Participants16,
+} from '@toptal/picasso/Icon'
+
+const Menu = ({ size }: { size: 'small' | 'medium' | 'large' }) => (
+  <Page.Sidebar size={size}>
+    <Page.Sidebar.Logo>
+      <Logo />
+    </Page.Sidebar.Logo>
+    <Page.Sidebar.Menu>
+      <Page.Sidebar.Item icon={<Overview16 />} selected>
+        Overview
+      </Page.Sidebar.Item>
+      <Page.Sidebar.Item icon={<Jobs16 />}>Jobs</Page.Sidebar.Item>
+      <Page.Sidebar.Item icon={<Candidates16 />}>Candidates</Page.Sidebar.Item>
+      <Page.Sidebar.Item icon={<Team16 />}>Team</Page.Sidebar.Item>
+      <Page.Sidebar.Item icon={<Participants16 />}>Users</Page.Sidebar.Item>
+    </Page.Sidebar.Menu>
+  </Page.Sidebar>
+)
+
+const Example = () => (
+  <Container flex gap='large'>
+    <Container>
+      <Typography variant='heading' size='xsmall'>
+        Small (212px)
+      </Typography>
+      <Menu size='small' />
+    </Container>
+    <Container>
+      <Typography variant='heading' size='xsmall'>
+        Medium (236px)
+      </Typography>
+      <Menu size='medium' />
+    </Container>
+    <Container>
+      <Typography variant='heading' size='xsmall'>
+        Large (280px)
+      </Typography>
+      <Menu size='large' />
+    </Container>
+  </Container>
+)
+
+export default Example

--- a/packages/picasso/src/PageSidebar/story/index.jsx
+++ b/packages/picasso/src/PageSidebar/story/index.jsx
@@ -6,8 +6,8 @@ import PicassoBook from '~/.storybook/components/PicassoBook'
 
 const page = PicassoBook.section('Components').createPage(
   'PageSidebar',
-  `Navigation items provide access to parts in your app 
-  
+  `Navigation items provide access to parts in your app
+
   ${PicassoBook.createSourceLink(__filename)}
   `
 )
@@ -32,6 +32,9 @@ page
   .addExample('PageSidebar/story/Collapsible.example.tsx', {
     title: 'Collapsible',
     takeScreenshot: false,
+  })
+  .addExample('PageSidebar/story/Size.example.tsx', {
+    title: 'Sizes',
   })
 
 page.connect(sidebarItemStory.chapter)

--- a/packages/picasso/src/PageSidebar/styles.ts
+++ b/packages/picasso/src/PageSidebar/styles.ts
@@ -1,4 +1,5 @@
 import { Theme, createStyles } from '@material-ui/core/styles'
+import { rem } from '@toptal/picasso-shared'
 
 // decided to use a custom shadow for the sidebar's collapse button
 const COLLAPSE_BUTTON_SHADOW =
@@ -8,7 +9,6 @@ export default ({ palette, screens, transitions }: Theme) =>
   createStyles({
     root: {
       height: '100%',
-      width: '14.75rem',
       boxShadow: `inset -1px 0px 0px 0px ${palette.grey.darker}`,
       padding: '1rem 0 0.5rem',
       fontSize: '1rem',
@@ -28,6 +28,15 @@ export default ({ palette, screens, transitions }: Theme) =>
         width: '15.50rem',
         height: '100%',
       },
+    },
+    small: {
+      width: rem('212px'),
+    },
+    medium: {
+      width: rem('236px'),
+    },
+    large: {
+      width: rem('280px'),
     },
     spacer: {
       order: 50,

--- a/packages/picasso/src/SidebarItem/__snapshots__/test.tsx.snap
+++ b/packages/picasso/src/SidebarItem/__snapshots__/test.tsx.snap
@@ -6,7 +6,7 @@ exports[`SidebarItem collapsible menu is expanded when one of the children is se
     class="Picasso-root"
   >
     <div
-      class="PicassoContainer-flex PicassoContainer-column PageSidebar-root PageSidebar-light"
+      class="PicassoContainer-flex PicassoContainer-column PageSidebar-root PageSidebar-light PageSidebar-medium"
     >
       <div
         class="PageSidebar-spacer"
@@ -144,7 +144,7 @@ exports[`SidebarItem collapsible menu is expanded when one of the children is se
     class="Picasso-root"
   >
     <div
-      class="PicassoContainer-flex PicassoContainer-column PageSidebar-root PageSidebar-light"
+      class="PicassoContainer-flex PicassoContainer-column PageSidebar-root PageSidebar-light PageSidebar-medium"
     >
       <div
         class="PageSidebar-spacer"


### PR DESCRIPTION
[FX-3279]

### Description

- [Figma](https://www.figma.com/file/5SCTOPrCDcHuk5We091GBn/Product-Library?node-id=408%3A15410&t=WvXC7OMI8HNnEpAF-0)

When working on the task I noticed, that we don't follow the BASE width of the Sidebar, so I have created a new prop `size`. By default `medium` has the same size as it had before, so there is no breaking change.

### How to test

- check t[he temploy](https://picasso.toptal.net/sidebar-size/?path=/story/components-pagesidebar--pagesidebar#sizes)

### Screenshots

![image](https://user-images.githubusercontent.com/6830426/205251464-c6c48eb0-6330-4c81-a3fd-f401874199d9.png)

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-3279]: https://toptal-core.atlassian.net/browse/FX-3279?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ