### PR TITLE
chore(docs): add form difference documentation

### DIFF
--- a/.storybook/stories/tutorials/form-components/story/Components.1.example.tsx
+++ b/.storybook/stories/tutorials/form-components/story/Components.1.example.tsx
@@ -1,0 +1,29 @@
+import React from 'react'
+import {
+  Container,
+  Form,
+  Input,
+  Select,
+  NumberInput,
+  PasswordInput,
+} from '@toptal/picasso'
+
+const Example = () => (
+  <Form>
+    <Container flex justifyContent='space-between'>
+      <Input width='auto' placeholder='Text input' />
+      <Select
+        options={[
+          { value: '1', text: 'Option 1' },
+          { value: '2', text: 'Option 2' },
+        ]}
+        placeholder='Select'
+        width='auto'
+      />
+      <PasswordInput placeholder='Password input' />
+      <NumberInput placeholder='Number input' />
+    </Container>
+  </Form>
+)
+
+export default Example

--- a/.storybook/stories/tutorials/form-components/story/Components.1.example.tsx
+++ b/.storybook/stories/tutorials/form-components/story/Components.1.example.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState } from 'react'
 import {
   Container,
   Form,
@@ -8,22 +8,37 @@ import {
   PasswordInput,
 } from '@toptal/picasso'
 
-const Example = () => (
-  <Form>
-    <Container flex justifyContent='space-between'>
-      <Input width='auto' placeholder='Text input' />
-      <Select
-        options={[
-          { value: '1', text: 'Option 1' },
-          { value: '2', text: 'Option 2' },
-        ]}
-        placeholder='Select'
-        width='auto'
-      />
-      <PasswordInput placeholder='Password input' />
-      <NumberInput placeholder='Number input' />
-    </Container>
-  </Form>
-)
+type SelectValue = '1' | '2' | undefined
+
+const Example = () => {
+  const [selectValue, setSelectValue] = useState<SelectValue>()
+
+  const handleSelectChange = (
+    event: React.ChangeEvent<{ value: SelectValue }>
+  ) => {
+    console.log('Select value:', event.target.value)
+    setSelectValue(event.target.value)
+  }
+
+  return (
+    <Form>
+      <Container flex justifyContent='space-between'>
+        <Input width='auto' placeholder='Text input' />
+        <Select
+          onChange={handleSelectChange}
+          value={selectValue}
+          options={[
+            { value: '1', text: 'Option 1' },
+            { value: '2', text: 'Option 2' },
+          ]}
+          placeholder='Select (controlled)'
+          width='auto'
+        />
+        <PasswordInput placeholder='Password input' />
+        <NumberInput placeholder='Number input' />
+      </Container>
+    </Form>
+  )
+}
 
 export default Example

--- a/.storybook/stories/tutorials/form-components/story/Components.2.example.tsx
+++ b/.storybook/stories/tutorials/form-components/story/Components.2.example.tsx
@@ -1,0 +1,34 @@
+import React from 'react'
+import { Form, Grid, Select, Input } from '@toptal/picasso'
+
+const Example = () => (
+  <Grid>
+    <Grid.Item small={5}>
+      <Form>
+        <Form.Field>
+          <Form.Label htmlFor='city'>Field label</Form.Label>
+          <Input id='city' width='full' />
+        </Form.Field>
+
+        <Form.Field>
+          <Form.Label requiredDecoration='optional' htmlFor='country'>
+            Optional label
+          </Form.Label>
+          <Input id='country' width='full' />
+        </Form.Field>
+
+        <Form.Field error='Error: HTTP 418'>
+          <Form.Label htmlFor='district'>Field with error</Form.Label>
+          <Input status='error' id='district' width='full' />
+        </Form.Field>
+
+        <Form.Field hint='Tip: do not eat the yellow snow'>
+          <Form.Label htmlFor='hinted'>Field with a hint</Form.Label>
+          <Input id='hinted' width='full' />
+        </Form.Field>
+      </Form>
+    </Grid.Item>
+  </Grid>
+)
+
+export default Example

--- a/.storybook/stories/tutorials/form-components/story/Components.3.example.tsx
+++ b/.storybook/stories/tutorials/form-components/story/Components.3.example.tsx
@@ -1,0 +1,26 @@
+import React from 'react'
+import { Container } from '@toptal/picasso'
+import { Form } from '@toptal/picasso-forms'
+
+const Example = () => (
+  <Form onSubmit={values => window.alert(JSON.stringify(values, undefined, 2))}>
+    <Form.Input
+      required
+      name='userName'
+      label='First name'
+      placeholder='e.g. Bruce'
+    />
+    <Form.NumberInput
+      required
+      name='userAge'
+      label="What's your age?"
+      placeholder='e.g. 25'
+    />
+
+    <Container top='small'>
+      <Form.SubmitButton>Submit</Form.SubmitButton>
+    </Container>
+  </Form>
+)
+
+export default Example

--- a/.storybook/stories/tutorials/form-components/story/index.jsx
+++ b/.storybook/stories/tutorials/form-components/story/index.jsx
@@ -1,30 +1,33 @@
 import PicassoBook from '~/.storybook/components/PicassoBook'
 
 const formsPage = PicassoBook.section('Tutorials').createPage(
-  'Difference between Picasso-forms and base form components',
+  'Difference between Picasso Forms and base form components',
   'Learn how to pick the right abstraction for working with inputs and forms in different scenarios.'
 )
 
 formsPage.createChapter().addTextSection(
   `
-In this document you'll learn all the differences between \`Form\` from Picasso core and Picasso Forms,
+In this document you'll learn all the differences between [Form](/?path=/story/forms-form--form) from Picasso core and [Picasso Forms](/?path=/story/picasso-forms-form--form),
 learn about what the differences are and how to apply each to a particular task you have.
 There are several ways to work with forms and inputs in Picasso and this may look confusing at first, so let's take a deeper look at what are your options and what do they do.
 `
 )
 
-const basicChapter = formsPage.createChapter('Basic Form and form elements')
+const basicChapter = formsPage.createChapter(
+  'Basic Form and base form components'
+)
 
 basicChapter
   .addTextSection(
     `
 Let's take a look at the basic \`Form\` and inputs first.
-Basic Form component and all inputs / form elements you can find in Picasso are mostly just pure decorations on top of basic HTML elements you got used to.
+Basic Form component and all inputs / form elements you can find in Picasso are mostly just pure decorations on top of basic HTML elements you got used to. They are built on top of the Material UI input components.
 
 They can be directly imported from \`@toptal/picasso\` and found in the "Forms" section in the Storybook sidebar.
 
 There are some more complex components like Autocomplete, but most components accept the same props and have the same properties as pure HTML inputs.
 They do not contain any extra styling, spacing or labels you used to see in most big forms.
+Form elements imported directly from Picasso also won't show any field-level errors in the form.
 You can use them in a fully controlled manner by directly manipulating their \`value\` and \`onChange\` props or have them uncontrolled as a part of the form.
   `,
     {
@@ -69,7 +72,9 @@ You will find exactly the same set of form inputs as in regular Picasso, but as 
 
 Please note: most of the time you want to use **either** only pure components from Picasso or only components from Picasso Forms,
 almost never both types at the same time (unless you need something very specific-looking).
+
 Form elements provided by Picasso Forms already include a set of UI of basic components, labels and spacing + the all the Final Form abstractions on top of it.
+Picasso Form components are written especially to operate inside a React Final Form and they have error handling, labels and validation working out of the box.
       `,
     {
       title: 'Form and form field wrappers',

--- a/.storybook/stories/tutorials/form-components/story/index.jsx
+++ b/.storybook/stories/tutorials/form-components/story/index.jsx
@@ -1,0 +1,106 @@
+import PicassoBook from '~/.storybook/components/PicassoBook'
+
+const formsPage = PicassoBook.section('Tutorials').createPage(
+  'Difference between Picasso-forms and base form components',
+  'Learn how to pick the right abstraction for working with inputs and forms in different scenarios.'
+)
+
+formsPage.createChapter().addTextSection(
+  `
+In this document you'll learn all the differences between \`Form\` from Picasso core and Picasso Forms,
+learn about what the differences are and how to apply each to a particular task you have.
+There are several ways to work with forms and inputs in Picasso and this may look confusing at first, so let's take a deeper look at what are your options and what do they do.
+`
+)
+
+const basicChapter = formsPage.createChapter('Basic Form and form elements')
+
+basicChapter
+  .addTextSection(
+    `
+Let's take a look at the basic \`Form\` and inputs first.
+Basic Form component and all inputs / form elements you can find in Picasso are mostly just pure decorations on top of basic HTML elements you got used to.
+
+They can be directly imported from \`@toptal/picasso\` and found in the "Forms" section in the Storybook sidebar.
+
+There are some more complex components like Autocomplete, but most components accept the same props and have the same properties as pure HTML inputs.
+They do not contain any extra styling, spacing or labels you used to see in most big forms.
+You can use them in a fully controlled manner by directly manipulating their \`value\` and \`onChange\` props or have them uncontrolled as a part of the form.
+  `,
+    {
+      title: 'Form elements',
+    }
+  )
+  .addExample('tutorials/form-components/story/Components.1.example.tsx', {
+    id: 'components-1',
+    takeScreenshot: false,
+  })
+
+basicChapter
+  .addTextSection(
+    `
+Now, the [Form](/?path=/story/forms-form--form) itself is a very simple wrapper around HTML \`<form>\`
+and is both visually and functionally identical to it.
+
+A main purpose of the Form component is to expose field wrappers
+as compound components to easily apply form decorations like Labels, Hints, add spacing around form elements and display form errors.
+
+Form component and field wrappers **still** do not provide any abstractions / extra validations outside the ones provided by the DOM.
+      `,
+    {
+      title: 'Form and form field wrappers',
+    }
+  )
+  .addExample('tutorials/form-components/story/Components.2.example.tsx', {
+    id: 'components-2',
+    takeScreenshot: false,
+  })
+
+const advancedChapter = formsPage.createChapter(
+  'Advanced forms with Picasso Forms'
+)
+
+advancedChapter
+  .addTextSection(
+    `
+Picasso Forms is a powerful wrapper around React Final Form. it comes with a full set of tools to validate, parse, keep and sanitize the form state.
+
+You will find exactly the same set of form inputs as in regular Picasso, but as a part of a compound \`Form\` component imported from \`@toptal/picasso-forms\`.
+
+Please note: most of the time you want to use **either** only pure components from Picasso or only components from Picasso Forms,
+almost never both types at the same time (unless you need something very specific-looking).
+Form elements provided by Picasso Forms already include a set of UI of basic components, labels and spacing + the all the Final Form abstractions on top of it.
+      `,
+    {
+      title: 'Form and form field wrappers',
+    }
+  )
+  .addExample('tutorials/form-components/story/Components.3.example.tsx', {
+    id: 'components-3',
+    takeScreenshot: false,
+  })
+
+advancedChapter.addTextSection(
+  `
+If you look for handlers for sanitizing / validating your form component data into form state, you can do so by taking a look at the available props for FieldWrapper.
+
+All the components that are a part of the compound \`Form\` share the common set of props from the [FieldWrapper](/?path=/story/picasso-forms-form--form).
+If you need converting your data between plain HTML form values (always string) and internal form state, \`parse\` and \`format\` is a good place to start.
+
+You can also convert your data before submitting if you need it. Field and form level validators are also available in \`Form\` and it's compound components respectively.
+`,
+  {
+    title: 'Sanitizing and validating',
+  }
+)
+
+const finalChapter = formsPage.createChapter('Summary')
+finalChapter.addTextSection(
+  `
+If you need a single form element with no complex validations - use it as a controlled component (directly set and manipulate state) and import it from \`@toptal/picasso\`.
+
+If you need to quickly build a standard form with sanitizing, validating and complex state - use Form from Picasso Forms and import it from \`@toptal/picasso-forms\`. Do **not** use base components together with Picasso Forms.
+
+If you need to have a standard form with some fields being very different from ones provided by Picasso Forms, use \`FieldWrapper\` with a combination of base Picasso components.
+`
+)

--- a/packages/picasso-forms/src/Form/story/index.jsx
+++ b/packages/picasso-forms/src/Form/story/index.jsx
@@ -7,6 +7,10 @@ const page = PicassoBook.section('Picasso Forms').createPage(
   `Form
 
    ${PicassoBook.createSourceLink(__filename)}
+
+  Confused between Form from Picasso and Picasso Forms?
+  Take a look at this
+  [page](/?path=/story/tutorials-difference-between-picasso-forms-and-base-form-components--difference-between-picasso-forms-and-base-form-components).
 `
 )
 

--- a/packages/picasso/src/Form/story/index.jsx
+++ b/packages/picasso/src/Form/story/index.jsx
@@ -10,6 +10,10 @@ const page = PicassoBook.section('Forms').createPage(
   `Helper components for building forms.
   
   ${PicassoBook.createSourceLink(__filename)}
+
+  Confused between Form from Picasso and Picasso Forms?
+  Take a look at this
+  [page](/?path=/story/tutorials-difference-between-picasso-forms-and-base-form-components--difference-between-picasso-forms-and-base-form-components).
   `
 )
 


### PR DESCRIPTION
[FX-3424](https://toptal-core.atlassian.net/browse/FX-3424)

### Description

Adds a documentation clearing out the key difference between `Form` Picasso and Picasso Forms

### How to test

- Take a look at the new page on the [temploy](https://picasso.toptal.net/fx-3424-create-documentation-on-picasso-forms/?path=/story/tutorials-difference-between-picasso-forms-and-base-form-components--difference-between-picasso-forms-and-base-form-components) and see if it's missing something. 

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| Insert screenshots or screen recordings | Insert screenshots or screen recordings |

### Development checks

- [n/a] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [n/a] Covered with tests


> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-3424]: https://toptal-core.atlassian.net/browse/FX-3424?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ