### PR TITLE
fix(RichTextEditor): when disabled it shows defaultValue

### DIFF
--- a/.changeset/flat-beans-kick.md
+++ b/.changeset/flat-beans-kick.md
@@ -1,0 +1,7 @@
+---
+'@toptal/picasso': patch
+---
+
+---
+
+- richTextEditor disabled default value bug fix

--- a/.changeset/flat-beans-kick.md
+++ b/.changeset/flat-beans-kick.md
@@ -4,4 +4,5 @@
 
 ---
 
-- richTextEditor disabled default value bug fix
+### RichTextEditor
+- fix disabled default value bug

--- a/packages/picasso/src/QuillEditor/QuillEditor.tsx
+++ b/packages/picasso/src/QuillEditor/QuillEditor.tsx
@@ -59,7 +59,6 @@ const QuillEditor = forwardRef<HTMLDivElement, Props>(function QuillEditor(
   )
 
   useFocus({ isFocused, quill })
-  useDisabledEditor({ disabled, quill })
   useKeyBindings({ quill, onTextFormat })
   useSubscribeToQuillEvents({
     quill,
@@ -72,6 +71,7 @@ const QuillEditor = forwardRef<HTMLDivElement, Props>(function QuillEditor(
     quill,
   })
   useDefaultValue({ defaultValue, quill })
+  useDisabledEditor({ disabled, quill })
 
   return <QuillEditorView ref={editorRef} data-testid={dataTestId} id={id} />
 })

--- a/packages/picasso/src/RichTextEditor/story/Disabled.example.tsx
+++ b/packages/picasso/src/RichTextEditor/story/Disabled.example.tsx
@@ -1,15 +1,43 @@
 import React from 'react'
-import { RichTextEditor } from '@toptal/picasso'
+import { ASTType } from '@toptal/picasso'
+import { Form } from '@toptal/picasso-forms'
 import { noop } from '@toptal/picasso/utils'
+
+const ast: ASTType = {
+  type: 'root',
+  children: [
+    {
+      type: 'element',
+      tagName: 'h3',
+      properties: {},
+      children: [
+        { type: 'text', value: 'Values inside disabled RichTextEditor' },
+      ],
+    },
+  ],
+}
 
 const Example = () => {
   return (
-    <RichTextEditor
-      id='foo'
-      onChange={noop}
-      placeholder='Write some cool rich text'
-      disabled
-    />
+    <Form onSubmit={() => {}}>
+      {' '}
+      <Form.RichTextEditor
+        id='disabled-no-value'
+        name='disabledWithNoValue'
+        label='disabled without value'
+        onChange={noop}
+        placeholder='Write some cool rich text'
+        disabled
+      />
+      <Form.RichTextEditor
+        id='disabled-with-value'
+        name='disabledWithValue'
+        label='disabled with default value'
+        onChange={noop}
+        defaultValue={ast}
+        disabled
+      />
+    </Form>
   )
 }
 


### PR DESCRIPTION
[FX-3572](https://toptal-core.atlassian.net/browse/FX-3572)

### Description

`RichTextEditor` when is disabled the default value appear  for this ticket: [SCX-555](https://toptal-core.atlassian.net/browse/SCX-555)

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
|![image](https://user-images.githubusercontent.com/25435884/213496906-b5b4c3ad-4309-45a2-96b4-a7362cdef288.png)|![image](https://user-images.githubusercontent.com/25435884/213497035-00183abe-690a-4f08-8f5a-19c8b8fa5219.png)|

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests

**Breaking change**

- [x] codemod is created and showcased in the changeset
- [x] test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[SCX-555]: https://toptal-core.atlassian.net/browse/SCX-555?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[FX-3572]: https://toptal-core.atlassian.net/browse/FX-3572?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ