### PR TITLE
fix: target form mutator for components with multiline counter

### DIFF
--- a/.changeset/sharp-wolves-learn.md
+++ b/.changeset/sharp-wolves-learn.md
@@ -1,0 +1,7 @@
+---
+'@toptal/picasso-forms': patch
+---
+
+---
+
+- fix `setHasMultilineCounter` prop propagating to DOM

--- a/packages/picasso-forms/src/Field/Field.tsx
+++ b/packages/picasso-forms/src/Field/Field.tsx
@@ -3,7 +3,6 @@ import {
   useField,
   FieldProps as FinalFieldProps,
   FieldRenderProps,
-  useForm,
 } from 'react-final-form'
 import { Form as PicassoForm, OutlinedInputStatus } from '@toptal/picasso'
 import { TextLabelProps } from '@toptal/picasso-shared'
@@ -91,9 +90,6 @@ const Field = <
   } = props
 
   const { validateOnSubmit: shouldValidateOnSubmit } = useFormConfig()
-  const {
-    mutators: { setHasMultilineCounter },
-  } = useForm()
   const validators = useMemo(
     () => getValidators(required, validate),
     [required, validate]
@@ -127,7 +123,6 @@ const Field = <
   const childProps: Record<string, unknown> = {
     id,
     status,
-    setHasMultilineCounter,
     ...rest,
     ...input,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/picasso-forms/src/Input/Input.tsx
+++ b/packages/picasso-forms/src/Input/Input.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect } from 'react'
 import { Input as PicassoInput, InputProps } from '@toptal/picasso'
+import { useForm } from 'react-final-form'
 
 import { FieldProps } from '../Field'
 import FieldLabel from '../FieldLabel'
@@ -31,11 +32,16 @@ export const Input = React.forwardRef<HTMLInputElement, Props>((props, ref) => {
     warnAutocompleteDisabledInput(props.name)
   }, [props.name])
 
+  const {
+    mutators: { setHasMultilineCounter },
+  } = useForm()
+
   const { label, titleCase, ...rest } = props
 
   return (
     <InputField<FormInputProps>
       {...rest}
+      setHasMultilineCounter={setHasMultilineCounter}
       label={
         label ? (
           <FieldLabel

--- a/packages/picasso-forms/src/RichTextEditor/RichTextEditor.tsx
+++ b/packages/picasso-forms/src/RichTextEditor/RichTextEditor.tsx
@@ -5,6 +5,7 @@ import {
 } from '@toptal/picasso'
 import React, { useCallback, useState } from 'react'
 import { Except } from 'type-fest'
+import { useForm } from 'react-final-form'
 
 import { FieldProps } from '../FieldWrapper'
 import InputField from '../InputField'
@@ -25,6 +26,9 @@ type InternalProps = RichTextEditorProps & { value: string }
 export const RichTextEditor = (props: Props) => {
   const { onChange, defaultValue, label, titleCase, ...rest } = props
   const [value, setValue] = useState('')
+  const {
+    mutators: { setHasMultilineCounter },
+  } = useForm()
 
   // Because RichTextEditor doesn't have an value input we need to implement this
   // as an compatibility layer between final-form
@@ -51,6 +55,7 @@ export const RichTextEditor = (props: Props) => {
           />
         ) : null
       }
+      setHasMultilineCounter={setHasMultilineCounter}
       {...rest}
     >
       {(inputProps: RichTextEditorProps) => (


### PR DESCRIPTION
### Description

Pass `setHasMultilineCounter` mutator to only those form components that need it.
Previously, `Field` component passed this function to every form element and it propagated into dom via `...rest`.
With this change, mutator is passed only to `Input` and `RichTextEditor` components.

### How to test

- go to Picasso Forms page and search for error `setHasMultilineCounter`

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| ![image](https://user-images.githubusercontent.com/22159416/206543259-b147fa75-7b1e-4232-a455-98bb2d601bba.png) | ![image](https://user-images.githubusercontent.com/22159416/206543132-c8735075-f6d4-414e-ae67-f742bc581f03.png) |

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- Make sure that additions and changes on design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- Annotate all `props` in component with documentation
- Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- Covered with tests

**Breaking change**

- codemod is created and showcased in the changeset
- test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>
