### PR TITLE
fix(InputLimitAdornment): handle google translate better

### DIFF
--- a/.changeset/weak-radios-clap.md
+++ b/.changeset/weak-radios-clap.md
@@ -6,4 +6,4 @@
 
 ### InputLimitAdornment
 
-- handle google translate better
+- split limit message into translatable and non-translatable part to handle google translation better

--- a/.changeset/weak-radios-clap.md
+++ b/.changeset/weak-radios-clap.md
@@ -1,0 +1,9 @@
+---
+'@toptal/picasso': patch
+---
+
+---
+
+### InputLimitAdornment
+
+- handle google translate better

--- a/packages/picasso/src/Input/__snapshots__/test.tsx.snap
+++ b/packages/picasso/src/Input/__snapshots__/test.tsx.snap
@@ -280,9 +280,19 @@ exports[`Input shows excess chars for multiline input with exceeded limit 1`] = 
   class="PicassoContainer-flex PicassoInputMultilineAdornment-root PicassoInputMultilineAdornment-error"
   data-testid="limit-adornment-multiline-label"
 >
-  1
-   
-  over the limit
+  <span
+    data-testid="message"
+  >
+    <span
+      translate="no"
+    >
+      1
+    </span>
+     
+    <span>
+      over the limit
+    </span>
+  </span>
 </div>
 `;
 
@@ -291,8 +301,18 @@ exports[`Input shows remaining chars for for multiline input with limit 1`] = `
   class="PicassoContainer-flex PicassoInputMultilineAdornment-root PicassoInputMultilineAdornment-error"
   data-testid="limit-adornment-multiline-label"
 >
-  0
-   
-  characters left
+  <span
+    data-testid="message"
+  >
+    <span
+      translate="no"
+    >
+      0
+    </span>
+     
+    <span>
+      characters left
+    </span>
+  </span>
 </div>
 `;

--- a/packages/picasso/src/Input/__snapshots__/test.tsx.snap
+++ b/packages/picasso/src/Input/__snapshots__/test.tsx.snap
@@ -280,9 +280,7 @@ exports[`Input shows excess chars for multiline input with exceeded limit 1`] = 
   class="PicassoContainer-flex PicassoInputMultilineAdornment-root PicassoInputMultilineAdornment-error"
   data-testid="limit-adornment-multiline-label"
 >
-  <span
-    data-testid="message"
-  >
+  <span>
     <span
       translate="no"
     >
@@ -301,9 +299,7 @@ exports[`Input shows remaining chars for for multiline input with limit 1`] = `
   class="PicassoContainer-flex PicassoInputMultilineAdornment-root PicassoInputMultilineAdornment-error"
   data-testid="limit-adornment-multiline-label"
 >
-  <span
-    data-testid="message"
-  >
+  <span>
     <span
       translate="no"
     >

--- a/packages/picasso/src/InputLimitAdornment/InputLimitAdornment.tsx
+++ b/packages/picasso/src/InputLimitAdornment/InputLimitAdornment.tsx
@@ -70,7 +70,10 @@ const InputLimitAdornment = (props: Props) => {
         data-testid={testIds?.inputAdornment}
         error={error}
       >
-        {Math.abs(charsTillLimit)} {multilineLabel}
+        <span data-testid='message'>
+          <span translate='no'>{Math.abs(charsTillLimit)}</span>{' '}
+          <span>{multilineLabel}</span>
+        </span>
       </InputMultilineAdornment>
     )
   }
@@ -84,7 +87,10 @@ const InputLimitAdornment = (props: Props) => {
         [classes.limiterLabelError]: error,
       })}
     >
-      {charsTillLimit} {multilineLabel}
+      <span data-testid='message'>
+        <span translate='no'>{charsTillLimit}</span>{' '}
+        <span>{multilineLabel}</span>
+      </span>
     </InputAdornment>
   )
 }

--- a/packages/picasso/src/InputLimitAdornment/InputLimitAdornment.tsx
+++ b/packages/picasso/src/InputLimitAdornment/InputLimitAdornment.tsx
@@ -15,6 +15,7 @@ export interface Props {
   counter: CounterType
   testIds?: {
     inputAdornment?: string
+    message?: string
   }
 }
 
@@ -70,7 +71,7 @@ const InputLimitAdornment = (props: Props) => {
         data-testid={testIds?.inputAdornment}
         error={error}
       >
-        <span data-testid='message'>
+        <span data-testid={testIds?.message}>
           <span translate='no'>{Math.abs(charsTillLimit)}</span>{' '}
           <span>{multilineLabel}</span>
         </span>
@@ -87,7 +88,7 @@ const InputLimitAdornment = (props: Props) => {
         [classes.limiterLabelError]: error,
       })}
     >
-      <span data-testid='message'>
+      <span data-testid={testIds?.message}>
         <span translate='no'>{charsTillLimit}</span>{' '}
         <span>{multilineLabel}</span>
       </span>

--- a/packages/picasso/src/InputLimitAdornment/test.tsx
+++ b/packages/picasso/src/InputLimitAdornment/test.tsx
@@ -14,16 +14,16 @@ describe('InputLimitAdornment', () => {
     ])(
       "expect '$expectedMessage' message for $charsLength characters",
       async ({ charsLength, expectedMessage }) => {
-        const { findByText } = renderAdornment({
+        const { getByTestId } = renderAdornment({
           counter: 'entered',
           limit: 0,
           multiline: true,
           charsLength,
         })
 
-        const limitText = await findByText(expectedMessage)
+        const limitText = getByTestId('message').textContent
 
-        expect(limitText).toBeInTheDocument()
+        expect(limitText).toBe(expectedMessage)
       }
     )
   })
@@ -36,16 +36,16 @@ describe('InputLimitAdornment', () => {
     ])(
       "expect '$expectedMessage' message for $remainingChars characters",
       async ({ remainingChars, expectedMessage }) => {
-        const { findByText } = renderAdornment({
+        const { getByTestId } = renderAdornment({
           counter: 'remaining',
           limit: 3,
           multiline: true,
           charsLength: 3 - remainingChars,
         })
 
-        const limitText = await findByText(expectedMessage)
+        const limitText = getByTestId('message').textContent
 
-        expect(limitText).toBeInTheDocument()
+        expect(limitText).toBe(expectedMessage)
       }
     )
   })

--- a/packages/picasso/src/InputLimitAdornment/test.tsx
+++ b/packages/picasso/src/InputLimitAdornment/test.tsx
@@ -13,7 +13,7 @@ describe('InputLimitAdornment', () => {
       { charsLength: 2, expectedMessage: '2 characters entered' },
     ])(
       "expect '$expectedMessage' message for $charsLength characters",
-      async ({ charsLength, expectedMessage }) => {
+      ({ charsLength, expectedMessage }) => {
         const { getByTestId } = renderAdornment({
           counter: 'entered',
           limit: 0,
@@ -35,7 +35,7 @@ describe('InputLimitAdornment', () => {
       { remainingChars: 2, expectedMessage: '2 characters left' },
     ])(
       "expect '$expectedMessage' message for $remainingChars characters",
-      async ({ remainingChars, expectedMessage }) => {
+      ({ remainingChars, expectedMessage }) => {
         const { getByTestId } = renderAdornment({
           counter: 'remaining',
           limit: 3,

--- a/packages/picasso/src/InputLimitAdornment/test.tsx
+++ b/packages/picasso/src/InputLimitAdornment/test.tsx
@@ -19,6 +19,7 @@ describe('InputLimitAdornment', () => {
           limit: 0,
           multiline: true,
           charsLength,
+          testIds: { message: 'message' },
         })
 
         const limitText = getByTestId('message').textContent
@@ -41,6 +42,7 @@ describe('InputLimitAdornment', () => {
           limit: 3,
           multiline: true,
           charsLength: 3 - remainingChars,
+          testIds: { message: 'message' },
         })
 
         const limitText = getByTestId('message').textContent


### PR DESCRIPTION
[TACO-2080]

### Description

Translating the page with google translate breaks the limit text. This PR aims to improve this.

Check https://toptal-core.slack.com/archives/CERF5NHT3/p1670406303204869 for details

### How to test

Check https://toptal-core.slack.com/archives/CERF5NHT3/p1670406303204869 for videos on how to reproduce behaviour 

### Screenshots

Before

https://user-images.githubusercontent.com/4757057/206159171-f856c1ff-2c2b-4c05-a563-67e04dec2074.mp4

After

https://user-images.githubusercontent.com/4757057/206159239-d9887a74-bb89-4394-a4f5-079284e70b5c.mp4


### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- n/a ~~Annotate all `props` in component with documentation~~
- n/a ~~Create `examples` for component~~
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests

**Breaking change**

- n/a ~~codemod is created and showcased in the changeset~~
- n/a ~~test alpha package of Picasso in StaffPortal~~

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[TACO-2080]: https://toptal-core.atlassian.net/browse/TACO-2080?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ