### PR TITLE
fix(calendar): add disabled attribute & default cursor to disabled days

### DIFF
--- a/.changeset/afraid-clocks-shave.md
+++ b/.changeset/afraid-clocks-shave.md
@@ -1,0 +1,8 @@
+---
+'@toptal/picasso': patch
+---
+
+---
+### Calendar
+
+- fix `calendar` disabled dates by adding disabled attribute and default cursor

--- a/packages/picasso/src/Calendar/Calendar.tsx
+++ b/packages/picasso/src/Calendar/Calendar.tsx
@@ -149,6 +149,7 @@ export const Calendar = forwardRef<HTMLDivElement, Props>(function Calendar(
               onMouseEnter={handleOnEnter}
               value={date.toString()}
               type='button'
+              disabled={isDisabled}
             >
               {getDayFormatted(date)}
               <CalendarIndicators

--- a/packages/picasso/src/Calendar/styles.ts
+++ b/packages/picasso/src/Calendar/styles.ts
@@ -85,5 +85,6 @@ export default ({ palette, sizes }: Theme) =>
     },
     disabled: {
       color: palette.grey.main,
-    },
+      cursor: 'default'
+    }
   })


### PR DESCRIPTION
[SDE-842](https://toptal-core.atlassian.net/browse/SDE-842)

### Description

Adds `disabled` attribute to disabled days in Calendar, along with the default cursor instead of the pointer

### How to test

- Go to the Calendar component with disabled days, the day button should have the attribute `disabled` and the cursor should be `default` instead of `pointer`

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
|![image](https://user-images.githubusercontent.com/17644982/218646647-8165ede1-d4d3-4bb1-9093-90870af45256.png)|![image](https://user-images.githubusercontent.com/17644982/218646698-f85b7bf4-d2bd-4580-a073-29a3719d670b.png)|

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests

**Breaking change**

- [x] codemod is created and showcased in the changeset
- [x] test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[SDE-842]: https://toptal-core.atlassian.net/browse/SDE-842?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ