### PR TITLE
fix(Autocomplete): focus input after clicking on adornment

### DIFF
--- a/.changeset/shy-pets-accept.md
+++ b/.changeset/shy-pets-accept.md
@@ -1,0 +1,12 @@
+---
+'@toptal/picasso': patch
+---
+
+---
+
+### Autocomplete
+
+- focus Autocomplete when clicking on its adornments
+
+> NOTE: when using custom `inputComponent` in Autocomplete,
+> make sure you wrap it with React.forwardRef

--- a/.changeset/two-lamps-jam.md
+++ b/.changeset/two-lamps-jam.md
@@ -1,0 +1,7 @@
+---
+'@toptal/picasso-shared': minor
+---
+
+---
+
+- add new `isForwardRef` util function to detect whether React component has a React.forwardRef wrapper

--- a/packages/picasso/src/Autocomplete/Autocomplete.tsx
+++ b/packages/picasso/src/Autocomplete/Autocomplete.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable max-lines */
-/* eslint-disable complexity, max-statements */ // Squiggly lines makes code difficult to work with
+/* eslint-disable complexity, max-statements, max-lines-per-function */ // Squiggly lines makes code difficult to work with
 
 import React, {
   InputHTMLAttributes,
@@ -10,11 +10,12 @@ import React, {
   useRef,
   FocusEventHandler,
   MouseEvent,
+  Ref,
 } from 'react'
 import { makeStyles, Theme } from '@material-ui/core/styles'
 import capitalize from '@material-ui/core/utils/capitalize'
 import cx from 'classnames'
-import { BaseProps } from '@toptal/picasso-shared'
+import { BaseProps, isForwardRef } from '@toptal/picasso-shared'
 import { PopperOptions } from 'popper.js'
 
 import Input, { InputProps } from '../Input'
@@ -137,7 +138,7 @@ const getItemText = (item: Item | null) =>
   (item && item.text) || EMPTY_INPUT_VALUE
 
 export const Autocomplete = forwardRef<HTMLInputElement, Props>(
-  function Autocomplete(props, ref) {
+  function Autocomplete(props, customRef) {
     const {
       autoComplete,
       className,
@@ -178,6 +179,16 @@ export const Autocomplete = forwardRef<HTMLInputElement, Props>(
       disabled = false,
       ...rest
     } = props
+
+    const inputRef = useRef<HTMLInputElement | null>(null)
+    let ref: Ref<HTMLInputElement> | undefined = customRef || inputRef
+
+    if (inputComponent && !isForwardRef(inputComponent)) {
+      ref = undefined
+      unsafeErrorLog(
+        'You provided `inputComponent` prop to Autocomplete without using React.forwardRef wrapper. This is not supported and may cause unexpected behavior. Consider wrapping your input component with React.forwardRef.'
+      )
+    }
 
     usePropDeprecationWarning({
       props,
@@ -227,6 +238,7 @@ export const Autocomplete = forwardRef<HTMLInputElement, Props>(
       onBlur,
       enableReset,
       showOtherOption,
+      ref,
     })
 
     const optionsLength = options ? options.length : 0

--- a/packages/picasso/src/Autocomplete/test.tsx
+++ b/packages/picasso/src/Autocomplete/test.tsx
@@ -623,3 +623,41 @@ describe('Autocomplete', () => {
     })
   })
 })
+
+describe('Focus behavior', () => {
+  it('focuses input when start adornment is clicked', () => {
+    const { getByTestId } = renderAutocomplete({
+      options: testOptions,
+      value: '',
+      startAdornment: <div data-testid='start-adornment' />,
+    })
+
+    const input = getByTestId('autocomplete')
+
+    expect(input).not.toHaveFocus()
+
+    const startAdornment = getByTestId('start-adornment')
+
+    fireEvent.click(startAdornment)
+
+    expect(input).toHaveFocus()
+  })
+
+  it('focuses input when end adornment is clicked', () => {
+    const { getByTestId } = renderAutocomplete({
+      options: testOptions,
+      value: '',
+      endAdornment: <div data-testid='end-adornment' />,
+    })
+
+    const input = getByTestId('autocomplete')
+
+    expect(input).not.toHaveFocus()
+
+    const endAdornment = getByTestId('end-adornment')
+
+    fireEvent.click(endAdornment)
+
+    expect(input).toHaveFocus()
+  })
+})

--- a/packages/picasso/src/Autocomplete/test.tsx
+++ b/packages/picasso/src/Autocomplete/test.tsx
@@ -1,12 +1,13 @@
 /* eslint-disable max-lines */
 /* eslint-disable max-lines-per-function */
-import React from 'react'
+import React, { forwardRef } from 'react'
 import { render, fireEvent, PicassoConfig } from '@toptal/picasso/test-utils'
 import { OmitInternalProps } from '@toptal/picasso-shared'
 import { generateRandomString } from '@toptal/picasso-provider'
 import * as titleCaseModule from 'ap-style-title-case'
 
 import Autocomplete, { Props } from './Autocomplete'
+import { InputProps } from '../Input'
 
 jest.mock('ap-style-title-case')
 
@@ -150,8 +151,9 @@ describe('Autocomplete', () => {
     it('with custom input component', async () => {
       const { getByTestId } = renderAutocomplete({
         value: '',
-        // eslint-disable-next-line react/display-name
-        inputComponent: () => <input data-testid='custom-input' />,
+        inputComponent: forwardRef<HTMLInputElement, InputProps>((_, ref) => (
+          <input ref={ref} data-testid='custom-input' />
+        )),
       })
 
       const input = getByTestId('custom-input')

--- a/packages/picasso/src/Autocomplete/use-autocomplete/use-autocomplete.ts
+++ b/packages/picasso/src/Autocomplete/use-autocomplete/use-autocomplete.ts
@@ -6,6 +6,7 @@ import {
   useState,
   ChangeEvent,
   FocusEventHandler,
+  Ref,
   useEffect,
   useMemo,
 } from 'react'
@@ -94,6 +95,7 @@ export interface Props {
   enableReset?: boolean
   showOtherOption?: boolean
   disabled?: boolean
+  ref?: Ref<HTMLInputElement>
 }
 
 export const useAutocomplete = ({
@@ -111,6 +113,7 @@ export const useAutocomplete = ({
   enableReset,
   showOtherOption,
   disabled = false,
+  ref,
 }: Props) => {
   const [isOpen, setOpen] = useState<boolean>(false)
   const [highlightedIndex, setHighlightedIndex] = useState<number>(
@@ -135,6 +138,15 @@ export const useAutocomplete = ({
       }
     }
   }, [isOpen, selectedIndex, highlightedIndex])
+
+  useEffect(() => {
+    if (typeof ref === 'function' || !isOpen || !ref?.current) {
+      return
+    }
+    if (document.activeElement !== ref.current) {
+      ref.current.focus()
+    }
+  }, [isOpen, ref])
 
   const shouldShowOtherOption = Boolean(showOtherOption) && selectedIndex === -1
 

--- a/packages/shared/src/utils/index.ts
+++ b/packages/shared/src/utils/index.ts
@@ -1,2 +1,3 @@
 export { default as isBrowser } from './is-browser'
 export { default as getElementById } from './get-element-by-id'
+export { default as isForwardRef } from './is-forward-ref'

--- a/packages/shared/src/utils/is-forward-ref.ts
+++ b/packages/shared/src/utils/is-forward-ref.ts
@@ -1,0 +1,6 @@
+const isForwardRef = (Component: any) =>
+  typeof Component === 'object' &&
+  Component !== null &&
+  Component.$$typeof === Symbol.for('react.forward_ref')
+
+export default isForwardRef


### PR DESCRIPTION
[FX-3119]

### Description

Currently, when clicking on [Autocomplete adornments](https://picasso.toptal.net/?path=/story/forms-autocomplete--autocomplete#with-adornments), the Input does not focus, leading to opened Select that does not close when clicking outside of Autocomplete. This bug also appears in TagSelector, where values (Tags) are displayed as adornments. 

There are two ways to handle this issue:

**1. Do not open Select when clicking on adornments**

This has a drawback for TagSelector, because values can take up most of the space in Autocomplete, leaving the Input that opens the Select hard to click on. It also reduces UX

**2. Trigger focus on Input when Select is open**

This requires having a reference to Input. Possible drawback is when user defines a reference to Autocomplete as a function - this way we can't reach the input to trigger focus. But that should be edge case, since standard way to create refs in React is through `useRef` hook.

I went for solution 2., although I'm open to better suggestions 🙇 

### How to test

- clicking on [TagSelector's values](https://picasso.toptal.net/fx-3119-tagselector-input-doesn-t-get-focused-when-click-on-a-selected-option/?path=/story/forms-tagselector--tagselector#initially-set-value) should focus the Input

### Before


https://user-images.githubusercontent.com/22159416/210854017-73dc085a-6517-4117-81a5-9d08569c302f.mov

### After


https://user-images.githubusercontent.com/22159416/210854046-889a9660-9caa-460b-84d5-44134e98e7e8.mov




### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- Make sure that additions and changes on design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- Annotate all `props` in component with documentation
- Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests

**Breaking change**

- codemod is created and showcased in the changeset
- test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
4. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
5. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-3119]: https://toptal-core.atlassian.net/browse/FX-3119?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ