### PR TITLE
feat(Select): introduce new filterOptions prop

### DIFF
--- a/.changeset/brown-phones-worry.md
+++ b/.changeset/brown-phones-worry.md
@@ -1,0 +1,9 @@
+---
+'@toptal/picasso': minor
+---
+
+---
+
+### Select
+
+- add new `filterOptions` prop to provide custom filtering functionality

--- a/packages/picasso/src/NonNativeSelect/NonNativeSelect.tsx
+++ b/packages/picasso/src/NonNativeSelect/NonNativeSelect.tsx
@@ -22,6 +22,7 @@ import {
   DEFAULT_LIMIT,
   DEFAULT_SEARCH_THRESHOLD,
   countOptions,
+  filterFlatOptions as defaultFilterOptions,
 } from '../SelectBase'
 import NonNativeSelectOptions from '../NonNativeSelectOptions'
 import { documentable, forwardRef, noop, useCombinedRefs } from '../utils'
@@ -35,6 +36,7 @@ const DEFAULT_EMPTY_ARRAY_VALUE: ValueType[] = []
 
 export const NonNativeSelect = documentable(
   forwardRef(
+    // eslint-disable-next-line max-lines-per-function
     <T extends ValueType, M extends boolean = false>(
       props: SelectProps<T, M>,
       ref: React.Ref<HTMLInputElement> | null
@@ -69,6 +71,7 @@ export const NonNativeSelect = documentable(
         getDisplayValue = getOptionText,
         options,
         onChange,
+        filterOptions = defaultFilterOptions,
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
         native,
         testIds,
@@ -87,6 +90,7 @@ export const NonNativeSelect = documentable(
 
       const selectState = useSelectState({
         getDisplayValue,
+        filterFlatOptions: filterOptions,
         options,
         disabled,
         multiple,
@@ -267,6 +271,7 @@ NonNativeSelect.defaultProps = {
   limit: DEFAULT_LIMIT,
   enableAutofill: false,
   searchPlaceholder: 'Search',
+  filterOptions: defaultFilterOptions,
 }
 
 NonNativeSelect.displayName = 'NonNativeSelect'

--- a/packages/picasso/src/NonNativeSelect/test.tsx
+++ b/packages/picasso/src/NonNativeSelect/test.tsx
@@ -458,7 +458,7 @@ describe('NonNativeSelect', () => {
         placeholder,
         searchPlaceholder,
         searchThreshold: -1,
-        // for testing purposes, we want to filter out all options that doesn't contain the search value
+        // for testing purposes, we want to filter out all options that don't contain the search value
         filterOptions: (options, searchValue) =>
           options.filter(option => !option.text.includes(searchValue)),
       })

--- a/packages/picasso/src/NonNativeSelect/test.tsx
+++ b/packages/picasso/src/NonNativeSelect/test.tsx
@@ -22,6 +22,7 @@ const renderSelect = (
     onChange = () => {},
     renderOption,
     getDisplayValue,
+    filterOptions,
     ...rest
   } = props
 
@@ -37,6 +38,7 @@ const renderSelect = (
       placeholder={placeholder}
       multiple={multiple}
       onChange={onChange}
+      filterOptions={filterOptions}
     />,
     undefined,
     picassoConfig
@@ -444,6 +446,38 @@ describe('NonNativeSelect', () => {
 
     expect(highlightedOption).not.toBeNull()
     expect(highlightedOption?.textContent).toEqual(OPTIONS[2].text)
+  })
+
+  describe('when filterOptions is provided', () => {
+    it('filters options', () => {
+      const placeholder = 'Choose an option...'
+      const searchPlaceholder = 'Search for an option'
+
+      const { getByPlaceholderText, getByRole } = renderSelect({
+        options: OPTIONS,
+        placeholder,
+        searchPlaceholder,
+        searchThreshold: -1,
+        // for testing purposes, we want to filter out all options that doesn't contain the search value
+        filterOptions: (options, searchValue) =>
+          options.filter(option => !option.text.includes(searchValue)),
+      })
+
+      const selectInput = getByPlaceholderText(placeholder)
+
+      fireEvent.click(selectInput)
+
+      const searchInput = getByPlaceholderText(searchPlaceholder)
+
+      fireEvent.focus(searchInput)
+      fireEvent.change(searchInput, { target: { value: '1' } })
+
+      const menu = getByRole('listbox')
+
+      expect(menu).not.toHaveTextContent(OPTIONS[0].text)
+      expect(menu).toHaveTextContent(OPTIONS[1].text)
+      expect(menu).toHaveTextContent(OPTIONS[2].text)
+    })
   })
 
   describe('when value prop is not updated after onChange', () => {

--- a/packages/picasso/src/Select/story/FilterOptions.example.tsx
+++ b/packages/picasso/src/Select/story/FilterOptions.example.tsx
@@ -1,0 +1,95 @@
+import React, { useState, ChangeEvent, useCallback } from 'react'
+import { Select, Container, SelectOption, Typography } from '@toptal/picasso'
+
+const FilterOptionsExample = () => {
+  const [value, setValue] = useState<string>('')
+  const [values, setValues] = useState<string[]>([])
+
+  const handleChange = (
+    event: ChangeEvent<{
+      name?: string
+      value: string
+    }>
+  ) => {
+    setValue(event.target.value)
+  }
+
+  const handleMultipleChange = (
+    event: React.ChangeEvent<{ value: string[] }>
+  ) => {
+    setValues(event.target.value)
+  }
+
+  const filterOptions = useCallback(
+    (options: SelectOption[], searchValue: string) => {
+      // custom filtering logic (e.g. filtering by the last word)
+      const filteredOptions = options.filter(option =>
+        option.text.toLowerCase().endsWith(searchValue.toLowerCase())
+      )
+
+      return filteredOptions
+    },
+    []
+  )
+
+  return (
+    <Container flex inline>
+      <Container right='small'>
+        <Typography variant='heading' size='small'>
+          Non grouped
+        </Typography>
+        <Select
+          onChange={handleChange}
+          value={value}
+          options={OPTIONS}
+          placeholder='Choose an option...'
+          width='auto'
+          data-testid='select'
+          searchThreshold={4}
+          filterOptions={filterOptions}
+        />
+      </Container>
+      <Container right='small'>
+        <Typography variant='heading' size='small'>
+          Grouped
+        </Typography>
+        <Select
+          onChange={handleMultipleChange}
+          options={OPTION_GROUPS}
+          value={values}
+          placeholder='Choose an option...'
+          width='auto'
+          searchThreshold={4}
+          filterOptions={filterOptions}
+          multiple
+        />
+      </Container>
+    </Container>
+  )
+}
+
+const OPTIONS = [
+  { text: 'Belarus', value: 'BY' },
+  { text: 'Croatia', value: 'HR' },
+  { text: 'Lithuania', value: 'LU' },
+  { text: 'Slovakia', value: 'SK' },
+  { text: 'Ukraine', value: 'UA' },
+  { text: 'Romania', value: 'RO' },
+]
+
+const OPTION_GROUPS = {
+  'Group 1': [
+    { text: 'Belarus', value: 'BY' },
+    { text: 'Croatia', value: 'HR' },
+  ],
+  'Group 2': [
+    { text: 'Lithuania', value: 'LU' },
+    { text: 'Slovakia', value: 'SK' },
+  ],
+  'Group 3': [
+    { text: 'Ukraine', value: 'UA' },
+    { text: 'Romania', value: 'RO' },
+  ],
+}
+
+export default FilterOptionsExample

--- a/packages/picasso/src/Select/story/index.jsx
+++ b/packages/picasso/src/Select/story/index.jsx
@@ -5,7 +5,7 @@ const page = PicassoBook.section('Forms').createPage(
   'Select',
   `Selects are interactive elements that prompt users to make selections
     or take actions from a set of list of available options.
-    
+
   ${PicassoBook.createSourceLink(__filename)}
     `
 )
@@ -43,7 +43,7 @@ or\n
     },
     filterOptions: {
       defaultValue: `(options: Option[], searchValue: string) =>
-        options.filter(option => option.text.includes(searchValue))
+        options.filter(option => option.text.toLowerCase().includes(searchValue.trim().toLowerCase())))
       `,
     },
   },

--- a/packages/picasso/src/Select/story/index.jsx
+++ b/packages/picasso/src/Select/story/index.jsx
@@ -41,6 +41,11 @@ or\n
         name: 'boolean',
       },
     },
+    filterOptions: {
+      defaultValue: `(options: Option[], searchValue: string) =>
+        options.filter(option => option.text.includes(searchValue))
+      `,
+    },
   },
 })
 
@@ -121,5 +126,10 @@ page
   })
   .addExample('Select/story/Autofill.example.tsx', {
     title: 'Disable autofilling',
+    takeScreenshot: false,
+  })
+  .addExample('Select/story/FilterOptions.example.tsx', {
+    title: 'Filter options',
+    description: 'Filter options by custom function (e.g. ends with search)',
     takeScreenshot: false,
   })

--- a/packages/picasso/src/Select/story/index.jsx
+++ b/packages/picasso/src/Select/story/index.jsx
@@ -130,6 +130,7 @@ page
   })
   .addExample('Select/story/FilterOptions.example.tsx', {
     title: 'Filter options',
-    description: 'Filter options by custom function (e.g. ends with search)',
+    description:
+      'Use a custom filter function for search results (e.g. option text ends with search input)',
     takeScreenshot: false,
   })

--- a/packages/picasso/src/SelectBase/hooks/use-select-state/use-select-state.ts
+++ b/packages/picasso/src/SelectBase/hooks/use-select-state/use-select-state.ts
@@ -23,6 +23,11 @@ export const EMPTY_INPUT_VALUE = ''
 
 export interface Props {
   getDisplayValue: (option: Option | null) => string
+  filterFlatOptions?: (
+    options: Option[],
+    filterOptionsValue: string,
+    getDisplayValue: (option: Option | null) => string
+  ) => Option[]
   options: Option[] | OptionGroups
   disabled?: boolean
   multiple?: boolean
@@ -34,6 +39,7 @@ export interface Props {
 const useSelectState = (props: Props): UseSelectStateOutput => {
   const {
     getDisplayValue,
+    filterFlatOptions,
     options = [],
     disabled = false,
     multiple,
@@ -69,8 +75,9 @@ const useSelectState = (props: Props): UseSelectStateOutput => {
         options,
         filterOptionsValue,
         getDisplayValue,
+        filterFlatOptions,
       }),
-    [options, filterOptionsValue, getDisplayValue]
+    [options, filterOptionsValue, getDisplayValue, filterFlatOptions]
   )
   const filteredLimitedOptions = useMemo(
     () => limitOptions({ options: filteredOptions, limit }),

--- a/packages/picasso/src/SelectBase/types.ts
+++ b/packages/picasso/src/SelectBase/types.ts
@@ -91,6 +91,12 @@ export interface SelectProps<
   limit?: number
   /** Specifies whether the autofill enabled or not, disabled by default */
   enableAutofill?: boolean
+  /** A function that takes an array of options and a value and returns filtered options */
+  filterOptions?: (
+    options: Option[],
+    searchValue: string,
+    getDisplayValue?: (option: Option | null) => string
+  ) => Option[]
   ref?: React.Ref<HTMLInputElement>
   testIds?: OutlinedInputProps['testIds'] & {
     noOptions?: string

--- a/packages/picasso/src/SelectBase/types.ts
+++ b/packages/picasso/src/SelectBase/types.ts
@@ -91,7 +91,7 @@ export interface SelectProps<
   limit?: number
   /** Specifies whether the autofill enabled or not, disabled by default */
   enableAutofill?: boolean
-  /** A function that takes an array of options and a value and returns filtered options */
+  /** A function that is invoked during search. It takes an array of options and a search value and returns filtered options */
   filterOptions?: (
     options: Option[],
     searchValue: string,

--- a/packages/picasso/src/SelectBase/utils/filter-options/filter-options.ts
+++ b/packages/picasso/src/SelectBase/utils/filter-options/filter-options.ts
@@ -1,28 +1,39 @@
 import { isSubstring } from '../../../utils'
 import { Option, OptionGroups } from '../../types'
 import isOptionsType from '../../utils/is-options-type'
+import getOptionText from '../get-option-text'
 
 interface Props {
   options: Option[] | OptionGroups
   filterOptionsValue: string
   getDisplayValue: (option: Option | null) => string
+  filterFlatOptions?: (
+    options: Option[],
+    filterOptionsValue: string,
+    getDisplayValue: (option: Option | null) => string
+  ) => Option[]
 }
 
 const filterOptions = ({
   options,
   filterOptionsValue,
   getDisplayValue,
+  filterFlatOptions: filterFlatOptionsFunction = filterFlatOptions,
 }: Props): Option[] | OptionGroups => {
   if (isOptionsType(options)) {
-    return filterFlatOptions({ options, filterOptionsValue, getDisplayValue })
+    return filterFlatOptionsFunction(
+      options,
+      filterOptionsValue,
+      getDisplayValue
+    )
   }
 
   return Object.keys(options).reduce((result: OptionGroups, group) => {
-    const filteredFlatOptions = filterFlatOptions({
-      options: options[group],
+    const filteredFlatOptions = filterFlatOptionsFunction(
+      options[group],
       filterOptionsValue,
-      getDisplayValue,
-    })
+      getDisplayValue
+    )
 
     if (filteredFlatOptions.length > 0) {
       result[group] = filteredFlatOptions
@@ -32,11 +43,11 @@ const filterOptions = ({
   }, {})
 }
 
-const filterFlatOptions = ({
-  options,
-  filterOptionsValue,
-  getDisplayValue,
-}: Props & { options: Option[] }): Option[] =>
+export const filterFlatOptions = (
+  options: Option[],
+  filterOptionsValue: string,
+  getDisplayValue: (option: Option | null) => string = getOptionText
+): Option[] =>
   options.filter(option =>
     isSubstring(filterOptionsValue, getDisplayValue(option))
   )

--- a/packages/picasso/src/SelectBase/utils/filter-options/index.ts
+++ b/packages/picasso/src/SelectBase/utils/filter-options/index.ts
@@ -1,1 +1,2 @@
 export { default } from './filter-options'
+export { filterFlatOptions } from './filter-options'

--- a/packages/picasso/src/SelectBase/utils/index.ts
+++ b/packages/picasso/src/SelectBase/utils/index.ts
@@ -1,4 +1,4 @@
-export { default as filterOptions } from './filter-options'
+export { default as filterOptions, filterFlatOptions } from './filter-options'
 export { default as limitOptions } from './limit-options'
 export { default as fireOnChangeEvent } from './fire-on-change-event'
 export { default as flattenOptions } from './flatten-options'


### PR DESCRIPTION
[no-jira]

### Description

This PR is about adding a new `filterOptions` prop to Select component to enable custom filtering for options.

### How to test

- go to Select component storybook page and test both existing and new story

### Screenshots

<img width="673" alt="Screenshot 2023-02-06 at 12 25 46" src="https://user-images.githubusercontent.com/7733167/216939936-fe0b505c-b0d3-4ea5-ae55-f74519176ff7.png">
<img width="673" alt="Screenshot 2023-02-06 at 12 25 50" src="https://user-images.githubusercontent.com/7733167/216939947-cc9a5a93-8188-48ab-a06d-3cb25dddec4b.png">

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests

**Breaking change**

- [N/A] codemod is created and showcased in the changeset
- [x] test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>
