### PR TITLE
fix(PageTopBarMenu): initials in Avatar are centered on small screen

### DIFF
--- a/.changeset/neat-pianos-allow.md
+++ b/.changeset/neat-pianos-allow.md
@@ -1,0 +1,9 @@
+---
+'@toptal/picasso': patch
+---
+
+---
+
+### PageTopBarMenu
+
+- fix alignment of Avatar initials on small screens

--- a/packages/picasso/src/PageTopBar/story/Variants.example.tsx
+++ b/packages/picasso/src/PageTopBar/story/Variants.example.tsx
@@ -39,10 +39,7 @@ const Example = () => (
           </Container>
         }
         rightContent={
-          <Page.TopBarMenu
-            name='Jacqueline Roque'
-            avatar='./jacqueline-with-flowers-1954-square.jpg'
-          >
+          <Page.TopBarMenu name='Jacqueline Roque'>
             <Menu>
               <Menu.Item>My Account</Menu.Item>
               <Menu.Item>Log Out</Menu.Item>

--- a/packages/picasso/src/PageTopBarMenu/PageTopBarMenu.tsx
+++ b/packages/picasso/src/PageTopBarMenu/PageTopBarMenu.tsx
@@ -68,12 +68,7 @@ export const PageTopBarMenu = forwardRef<HTMLDivElement, Props>(
     )
 
     const trigger = isCompactLayout ? (
-      <Avatar
-        size='xxsmall'
-        className={classes.xsmall}
-        name={name}
-        src={avatar as string}
-      />
+      <Avatar size='xxsmall' name={name} src={avatar as string} />
     ) : (
       <UserBadge
         invert

--- a/packages/picasso/src/PageTopBarMenu/styles.ts
+++ b/packages/picasso/src/PageTopBarMenu/styles.ts
@@ -13,12 +13,6 @@ export default ({ screens }: Theme) =>
         position: 'relative',
       },
     },
-    xsmall: {
-      [screens('small', 'medium')]: {
-        height: '2em',
-        width: '2em',
-      },
-    },
     content: {
       width: '15em',
       maxHeight: 'calc(100vh - 4.5rem)', // viewport minus header height


### PR DESCRIPTION
[FX-3494]

### Description

Long time ago, a [customization to Avatar in PageTopBarMenu](https://github.com/toptal/picasso/pull/1955) was made to comply with talent portal needs.
Since then, [Avatar was refactored](https://github.com/toptal/picasso/pull/2202) and this change caused specific error that can be reproduced when using small screen and avatar without image.
The customization is no longer needed, since the AvatarWrapper has correct dimensions set.

### How to test

- Check [temploy PageSideBar](https://picasso.toptal.net/fx-3494-avatar-variant-with-initials-is-broken-on-smaller-screen/?path=/story/components-pagetopbar--pagetopbar#variants) and resize to smaller screen

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| ![image](https://user-images.githubusercontent.com/22159416/214293549-650c523e-eab7-4229-9b17-ef7034a74bfa.png) | ![image](https://user-images.githubusercontent.com/22159416/214293934-51b99d01-fcfe-4d16-b9ce-3e949867e1b0.png) |

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- Annotate all `props` in component with documentation
- Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- Covered with tests

**Breaking change**

- codemod is created and showcased in the changeset
- test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-3494]: https://toptal-core.atlassian.net/browse/FX-3494?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ