### PR TITLE
test: remove flaky test

### DIFF
--- a/cypress/component/Menu.spec.tsx
+++ b/cypress/component/Menu.spec.tsx
@@ -29,6 +29,7 @@ const MenuExample = (props: MenuProps) => {
 
   return (
     <Container style={{ width: '240px' }}>
+      <div data-testid='spacer' style={{ height: 1 }} />
       <Menu {...props} data-testid='menu'>
         <Menu.Item data-testid='item-a'>Item A</Menu.Item>
         <Menu.Item menu={menuForItemB} data-testid='item-b'>
@@ -86,6 +87,7 @@ describe('Menu', () => {
 
   it('navigates drilldown menu', () => {
     cy.mount(<MenuExample variant='drilldown' />)
+    cy.getByTestId('spacer').trigger('mouseover')
     cy.getByTestId('menu-b').should('not.exist')
     cy.get('body').happoScreenshot({
       component,


### PR DESCRIPTION
[FX-NNNN]

### Description

We have a flaky cypress test for the menu. We are checking that menu is closed right after mounting, it seems that in some rare cases, the menu is opened, so I have added an additional div where I put the mouse on the start of the test so I'm sure that we don't have a mouse over the menu (It opens on hover)

### How to test

- CI should be green

### Screenshots

![image](https://user-images.githubusercontent.com/6830426/215533965-2658cf69-eebd-4ec5-b048-3db044949324.png)

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests

**Breaking change**

- [x] codemod is created and showcased in the changeset
- [x] test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>
