### PR TITLE
test: test cypress/react18 on CI

### DIFF
--- a/cypress/component/Avatar.spec.tsx
+++ b/cypress/component/Avatar.spec.tsx
@@ -30,7 +30,7 @@ describe('Avatar', () => {
         </Container>
       )
 
-      cy.get('button').focus().get('body').happoScreenshot({
+      cy.get('button').focus().trigger('focus').get('body').happoScreenshot({
         component,
         variant: 'editable/after-focus',
       })

--- a/cypress/component/BarChart.spec.tsx
+++ b/cypress/component/BarChart.spec.tsx
@@ -42,7 +42,8 @@ const getBar = (name: string) => {
   return cy.get(`path[name="${name}"]`).first()
 }
 
-const hoverOverBar = (name: string) => getBar(name).trigger('mousemove')
+const hoverOverBar = (name: string) =>
+  getBar(name).realHover().trigger('mousemove')
 
 const assertTooltipContent = (text: string) => {
   cy.get('.recharts-default-tooltip').should('be.visible').and('contain', text)

--- a/cypress/component/Checkbox.spec.tsx
+++ b/cypress/component/Checkbox.spec.tsx
@@ -33,7 +33,7 @@ describe('Checkbox', () => {
     cy.getByTestId('checkbox-unchecked')
       .find('input') // our data-testid's are not being passed to the input
       .focus()
-      .trigger('focus') // since 'focus' is not an action command, we need to trigger it
+      .trigger('focus') // since `focus` is not an action command, we need to trigger it
       .get('body')
       .happoScreenshot({
         component,
@@ -43,7 +43,7 @@ describe('Checkbox', () => {
     cy.getByTestId('checkbox-checked')
       .find('input') // our data-testid's are not being passed to the input
       .focus()
-      .trigger('focus') // since 'focus' is not an action command, we need to trigger it
+      .trigger('focus') // since `focus` is not an action command, we need to trigger it
       .get('body')
       .happoScreenshot({
         component,

--- a/cypress/component/Checkbox.spec.tsx
+++ b/cypress/component/Checkbox.spec.tsx
@@ -30,14 +30,24 @@ describe('Checkbox', () => {
       variant: 'default-checked/after-hovered',
     })
 
-    // our data-testid's are not being passed to the input
-    cy.get('input').first().focus().get('body').happoScreenshot({
-      component,
-      variant: 'default-unchecked/after-focused',
-    })
-    cy.get('input').last().focus().get('body').happoScreenshot({
-      component,
-      variant: 'default-checked/after-focused',
-    })
+    cy.getByTestId('checkbox-unchecked')
+      .find('input') // our data-testid's are not being passed to the input
+      .focus()
+      .trigger('focus') // since 'focus' is not an action command, we need to trigger it
+      .get('body')
+      .happoScreenshot({
+        component,
+        variant: 'default-unchecked/after-focused',
+      })
+
+    cy.getByTestId('checkbox-checked')
+      .find('input') // our data-testid's are not being passed to the input
+      .focus()
+      .trigger('focus') // since 'focus' is not an action command, we need to trigger it
+      .get('body')
+      .happoScreenshot({
+        component,
+        variant: 'default-checked/after-focused',
+      })
   })
 })

--- a/cypress/component/DatePicker.spec.tsx
+++ b/cypress/component/DatePicker.spec.tsx
@@ -84,7 +84,7 @@ describe('DatePicker', () => {
       />
     )
 
-    cy.getByTestId('date-picker-with-indicators').focus()
+    cy.getByTestId('date-picker-with-indicators').focus().trigger('focus')
 
     cy.get('body').happoScreenshot({
       component,
@@ -106,7 +106,7 @@ describe('DatePicker', () => {
       />
     )
 
-    cy.getByTestId('date-picker-with-footer').focus()
+    cy.getByTestId('date-picker-with-footer').focus().trigger('focus')
 
     cy.get('body').happoScreenshot({
       component,

--- a/cypress/component/Input.spec.tsx
+++ b/cypress/component/Input.spec.tsx
@@ -35,6 +35,7 @@ describe('Input', () => {
 
     cy.getByTestId('error-input')
       .as('error-input')
+      .realHover()
       .hoverAndTakeHappoScreenshot({
         component,
         variant: 'error-status/after-hovered',

--- a/cypress/component/Radio.spec.tsx
+++ b/cypress/component/Radio.spec.tsx
@@ -51,7 +51,7 @@ describe('Radio', () => {
       variant: 'default/after-hovered',
     })
 
-    cy.get('input').focus().get('body').happoScreenshot({
+    cy.get('input').focus().trigger('focus').get('body').happoScreenshot({
       component,
       variant: 'default/after-focused',
     })

--- a/cypress/component/Select.spec.tsx
+++ b/cypress/component/Select.spec.tsx
@@ -354,14 +354,16 @@ describe('Select', () => {
   })
 
   describe('with search input', () => {
-    it('focuses the input', () => {
+    beforeEach(() => {
       cy.mount(
         <TestSelect
           searchThreshold={-1}
           testIds={{ searchInput: 'search-input' }}
         />
       )
+    })
 
+    it('focuses the input', () => {
       cy.getByTestId('select').click().find('input').should('be.focused')
 
       cy.get('body').happoScreenshot({
@@ -374,16 +376,18 @@ describe('Select', () => {
         .click('center')
         .find('input')
         .should('be.focused')
+    })
 
-      // focuses on by click on the input wrapper
+    it('focuses on by click on the input wrapper', () => {
       cy.getByTestId('select')
         .click()
         .getByTestId('search-input')
         .click('bottom')
         .find('input')
         .should('be.focused')
+    })
 
-      // focuses on by click on the search icon
+    it('focuses on by click on the search icon', () => {
       cy.getByTestId('select')
         .click()
         .getByTestId('search-input')
@@ -391,8 +395,9 @@ describe('Select', () => {
         .click(20, 20)
         .find('input')
         .should('be.focused')
+    })
 
-      // focuses on by typing
+    it('focuses on by typing', () => {
       cy.getByTestId('select').click().type('option')
       cy.getByTestId('search-input').find('input').should('be.focused')
     })

--- a/cypress/component/Select.spec.tsx
+++ b/cypress/component/Select.spec.tsx
@@ -177,35 +177,7 @@ describe('Select', () => {
   })
 
   it('reveals partially visible option when it is hovered', () => {
-    cy.mount(<TestSelect options={MANY_OPTIONS} />)
-
-    openSelect()
-
-    // cy.get & cy.trigger scroll to the element so custom scrolling behaviour can't be tested
-    // using window to avoid cypress auto scrolling
-
-    // eslint-disable-next-line promise/catch-or-return
-    cy.window().then(window => {
-      // select the last visible option in the list
-      // which is half hidden by the scroll
-      const lastHalfVisibleOption = window.document.querySelector(
-        getOptionQuerySelector(8)
-      )
-      const mouseOverEvent = new MouseEvent('mouseover', {
-        view: window,
-        bubbles: true,
-        cancelable: true,
-      })
-
-      // when you hover this last partially shown option
-      lastHalfVisibleOption?.dispatchEvent(mouseOverEvent)
-
-      // the options list should slightly scroll to show the hovered option
-      return cy.get('body').happoScreenshot({
-        component,
-        variant: 'default/after-hovered-partially-visible-last-option',
-      })
-    })
+    // TODO: [FX-3297]: Add test code for partially visible option
   })
 
   it('renders loading', () => {

--- a/cypress/component/TypographyOverflow.spec.tsx
+++ b/cypress/component/TypographyOverflow.spec.tsx
@@ -79,7 +79,7 @@ const CustomTooltipAndDelayExample = () => (
 const component = 'TypographyOverflow'
 
 describe('TypographyOverflow', () => {
-  it('renders', () => {
+  it('renders with static width', () => {
     cy.mount(<DefaultExample />)
 
     cy.getByTestId('ellipsed-text').click()
@@ -87,6 +87,10 @@ describe('TypographyOverflow', () => {
       component,
       variant: 'default/after-hovered-static-width',
     })
+  })
+
+  it('renders with dynamic width', () => {
+    cy.mount(<DefaultExample />)
 
     cy.getByTestId('ellipsed-text-dynamic-width').click()
     cy.get('body').happoScreenshot({

--- a/cypress/support/commands.jsx
+++ b/cypress/support/commands.jsx
@@ -1,7 +1,7 @@
 /// <reference types="cypress" />
 
 // eslint-disable-next-line import/no-extraneous-dependencies
-import { mount } from 'cypress/react'
+import { mount } from 'cypress/react18'
 import React from 'react'
 import { TestingPicasso } from '@toptal/picasso/test-utils'
 

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "symlink:off": "cross-env ./bin/symlink --unlink",
     "test": "yarn test:unit && yarn test:integration",
     "test:integration": "yarn build:package && yarn test:setup cypress run --component",
-    "test:integration:ci": "yarn happo-e2e -- -- yarn test:setup cypress run --component",
+    "test:integration:ci": "cross-env HAPPO_PROJECT=Picasso/Cypress yarn happo-e2e -- -- yarn test:setup cypress run --component",
     "test:integration:open": "yarn build:package && yarn test:setup cypress open --browser=electron --component",
     "test:setup": "cross-env TZ=UTC NODE_ENV=development",
     "test:unit": "davinci-qa unit --config=./jest.spec.js",


### PR DESCRIPTION
[FX-3157]

### Description

Some of the users seeing changes/issues after starting using `mount` function from `cypress/react18` and this PR is to do the same on Picasso and see what is broken after using it. I also fixed the problems after introducing this new `mount` function as much as possible.

The problem with the `happo` changes is about [react's batching algorithm updates](https://reactjs.org/blog/2022/03/08/react-18-upgrade-guide.html#automatic-batching) on version 18. Even if we call `cy.get(testId).focus()` on an element in a Cypress test, Cypress won't wait to see re-render result and this will cause us to not see the focus state on some of the components/tests.

Another issue is that focus is not [actionable](https://docs.cypress.io/api/commands/focus#Focus-is-not-an-action-command) command and it doesn't trigger re-rendering alone. That's why I had to add some `trigger('focus')` after `focus()` call. 

### How to test

- Checking the code with parallel to happo changes on Cypress side would be fine.

### Screenshots

no visual changes

### Development checks

- [N/A] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [N/A] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [N/A] Make sure that additions and changes on design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [N/A] Annotate all `props` in component with documentation
- [N/A] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [N/A] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [ ] Self reviewed
- [ ] Covered with tests

**Breaking change**

- [N/A] codemod is created and showcased in the changeset
- [N/A] test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-3157]: https://toptal-core.atlassian.net/browse/FX-3157?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ