### PR TITLE
fix(Autocomplete): use currect data-testid

### DIFF
--- a/.changeset/pretty-suits-beg.md
+++ b/.changeset/pretty-suits-beg.md
@@ -1,0 +1,9 @@
+---
+'@toptal/picasso': patch
+---
+
+---
+
+### Autocomplete
+
+- fix typo `data-test-id` -> `data-testid` so `getByTestId` works correctly

--- a/packages/picasso/src/Autocomplete/Autocomplete.tsx
+++ b/packages/picasso/src/Autocomplete/Autocomplete.tsx
@@ -254,7 +254,7 @@ export const Autocomplete = forwardRef<HTMLInputElement, Props>(
       >
         {options?.map((option, index) => (
           <Menu.Item
-            data-test-id={`${testIds?.menuItem}-${index}`}
+            data-testid={`${testIds?.menuItem}-${index}`}
             key={getKey(option)}
             {...getItemProps(index, option)}
             titleCase={false}

--- a/packages/picasso/src/Autocomplete/__snapshots__/test.tsx.snap
+++ b/packages/picasso/src/Autocomplete/__snapshots__/test.tsx.snap
@@ -17,7 +17,7 @@ exports[`Autocomplete dynamic behavior on focus 1`] = `
         aria-disabled="false"
         aria-selected="true"
         class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root PicassoMenuItem-root PicassoMenuItem-light PicassoAutocomplete-option Mui-selected PicassoMenuItem-selected MuiMenuItem-gutters PicassoMenuItem-gutters MuiListItem-gutters MuiListItem-button Mui-selected"
-        data-test-id="menu-item-0"
+        data-testid="menu-item-0"
         role="option"
         tabindex="-1"
       >
@@ -43,7 +43,7 @@ exports[`Autocomplete dynamic behavior on focus 1`] = `
         aria-disabled="false"
         aria-selected="false"
         class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root PicassoMenuItem-root PicassoMenuItem-light PicassoAutocomplete-option MuiMenuItem-gutters PicassoMenuItem-gutters MuiListItem-gutters MuiListItem-button"
-        data-test-id="menu-item-1"
+        data-testid="menu-item-1"
         role="option"
         tabindex="-1"
       >
@@ -69,7 +69,7 @@ exports[`Autocomplete dynamic behavior on focus 1`] = `
         aria-disabled="false"
         aria-selected="false"
         class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root PicassoMenuItem-root PicassoMenuItem-light PicassoAutocomplete-option MuiMenuItem-gutters PicassoMenuItem-gutters MuiListItem-gutters MuiListItem-button"
-        data-test-id="menu-item-2"
+        data-testid="menu-item-2"
         role="option"
         tabindex="-1"
       >
@@ -95,7 +95,7 @@ exports[`Autocomplete dynamic behavior on focus 1`] = `
         aria-disabled="false"
         aria-selected="false"
         class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root PicassoMenuItem-root PicassoMenuItem-light PicassoAutocomplete-option MuiMenuItem-gutters PicassoMenuItem-gutters MuiListItem-gutters MuiListItem-button"
-        data-test-id="menu-item-3"
+        data-testid="menu-item-3"
         role="option"
         tabindex="-1"
       >
@@ -121,7 +121,7 @@ exports[`Autocomplete dynamic behavior on focus 1`] = `
         aria-disabled="false"
         aria-selected="false"
         class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root PicassoMenuItem-root PicassoMenuItem-light PicassoAutocomplete-option MuiMenuItem-gutters PicassoMenuItem-gutters MuiListItem-gutters MuiListItem-button"
-        data-test-id="menu-item-4"
+        data-testid="menu-item-4"
         role="option"
         tabindex="-1"
       >
@@ -350,7 +350,7 @@ exports[`Autocomplete static behavior renders custom display value 1`] = `
         aria-disabled="false"
         aria-selected="true"
         class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root PicassoMenuItem-root PicassoMenuItem-light PicassoAutocomplete-option Mui-selected PicassoMenuItem-selected MuiMenuItem-gutters PicassoMenuItem-gutters MuiListItem-gutters MuiListItem-button Mui-selected"
-        data-test-id="menu-item-0"
+        data-testid="menu-item-0"
         role="option"
         tabindex="-1"
       >
@@ -376,7 +376,7 @@ exports[`Autocomplete static behavior renders custom display value 1`] = `
         aria-disabled="false"
         aria-selected="false"
         class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root PicassoMenuItem-root PicassoMenuItem-light PicassoAutocomplete-option MuiMenuItem-gutters PicassoMenuItem-gutters MuiListItem-gutters MuiListItem-button"
-        data-test-id="menu-item-1"
+        data-testid="menu-item-1"
         role="option"
         tabindex="-1"
       >
@@ -402,7 +402,7 @@ exports[`Autocomplete static behavior renders custom display value 1`] = `
         aria-disabled="false"
         aria-selected="false"
         class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root PicassoMenuItem-root PicassoMenuItem-light PicassoAutocomplete-option MuiMenuItem-gutters PicassoMenuItem-gutters MuiListItem-gutters MuiListItem-button"
-        data-test-id="menu-item-2"
+        data-testid="menu-item-2"
         role="option"
         tabindex="-1"
       >
@@ -428,7 +428,7 @@ exports[`Autocomplete static behavior renders custom display value 1`] = `
         aria-disabled="false"
         aria-selected="false"
         class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root PicassoMenuItem-root PicassoMenuItem-light PicassoAutocomplete-option MuiMenuItem-gutters PicassoMenuItem-gutters MuiListItem-gutters MuiListItem-button"
-        data-test-id="menu-item-3"
+        data-testid="menu-item-3"
         role="option"
         tabindex="-1"
       >
@@ -454,7 +454,7 @@ exports[`Autocomplete static behavior renders custom display value 1`] = `
         aria-disabled="false"
         aria-selected="false"
         class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root PicassoMenuItem-root PicassoMenuItem-light PicassoAutocomplete-option MuiMenuItem-gutters PicassoMenuItem-gutters MuiListItem-gutters MuiListItem-button"
-        data-test-id="menu-item-4"
+        data-testid="menu-item-4"
         role="option"
         tabindex="-1"
       >
@@ -498,7 +498,7 @@ exports[`Autocomplete static behavior renders custom options with custom keys 1`
         aria-disabled="false"
         aria-selected="true"
         class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root PicassoMenuItem-root PicassoMenuItem-light PicassoAutocomplete-option Mui-selected PicassoMenuItem-selected MuiMenuItem-gutters PicassoMenuItem-gutters MuiListItem-gutters MuiListItem-button Mui-selected"
-        data-test-id="menu-item-0"
+        data-testid="menu-item-0"
         role="option"
         tabindex="-1"
       >
@@ -524,7 +524,7 @@ exports[`Autocomplete static behavior renders custom options with custom keys 1`
         aria-disabled="false"
         aria-selected="false"
         class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root PicassoMenuItem-root PicassoMenuItem-light PicassoAutocomplete-option MuiMenuItem-gutters PicassoMenuItem-gutters MuiListItem-gutters MuiListItem-button"
-        data-test-id="menu-item-1"
+        data-testid="menu-item-1"
         role="option"
         tabindex="-1"
       >
@@ -550,7 +550,7 @@ exports[`Autocomplete static behavior renders custom options with custom keys 1`
         aria-disabled="false"
         aria-selected="false"
         class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root PicassoMenuItem-root PicassoMenuItem-light PicassoAutocomplete-option MuiMenuItem-gutters PicassoMenuItem-gutters MuiListItem-gutters MuiListItem-button"
-        data-test-id="menu-item-2"
+        data-testid="menu-item-2"
         role="option"
         tabindex="-1"
       >
@@ -576,7 +576,7 @@ exports[`Autocomplete static behavior renders custom options with custom keys 1`
         aria-disabled="false"
         aria-selected="false"
         class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root PicassoMenuItem-root PicassoMenuItem-light PicassoAutocomplete-option MuiMenuItem-gutters PicassoMenuItem-gutters MuiListItem-gutters MuiListItem-button"
-        data-test-id="menu-item-3"
+        data-testid="menu-item-3"
         role="option"
         tabindex="-1"
       >
@@ -602,7 +602,7 @@ exports[`Autocomplete static behavior renders custom options with custom keys 1`
         aria-disabled="false"
         aria-selected="false"
         class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root PicassoMenuItem-root PicassoMenuItem-light PicassoAutocomplete-option MuiMenuItem-gutters PicassoMenuItem-gutters MuiListItem-gutters MuiListItem-button"
-        data-test-id="menu-item-4"
+        data-testid="menu-item-4"
         role="option"
         tabindex="-1"
       >


### PR DESCRIPTION
[FX-2222]

### Description

A typo that prevents users to use `getByTestId`

### How to test

- CI should be green

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| Insert screenshots or screen recordings | Insert screenshots or screen recordings |

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- n/a Make sure that additions and changes on design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- n/a Annotate all `props` in component with documentation
- n/a Create `examples` for component
- n/a Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests

**Breaking change**

- n/a codemod is created and showcased in the changeset
- n/a test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-2222]: https://toptal-core.atlassian.net/browse/FX-2222?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ