### PR TITLE
chore(Sidebar): introduce `onCollapse` callback

### DIFF
--- a/.changeset/pink-experts-cheat.md
+++ b/.changeset/pink-experts-cheat.md
@@ -1,0 +1,6 @@
+---
+'@toptal/picasso': minor
+---
+
+- add new `onCollapse` prop
+- call `onCollapse` when collapse button is clicked

--- a/packages/picasso/src/PageSidebar/PageSidebar.tsx
+++ b/packages/picasso/src/PageSidebar/PageSidebar.tsx
@@ -43,6 +43,8 @@ export interface Props extends BaseProps {
   /** Make sidebar scroll with the content */
   disableSticky?: boolean
   wrapperMaxHeight?: string | number
+  /** Callback when sidebar is collapsed */
+  onCollapse?: () => void
 }
 
 const useStyles = makeStyles<Theme>(styles, {
@@ -64,6 +66,7 @@ export const PageSidebar = forwardRef<HTMLDivElement, Props>(function Sidebar(
     size = 'medium',
     wrapperMaxHeight,
     disableSticky,
+    onCollapse
   } = props
   const classes = useStyles()
   const { setHasSidebar } = useSidebar()
@@ -92,6 +95,7 @@ export const PageSidebar = forwardRef<HTMLDivElement, Props>(function Sidebar(
 
   const handleCollapseButtonClick = useCallback(() => {
     setIsCollapsed(previousState => !previousState)
+    onCollapse?.()
   }, [setIsCollapsed])
 
   const sidebar = (

--- a/packages/picasso/src/PageSidebar/story/Collapsible.example.tsx
+++ b/packages/picasso/src/PageSidebar/story/Collapsible.example.tsx
@@ -14,7 +14,12 @@ import {
   Participants16,
 } from '@toptal/picasso/Icon'
 
-const Example = () => (
+const Example = () => {
+  const handleCollapse = () => {
+    window.alert('Sidebar onCollapse called')
+  }
+
+  return (
   <div
     style={{
       height: '58rem',
@@ -22,7 +27,7 @@ const Example = () => (
       overflowY: 'scroll',
     }}
   >
-    <Page.Sidebar collapsible>
+    <Page.Sidebar collapsible onCollapse={handleCollapse}>
       <Page.Sidebar.Logo collapsedLogo={<Logo emblem />} fullLogo={<Logo />} />
       <Page.Sidebar.Menu>
         <Page.Sidebar.Item icon={<Overview16 />} selected>
@@ -83,6 +88,6 @@ const Example = () => (
       </Page.Sidebar.Menu>
     </Page.Sidebar>
   </div>
-)
+)}
 
 export default Example


### PR DESCRIPTION
[TRN-4574]

### Description

On Talent Portal we're working on removing an option for collapsing the sidebar from our settings page and we want to keep only built-in collapse option of Sidebar but we want to keep an ability to store the state or sidebar talent choose on our Backend so we can retain it on next visit and display sidebar at same state your left in on previous visit.

For that purpose, we're introducing `onCollapse` callback which will allow us to trigger our API each time collapse button in Sidebar is clicked.

### How to test

- `Collapsible` story is modified to trigger `onCollapse` callback, check the temploy

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests

**Breaking change**

- [x] codemod is created and showcased in the changeset
- [x] test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[TRN-4574]: https://toptal-core.atlassian.net/browse/TRN-4574?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ