### PR TITLE
feat(ShowMore): pass new state to the `onToggle` callback

### DIFF
--- a/.changeset/nervous-chicken-trade.md
+++ b/.changeset/nervous-chicken-trade.md
@@ -1,0 +1,18 @@
+---
+'@toptal/picasso': minor
+---
+
+---
+
+### ShowMore
+
+- the `onToggle` callback has a new state as a parameter
+
+```diff
+<ShowMore
+  onToggle={
+-    () => {}
++    (newState) => {}
+  }
+/>
+```

--- a/.changeset/nervous-chicken-trade.md
+++ b/.changeset/nervous-chicken-trade.md
@@ -6,7 +6,7 @@
 
 ### ShowMore
 
-- the `onToggle` callback has a new state as a parameter
+- add a new state as a parameter to `onToggle` callback
 
 ```diff
 <ShowMore

--- a/packages/picasso/src/ShowMore/ShowMore.tsx
+++ b/packages/picasso/src/ShowMore/ShowMore.tsx
@@ -96,8 +96,10 @@ export const ShowMore = forwardRef<HTMLSpanElement, Props>(function ShowMore(
       {!disableToggle && needsTruncation && (
         <ButtonAction
           onClick={() => {
-            setShownMore(!shownMore)
-            onToggle(!shownMore)
+            const nextState = !shownMore
+
+            setShownMore(nextState)
+            onToggle(nextState)
           }}
           className={classes.toggleText}
           icon={

--- a/packages/picasso/src/ShowMore/ShowMore.tsx
+++ b/packages/picasso/src/ShowMore/ShowMore.tsx
@@ -30,7 +30,7 @@ export interface Props extends BaseProps {
   /** Define whether action link should be displayed or not */
   disableToggle?: boolean
   /** Callback triggered when show more/less is clicked */
-  onToggle?: () => void
+  onToggle?: (nextState: boolean) => void
   testIds?: {
     contentWrapper?: string
     toggleButton?: string
@@ -97,7 +97,7 @@ export const ShowMore = forwardRef<HTMLSpanElement, Props>(function ShowMore(
         <ButtonAction
           onClick={() => {
             setShownMore(!shownMore)
-            onToggle()
+            onToggle(!shownMore)
           }}
           className={classes.toggleText}
           icon={

--- a/packages/picasso/src/ShowMore/story/OnToggle.example.tsx
+++ b/packages/picasso/src/ShowMore/story/OnToggle.example.tsx
@@ -1,0 +1,38 @@
+import React, { useState } from 'react'
+import { ShowMore, Tag } from '@toptal/picasso'
+
+const Example = () => {
+  const [isExpanded, setExpanded] = useState(false)
+
+  return (
+    <div style={{ width: '430px' }}>
+      {isExpanded ? (
+        <Tag variant='green'>expanded</Tag>
+      ) : (
+        <Tag variant='red'>closed</Tag>
+      )}
+
+      <ShowMore onToggle={setExpanded}>
+        Lorem ipsum dolor sit amet consectetur adipisicing elit. Eos earum vitae
+        quam odit omnis quod in voluptates est doloremque nulla sequi, illum
+        deleniti, beatae quo? Eaque similique nemo omnis quasi? Lorem ipsum
+        dolor sit amet consectetur adipisicing elit. Eos earum vitae quam odit
+        omnis quod in voluptates est doloremque nulla sequi, illum deleniti,
+        beatae quo? Eaque similique nemo omnis quasi? Lorem ipsum dolor sit amet
+        consectetur adipisicing elit. Eos earum vitae quam odit omnis quod in
+        voluptates est doloremque nulla sequi, illum deleniti, beatae quo? Eaque
+        similique nemo omnis quasi? Lorem ipsum dolor sit amet consectetur
+        adipisicing elit. Eos earum vitae quam odit omnis quod in voluptates est
+        doloremque nulla sequi, illum deleniti, beatae quo? Eaque similique nemo
+        omnis quasi? Lorem ipsum dolor sit amet consectetur adipisicing elit.
+        Eos earum vitae quam odit omnis quod in voluptates est doloremque nulla
+        sequi, illum deleniti, beatae quo? Eaque similique nemo omnis quasi?
+        Lorem ipsum dolor sit amet consectetur adipisicing elit. Eos earum vitae
+        quam odit omnis quod in voluptates est doloremque nulla sequi, illum
+        deleniti, beatae quo? Eaque similique nemo omnis quasi?
+      </ShowMore>
+    </div>
+  )
+}
+
+export default Example

--- a/packages/picasso/src/ShowMore/story/index.jsx
+++ b/packages/picasso/src/ShowMore/story/index.jsx
@@ -4,7 +4,7 @@ import PicassoBook from '~/.storybook/components/PicassoBook'
 const page = PicassoBook.section('Components').createPage(
   'ShowMore',
   `Strips provided content.
-  
+
   ${PicassoBook.createSourceLink(__filename)}
   `
 )
@@ -15,21 +15,25 @@ page
 
 page
   .createChapter()
-  .addExample('ShowMore/story/Default.example.tsx', 'Default')
-  .addExample('ShowMore/story/LineBreaks.example.tsx', 'Line Breaks')
-  .addExample('ShowMore/story/Expanded.example.tsx', 'Expanded')
-  .addExample('ShowMore/story/CustomLimit.example.tsx', 'Custom Limit')
-  .addExample('ShowMore/story/ToggleDisabled.example.tsx', 'Toggle Disabled')
-  .addExample('ShowMore/story/ZeroRows.example.tsx', {
-    title: 'With zero rows',
+  // .addExample('ShowMore/story/Default.example.tsx', 'Default')
+  // .addExample('ShowMore/story/LineBreaks.example.tsx', 'Line Breaks')
+  // .addExample('ShowMore/story/Expanded.example.tsx', 'Expanded')
+  // .addExample('ShowMore/story/CustomLimit.example.tsx', 'Custom Limit')
+  // .addExample('ShowMore/story/ToggleDisabled.example.tsx', 'Toggle Disabled')
+  // .addExample('ShowMore/story/ZeroRows.example.tsx', {
+  //   title: 'With zero rows',
+  //   takeScreenshot: false,
+  // })
+  // .addExample('ShowMore/story/ReactChildren.example.tsx', {
+  //   title: 'With React children',
+  //   takeScreenshot: false,
+  // })
+  .addExample('ShowMore/story/OnToggle.example.tsx', {
+    title: 'With onToggle callback',
     takeScreenshot: false,
   })
-  .addExample('ShowMore/story/ReactChildren.example.tsx', {
-    title: 'With React children',
-    takeScreenshot: false,
-  })
-  .addExample('ShowMore/story/ShortText.example.tsx', {
-    title: 'With short text',
-    description:
-      'If number of lines are less than `rows` defined, the "Show More" button is hidden',
-  })
+// .addExample('ShowMore/story/ShortText.example.tsx', {
+//   title: 'With short text',
+//   description:
+//     'If number of lines are less than `rows` defined, the "Show More" button is hidden',
+// })

--- a/packages/picasso/src/ShowMore/story/index.jsx
+++ b/packages/picasso/src/ShowMore/story/index.jsx
@@ -15,25 +15,25 @@ page
 
 page
   .createChapter()
-  // .addExample('ShowMore/story/Default.example.tsx', 'Default')
-  // .addExample('ShowMore/story/LineBreaks.example.tsx', 'Line Breaks')
-  // .addExample('ShowMore/story/Expanded.example.tsx', 'Expanded')
-  // .addExample('ShowMore/story/CustomLimit.example.tsx', 'Custom Limit')
-  // .addExample('ShowMore/story/ToggleDisabled.example.tsx', 'Toggle Disabled')
-  // .addExample('ShowMore/story/ZeroRows.example.tsx', {
-  //   title: 'With zero rows',
-  //   takeScreenshot: false,
-  // })
-  // .addExample('ShowMore/story/ReactChildren.example.tsx', {
-  //   title: 'With React children',
-  //   takeScreenshot: false,
-  // })
+  .addExample('ShowMore/story/Default.example.tsx', 'Default')
+  .addExample('ShowMore/story/LineBreaks.example.tsx', 'Line Breaks')
+  .addExample('ShowMore/story/Expanded.example.tsx', 'Expanded')
+  .addExample('ShowMore/story/CustomLimit.example.tsx', 'Custom Limit')
+  .addExample('ShowMore/story/ToggleDisabled.example.tsx', 'Toggle Disabled')
+  .addExample('ShowMore/story/ZeroRows.example.tsx', {
+    title: 'With zero rows',
+    takeScreenshot: false,
+  })
+  .addExample('ShowMore/story/ReactChildren.example.tsx', {
+    title: 'With React children',
+    takeScreenshot: false,
+  })
   .addExample('ShowMore/story/OnToggle.example.tsx', {
     title: 'With onToggle callback',
     takeScreenshot: false,
   })
-// .addExample('ShowMore/story/ShortText.example.tsx', {
-//   title: 'With short text',
-//   description:
-//     'If number of lines are less than `rows` defined, the "Show More" button is hidden',
-// })
+  .addExample('ShowMore/story/ShortText.example.tsx', {
+    title: 'With short text',
+    description:
+      'If number of lines are less than `rows` defined, the "Show More" button is hidden',
+  })

--- a/packages/picasso/src/ShowMore/test.tsx
+++ b/packages/picasso/src/ShowMore/test.tsx
@@ -43,6 +43,11 @@ describe('when onToggle function is passed', () => {
     fireEvent.click(toggleText)
 
     expect(onToggle).toHaveBeenCalledTimes(1)
+    expect(onToggle).toHaveBeenCalledWith(true)
+
+    fireEvent.click(toggleText)
+    expect(onToggle).toHaveBeenCalledTimes(2)
+    expect(onToggle).toHaveBeenCalledWith(false)
   })
 })
 


### PR DESCRIPTION
[FX-3724]

### Description

We had [a discussion](https://toptal-core.slack.com/archives/CERF5NHT3/p1676299119242719) in Slack about users who would like to have information about the current state of the ShowMore component in `onToggle` callback

### How to test

- check updated unit tests
- play with the storybook

### Screenshots

n/a

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- n/a Make sure that additions and changes on design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests

**Breaking change**

- [x] codemod is created and showcased in the changeset
- [x] test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-3723]: https://toptal-core.atlassian.net/browse/FX-3723?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[FX-3724]: https://toptal-core.atlassian.net/browse/FX-3724?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ