### PR TITLE
fix: change role from  to  for hamburger

### DIFF
--- a/.changeset/proud-terms-poke.md
+++ b/.changeset/proud-terms-poke.md
@@ -1,0 +1,9 @@
+---
+'@toptal/picasso': patch
+---
+
+---
+
+### PageHamburger
+
+- change role from `tooltip` to `navigation` for hamburger content

--- a/packages/picasso/src/Dropdown/Dropdown.tsx
+++ b/packages/picasso/src/Dropdown/Dropdown.tsx
@@ -50,6 +50,7 @@ export interface Props
   /** Disable the portal behavior. The children stay within it's parent DOM hierarchy. */
   disablePortal?: boolean
   popperOptions?: PopperOptions
+  popperProps?: HTMLAttributes<HTMLDivElement>
   /** Always keep Popper's children in the DOM */
   keepMounted?: boolean
   /** Callback invoked when component is opened */
@@ -99,6 +100,7 @@ export const Dropdown = forwardRef<HTMLDivElement, Props>(function Dropdown(
     disableAutoFocus,
     disablePortal,
     popperOptions,
+    popperProps,
     keepMounted,
     onOpen = noop,
     popperContainer,
@@ -251,6 +253,7 @@ export const Dropdown = forwardRef<HTMLDivElement, Props>(function Dropdown(
           open={isOpen}
           enableCompactMode
           container={popperContainer}
+          {...popperProps}
         >
           <ClickAwayListener onClickAway={handleClickAway}>
             {/* TODO: Remove this extra markup and put the onClick handler on `Paper` element */}

--- a/packages/picasso/src/PageHamburger/PageHamburger.tsx
+++ b/packages/picasso/src/PageHamburger/PageHamburger.tsx
@@ -42,6 +42,9 @@ const PageHamburger = ({ id }: Props) => {
           },
         },
       }}
+      popperProps={{
+        role: 'navigation',
+      }}
       onOpen={handleShowContent}
       onClose={handleHideContent}
       keepMounted

--- a/packages/picasso/src/PageTopBar/__snapshots__/test.tsx.snap
+++ b/packages/picasso/src/PageTopBar/__snapshots__/test.tsx.snap
@@ -77,7 +77,7 @@ exports[`Page.TopBar render with custom logo 1`] = `
     </div>
     <div
       class="PicassoPopper-root PicassoDropdown-popper"
-      role="tooltip"
+      role="navigation"
       style="position: fixed; top: 0px; left: 0px; display: none; margin-top: 0.4rem;"
     >
       <div>
@@ -188,7 +188,7 @@ exports[`Page.TopBar render with link 1`] = `
     </div>
     <div
       class="PicassoPopper-root PicassoDropdown-popper"
-      role="tooltip"
+      role="navigation"
       style="position: fixed; top: 0px; left: 0px; display: none; margin-top: 0.4rem;"
     >
       <div>
@@ -294,7 +294,7 @@ exports[`Page.TopBar renders 1`] = `
     </div>
     <div
       class="PicassoPopper-root PicassoDropdown-popper"
-      role="tooltip"
+      role="navigation"
       style="position: fixed; top: 0px; left: 0px; display: none; margin-top: 0.4rem;"
     >
       <div>


### PR DESCRIPTION
### Description

Previously hamburger content had a `role="tooltip"` attribute (default for Popper component). 
Since picasso `v28.11.0` the hamburger content is always present in the DOM via `keepMounted` prop, and that causes failings in cucumber tests for SP.
This PR change introduce `popperOption` property through which we can adjust the role to `navigation`.

### How to test

- check the code/temploy page 

### Screenshots

![image](https://user-images.githubusercontent.com/22159416/205333587-ad91e7ae-ff60-414e-b47c-88b62a178b1e.png)



### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- Make sure that additions and changes on design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- Annotate all `props` in component with documentation
- Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- Covered with tests

**Breaking change**

- codemod is created and showcased in the changeset
- test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>
