### PR TITLE
chore(Modal): remove onBackdropClick and update onClose

### DIFF
--- a/.changeset/forty-snails-compete.md
+++ b/.changeset/forty-snails-compete.md
@@ -1,0 +1,10 @@
+---
+'@toptal/picasso': major
+---
+
+---
+
+### Modal
+
+- trigger `onClose` callback by default when the backdrop is clicked
+- add new prop `disableBackdropClick` to prevent calling onClose after clicking the backdrop

--- a/packages/picasso/src/Modal/Modal.tsx
+++ b/packages/picasso/src/Modal/Modal.tsx
@@ -37,6 +37,8 @@ export interface Props extends StandardProps, HTMLAttributes<HTMLDivElement> {
   size?: SizeType<'small' | 'medium' | 'large'> | 'full-screen'
   /** Callback executed when backdrop was clicked */
   onBackdropClick?: () => void
+  /** If `true`, clicking the backdrop will not fire `onClose` or `onBackdropClick` */
+  disableBackdropClick?: boolean
   /** Callback executed when attempting to close modal */
   onClose?: () => void
   /** Callback executed when modal is being opened */
@@ -127,6 +129,7 @@ export const Modal = forwardRef<HTMLElement, Props>(function Modal(props, ref) {
     align = 'centered',
     testIds,
     transitionProps,
+    disableBackdropClick = false,
     ...rest
   } = props
   const classes = useStyles(props)
@@ -186,11 +189,17 @@ export const Modal = forwardRef<HTMLElement, Props>(function Modal(props, ref) {
     (_event, reason: 'backdropClick' | 'escapeKeyDown') => {
       if (reason === 'escapeKeyDown' && onClose) {
         onClose()
-      } else if (reason === 'backdropClick' && onBackdropClick) {
-        onBackdropClick()
+      } else if (reason === 'backdropClick' && !disableBackdropClick) {
+        if (onBackdropClick) {
+          onBackdropClick()
+        }
+
+        if (onClose) {
+          onClose()
+        }
       }
     },
-    [onBackdropClick, onClose]
+    [disableBackdropClick, onBackdropClick, onClose]
   )
 
   return (
@@ -236,6 +245,7 @@ export const Modal = forwardRef<HTMLElement, Props>(function Modal(props, ref) {
 
 Modal.defaultProps = {
   hideBackdrop: false,
+  disableBackdropClick: false,
   size: 'medium',
   transitionDuration: 300,
   align: 'centered',

--- a/packages/picasso/src/Modal/story/DisableBackdropClick.example.tsx
+++ b/packages/picasso/src/Modal/story/DisableBackdropClick.example.tsx
@@ -1,0 +1,27 @@
+import React from 'react'
+import { Modal, Button } from '@toptal/picasso'
+import { useModal } from '@toptal/picasso/utils'
+
+const Example = () => {
+  const { showModal, hideModal, isOpen } = useModal()
+
+  return (
+    <>
+      <Button onClick={showModal}>Open</Button>
+
+      <Modal onClose={hideModal} open={isOpen} disableBackdropClick>
+        <Modal.Title>Disable backdrop click</Modal.Title>
+        <Modal.Content>
+          Clicking backdrop won't cause Modal to close.
+        </Modal.Content>
+        <Modal.Actions>
+          <Button variant='secondary' onClick={hideModal}>
+            Ok
+          </Button>
+        </Modal.Actions>
+      </Modal>
+    </>
+  )
+}
+
+export default Example

--- a/packages/picasso/src/Modal/story/index.jsx
+++ b/packages/picasso/src/Modal/story/index.jsx
@@ -52,3 +52,9 @@ component and manage the internal state there.
     description: 'Demonstrate how `align` prop works',
     takeScreenshot: false,
   })
+  .addExample('Modal/story/DisableBackdropClick.example.tsx', {
+    title: 'Disable backdrop click',
+    description:
+      'Demonstrate how `disableBackdropClick` prop can be used to avoid closing modal on backdrop click',
+    takeScreenshot: false,
+  })


### PR DESCRIPTION
[no-jira]

### Description

According to the [discussions](https://toptal-core.slack.com/archives/CERF5NHT3/p1673903476781539), it is decided to add functionality to the backdrop to trigger onClose when clicked.

With this update (inspired by MUIv5 Dialog component [updates](https://mui.com/material-ui/migration/v5-component-changes/#%E2%9C%85-remove-disablebackdropclick-prop)), onClose callback will be triggered with closing reason so anyone can decide to let Modal stay even after backdrop clicked.

- according to discussions in the PR, codemod can be considered to remove `onBackdropClick` prop usage.

### How to test

- I have added a new story, check temploy

### Screenshots

- no visual updates

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [N/A] Make sure that additions and changes on design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests

**Breaking change**

- [N/A] codemod is created and showcased in the changeset
- [x] test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>
