### PR TITLE
feat(Drawer): add body scroll lock

### DIFF
--- a/.changeset/nice-donuts-check.md
+++ b/.changeset/nice-donuts-check.md
@@ -1,0 +1,9 @@
+---
+'@toptal/picasso': minor
+---
+
+---
+
+### Drawer
+
+- Add support for optional body scroll lock enabled mode

--- a/packages/picasso/src/Drawer/Drawer.tsx
+++ b/packages/picasso/src/Drawer/Drawer.tsx
@@ -11,6 +11,7 @@ import ButtonCircular from '../ButtonCircular'
 import Container from '../Container'
 import DrawerTitle from '../DrawerTitle'
 import { useIsomorphicLayoutEffect } from '../utils'
+import { useBodyScrollLock } from '../utils/use-body-scroll-lock'
 
 type AnchorType = 'bottom' | 'left' | 'right' | 'top'
 
@@ -33,6 +34,8 @@ export interface Props extends BaseProps {
   width?: WidthType
   /** Animation lifecycle callbacks. Backed by [react-transition-group/Transition](https://reactcommunity.org/react-transition-group/transition#Transition-props) */
   transitionProps?: TransitionProps
+  /** enable Drawer to maintain body scroll lock */
+  maintainBodyScrollLock?: boolean
 }
 
 const useStyles = makeStyles<Theme>(styles, { name: 'PicassoDrawer' })
@@ -46,12 +49,15 @@ export const Drawer = (props: Props) => {
     title,
     width = 'regular',
     transitionProps,
+    maintainBodyScrollLock,
     ...rest
   } = props
   const classes = useStyles()
   const { setHasDrawer } = useDrawer()
   const theme = useTheme()
   const container = usePicassoRoot()
+
+  useBodyScrollLock(Boolean(maintainBodyScrollLock && open))
 
   useIsomorphicLayoutEffect(() => {
     setHasDrawer(open)

--- a/packages/picasso/src/Drawer/story/WithBodyScrollLock.example.tsx
+++ b/packages/picasso/src/Drawer/story/WithBodyScrollLock.example.tsx
@@ -1,0 +1,43 @@
+import { Button, Container, List, Drawer, Checkbox } from '@toptal/picasso'
+import React, { useState } from 'react'
+
+const Example = () => {
+  const [open, setOpen] = useState(false)
+  const [maintainBodyScrollLock, setMaintainBodyScrollLock] = useState(true)
+
+  return (
+    <div>    
+      <Checkbox 
+        checked={maintainBodyScrollLock} 
+        onChange={(evt, val) => {
+          setMaintainBodyScrollLock(val)
+        }} 
+        label="Maintain body scroll lock" 
+      />
+      <Container top='small'>
+        <Button data-testid='trigger' onClick={() => setOpen(!open)}>
+          Show drawer
+        </Button>
+      </Container>
+      <Drawer
+        title='My Operational Issues'
+        open={open}
+        onClose={() => setOpen(false)}    
+        maintainBodyScrollLock={maintainBodyScrollLock} 
+      >
+        <Container data-testid='content' padded='medium'>
+          <List variant='ordered'>
+            {Array(100).fill(undefined).map((_, index) => (
+              // eslint-disable-next-line react/no-array-index-key
+              <List.Item key={index}>Row {index}</List.Item>
+            ))}
+            <List.Item>Add at least 10 skills</List.Item>
+            <List.Item>Set your age</List.Item>
+          </List>
+        </Container>
+      </Drawer>
+    </div>
+  )
+}
+
+export default Example

--- a/packages/picasso/src/Drawer/story/index.jsx
+++ b/packages/picasso/src/Drawer/story/index.jsx
@@ -25,6 +25,10 @@ page
     title: 'Default',
     takeScreenshot: false,
   })
+  .addExample('Drawer/story/WithBodyScrollLock.example.tsx', {
+    title: 'With body scroll lock',
+    takeScreenshot: false,
+  })
   .addExample('Drawer/story/WithoutTitle.example.tsx', {
     title: 'Without Title',
     takeScreenshot: false,

--- a/packages/picasso/src/Modal/Modal.tsx
+++ b/packages/picasso/src/Modal/Modal.tsx
@@ -23,6 +23,7 @@ import { ModalManager } from '../utils/Modal'
 import ButtonCircular from '../ButtonCircular'
 import styles from './styles'
 import ModalContext from './ModalContext'
+import { useBodyScrollLock } from '../utils/use-body-scroll-lock'
 
 type ContainerValue = HTMLElement | (() => HTMLElement)
 type Alignment = 'top' | 'centered'
@@ -176,6 +177,8 @@ export const Modal = forwardRef<HTMLElement, Props>(function Modal(props, ref) {
       defaultManager.remove(currentModalId)
     }
   }, [open])
+
+  useBodyScrollLock(open)
 
   const isSmall = useBreakpoint('small')
 

--- a/packages/picasso/src/utils/Modal/modal-manager.ts
+++ b/packages/picasso/src/utils/Modal/modal-manager.ts
@@ -1,8 +1,5 @@
-import { isBrowser } from '@toptal/picasso-shared'
-
 export class ModalManager {
   modals: number[] = []
-  scrollLock: { prevBodyOverflow: string } | undefined
 
   add(modalId: number) {
     if (this.modals.includes(modalId)) {
@@ -10,7 +7,6 @@ export class ModalManager {
     }
 
     this.modals.push(modalId)
-    this.dropScrollLock()
   }
 
   remove(modalId: number) {
@@ -21,36 +17,11 @@ export class ModalManager {
     }
 
     this.modals.splice(modalIndex, 1)
-    this.liftScrollLock()
   }
 
   isTopModal(modalId: number) {
     return (
       this.modals.length > 0 && this.modals[this.modals.length - 1] === modalId
     )
-  }
-
-  private dropScrollLock() {
-    if (!isBrowser()) {
-      return
-    }
-
-    if (!this.scrollLock) {
-      this.scrollLock = {
-        prevBodyOverflow: window.getComputedStyle(document.body).overflow,
-      }
-      document.body.style.overflow = 'hidden'
-    }
-  }
-
-  private liftScrollLock() {
-    if (!isBrowser()) {
-      return
-    }
-
-    if (this.scrollLock && this.modals.length === 0) {
-      document.body.style.overflow = this.scrollLock.prevBodyOverflow
-      this.scrollLock = undefined
-    }
   }
 }

--- a/packages/picasso/src/utils/__tests__/use-body-scroll-lock.test.tsx
+++ b/packages/picasso/src/utils/__tests__/use-body-scroll-lock.test.tsx
@@ -1,0 +1,100 @@
+import { renderHook } from '@testing-library/react-hooks';
+
+import { useBodyScrollLock } from '../use-body-scroll-lock';
+
+let defaultBodyOverflow: string;
+
+describe('useBodyScrollLock', () => {
+
+  beforeEach(() => {
+    defaultBodyOverflow = document.body.style.overflow;
+  })
+
+  afterEach(() => {
+    document.body.style.overflow = defaultBodyOverflow;
+  })
+
+  describe('single usage', () => {
+    it('drops scroll lock when mounted with true', () => {      
+      renderHook(() => useBodyScrollLock(true));
+
+      expect(document.body.style.overflow).toBe('hidden');
+    })
+
+    describe('lifts scroll lock', () => {
+      it('when unmounted', () => {        
+        const {unmount} = renderHook(() => useBodyScrollLock(true));
+  
+        expect(document.body.style.overflow).toBe('hidden');
+  
+        unmount()
+  
+        expect(document.body.style.overflow).toBe('');
+      })
+
+      it('when isLocked switches into false', () => {  
+        const {rerender} = renderHook((isLocked) => useBodyScrollLock(isLocked), { initialProps: true });
+  
+        expect(document.body.style.overflow).toBe('hidden');
+  
+        rerender(false)
+  
+        expect(document.body.style.overflow).toBe('');
+      })
+
+      it('restores prev body overflow', () => {
+        document.body.style.overflow = 'grid';
+
+        const {unmount} = renderHook(() => useBodyScrollLock(true));
+  
+        expect(document.body.style.overflow).toBe('hidden');
+  
+        unmount()
+  
+        expect(document.body.style.overflow).toBe('grid');
+      })
+    })    
+  })
+
+  describe('multiple instances usage', () => {
+    it('drops scroll lock once any hook gets isLocked=true', () => {
+      const hook1 = renderHook((isLocked) => useBodyScrollLock(isLocked), { initialProps: false });
+      const hook2 = renderHook((isLocked) => useBodyScrollLock(isLocked), { initialProps: false });
+      const hook3 = renderHook((isLocked) => useBodyScrollLock(isLocked), { initialProps: false });  
+    
+      expect(document.body.style.overflow).toBe('');
+
+      hook1.rerender(true)
+
+      expect(document.body.style.overflow).toBe('hidden');
+
+      hook2.rerender(true)
+      hook3.rerender(true)
+
+      expect(document.body.style.overflow).toBe('hidden');
+    })
+
+    it('lifts scroll lock once no hook with isLocked=true left mounted', () => {
+      document.body.style.overflow = 'block';
+      
+      const hook1 = renderHook((isLocked) => useBodyScrollLock(isLocked), { initialProps: true });
+      const hook2 = renderHook((isLocked) => useBodyScrollLock(isLocked), { initialProps: true });
+      const hook3 = renderHook((isLocked) => useBodyScrollLock(isLocked), { initialProps: true });  
+    
+      expect(document.body.style.overflow).toBe('hidden');
+      
+      hook3.unmount()
+
+      expect(document.body.style.overflow).toBe('hidden');
+
+      hook2.rerender(false)
+
+      expect(document.body.style.overflow).toBe('hidden');
+
+      hook1.rerender(false)
+
+      expect(document.body.style.overflow).toBe('block');
+    })
+    
+  })
+})

--- a/packages/picasso/src/utils/use-body-scroll-lock.ts
+++ b/packages/picasso/src/utils/use-body-scroll-lock.ts
@@ -1,0 +1,63 @@
+import { isBrowser } from '@toptal/picasso-shared'
+import { useEffect, useMemo } from 'react'
+
+const layers = new Set<number>();
+let scrollLock: { prevBodyOverflow: string } | undefined = undefined;
+
+export const useBodyScrollLock = (isLocked: boolean) => {
+  const layerId = useMemo(generateLayerId, [])
+
+  useEffect(() => {
+    if (isLocked) {
+      layers.add(layerId)
+      syncBodyScrollLock()
+    }
+
+    return () => {
+      layers.delete(layerId)
+      syncBodyScrollLock()
+    }
+  }, [layerId, isLocked])
+}
+
+const generateLayerId = (() => {
+  let count = 0
+
+  return () => {
+    count = count + 1
+    
+    return count;
+  }
+})()
+
+const syncBodyScrollLock = () => {
+  if (layers.size > 0) {
+    addBodyScrollLock()
+  } else {
+    removeBodyScrollLock()
+  }  
+}
+
+const addBodyScrollLock = () => {
+  if (!isBrowser()) {
+    return
+  }
+
+  if (!scrollLock) {
+    scrollLock = {
+      prevBodyOverflow: document.body.style.overflow,
+    }
+    document.body.style.overflow = 'hidden'
+  }
+}
+
+const removeBodyScrollLock = () => {
+  if (!isBrowser()) {
+    return
+  }
+
+  if (scrollLock) {
+    document.body.style.overflow = scrollLock.prevBodyOverflow
+    scrollLock = undefined
+  }
+}


### PR DESCRIPTION
[TOP-2735]

### Description

Decoupled body scroll management logic from ModalManager class to make it independent from modals and reusable. Added a prop to Drawer that allows to opt-in for body scroll lock enabled mode. 

### How to test

- Ensure modals lock body scrolling just like they would do it previously
- Ensure drawers lock body scrolling when rendered with `maintainBodyScrollLock=true`

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests

**Breaking change**

- ~codemod is created and showcased in the changeset~
- ~test alpha package of Picasso in StaffPortal~

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[TOP-2735]: https://toptal-core.atlassian.net/browse/TOP-2735?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ