### PR TITLE
fix: import from material-ui's barrel module

### DIFF
--- a/.changeset/angry-apricots-flow.md
+++ b/.changeset/angry-apricots-flow.md
@@ -1,0 +1,7 @@
+---
+'@toptal/picasso': patch
+---
+
+---
+
+- import from `@material-ui/core` barrel module in restyled components to fix MUI's side-effects being executed in wrong order

--- a/packages/picasso/src/Accordion/Accordion.tsx
+++ b/packages/picasso/src/Accordion/Accordion.tsx
@@ -7,7 +7,7 @@ import React, {
   useState,
 } from 'react'
 import cx from 'classnames'
-import MUIAccordion from '@material-ui/core/Accordion'
+import { Accordion as MUIAccordion } from '@material-ui/core'
 import { makeStyles, Theme } from '@material-ui/core/styles'
 import { StandardProps, TransitionProps } from '@toptal/picasso-shared'
 

--- a/packages/picasso/src/AccordionDetails/AccordionDetails.tsx
+++ b/packages/picasso/src/AccordionDetails/AccordionDetails.tsx
@@ -1,6 +1,6 @@
 import React, { ReactNode, HTMLAttributes } from 'react'
 import { makeStyles, Theme } from '@material-ui/core/styles'
-import MUIAccordionDetails from '@material-ui/core/AccordionDetails'
+import { AccordionDetails as MUIAccordionDetails } from '@material-ui/core'
 import { StandardProps } from '@toptal/picasso-shared'
 
 import styles from './styles'

--- a/packages/picasso/src/AccordionSummary/AccordionSummary.tsx
+++ b/packages/picasso/src/AccordionSummary/AccordionSummary.tsx
@@ -1,6 +1,6 @@
 import { ReactNode, FunctionComponent } from 'react'
 import { withStyles } from '@material-ui/core/styles'
-import MUIAccordionSummary from '@material-ui/core/AccordionSummary'
+import { AccordionSummary as MUIAccordionSummary } from '@material-ui/core'
 import { StandardProps, ButtonOrAnchorProps } from '@toptal/picasso-shared'
 
 import styles from './styles'

--- a/packages/picasso/src/ApplicationUpdateNotification/ApplicationUpdateNotification.tsx
+++ b/packages/picasso/src/ApplicationUpdateNotification/ApplicationUpdateNotification.tsx
@@ -1,7 +1,7 @@
 import React, { forwardRef, ReactNode } from 'react'
 import cx from 'classnames'
 import { makeStyles, Theme } from '@material-ui/core/styles'
-import SnackbarContent from '@material-ui/core/SnackbarContent'
+import { SnackbarContent } from '@material-ui/core'
 import { BaseProps } from '@toptal/picasso-shared'
 
 import Typography from '../Typography'

--- a/packages/picasso/src/Button/Button.tsx
+++ b/packages/picasso/src/Button/Button.tsx
@@ -6,7 +6,6 @@ import React, {
   ElementType,
 } from 'react'
 import cx from 'classnames'
-import ButtonBase from '@material-ui/core/ButtonBase'
 import {
   StandardProps,
   SizeType,
@@ -16,7 +15,7 @@ import {
   TextLabelProps,
   Classes,
 } from '@toptal/picasso-shared'
-import { makeStyles, Theme } from '@material-ui/core'
+import { makeStyles, Theme, ButtonBase } from '@material-ui/core'
 
 import styles from './styles'
 import Loader from '../Loader'

--- a/packages/picasso/src/Checkbox/Checkbox.tsx
+++ b/packages/picasso/src/Checkbox/Checkbox.tsx
@@ -1,4 +1,4 @@
-import MUICheckbox from '@material-ui/core/Checkbox'
+import { Checkbox as MUICheckbox } from '@material-ui/core'
 import { makeStyles, Theme } from '@material-ui/core/styles'
 import {
   ButtonOrAnchorProps,

--- a/packages/picasso/src/CheckboxGroup/CheckboxGroup.tsx
+++ b/packages/picasso/src/CheckboxGroup/CheckboxGroup.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/no-array-index-key */
 import React from 'react'
-import FormGroup, { FormGroupProps } from '@material-ui/core/FormGroup'
+import { FormGroup, FormGroupProps } from '@material-ui/core'
 import { GridSize } from '@material-ui/core/Grid'
 import { makeStyles, Theme, useTheme } from '@material-ui/core/styles'
 import cx from 'classnames'

--- a/packages/picasso/src/Chip/index.ts
+++ b/packages/picasso/src/Chip/index.ts
@@ -1,3 +1,3 @@
 import './styles'
 
-export { default } from '@material-ui/core/Chip'
+export { Chip as default } from '@material-ui/core'

--- a/packages/picasso/src/CircularProgress/CircularProgress.tsx
+++ b/packages/picasso/src/CircularProgress/CircularProgress.tsx
@@ -1,6 +1,6 @@
 import React, { HTMLAttributes } from 'react'
 import { makeStyles, Theme } from '@material-ui/core/styles'
-import MUICircularProgress from '@material-ui/core/CircularProgress'
+import { CircularProgress as MUICircularProgress } from '@material-ui/core'
 import { StandardProps } from '@toptal/picasso-shared'
 
 import styles from './styles'

--- a/packages/picasso/src/Drawer/Drawer.tsx
+++ b/packages/picasso/src/Drawer/Drawer.tsx
@@ -1,4 +1,4 @@
-import MUIDrawer from '@material-ui/core/Drawer'
+import { Drawer as MUIDrawer } from '@material-ui/core'
 import { makeStyles, Theme, useTheme } from '@material-ui/core/styles'
 import cx from 'classnames'
 import { BaseProps, TransitionProps } from '@toptal/picasso-shared'

--- a/packages/picasso/src/Grid/Grid.tsx
+++ b/packages/picasso/src/Grid/Grid.tsx
@@ -1,12 +1,13 @@
 import React, { ReactNode, forwardRef, HTMLAttributes } from 'react'
 import { makeStyles, Theme } from '@material-ui/core/styles'
-import MUIGrid, {
+import {
+  Grid as MUIGrid,
   GridSpacing,
   GridItemsAlignment,
   GridDirection,
   GridJustification,
   GridWrap,
-} from '@material-ui/core/Grid'
+} from '@material-ui/core'
 import { BaseProps } from '@toptal/picasso-shared'
 
 import styles from './styles'

--- a/packages/picasso/src/GridItem/GridItem.tsx
+++ b/packages/picasso/src/GridItem/GridItem.tsx
@@ -1,6 +1,6 @@
 import React, { ReactNode, forwardRef, HTMLAttributes } from 'react'
 import { makeStyles, Theme } from '@material-ui/core/styles'
-import MUIGrid, { GridSize } from '@material-ui/core/Grid'
+import { Grid as MUIGrid, GridSize } from '@material-ui/core'
 import { BaseProps } from '@toptal/picasso-shared'
 
 import styles from './styles'

--- a/packages/picasso/src/InputAdornment/InputAdornment.tsx
+++ b/packages/picasso/src/InputAdornment/InputAdornment.tsx
@@ -5,7 +5,7 @@ import React, {
   useCallback,
 } from 'react'
 import { makeStyles, Theme } from '@material-ui/core/styles'
-import MUIInputAdornment from '@material-ui/core/InputAdornment'
+import { InputAdornment as MUIInputAdornment } from '@material-ui/core'
 import cx from 'classnames'
 import { BaseProps } from '@toptal/picasso-shared'
 

--- a/packages/picasso/src/InputLabel/InputLabel.tsx
+++ b/packages/picasso/src/InputLabel/InputLabel.tsx
@@ -1,6 +1,6 @@
 import React, { ReactNode, LabelHTMLAttributes } from 'react'
 import { makeStyles, Theme } from '@material-ui/core/styles'
-import MUIInputLabel from '@material-ui/core/InputLabel'
+import { InputLabel as MUIInputLabel } from '@material-ui/core'
 import { BaseProps } from '@toptal/picasso-shared'
 
 import styles from './styles'

--- a/packages/picasso/src/Link/Link.tsx
+++ b/packages/picasso/src/Link/Link.tsx
@@ -4,7 +4,7 @@ import React, {
   ElementType,
   AnchorHTMLAttributes,
 } from 'react'
-import MUILink from '@material-ui/core/Link'
+import { Link as MUILink } from '@material-ui/core'
 import { Theme, makeStyles } from '@material-ui/core/styles'
 import cx from 'classnames'
 import { BaseProps, OverridableComponent } from '@toptal/picasso-shared'

--- a/packages/picasso/src/Menu/Menu.tsx
+++ b/packages/picasso/src/Menu/Menu.tsx
@@ -1,6 +1,6 @@
 import React, { HTMLAttributes, forwardRef } from 'react'
 import cx from 'classnames'
-import MUIMenuList from '@material-ui/core/MenuList'
+import { MenuList as MUIMenuList } from '@material-ui/core'
 import { makeStyles, Theme } from '@material-ui/core/styles'
 import { BaseProps } from '@toptal/picasso-shared'
 

--- a/packages/picasso/src/MenuItem/MenuItem.tsx
+++ b/packages/picasso/src/MenuItem/MenuItem.tsx
@@ -9,7 +9,7 @@ import React, {
 } from 'react'
 import cx from 'classnames'
 import { Theme, makeStyles } from '@material-ui/core/styles'
-import MUIMenuItem from '@material-ui/core/MenuItem'
+import { MenuItem as MUIMenuItem } from '@material-ui/core'
 import {
   useTitleCase,
   BaseProps,

--- a/packages/picasso/src/Modal/Modal.tsx
+++ b/packages/picasso/src/Modal/Modal.tsx
@@ -7,7 +7,7 @@ import React, {
   useCallback,
 } from 'react'
 import { makeStyles, Theme } from '@material-ui/core/styles'
-import Dialog from '@material-ui/core/Dialog'
+import { Dialog } from '@material-ui/core'
 import { PaperProps } from '@material-ui/core/Paper'
 import cx from 'classnames'
 import {

--- a/packages/picasso/src/NativeSelect/NativeSelect.tsx
+++ b/packages/picasso/src/NativeSelect/NativeSelect.tsx
@@ -1,6 +1,6 @@
 import React, { useRef } from 'react'
 import cx from 'classnames'
-import MuiNativeSelect from '@material-ui/core/NativeSelect'
+import { NativeSelect as MUINativeSelect } from '@material-ui/core'
 import { Theme, makeStyles } from '@material-ui/core/styles'
 import capitalize from '@material-ui/core/utils/capitalize'
 
@@ -103,7 +103,7 @@ export const NativeSelect = documentable(
       )
 
       const nativeSelectComponent = (
-        <MuiNativeSelect
+        <MUINativeSelect
           // eslint-disable-next-line react/jsx-props-no-spreading
           {...rest}
           ref={selectRef}
@@ -150,7 +150,7 @@ export const NativeSelect = documentable(
             renderOption={renderOption as any}
             getItemProps={getItemProps}
           />
-        </MuiNativeSelect>
+        </MUINativeSelect>
       )
 
       return (

--- a/packages/picasso/src/Notification/Notification.tsx
+++ b/packages/picasso/src/Notification/Notification.tsx
@@ -7,7 +7,7 @@ import React, {
   HTMLAttributes,
 } from 'react'
 import { makeStyles, Theme } from '@material-ui/core/styles'
-import SnackbarContent from '@material-ui/core/SnackbarContent'
+import { SnackbarContent } from '@material-ui/core'
 import cx from 'classnames'
 import capitalize from '@material-ui/core/utils/capitalize'
 import { StandardProps } from '@toptal/picasso-shared'

--- a/packages/picasso/src/NumberInputEndAdornment/NumberInputEndAdornment.tsx
+++ b/packages/picasso/src/NumberInputEndAdornment/NumberInputEndAdornment.tsx
@@ -2,7 +2,7 @@
 import React, { RefObject } from 'react'
 import { makeStyles, Theme } from '@material-ui/core/styles'
 import { BaseProps, SizeType, isBrowser } from '@toptal/picasso-shared'
-import ButtonBase from '@material-ui/core/ButtonBase'
+import { ButtonBase } from '@material-ui/core'
 import cx from 'classnames'
 
 import InputAdornment from '../InputAdornment'

--- a/packages/picasso/src/OutlinedInput/OutlinedInput.tsx
+++ b/packages/picasso/src/OutlinedInput/OutlinedInput.tsx
@@ -8,7 +8,7 @@ import React, {
 } from 'react'
 import cx from 'classnames'
 import { makeStyles, Theme } from '@material-ui/core/styles'
-import MUIOutlinedInput from '@material-ui/core/OutlinedInput'
+import { OutlinedInput as MUIOutlinedInput } from '@material-ui/core'
 import { InputBaseComponentProps } from '@material-ui/core/InputBase'
 import capitalize from '@material-ui/core/utils/capitalize'
 import { StandardProps, SizeType, Classes } from '@toptal/picasso-shared'

--- a/packages/picasso/src/Paper/Paper.tsx
+++ b/packages/picasso/src/Paper/Paper.tsx
@@ -1,5 +1,5 @@
-import MUIPaper from '@material-ui/core/Paper'
 import { makeStyles, Theme } from '@material-ui/core/styles'
+import { Paper as MUIPaper } from '@material-ui/core'
 import React, { forwardRef, HTMLAttributes, ReactNode } from 'react'
 import { BaseProps } from '@toptal/picasso-shared'
 

--- a/packages/picasso/src/Popover/index.ts
+++ b/packages/picasso/src/Popover/index.ts
@@ -1,3 +1,3 @@
 import './styles'
 
-export { default } from '@material-ui/core/Popover'
+export { Popover as default } from '@material-ui/core'

--- a/packages/picasso/src/Popper/Popper.tsx
+++ b/packages/picasso/src/Popper/Popper.tsx
@@ -1,6 +1,6 @@
 import React, { forwardRef, ReactNode, useContext } from 'react'
 import cx from 'classnames'
-import MUIPopper from '@material-ui/core/Popper'
+import { Popper as MUIPopper } from '@material-ui/core'
 import { Theme, makeStyles } from '@material-ui/core/styles'
 import PopperJs, { ReferenceObject, PopperOptions } from 'popper.js'
 import { BaseProps, useIsomorphicLayoutEffect } from '@toptal/picasso-shared'

--- a/packages/picasso/src/Radio/Radio.tsx
+++ b/packages/picasso/src/Radio/Radio.tsx
@@ -1,5 +1,5 @@
 import React, { ComponentProps, forwardRef, ReactNode } from 'react'
-import MUIRadio from '@material-ui/core/Radio'
+import { Radio as MUIRadio } from '@material-ui/core'
 import { makeStyles, Theme } from '@material-ui/core/styles'
 import {
   StandardProps,

--- a/packages/picasso/src/RadioGroup/RadioGroup.tsx
+++ b/packages/picasso/src/RadioGroup/RadioGroup.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable react/no-array-index-key */
 import React from 'react'
 import { GridSize } from '@material-ui/core/Grid'
-import MUIRadioGroup, { RadioGroupProps } from '@material-ui/core/RadioGroup'
+import { RadioGroup as MUIRadioGroup, RadioGroupProps } from '@material-ui/core'
 import { makeStyles, Theme, useTheme } from '@material-ui/core/styles'
 
 import { GridProps } from '../Grid'

--- a/packages/picasso/src/Slider/Slider.tsx
+++ b/packages/picasso/src/Slider/Slider.tsx
@@ -6,9 +6,10 @@ import React, {
   useMemo,
 } from 'react'
 import { makeStyles, Theme } from '@material-ui/core/styles'
-import MUISlider, {
+import {
+  Slider as MUISlider,
   ValueLabelProps as MUIValueLabelProps,
-} from '@material-ui/core/Slider'
+} from '@material-ui/core'
 import cx from 'classnames'
 
 import SliderValueLabel, { ValueLabelProps } from '../SliderValueLabel'

--- a/packages/picasso/src/Step/Step.tsx
+++ b/packages/picasso/src/Step/Step.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { makeStyles, Theme } from '@material-ui/core/styles'
-import MUIStep, { StepProps } from '@material-ui/core/Step'
+import { Step as MUIStep, StepProps } from '@material-ui/core'
 
 import styles from './styles'
 

--- a/packages/picasso/src/Stepper/Stepper.tsx
+++ b/packages/picasso/src/Stepper/Stepper.tsx
@@ -1,7 +1,7 @@
 import React, { forwardRef, HTMLAttributes } from 'react'
 import cx from 'classnames'
 import { makeStyles, Theme } from '@material-ui/core/styles'
-import MUIStepper from '@material-ui/core/Stepper'
+import { Stepper as MUIStepper } from '@material-ui/core'
 import { BaseProps, TextLabelProps } from '@toptal/picasso-shared'
 
 import Step from '../Step'

--- a/packages/picasso/src/Switch/Switch.tsx
+++ b/packages/picasso/src/Switch/Switch.tsx
@@ -1,4 +1,4 @@
-import MUISwitch from '@material-ui/core/Switch'
+import { Switch as MUISwitch } from '@material-ui/core'
 import { makeStyles, Theme } from '@material-ui/core/styles'
 import { BaseProps, TextLabelProps } from '@toptal/picasso-shared'
 import React, { ButtonHTMLAttributes, forwardRef, ReactNode } from 'react'

--- a/packages/picasso/src/Tab/Tab.tsx
+++ b/packages/picasso/src/Tab/Tab.tsx
@@ -6,7 +6,7 @@ import React, {
   useContext,
 } from 'react'
 import { makeStyles, Theme } from '@material-ui/core/styles'
-import MUITab, { TabProps } from '@material-ui/core/Tab'
+import { Tab as MUITab, TabProps } from '@material-ui/core'
 import { BaseProps, TextLabelProps, useTitleCase } from '@toptal/picasso-shared'
 
 import UserBadge from '../UserBadge'

--- a/packages/picasso/src/Table/Table.tsx
+++ b/packages/picasso/src/Table/Table.tsx
@@ -5,7 +5,7 @@ import React, {
   useMemo,
 } from 'react'
 import { makeStyles, Theme } from '@material-ui/core/styles'
-import MUITable from '@material-ui/core/Table'
+import { Table as MUITable } from '@material-ui/core'
 import { BaseProps } from '@toptal/picasso-shared'
 
 import TableContext from './TableContext'

--- a/packages/picasso/src/TableBody/TableBody.tsx
+++ b/packages/picasso/src/TableBody/TableBody.tsx
@@ -1,6 +1,6 @@
 import React, { forwardRef, ReactNode, HTMLAttributes, useContext } from 'react'
 import { makeStyles, Theme } from '@material-ui/core/styles'
-import MUITableBody from '@material-ui/core/TableBody'
+import { TableBody as MUITableBody } from '@material-ui/core'
 import { BaseProps } from '@toptal/picasso-shared'
 
 import styles from './styles'

--- a/packages/picasso/src/TableCell/TableCell.tsx
+++ b/packages/picasso/src/TableCell/TableCell.tsx
@@ -1,6 +1,6 @@
 import React, { forwardRef, HTMLAttributes, useContext } from 'react'
 import { makeStyles, Theme } from '@material-ui/core/styles'
-import MUITableCell from '@material-ui/core/TableCell'
+import { TableCell as MUITableCell } from '@material-ui/core'
 import {
   BaseProps,
   ColorType,

--- a/packages/picasso/src/TableExpandableRow/TableExpandableRow.tsx
+++ b/packages/picasso/src/TableExpandableRow/TableExpandableRow.tsx
@@ -7,7 +7,7 @@ import React, {
 } from 'react'
 import cx from 'classnames'
 import { makeStyles, Theme } from '@material-ui/core/styles'
-import MUICollapse from '@material-ui/core/Collapse'
+import { Collapse as MUICollapse } from '@material-ui/core'
 import { BaseProps } from '@toptal/picasso-shared'
 
 import TableRow from '../TableRow'

--- a/packages/picasso/src/TableFooter/TableFooter.tsx
+++ b/packages/picasso/src/TableFooter/TableFooter.tsx
@@ -1,5 +1,5 @@
 import { makeStyles, Theme } from '@material-ui/core/styles'
-import MUITableFooter from '@material-ui/core/TableFooter'
+import { TableFooter as MUITableFooter } from '@material-ui/core'
 import React, { forwardRef, ReactNode, HTMLAttributes } from 'react'
 import { BaseProps } from '@toptal/picasso-shared'
 

--- a/packages/picasso/src/TableHead/TableHead.tsx
+++ b/packages/picasso/src/TableHead/TableHead.tsx
@@ -1,6 +1,6 @@
 import React, { forwardRef, ReactNode, HTMLAttributes } from 'react'
 import { makeStyles, Theme } from '@material-ui/core/styles'
-import MUITableHead from '@material-ui/core/TableHead'
+import { TableHead as MUITableHead } from '@material-ui/core'
 import { BaseProps } from '@toptal/picasso-shared'
 
 import styles from './styles'

--- a/packages/picasso/src/TableRow/TableRow.tsx
+++ b/packages/picasso/src/TableRow/TableRow.tsx
@@ -7,7 +7,7 @@ import React, {
 } from 'react'
 import cx from 'classnames'
 import { makeStyles, Theme } from '@material-ui/core/styles'
-import MUITableRow from '@material-ui/core/TableRow'
+import { TableRow as MUITableRow } from '@material-ui/core'
 import { BaseProps } from '@toptal/picasso-shared'
 
 import styles from './styles'

--- a/packages/picasso/src/Tabs/Tabs.tsx
+++ b/packages/picasso/src/Tabs/Tabs.tsx
@@ -1,6 +1,6 @@
 import React, { forwardRef, ReactNode } from 'react'
 import { makeStyles, Theme } from '@material-ui/core/styles'
-import MUITabs, { TabsProps } from '@material-ui/core/Tabs'
+import { Tabs as MUITabs, TabsProps } from '@material-ui/core'
 import { ButtonOrAnchorProps, BaseProps } from '@toptal/picasso-shared'
 
 import TabScrollButton from '../TabScrollButton'

--- a/packages/picasso/src/Tooltip/Tooltip.tsx
+++ b/packages/picasso/src/Tooltip/Tooltip.tsx
@@ -6,7 +6,7 @@ import React, {
   HTMLAttributes,
 } from 'react'
 import { makeStyles, Theme } from '@material-ui/core/styles'
-import MUITooltip, { TooltipProps } from '@material-ui/core/Tooltip'
+import { Tooltip as MUITooltip, TooltipProps } from '@material-ui/core'
 import cx from 'classnames'
 import { BaseProps } from '@toptal/picasso-shared'
 import { usePicassoRoot } from '@toptal/picasso-provider'

--- a/packages/picasso/src/Typography/Typography.tsx
+++ b/packages/picasso/src/Typography/Typography.tsx
@@ -1,7 +1,6 @@
 import React, { forwardRef, ReactNode, HTMLAttributes } from 'react'
 import { makeStyles, Theme } from '@material-ui/core/styles'
-import { PropTypes } from '@material-ui/core'
-import MUITypography from '@material-ui/core/Typography'
+import { PropTypes, Typography as MUITypography } from '@material-ui/core'
 import {
   StandardProps,
   ColorType,


### PR DESCRIPTION
[FX-3568]

Context: we are experiencing style-ordering issues in a production build of our project, in dev mode everything is fine. In our case the `Typography` component loses styles that come from Picasso.

### Description

First of all I would like to thank you very much for the smooth experience I had while I was debugging the bug. Everything was easy to understand and follow, the package linking script saved me a ton of time and I had no issues the whole time I was working with Picasso locally, you did an amazing job and I really appreciate it!!

Now, this bug is a nasty one, it appears in specific conditions, in our case I was able to create a simple test case where I was rendering a `Typography` component followed by a `Link`. This alone has caused the paragraph to lose almost all its styles, as Material-UI's `<style>` block had higher precedence.

One of the fixes I experimented with was to pass an `index` property to `makeStyles` and `withStyles` to increase the order of styles coming from Picasso, but I did not like this solution at all. It should not be on us to order those styles, the order should be automatically inferred.

Then I started digging, it turns out `@material-ui/styles@4` has some singletons and [one of them](https://github.com/mui/material-ui/blob/v4.x/packages/material-ui-styles/src/makeStyles/indexCounter.js#L10) is used to configure the `index` property (exactly the one I mentioned above) for style insertion order. The thing with modules that have side-effects is that you have to be careful about how and when you import them, in this instance the order matters as it is going to affect the `index` property. I experimented a bit and the cleanest and simplest solution turned out to be a switch to barrel imports for all components from Material-UI that were reused and restyled. This ensures that the counter runs for MUI components first, then for other instances of `makeStyles` and `withStyles` inside Picasso.

I hope my description is clear enough, feel free to ping me if you want to talk about it and maybe see the bug in action :)

### How to test

- `yarn install`
- `yarn symlink`
- `cd path_to_gcp_repo`
- `yarn symlink:off && yarn symlink`
- `yarn build`
- Check if styles are in correct order

I will try to see if I can create a simple reproduction repo.

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| Insert screenshots or screen recordings | Insert screenshots or screen recordings |

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests

**Breaking change**

- [x] codemod is created and showcased in the changeset
- [x] test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-3568]: https://toptal-core.atlassian.net/browse/FX-3568?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ