### PR TITLE
fix: success state for multiline input with counter

### DIFF
--- a/.changeset/tall-eagles-joke.md
+++ b/.changeset/tall-eagles-joke.md
@@ -1,0 +1,9 @@
+---
+'@toptal/picasso': patch
+---
+
+---
+
+### Input
+
+- fix success state for multiline input with counter

--- a/packages/picasso/src/Input/Input.tsx
+++ b/packages/picasso/src/Input/Input.tsx
@@ -199,7 +199,7 @@ const MultilineAdornment = ({
   testIds,
 }: MultilineAdornmentProps) => {
   return (
-    <Container>
+    <Container flex>
       {showCounter && (
         <InputLimitAdornment
           testIds={testIds}

--- a/packages/picasso/src/Input/__snapshots__/test.tsx.snap
+++ b/packages/picasso/src/Input/__snapshots__/test.tsx.snap
@@ -235,7 +235,7 @@ exports[`Input shows counter for multiline input 1`] = `
       </fieldset>
     </div>
     <div
-      class=""
+      class="PicassoContainer-flex"
     />
   </div>
 </div>

--- a/packages/picasso/src/Input/story/Status.example.tsx
+++ b/packages/picasso/src/Input/story/Status.example.tsx
@@ -20,6 +20,16 @@ const Example = () => {
         <Form.Label>Multiline Success</Form.Label>
         <Input value='Ukraine' multiline rows={4} status='success' />
       </Form.Field>
+      <Form.Field>
+        <Form.Label>Multiline Success With Counter</Form.Label>
+        <Input
+          value='Ukraine'
+          multiline
+          rows={4}
+          status='success'
+          counter='entered'
+        />
+      </Form.Field>
     </Form>
   )
 }


### PR DESCRIPTION
### Description

This is a fix for multiline input with counter and success state. 

### How to test

- Check added temploy example of multiline input with success state and counter

### Screenshots


### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- Covered with tests

**Breaking change**

- codemod is created and showcased in the changeset
- test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>
