### PR TITLE
feat(PageSidebar): make sidebar sticky

### DIFF
--- a/.changeset/afraid-queens-drive.md
+++ b/.changeset/afraid-queens-drive.md
@@ -1,0 +1,18 @@
+---
+'@toptal/picasso': major
+---
+
+---
+
+### PageSidebar
+
+#### BREAKING CHANGE
+
+- sidebar sticks to TopBar on scroll
+- you can opt-out by setting:
+
+```jsx
+<Page.Sidebar disableSticky>
+  <Page.Sidebar.Menu>...</Page.Sidebar.Menu>
+</Page.Sidebar>
+```

--- a/cypress/component/Page.spec.tsx
+++ b/cypress/component/Page.spec.tsx
@@ -1,0 +1,180 @@
+import React from 'react'
+import {
+  Container,
+  Menu,
+  Page,
+  PageSidebarProps,
+  Typography,
+} from '@toptal/picasso'
+
+const component = 'Page'
+const containerHeight = '30rem'
+
+enum TestIds {
+  WRAPPER = 'wrapper',
+  SIDEBAR_SCROLLABLE_CONTAINER = 'sidebar-scrollable-container',
+}
+
+const Paragraph = () => (
+  <Typography>
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+    tempor incididunt ut labore et dolore magna aliqua. Sollicitudin ac orci
+    phasellus egestas tellus rutrum tellus pellentesque eu. Elementum facilisis
+    leo vel fringilla est ullamcorper eget nulla. Massa id neque aliquam
+    vestibulum. Lorem donec massa sapien faucibus et molestie ac feugiat sed. In
+    aliquam sem fringilla ut morbi tincidunt augue interdum velit. Erat velit
+    scelerisque in dictum non. Eros donec ac odio tempor orci dapibus. Ac tortor
+    vitae purus faucibus ornare suspendisse. Amet commodo nulla facilisi nullam
+    vehicula. Lacus vel facilisis volutpat est velit egestas dui id. Tortor
+    dignissim convallis aenean et tortor at risus. Mauris in aliquam sem
+    fringilla ut morbi tincidunt augue interdum. Nisl suscipit adipiscing
+    bibendum est ultricies integer.
+  </Typography>
+)
+
+const Sidebar = (props: PageSidebarProps) => (
+  <Page.Sidebar
+    wrapperMaxHeight={`calc(${containerHeight} - 3.5rem)`}
+    testIds={{
+      scrollableContainer: TestIds.SIDEBAR_SCROLLABLE_CONTAINER,
+    }}
+    {...props}
+  >
+    <Page.Sidebar.Menu>
+      <Page.Sidebar.Item selected>
+        Overview
+      </Page.Sidebar.Item>
+      <Page.Sidebar.Item>Jobs</Page.Sidebar.Item>
+      <Page.Sidebar.Item>Candidates</Page.Sidebar.Item>
+      <Page.Sidebar.Item>Team</Page.Sidebar.Item>
+      <Page.Sidebar.Item>Users</Page.Sidebar.Item>
+      <Page.Sidebar.Item disabled>
+        Billing
+      </Page.Sidebar.Item>
+      <Page.Sidebar.Item
+        badge={{ content: 5 }}
+        menu={
+          <Page.Sidebar.Menu>
+            <Page.Sidebar.Item>Terms and Conditions</Page.Sidebar.Item>
+            <Page.Sidebar.Item>Support</Page.Sidebar.Item>
+          </Page.Sidebar.Menu>
+        }
+      >
+        <Typography size='medium' color='inherit'>
+          Legal Info
+        </Typography>
+      </Page.Sidebar.Item>
+      <Page.Sidebar.Item badge={{ content: 10 }}>
+        Menu item with surprisingly long text content
+      </Page.Sidebar.Item>
+    </Page.Sidebar.Menu>
+  </Page.Sidebar>
+)
+
+const handleClick = () => window.alert('Item clicked')
+
+const RightContent = () => (
+  <Page.TopBarMenu
+    name='Jacqueline Roque'
+    avatar='./jacqueline-with-flowers-1954-square.jpg'
+  >
+    <Menu>
+      <Menu.Item onClick={handleClick}>My Account</Menu.Item>
+      <Menu.Item onClick={handleClick}>Log Out</Menu.Item>
+    </Menu>
+  </Page.TopBarMenu>
+)
+
+const Content = () => (
+  <Container top='small' bottom='small'>
+    <Container bottom='small'>
+      <Typography align='center' variant='heading' size='large'>
+        Banner example
+      </Typography>
+    </Container>
+    <Paragraph />
+    <Paragraph />
+    <Paragraph />
+    <Paragraph />
+    <Paragraph />
+  </Container>
+)
+
+type ExampleProps = {
+  sidebarProps?: PageSidebarProps
+}
+
+const Example = ({ sidebarProps }: ExampleProps) => (
+  <div
+    data-testid={TestIds.WRAPPER}
+    style={{ height: containerHeight, overflowY: 'scroll' }}
+  >
+    <Page hamburgerId='banner-and-sidebar-example'>
+      <Page.TopBar rightContent={<RightContent />} title='Default example' />
+      <Page.Banner>
+        We are now in the process of reviewing your profile. After your profile
+        has been checked, we will reach to you via email about next steps.
+      </Page.Banner>
+      <Page.Content>
+        <Sidebar {...sidebarProps} />
+        <Page.Article>
+          <Content />
+        </Page.Article>
+      </Page.Content>
+      <Page.Footer />
+    </Page>
+  </div>
+)
+
+describe('Page', () => {
+  describe('when the sidebar is sticky', () => {
+    it('sticks to TopBar on scroll', () => {
+      cy.mount(<Example />)
+
+      cy.get('body').happoScreenshot({
+        component,
+        variant: 'default',
+      })
+
+      // Scroll down
+      cy.getByTestId(TestIds.WRAPPER).scrollTo(0, 200)
+
+      cy.get('body').happoScreenshot({
+        component,
+        variant: 'default/sticky-sidebar',
+      })
+
+      // Scroll sidebar to the bottom
+      cy.getByTestId(TestIds.SIDEBAR_SCROLLABLE_CONTAINER).scrollTo('bottom')
+      // Scroll page to the bottom
+      cy.getByTestId(TestIds.WRAPPER).scrollTo('bottom')
+
+      cy.get('body').happoScreenshot({
+        component,
+        variant: 'default/sticky-sidebar-scroll-bottom',
+      })
+    })
+  })
+
+  describe('when the sidebar is not sticky', () => {
+    it('scrolls with content', () => {
+      cy.mount(<Example sidebarProps={{ disableSticky: true }} />)
+
+      // Scroll down
+      cy.getByTestId(TestIds.WRAPPER).scrollTo(0, 200)
+
+      cy.get('body').happoScreenshot({
+        component,
+        variant: 'default/sidebar-scroll',
+      })
+
+      // Scroll page to the bottom
+      cy.getByTestId(TestIds.WRAPPER).scrollTo('bottom')
+
+      cy.get('body').happoScreenshot({
+        component,
+        variant: 'default/sidebar-scroll-bottom',
+      })
+    })
+  })
+})

--- a/packages/picasso/src/Page/story/WithBannerAndSidebar.example.tsx
+++ b/packages/picasso/src/Page/story/WithBannerAndSidebar.example.tsx
@@ -1,0 +1,152 @@
+import React from 'react'
+import {
+  Page,
+  Container,
+  Menu,
+  Typography,
+  Overview16,
+  Jobs16,
+  Candidates16,
+  Billing16,
+  LegalInfo16,
+  Participants16,
+  Referrals16,
+  Resources16,
+  Team16,
+  ReferralBonus16,
+  Help16,
+  Logo,
+} from '@toptal/picasso'
+
+const containerHeight = '30rem'
+
+const Example = () => (
+  <div style={{ height: containerHeight, overflowY: 'scroll' }}>
+    <Page hamburgerId='banner-and-sidebar-example'>
+      <Page.TopBar rightContent={<RightContent />} title='Default example' />
+      <Page.Banner>
+        We are now in the process of reviewing your profile. After your profile
+        has been checked, we will reach to you via email about next steps.
+      </Page.Banner>
+      <Page.Content>
+        <Sidebar />
+        <Page.Article>
+          <Content />
+        </Page.Article>
+      </Page.Content>
+      <Page.Footer />
+    </Page>
+  </div>
+)
+
+const handleClick = () => window.alert('Item clicked')
+
+const RightContent = () => (
+  <Page.TopBarMenu
+    name='Jacqueline Roque'
+    avatar='./jacqueline-with-flowers-1954-square.jpg'
+  >
+    <Menu>
+      <Menu.Item onClick={handleClick}>My Account</Menu.Item>
+      <Menu.Item onClick={handleClick}>Log Out</Menu.Item>
+    </Menu>
+  </Page.TopBarMenu>
+)
+
+const Content = () => (
+  <Container top='small' bottom='small'>
+    <Container bottom='small'>
+      <Typography align='center' variant='heading' size='large'>
+        Banner example
+      </Typography>
+    </Container>
+    <Paragraph />
+    <Paragraph />
+    <Paragraph />
+    <Paragraph />
+    <Paragraph />
+  </Container>
+)
+
+const Paragraph = () => (
+  <Typography>
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+    tempor incididunt ut labore et dolore magna aliqua. Sollicitudin ac orci
+    phasellus egestas tellus rutrum tellus pellentesque eu. Elementum facilisis
+    leo vel fringilla est ullamcorper eget nulla. Massa id neque aliquam
+    vestibulum. Lorem donec massa sapien faucibus et molestie ac feugiat sed. In
+    aliquam sem fringilla ut morbi tincidunt augue interdum velit. Erat velit
+    scelerisque in dictum non. Eros donec ac odio tempor orci dapibus. Ac tortor
+    vitae purus faucibus ornare suspendisse. Amet commodo nulla facilisi nullam
+    vehicula. Lacus vel facilisis volutpat est velit egestas dui id. Tortor
+    dignissim convallis aenean et tortor at risus. Mauris in aliquam sem
+    fringilla ut morbi tincidunt augue interdum. Nisl suscipit adipiscing
+    bibendum est ultricies integer.
+  </Typography>
+)
+
+const Sidebar = () => (
+  <Page.Sidebar
+    collapsible
+    wrapperMaxHeight={`calc(${containerHeight} - 3.5rem)`}
+  >
+    <Page.Sidebar.Logo collapsedLogo={<Logo emblem />} fullLogo={<Logo />} />
+    <Page.Sidebar.Menu>
+      <Page.Sidebar.Item icon={<Overview16 />} selected>
+        Overview
+      </Page.Sidebar.Item>
+      <Page.Sidebar.Item icon={<Jobs16 />}>Jobs</Page.Sidebar.Item>
+      <Page.Sidebar.Item icon={<Candidates16 />}>Candidates</Page.Sidebar.Item>
+      <Page.Sidebar.Item icon={<Team16 />}>Team</Page.Sidebar.Item>
+      <Page.Sidebar.Item icon={<Participants16 />}>Users</Page.Sidebar.Item>
+      <Page.Sidebar.Item icon={<Billing16 />} disabled>
+        Billing
+      </Page.Sidebar.Item>
+      <Page.Sidebar.Item
+        badge={{ content: 5 }}
+        icon={<LegalInfo16 />}
+        menu={
+          <Page.Sidebar.Menu>
+            <Page.Sidebar.Item>Terms and Conditions</Page.Sidebar.Item>
+            <Page.Sidebar.Item>Support</Page.Sidebar.Item>
+          </Page.Sidebar.Menu>
+        }
+      >
+        <Typography size='medium' color='inherit'>
+          Legal Info
+        </Typography>
+      </Page.Sidebar.Item>
+      <Page.Sidebar.Item
+        collapsible
+        badge={{ content: 10 }}
+        icon={<Referrals16 />}
+        menu={
+          <Page.Sidebar.Menu>
+            <Page.Sidebar.Item>Share Online</Page.Sidebar.Item>
+            <Page.Sidebar.Item>Referred Users</Page.Sidebar.Item>
+            <Page.Sidebar.Item>Commissions</Page.Sidebar.Item>
+            <Page.Sidebar.Item>Payment Options</Page.Sidebar.Item>
+            <Page.Sidebar.Item>Expected Commissions</Page.Sidebar.Item>
+          </Page.Sidebar.Menu>
+        }
+      >
+        Referrals
+      </Page.Sidebar.Item>
+      <Page.Sidebar.Item badge={{ content: 10 }} icon={<Resources16 />}>
+        Menu item with surprisingly long text content
+      </Page.Sidebar.Item>
+    </Page.Sidebar.Menu>
+
+    <Page.Sidebar.Menu bottom>
+      <Page.Sidebar.Item icon={<Candidates16 />}>
+        Opportunities
+      </Page.Sidebar.Item>
+      <Page.Sidebar.Item icon={<ReferralBonus16 />}>
+        Referral Bonus
+      </Page.Sidebar.Item>
+      <Page.Sidebar.Item icon={<Help16 />}>Help</Page.Sidebar.Item>
+    </Page.Sidebar.Menu>
+  </Page.Sidebar>
+)
+
+export default Example

--- a/packages/picasso/src/Page/story/index.jsx
+++ b/packages/picasso/src/Page/story/index.jsx
@@ -47,6 +47,9 @@ page
   .addExample('Page/story/WithCompoundBanner.example.tsx', {
     title: 'With Compound Banner',
   })
+  .addExample('Page/story/WithBannerAndSidebar.example.tsx', {
+    title: 'With Banner and Sidebar',
+  })
 
 page.connect(pageHelmetStory.chapter)
 

--- a/packages/picasso/src/PageSidebar/PageSidebar.tsx
+++ b/packages/picasso/src/PageSidebar/PageSidebar.tsx
@@ -8,6 +8,7 @@ import React, {
   useCallback,
   useEffect,
   useState,
+  CSSProperties,
 } from 'react'
 
 import ButtonCircular from '../ButtonCircular'
@@ -35,9 +36,13 @@ export interface Props extends BaseProps {
   testIds?: {
     collapseButton?: string
     container?: string
+    scrollableContainer?: string
   }
   /** Different width of sidebar */
   size?: SizeType<'small' | 'medium' | 'large'>
+  /** Make sidebar scroll with the content */
+  disableSticky?: boolean
+  wrapperMaxHeight?: string | number
 }
 
 const useStyles = makeStyles<Theme>(styles, {
@@ -57,6 +62,8 @@ export const PageSidebar = forwardRef<HTMLDivElement, Props>(function Sidebar(
     defaultCollapsed,
     testIds,
     size = 'medium',
+    wrapperMaxHeight,
+    disableSticky,
   } = props
   const classes = useStyles()
   const { setHasSidebar } = useSidebar()
@@ -100,28 +107,39 @@ export const PageSidebar = forwardRef<HTMLDivElement, Props>(function Sidebar(
       onMouseEnter={collapsible ? () => setIsHovered(true) : noop}
       onMouseLeave={collapsible ? () => setIsHovered(false) : noop}
     >
-      <div className={classes.spacer} />
-      {collapsible && (
-        <ButtonCircular
-          className={cx(classes.collapseButton, {
-            [classes.buttonVisible]: isHovered,
-          })}
-          onClick={handleCollapseButtonClick}
-          icon={isCollapsed ? <ChevronRight16 /> : <BackMinor16 />}
-          aria-label='collapse sidebar'
-          variant='primary'
-          data-testid={testIds?.collapseButton}
-        />
-      )}
-      <SidebarContextProvider
-        isCollapsed={isCollapsed}
-        isHovered={isHovered}
-        variant={variant}
-        expandedItemKey={expandedItemKey}
-        setExpandedItemKey={setExpandedItemKey}
+      <div
+        style={{
+          maxHeight: wrapperMaxHeight,
+        }}
+        className={cx(classes.wrapper, {
+          [classes.sticky]: !disableSticky,
+        })}
       >
-        {children}
-      </SidebarContextProvider>
+        <Container flex direction='column' className={classes.scrollable}>
+          {collapsible && (
+            <ButtonCircular
+              className={cx(classes.collapseButton, {
+                [classes.buttonVisible]: isHovered,
+              })}
+              onClick={handleCollapseButtonClick}
+              icon={isCollapsed ? <ChevronRight16 /> : <BackMinor16 />}
+              aria-label='collapse sidebar'
+              variant='primary'
+              data-testid={testIds?.collapseButton}
+            />
+          )}
+          <div className={classes.spacer} />
+          <SidebarContextProvider
+            isCollapsed={isCollapsed}
+            isHovered={isHovered}
+            variant={variant}
+            expandedItemKey={expandedItemKey}
+            setExpandedItemKey={setExpandedItemKey}
+          >
+            {children}
+          </SidebarContextProvider>
+        </Container>
+      </div>
     </Container>
   )
 

--- a/packages/picasso/src/PageSidebar/PageSidebar.tsx
+++ b/packages/picasso/src/PageSidebar/PageSidebar.tsx
@@ -115,7 +115,12 @@ export const PageSidebar = forwardRef<HTMLDivElement, Props>(function Sidebar(
           [classes.sticky]: !disableSticky,
         })}
       >
-        <Container flex direction='column' className={classes.scrollable}>
+        <Container
+          flex
+          direction='column'
+          className={classes.scrollableContent}
+          data-testid={testIds?.scrollableContainer}
+        >
           {collapsible && (
             <ButtonCircular
               className={cx(classes.collapseButton, {

--- a/packages/picasso/src/PageSidebar/__snapshots__/test.tsx.snap
+++ b/packages/picasso/src/PageSidebar/__snapshots__/test.tsx.snap
@@ -9,8 +9,16 @@ exports[`PageSidebar renders 1`] = `
       class="PicassoContainer-flex PicassoContainer-column PageSidebar-root PageSidebar-light PageSidebar-medium"
     >
       <div
-        class="PageSidebar-spacer"
-      />
+        class="PageSidebar-wrapper PageSidebar-sticky"
+      >
+        <div
+          class="PicassoContainer-flex PicassoContainer-column PageSidebar-scrollableContent"
+        >
+          <div
+            class="PageSidebar-spacer"
+          />
+        </div>
+      </div>
     </div>
   </div>
 </div>
@@ -25,13 +33,21 @@ exports[`PageSidebar with menu 1`] = `
       class="PicassoContainer-flex PicassoContainer-column PageSidebar-root PageSidebar-light PageSidebar-medium"
     >
       <div
-        class="PageSidebar-spacer"
-      />
-      <ul
-        class="MuiList-root PicassoMenu-root PicassoSidebarMenu-root"
-        role="menu"
-        tabindex="-1"
-      />
+        class="PageSidebar-wrapper PageSidebar-sticky"
+      >
+        <div
+          class="PicassoContainer-flex PicassoContainer-column PageSidebar-scrollableContent"
+        >
+          <div
+            class="PageSidebar-spacer"
+          />
+          <ul
+            class="MuiList-root PicassoMenu-root PicassoSidebarMenu-root"
+            role="menu"
+            tabindex="-1"
+          />
+        </div>
+      </div>
     </div>
   </div>
 </div>
@@ -46,18 +62,26 @@ exports[`PageSidebar with one normal and one bottom menu 1`] = `
       class="PicassoContainer-flex PicassoContainer-column PageSidebar-root PageSidebar-light PageSidebar-medium"
     >
       <div
-        class="PageSidebar-spacer"
-      />
-      <ul
-        class="MuiList-root PicassoMenu-root PicassoSidebarMenu-root"
-        role="menu"
-        tabindex="-1"
-      />
-      <ul
-        class="MuiList-root PicassoMenu-root PicassoSidebarMenu-root PicassoSidebarMenu-bottom"
-        role="menu"
-        tabindex="-1"
-      />
+        class="PageSidebar-wrapper PageSidebar-sticky"
+      >
+        <div
+          class="PicassoContainer-flex PicassoContainer-column PageSidebar-scrollableContent"
+        >
+          <div
+            class="PageSidebar-spacer"
+          />
+          <ul
+            class="MuiList-root PicassoMenu-root PicassoSidebarMenu-root"
+            role="menu"
+            tabindex="-1"
+          />
+          <ul
+            class="MuiList-root PicassoMenu-root PicassoSidebarMenu-root PicassoSidebarMenu-bottom"
+            role="menu"
+            tabindex="-1"
+          />
+        </div>
+      </div>
     </div>
   </div>
 </div>

--- a/packages/picasso/src/PageSidebar/styles.ts
+++ b/packages/picasso/src/PageSidebar/styles.ts
@@ -42,7 +42,7 @@ export default ({ palette, screens, transitions }: Theme) =>
         },
       },
     },
-    scrollable: {
+    scrollableContent: {
       height: '100%',
       overflowY: 'auto',
       padding: '1rem 0 0.5rem',
@@ -94,6 +94,13 @@ export default ({ palette, screens, transitions }: Theme) =>
 
       '&::before': {
         width: '5.75rem',
+      },
+      '& $scrollableContent': {
+        '-ms-overflow-style': 'none',
+        'scrollbar-width': 'none',
+        '&::-webkit-scrollbar': {
+          display: 'none',
+        },
       },
     },
     sticky: {},

--- a/packages/picasso/src/PageSidebar/styles.ts
+++ b/packages/picasso/src/PageSidebar/styles.ts
@@ -1,6 +1,8 @@
 import { Theme, createStyles } from '@material-ui/core/styles'
 import { rem } from '@toptal/picasso-shared'
 
+import { headerHeight } from '../PageTopBar/styles'
+
 // decided to use a custom shadow for the sidebar's collapse button
 const COLLAPSE_BUTTON_SHADOW =
   '0 0 0 1px rgba(0, 0, 0, 0.04), 0 0 8px 0 rgba(0, 0, 0, 0.16)'
@@ -10,7 +12,6 @@ export default ({ palette, screens, transitions }: Theme) =>
     root: {
       height: '100%',
       boxShadow: `inset -1px 0px 0px 0px ${palette.grey.darker}`,
-      padding: '1rem 0 0.5rem',
       fontSize: '1rem',
       position: 'relative',
       transition: `width ${transitions.duration.enteringScreen}ms ease-in-out`,
@@ -28,6 +29,23 @@ export default ({ palette, screens, transitions }: Theme) =>
         width: '15.50rem',
         height: '100%',
       },
+    },
+    wrapper: {
+      height: '100%',
+      '&$sticky': {
+        maxHeight: `calc(100vh - ${headerHeight.default})`,
+        position: 'sticky',
+        top: headerHeight.default,
+        [screens('small', 'medium')]: {
+          maxHeight: `calc(100vh - ${headerHeight.smallAndMedium})`,
+          top: headerHeight.smallAndMedium,
+        },
+      },
+    },
+    scrollable: {
+      height: '100%',
+      overflowY: 'auto',
+      padding: '1rem 0 0.5rem',
     },
     small: {
       width: rem('212px'),
@@ -78,4 +96,5 @@ export default ({ palette, screens, transitions }: Theme) =>
         width: '5.75rem',
       },
     },
+    sticky: {},
   })

--- a/packages/picasso/src/PageTopBar/styles.ts
+++ b/packages/picasso/src/PageTopBar/styles.ts
@@ -38,8 +38,10 @@ export default ({ palette, layout, zIndex, screens }: Theme) =>
     },
     wrapper: {
       height: headerHeight.default,
+      minHeight: headerHeight.default,
       [screens('small', 'medium')]: {
         height: headerHeight.smallAndMedium,
+        minHeight: headerHeight.smallAndMedium,
       },
     },
     wide: {

--- a/packages/picasso/src/SidebarItem/__snapshots__/test.tsx.snap
+++ b/packages/picasso/src/SidebarItem/__snapshots__/test.tsx.snap
@@ -9,130 +9,138 @@ exports[`SidebarItem collapsible menu is expanded when one of the children is se
       class="PicassoContainer-flex PicassoContainer-column PageSidebar-root PageSidebar-light PageSidebar-medium"
     >
       <div
-        class="PageSidebar-spacer"
-      />
-      <ul
-        class="MuiList-root PicassoMenu-root PicassoSidebarMenu-root"
-        role="menu"
-        tabindex="-1"
+        class="PageSidebar-wrapper PageSidebar-sticky"
       >
         <div
-          class="MuiPaper-root MuiAccordion-root PicassoAccordion-root PicassoAccordion-bordersNone Mui-expanded MuiAccordion-rounded MuiPaper-elevation0 MuiPaper-rounded"
+          class="PicassoContainer-flex PicassoContainer-column PageSidebar-scrollableContent"
         >
           <div
-            aria-disabled="false"
-            aria-expanded="true"
-            class="MuiButtonBase-root MuiAccordionSummary-root WithStyles(ForwardRef(AccordionSummary))-root PicassoAccordion-summary PicassoSidebarItemAccordion-collapsibleWrapper Mui-expanded"
-            role="button"
-            tabindex="0"
+            class="PageSidebar-spacer"
+          />
+          <ul
+            class="MuiList-root PicassoMenu-root PicassoSidebarMenu-root"
+            role="menu"
+            tabindex="-1"
           >
             <div
-              class="MuiAccordionSummary-content WithStyles(ForwardRef(AccordionSummary))-content PicassoAccordion-content PicassoSidebarItemAccordion-content Mui-expanded"
+              class="MuiPaper-root MuiAccordion-root PicassoAccordion-root PicassoAccordion-bordersNone Mui-expanded MuiAccordion-rounded MuiPaper-elevation0 MuiPaper-rounded"
             >
-              <li
+              <div
                 aria-disabled="false"
-                class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root PicassoMenuItem-root PicassoMenuItem-light PicassoSidebarItemHeader-root PicassoSidebarItemHeader-noWrap PicassoSidebarItemHeader-light PicassoSidebarItemHeader-collapsible PicassoMenuItem-nonSelectable MuiMenuItem-gutters PicassoMenuItem-gutters MuiListItem-gutters MuiListItem-button"
-                role="menuitem"
+                aria-expanded="true"
+                class="MuiButtonBase-root MuiAccordionSummary-root WithStyles(ForwardRef(AccordionSummary))-root PicassoAccordion-summary PicassoSidebarItemAccordion-collapsibleWrapper Mui-expanded"
+                role="button"
                 tabindex="0"
               >
                 <div
-                  class="PicassoContainer-flex PicassoMenuItem-itemWrapper"
+                  class="MuiAccordionSummary-content WithStyles(ForwardRef(AccordionSummary))-content PicassoAccordion-content PicassoSidebarItemAccordion-content Mui-expanded"
                 >
-                  <div
-                    class="PicassoContainer-flex PicassoContainer-column PicassoMenuItem-content"
+                  <li
+                    aria-disabled="false"
+                    class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root PicassoMenuItem-root PicassoMenuItem-light PicassoSidebarItemHeader-root PicassoSidebarItemHeader-noWrap PicassoSidebarItemHeader-light PicassoSidebarItemHeader-collapsible PicassoMenuItem-nonSelectable MuiMenuItem-gutters PicassoMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+                    role="menuitem"
+                    tabindex="0"
                   >
                     <div
-                      class="PicassoContainer-centerAlignItems PicassoContainer-flex"
+                      class="PicassoContainer-flex PicassoMenuItem-itemWrapper"
                     >
                       <div
-                        class="PicassoContainer-xsmallGap PicassoContainer-centerAlignItems PicassoContainer-flex PicassoContainer-inline PicassoSidebarItemContent-noWrap"
+                        class="PicassoContainer-flex PicassoContainer-column PicassoMenuItem-content"
                       >
                         <div
-                          class="PicassoContainer-centerAlignItems PicassoContainer-flex PicassoSidebarItemContent-noWrap"
+                          class="PicassoContainer-centerAlignItems PicassoContainer-flex"
                         >
-                          <p
-                            class="MuiTypography-root PicassoTypography-bodyMedium PicassoTypography-inherit MuiTypography-body1 MuiTypography-noWrap"
+                          <div
+                            class="PicassoContainer-xsmallGap PicassoContainer-centerAlignItems PicassoContainer-flex PicassoContainer-inline PicassoSidebarItemContent-noWrap"
                           >
-                            Test item
-                          </p>
+                            <div
+                              class="PicassoContainer-centerAlignItems PicassoContainer-flex PicassoSidebarItemContent-noWrap"
+                            >
+                              <p
+                                class="MuiTypography-root PicassoTypography-bodyMedium PicassoTypography-inherit MuiTypography-body1 MuiTypography-noWrap"
+                              >
+                                Test item
+                              </p>
+                            </div>
+                          </div>
                         </div>
+                      </div>
+                    </div>
+                  </li>
+                  <svg
+                    class="PicassoSvgArrowDownMinor16-root PicassoSidebarItemAccordion-expandIcon PicassoSidebarItemAccordion-lightExpandIcon PicassoAccordion-expandIcon PicassoAccordion-expandIconExpanded"
+                    style="min-width: 16px; min-height: 16px;"
+                    viewBox="0 0 16 16"
+                  >
+                    <path
+                      d="m11.997 5.29.707.707-4 4-.707.707-.707-.707-4-4 .707-.707 4 4 4-4Z"
+                    />
+                  </svg>
+                </div>
+              </div>
+              <div
+                class="MuiCollapse-root"
+                style="min-height: 0px; height: 0px; transition-duration: 0ms;"
+              >
+                <div
+                  class="MuiCollapse-wrapper"
+                >
+                  <div
+                    class="MuiCollapse-wrapperInner"
+                  >
+                    <div
+                      role="region"
+                    >
+                      <div
+                        class="MuiAccordionDetails-root PicassoAccordionDetails-root PicassoAccordion-details"
+                      >
+                        <ul
+                          class="MuiList-root PicassoMenu-root PicassoSidebarMenu-root"
+                          role="menu"
+                          tabindex="-1"
+                        >
+                          <li
+                            aria-disabled="false"
+                            class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root PicassoMenuItem-root PicassoMenuItem-light PicassoSidebarItemHeader-root PicassoSidebarItemHeader-noWrap PicassoSidebarItemHeader-light PicassoSidebarItemHeader-nestedMenu PicassoSidebarItemHeader-selected PicassoMenuItem-nonSelectable Mui-selected PicassoMenuItem-selected MuiMenuItem-gutters PicassoMenuItem-gutters MuiListItem-gutters MuiListItem-button Mui-selected"
+                            role="menuitem"
+                            tabindex="0"
+                          >
+                            <div
+                              class="PicassoContainer-flex PicassoMenuItem-itemWrapper"
+                            >
+                              <div
+                                class="PicassoContainer-flex PicassoContainer-column PicassoMenuItem-content"
+                              >
+                                <div
+                                  class="PicassoContainer-centerAlignItems PicassoContainer-flex"
+                                >
+                                  <div
+                                    class="PicassoContainer-xsmallGap PicassoContainer-centerAlignItems PicassoContainer-flex PicassoContainer-inline PicassoSidebarItemContent-noWrap"
+                                  >
+                                    <div
+                                      class="PicassoContainer-centerAlignItems PicassoContainer-flex PicassoSidebarItemContent-noWrap"
+                                    >
+                                      <p
+                                        class="MuiTypography-root PicassoTypography-bodyMedium PicassoTypography-inherit MuiTypography-body1 MuiTypography-noWrap"
+                                      >
+                                        Menu item
+                                      </p>
+                                    </div>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                          </li>
+                        </ul>
                       </div>
                     </div>
                   </div>
                 </div>
-              </li>
-              <svg
-                class="PicassoSvgArrowDownMinor16-root PicassoSidebarItemAccordion-expandIcon PicassoSidebarItemAccordion-lightExpandIcon PicassoAccordion-expandIcon PicassoAccordion-expandIconExpanded"
-                style="min-width: 16px; min-height: 16px;"
-                viewBox="0 0 16 16"
-              >
-                <path
-                  d="m11.997 5.29.707.707-4 4-.707.707-.707-.707-4-4 .707-.707 4 4 4-4Z"
-                />
-              </svg>
-            </div>
-          </div>
-          <div
-            class="MuiCollapse-root"
-            style="min-height: 0px; height: 0px; transition-duration: 0ms;"
-          >
-            <div
-              class="MuiCollapse-wrapper"
-            >
-              <div
-                class="MuiCollapse-wrapperInner"
-              >
-                <div
-                  role="region"
-                >
-                  <div
-                    class="MuiAccordionDetails-root PicassoAccordionDetails-root PicassoAccordion-details"
-                  >
-                    <ul
-                      class="MuiList-root PicassoMenu-root PicassoSidebarMenu-root"
-                      role="menu"
-                      tabindex="-1"
-                    >
-                      <li
-                        aria-disabled="false"
-                        class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root PicassoMenuItem-root PicassoMenuItem-light PicassoSidebarItemHeader-root PicassoSidebarItemHeader-noWrap PicassoSidebarItemHeader-light PicassoSidebarItemHeader-nestedMenu PicassoSidebarItemHeader-selected PicassoMenuItem-nonSelectable Mui-selected PicassoMenuItem-selected MuiMenuItem-gutters PicassoMenuItem-gutters MuiListItem-gutters MuiListItem-button Mui-selected"
-                        role="menuitem"
-                        tabindex="0"
-                      >
-                        <div
-                          class="PicassoContainer-flex PicassoMenuItem-itemWrapper"
-                        >
-                          <div
-                            class="PicassoContainer-flex PicassoContainer-column PicassoMenuItem-content"
-                          >
-                            <div
-                              class="PicassoContainer-centerAlignItems PicassoContainer-flex"
-                            >
-                              <div
-                                class="PicassoContainer-xsmallGap PicassoContainer-centerAlignItems PicassoContainer-flex PicassoContainer-inline PicassoSidebarItemContent-noWrap"
-                              >
-                                <div
-                                  class="PicassoContainer-centerAlignItems PicassoContainer-flex PicassoSidebarItemContent-noWrap"
-                                >
-                                  <p
-                                    class="MuiTypography-root PicassoTypography-bodyMedium PicassoTypography-inherit MuiTypography-body1 MuiTypography-noWrap"
-                                  >
-                                    Menu item
-                                  </p>
-                                </div>
-                              </div>
-                            </div>
-                          </div>
-                        </div>
-                      </li>
-                    </ul>
-                  </div>
-                </div>
               </div>
             </div>
-          </div>
+          </ul>
         </div>
-      </ul>
+      </div>
     </div>
   </div>
 </div>
@@ -147,130 +155,138 @@ exports[`SidebarItem collapsible menu is expanded when one of the children is se
       class="PicassoContainer-flex PicassoContainer-column PageSidebar-root PageSidebar-light PageSidebar-medium"
     >
       <div
-        class="PageSidebar-spacer"
-      />
-      <ul
-        class="MuiList-root PicassoMenu-root PicassoSidebarMenu-root"
-        role="menu"
-        tabindex="-1"
+        class="PageSidebar-wrapper PageSidebar-sticky"
       >
         <div
-          class="MuiPaper-root MuiAccordion-root PicassoAccordion-root PicassoAccordion-bordersNone Mui-expanded MuiAccordion-rounded MuiPaper-elevation0 MuiPaper-rounded"
+          class="PicassoContainer-flex PicassoContainer-column PageSidebar-scrollableContent"
         >
           <div
-            aria-disabled="false"
-            aria-expanded="true"
-            class="MuiButtonBase-root MuiAccordionSummary-root WithStyles(ForwardRef(AccordionSummary))-root PicassoAccordion-summary PicassoSidebarItemAccordion-collapsibleWrapper Mui-expanded"
-            role="button"
-            tabindex="0"
+            class="PageSidebar-spacer"
+          />
+          <ul
+            class="MuiList-root PicassoMenu-root PicassoSidebarMenu-root"
+            role="menu"
+            tabindex="-1"
           >
             <div
-              class="MuiAccordionSummary-content WithStyles(ForwardRef(AccordionSummary))-content PicassoAccordion-content PicassoSidebarItemAccordion-content Mui-expanded"
+              class="MuiPaper-root MuiAccordion-root PicassoAccordion-root PicassoAccordion-bordersNone Mui-expanded MuiAccordion-rounded MuiPaper-elevation0 MuiPaper-rounded"
             >
-              <li
+              <div
                 aria-disabled="false"
-                class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root PicassoMenuItem-root PicassoMenuItem-light PicassoSidebarItemHeader-root PicassoSidebarItemHeader-noWrap PicassoSidebarItemHeader-light PicassoSidebarItemHeader-collapsible PicassoMenuItem-nonSelectable MuiMenuItem-gutters PicassoMenuItem-gutters MuiListItem-gutters MuiListItem-button"
-                role="menuitem"
+                aria-expanded="true"
+                class="MuiButtonBase-root MuiAccordionSummary-root WithStyles(ForwardRef(AccordionSummary))-root PicassoAccordion-summary PicassoSidebarItemAccordion-collapsibleWrapper Mui-expanded"
+                role="button"
                 tabindex="0"
               >
                 <div
-                  class="PicassoContainer-flex PicassoMenuItem-itemWrapper"
+                  class="MuiAccordionSummary-content WithStyles(ForwardRef(AccordionSummary))-content PicassoAccordion-content PicassoSidebarItemAccordion-content Mui-expanded"
                 >
-                  <div
-                    class="PicassoContainer-flex PicassoContainer-column PicassoMenuItem-content"
+                  <li
+                    aria-disabled="false"
+                    class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root PicassoMenuItem-root PicassoMenuItem-light PicassoSidebarItemHeader-root PicassoSidebarItemHeader-noWrap PicassoSidebarItemHeader-light PicassoSidebarItemHeader-collapsible PicassoMenuItem-nonSelectable MuiMenuItem-gutters PicassoMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+                    role="menuitem"
+                    tabindex="0"
                   >
                     <div
-                      class="PicassoContainer-centerAlignItems PicassoContainer-flex"
+                      class="PicassoContainer-flex PicassoMenuItem-itemWrapper"
                     >
                       <div
-                        class="PicassoContainer-xsmallGap PicassoContainer-centerAlignItems PicassoContainer-flex PicassoContainer-inline PicassoSidebarItemContent-noWrap"
+                        class="PicassoContainer-flex PicassoContainer-column PicassoMenuItem-content"
                       >
                         <div
-                          class="PicassoContainer-centerAlignItems PicassoContainer-flex PicassoSidebarItemContent-noWrap"
+                          class="PicassoContainer-centerAlignItems PicassoContainer-flex"
                         >
-                          <p
-                            class="MuiTypography-root PicassoTypography-bodyMedium PicassoTypography-inherit MuiTypography-body1 MuiTypography-noWrap"
+                          <div
+                            class="PicassoContainer-xsmallGap PicassoContainer-centerAlignItems PicassoContainer-flex PicassoContainer-inline PicassoSidebarItemContent-noWrap"
                           >
-                            Test item
-                          </p>
+                            <div
+                              class="PicassoContainer-centerAlignItems PicassoContainer-flex PicassoSidebarItemContent-noWrap"
+                            >
+                              <p
+                                class="MuiTypography-root PicassoTypography-bodyMedium PicassoTypography-inherit MuiTypography-body1 MuiTypography-noWrap"
+                              >
+                                Test item
+                              </p>
+                            </div>
+                          </div>
                         </div>
+                      </div>
+                    </div>
+                  </li>
+                  <svg
+                    class="PicassoSvgArrowDownMinor16-root PicassoSidebarItemAccordion-expandIcon PicassoSidebarItemAccordion-lightExpandIcon PicassoAccordion-expandIcon PicassoAccordion-expandIconExpanded"
+                    style="min-width: 16px; min-height: 16px;"
+                    viewBox="0 0 16 16"
+                  >
+                    <path
+                      d="m11.997 5.29.707.707-4 4-.707.707-.707-.707-4-4 .707-.707 4 4 4-4Z"
+                    />
+                  </svg>
+                </div>
+              </div>
+              <div
+                class="MuiCollapse-root"
+                style="min-height: 0px; height: 0px; transition-duration: 0ms;"
+              >
+                <div
+                  class="MuiCollapse-wrapper"
+                >
+                  <div
+                    class="MuiCollapse-wrapperInner"
+                  >
+                    <div
+                      role="region"
+                    >
+                      <div
+                        class="MuiAccordionDetails-root PicassoAccordionDetails-root PicassoAccordion-details"
+                      >
+                        <ul
+                          class="MuiList-root PicassoMenu-root PicassoSidebarMenu-root"
+                          role="menu"
+                          tabindex="-1"
+                        >
+                          <li
+                            aria-disabled="false"
+                            class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root PicassoMenuItem-root PicassoMenuItem-light PicassoSidebarItemHeader-root PicassoSidebarItemHeader-noWrap PicassoSidebarItemHeader-light PicassoSidebarItemHeader-nestedMenu PicassoSidebarItemHeader-selected PicassoMenuItem-nonSelectable Mui-selected PicassoMenuItem-selected MuiMenuItem-gutters PicassoMenuItem-gutters MuiListItem-gutters MuiListItem-button Mui-selected"
+                            role="menuitem"
+                            tabindex="0"
+                          >
+                            <div
+                              class="PicassoContainer-flex PicassoMenuItem-itemWrapper"
+                            >
+                              <div
+                                class="PicassoContainer-flex PicassoContainer-column PicassoMenuItem-content"
+                              >
+                                <div
+                                  class="PicassoContainer-centerAlignItems PicassoContainer-flex"
+                                >
+                                  <div
+                                    class="PicassoContainer-xsmallGap PicassoContainer-centerAlignItems PicassoContainer-flex PicassoContainer-inline PicassoSidebarItemContent-noWrap"
+                                  >
+                                    <div
+                                      class="PicassoContainer-centerAlignItems PicassoContainer-flex PicassoSidebarItemContent-noWrap"
+                                    >
+                                      <p
+                                        class="MuiTypography-root PicassoTypography-bodyMedium PicassoTypography-inherit MuiTypography-body1 MuiTypography-noWrap"
+                                      >
+                                        Menu item
+                                      </p>
+                                    </div>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                          </li>
+                        </ul>
                       </div>
                     </div>
                   </div>
                 </div>
-              </li>
-              <svg
-                class="PicassoSvgArrowDownMinor16-root PicassoSidebarItemAccordion-expandIcon PicassoSidebarItemAccordion-lightExpandIcon PicassoAccordion-expandIcon PicassoAccordion-expandIconExpanded"
-                style="min-width: 16px; min-height: 16px;"
-                viewBox="0 0 16 16"
-              >
-                <path
-                  d="m11.997 5.29.707.707-4 4-.707.707-.707-.707-4-4 .707-.707 4 4 4-4Z"
-                />
-              </svg>
-            </div>
-          </div>
-          <div
-            class="MuiCollapse-root"
-            style="min-height: 0px; height: 0px; transition-duration: 0ms;"
-          >
-            <div
-              class="MuiCollapse-wrapper"
-            >
-              <div
-                class="MuiCollapse-wrapperInner"
-              >
-                <div
-                  role="region"
-                >
-                  <div
-                    class="MuiAccordionDetails-root PicassoAccordionDetails-root PicassoAccordion-details"
-                  >
-                    <ul
-                      class="MuiList-root PicassoMenu-root PicassoSidebarMenu-root"
-                      role="menu"
-                      tabindex="-1"
-                    >
-                      <li
-                        aria-disabled="false"
-                        class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root PicassoMenuItem-root PicassoMenuItem-light PicassoSidebarItemHeader-root PicassoSidebarItemHeader-noWrap PicassoSidebarItemHeader-light PicassoSidebarItemHeader-nestedMenu PicassoSidebarItemHeader-selected PicassoMenuItem-nonSelectable Mui-selected PicassoMenuItem-selected MuiMenuItem-gutters PicassoMenuItem-gutters MuiListItem-gutters MuiListItem-button Mui-selected"
-                        role="menuitem"
-                        tabindex="0"
-                      >
-                        <div
-                          class="PicassoContainer-flex PicassoMenuItem-itemWrapper"
-                        >
-                          <div
-                            class="PicassoContainer-flex PicassoContainer-column PicassoMenuItem-content"
-                          >
-                            <div
-                              class="PicassoContainer-centerAlignItems PicassoContainer-flex"
-                            >
-                              <div
-                                class="PicassoContainer-xsmallGap PicassoContainer-centerAlignItems PicassoContainer-flex PicassoContainer-inline PicassoSidebarItemContent-noWrap"
-                              >
-                                <div
-                                  class="PicassoContainer-centerAlignItems PicassoContainer-flex PicassoSidebarItemContent-noWrap"
-                                >
-                                  <p
-                                    class="MuiTypography-root PicassoTypography-bodyMedium PicassoTypography-inherit MuiTypography-body1 MuiTypography-noWrap"
-                                  >
-                                    Menu item
-                                  </p>
-                                </div>
-                              </div>
-                            </div>
-                          </div>
-                        </div>
-                      </li>
-                    </ul>
-                  </div>
-                </div>
               </div>
             </div>
-          </div>
+          </ul>
         </div>
-      </ul>
+      </div>
     </div>
   </div>
 </div>

--- a/packages/picasso/src/SidebarLogo/styles.ts
+++ b/packages/picasso/src/SidebarLogo/styles.ts
@@ -3,6 +3,7 @@ import { createStyles } from '@material-ui/core/styles'
 export default () =>
   createStyles({
     root: {
+      flexShrink: 0,
       display: 'block',
       overflow: 'hidden',
     },


### PR DESCRIPTION
[FX-3290]

### Description

Sidebar sticks to TopBar on scroll. Also the Sidebar has set a max height and is scrollable, if needed.
This functionality can be disabled with `sticky` property.

UPDATE: with Matt we decided to hide scrollbar on collapsed sidebar. But adding shadows on top&bottom like its in ModalContent proved problematic, since the scrollable content has set width and height, and the shadows should stretch to the edge of sidebar. We decided to leave it as it is. If you have an idea how to tackle it better, please share in comments or DM me 🙇 

### How to test

- Check out the [sticky example in temploy](https://picasso.toptal.net/fx-3290-sidebar-scrollable-sidebar/?path=/story/layout-page--page#with-banner-and-sidebar)

### Video

https://user-images.githubusercontent.com/22159416/206434319-61bb6a38-835c-495e-9a22-4250abad241e.mov

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests

**Breaking change**

- codemod is created and showcased in the changeset
- test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-3290]: https://toptal-core.atlassian.net/browse/FX-3290?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ