### PR TITLE
ci: move storybook visual tests to separate step

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -21,6 +21,8 @@ env:
   TOPTAL_DEVBOT_TOKEN: ${{ secrets.TOPTAL_DEVBOT_TOKEN }}
   NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
   HTTP_PROXY: http://${{ secrets.HTTP_PROXY }}
+  HAPPO_API_KEY: ${{ secrets.HAPPO_API_KEY }}
+  HAPPO_API_SECRET: ${{ secrets.HAPPO_API_SECRET }}
 
 jobs:
   build-docker-image:
@@ -43,7 +45,7 @@ jobs:
           environment: temploy
           docker-file: ./Dockerfile
 
-  tests:
+  static-checks:
     if: ${{ github.event.pull_request.head.ref != 'changeset-release/master' }}
     name: PR Checks
     runs-on: ubuntu-latest
@@ -57,10 +59,11 @@ jobs:
       # surfacing known-vulnerable versions of the packages declared or updated in the PR.
       # Once installed, if the workflow run is marked as required, PRs introducing known-vulnerable
       # packages will be blocked from merging.
-      - name: 'Dependency Review'
+      - name: Dependency Review
         uses: actions/dependency-review-action@v3
 
-      - uses: toptal/davinci-github-actions/yarn-install@v4.4.2
+      - name: Install Dependencies
+        uses: toptal/davinci-github-actions/yarn-install@v4.4.2
 
       - name: Syncpack check
         run: yarn syncpack:list
@@ -77,12 +80,25 @@ jobs:
       - name: Jest Tests
         run: yarn test:unit:ci
 
+  storybook-visual-tests:
+    if: ${{ github.event.pull_request.head.ref != 'changeset-release/master' }}
+    name: Storybook Visual Tests
+    runs-on: ubuntu-latest
+    needs: [static-checks]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Install dependencies from cache
+        uses: toptal/davinci-github-actions/yarn-install@v4.4.2
+
       - name: Visual Tests
         run: yarn happo:storybook
         env:
           HAPPO_PROJECT: Picasso/Storybook
-          HAPPO_API_KEY: ${{ secrets.HAPPO_API_KEY }}
-          HAPPO_API_SECRET: ${{ secrets.HAPPO_API_SECRET }}
+          HAPPO_API_KEY: ${{ env.HAPPO_API_KEY }}
+          HAPPO_API_SECRET: ${{ env.HAPPO_API_SECRET }}
 
   integration-tests:
     name: Integration Tests


### PR DESCRIPTION
[FX-NNNN]

### Description

I think, that might be useful to have static checks in one workflow job and storybook visual tests in a separate job, so if in the future some flaky visual test appears in the Happo, we can simply rerun the Happo part and we don't have to run all the static analysis for no reason.

### How to test

- FIXME: Add the steps describing how to verify your changes

### Screenshots

#### Before
![image](https://user-images.githubusercontent.com/6830426/205953208-5c1a7fcc-1770-41b7-87e7-c0dc5eff97ca.png)

#### After
![image](https://user-images.githubusercontent.com/6830426/205961360-b94cb7b7-15af-4a86-9449-57fdcfe49341.png)


### Development checks

- [n/a] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [n/a] Make sure that additions and changes on design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [n/a] Annotate all `props` in component with documentation
- [n/a] Create `examples` for component
- [n/a] Ensure that deployed demo has expected results and good examples
- [n/a] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [n/a] Covered with tests

**Breaking change**

- [n/a] codemod is created and showcased in the changeset
- [n/a] test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>
