### PR TITLE
fix(TimelineRow): add flex-grow

### DIFF
--- a/.changeset/rude-schools-drum.md
+++ b/.changeset/rude-schools-drum.md
@@ -1,0 +1,9 @@
+---
+'@toptal/picasso': patch
+---
+
+---
+
+### Timeline.Row
+
+- adjust row content to being able to take up to the full width of the container (`flex-grow: 1`)

--- a/packages/picasso/src/TimelineRow/styles.ts
+++ b/packages/picasso/src/TimelineRow/styles.ts
@@ -9,7 +9,9 @@ export default ({ palette }: Theme) =>
         marginBottom: 0,
       },
     },
-    content: {},
+    content: {
+      flexGrow: 1,
+    },
     icon: {
       margin: '4px 0',
       color: palette.grey.main2,


### PR DESCRIPTION
[FX-3281](https://toptal-core.atlassian.net/browse/FX-3281)

### Description

Added `flex-grow: 1` to the row content so it can fit the entire container width

### How to test

- Code looks good, you can't see the possibility of something being broken
- Use the code snippet to test in deployed storybook and on current [Picasso master](https://picasso.toptal.net/?path=/story/components-timeline--timeline). [Deployed storybook](https://picasso.toptal.net/fx-3281-timeline-row-does-not-allow-the-content-to-be-expanded-to-full-width/?path=/story/components-timeline--timeline) should have the button all the way to the left, content taking up the entire width of the container.

<details>
  <summary>Code example</summary>
  
  ```javascript
import React from "react";
import {
  Grid,
  Timeline,
  Typography,
  Link,
  Container,
  Button
} from "@toptal/picasso";


const Example = () => (
  <Timeline>
    <Timeline.Row date="May 21, 11:17 PM">
      <Grid justifyContent="space-between">
        <Grid.Item small={9}>
          <Container>
            <Typography as="div">
              <Link>Lavinia Maluf</Link> commented task{" "}
              <Typography weight="semibold">
                "Mark meetings' outcome (through the Unresolved Meetings page)"
              </Typography>{" "}
              on <Link>Obfuscated subject for meeting 124555</Link>
            </Typography>
          </Container>
        </Grid.Item>
        <Button>Action</Button>
      </Grid>
    </Timeline.Row>

    <Timeline.Row date="May 23, 9:19 AM" hasConnector={false}>
      <Typography as="div">
        <Link>Tomas Urban</Link> commented task{" "}
        <Typography weight="semibold">
          "Mark meetings' outcome (through the Unresolved Meetings page)"
        </Typography>{" "}
        on <Link>Obfuscated subject for meeting 124555</Link>
      </Typography>
    </Timeline.Row>
  </Timeline>
);

export default Example;

  ```
  
</details>

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
|Not possible to push the button all the way to the right ![image](https://user-images.githubusercontent.com/18409292/205264391-262a34cd-82cc-4d6b-9f97-ff9f507a37a4.png) | ![image](https://user-images.githubusercontent.com/18409292/205264253-0b2abf7a-f981-45d7-8c66-da5bb9c06318.png)|

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests

**Breaking change**

- [n/a] codemod is created and showcased in the changeset
- [n/a] test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>
