### PR TITLE
test: fix flaky test of StaticTreeView

### DIFF
--- a/packages/picasso/src/StaticTreeView/story/index.jsx
+++ b/packages/picasso/src/StaticTreeView/story/index.jsx
@@ -4,10 +4,51 @@ import PicassoBook from '~/.storybook/components/PicassoBook'
 const page = PicassoBook.section('Components').createPage(
   'StaticTreeView',
   `Allows rendering a static variant of tree view
-  
+
    ${PicassoBook.createSourceLink(__filename)}
   `
 )
+
+const waitForImageToLoad = url => {
+  return new Promise((resolve, reject) => {
+    const img = new Image()
+
+    img.onerror = () =>
+      reject(new Error(`Failed to load image with url ${url}`))
+    img.onload = resolve
+    img.src = url
+  })
+}
+
+const waitForSvgImagesToRender = () => {
+  return new Promise((resolve, reject) => {
+    const svgImages = document.querySelectorAll('svg image')
+    const promises = [...svgImages]
+      .map(image => image.href)
+      .filter(Boolean)
+      .map(waitForImageToLoad)
+
+    if (promises.length === 0) {
+      // There are no images to wait for, so we can just resolve right away.
+      resolve()
+    }
+
+    Promise.all(promises)
+      .then(() => {
+        // Now that the images have loaded, we need to wait for a couple of
+        // animation frames to go by before we think they will have finished
+        // rendering.
+        return requestAnimationFrame(() => {
+          // Start render
+          requestAnimationFrame(() => {
+            // Finish rendering
+            resolve()
+          })
+        })
+      })
+      .catch(reject)
+  })
+}
 
 page.createTabChapter('Props').addComponentDocs({
   component: StaticTreeView,
@@ -18,6 +59,11 @@ page
   .createChapter()
   .addExample('StaticTreeView/story/Default.example.tsx', {
     title: 'Default',
+    takeScreenshot: {
+      beforeScreenshot: async () => {
+        await waitForSvgImagesToRender()
+      },
+    },
   })
   .addExample('StaticTreeView/story/Horizontal.example.tsx', {
     title: 'Horizontal Direction',


### PR DESCRIPTION
[FX-3287]

### Description

We have a flaky test of StaticTreeView. Happo has [internal function](https://github.com/Galooshi/happo/pull/163/files#diff-1f258a895efc2f2440ec95bbe515ea54713a7f2363d78a380f15b4bc8b94fb72) to wait for images to load before taking a screenshot, but in our case we don't have simple `img`, but we have `svg>g>image`, so I copied the function from happo and adjusted to our needs, I believe that this function is useful only for this example, therefore I didn't move it util functions

### How to test

- The flake test should not appear, it is hard to test.

### Screenshots

N/A

### Development checks

- [n/a] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [n/a] Make sure that additions and changes on design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [n/a] Annotate all `props` in component with documentation
- [n/a] Create `examples` for component
- [n/a] Ensure that deployed demo has expected results and good examples
- [n/a] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [n/a] Covered with tests

**Breaking change**

- [n/a] codemod is created and showcased in the changeset
- [n/a] test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-3287]: https://toptal-core.atlassian.net/browse/FX-3287?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ