### PR TITLE
feat: convert Form to non-compound component

### DIFF
--- a/.changeset/nine-cycles-turn.md
+++ b/.changeset/nine-cycles-turn.md
@@ -1,0 +1,10 @@
+---
+'@toptal/picasso-codemod': minor
+'@toptal/picasso-forms': minor
+---
+
+---
+
+- all the Picasso Forms components exported from `picasso-forms` are now available to be directly imported from the root entry point
+- compound usage of `Form` is now deprecated, you can replace the compound `Form` with `FormNonCompound` (in the future compound Form will no longer be available)
+- added a codemod to effortlessly migrate your compound `Form` to separate components

--- a/.changeset/nine-cycles-turn.md
+++ b/.changeset/nine-cycles-turn.md
@@ -7,4 +7,4 @@
 
 - all the Picasso Forms components exported from `picasso-forms` are now available to be directly imported from the root entry point
 - compound usage of `Form` is now deprecated, you can replace the compound `Form` with `FormNonCompound` (in the future compound Form will no longer be available)
-- added a codemod to effortlessly migrate your compound `Form` to separate components
+- added a codemod to effortlessly migrate your compound `Form` to separate components `npx @toptal/picasso-codemod v52.2.0/non-compound-forms`

--- a/.storybook/stories/tutorials/form-components/story/index.jsx
+++ b/.storybook/stories/tutorials/form-components/story/index.jsx
@@ -68,7 +68,7 @@ advancedChapter
     `
 Picasso Forms is a powerful wrapper around React Final Form. it comes with a full set of tools to validate, parse, keep and sanitize the form state.
 
-You will find exactly the same set of form inputs as in regular Picasso, but as a part of a compound \`Form\` component imported from \`@toptal/picasso-forms\`.
+You will find exactly the same set of form inputs as in regular Picasso, but exported from \`@toptal/picasso-forms\`.
 
 Please note: most of the time you want to use **either** only pure components from Picasso or only components from Picasso Forms,
 almost never both types at the same time (unless you need something very specific-looking).
@@ -89,10 +89,10 @@ advancedChapter.addTextSection(
   `
 If you look for handlers for sanitizing / validating your form component data into form state, you can do so by taking a look at the available props for FieldWrapper.
 
-All the components that are a part of the compound \`Form\` share the common set of props from the [FieldWrapper](/?path=/story/picasso-forms-form--form).
+All the components exported from \`@toptal/picasso-forms\` share the common set of props from the [FieldWrapper](/?path=/story/picasso-forms-form--form).
 If you need converting your data between plain HTML form values (always string) and internal form state, \`parse\` and \`format\` is a good place to start.
 
-You can also convert your data before submitting if you need it. Field and form level validators are also available in \`Form\` and it's compound components respectively.
+You can also convert your data before submitting if you need it. Field and form level validators are also available in \`Form\` and all Picasso Forms components.
 `,
   {
     title: 'Sanitizing and validating',

--- a/packages/picasso-codemod/README.md
+++ b/packages/picasso-codemod/README.md
@@ -42,6 +42,37 @@ Codemods do not guarantee the code format preservation. Therefore be sure to run
 ## Included Scripts
 
 
+### v52.2.0
+
+Replaces compound `Form` with `FormNonCompound` and adjusts all the compound components to be directly imported from `picasso-forms`.
+
+#### `non-compound-forms`
+
+```diff
+-<Form>
+-  <Form.Input/>
+-  <Form.CheckboxGroup>
+-    <Form.Checkbox/>
+-  </Form.CheckboxGroup>
+-</Form>
++<FormNonCompound>
++  <Input/>
++  <CheckboxGroup>
++    <Checkbox/>
++  </CheckboxGroup>
++</FormNonCompound>
+```
+
+<details>
+<summary>Command</summary>
+
+```sh
+npx @toptal/picasso-codemod v52.2.0/non-compound-forms src/**/*.tsx
+```
+
+</details>
+
+
 ### v24.0.0
 
 Replaces imports and components from `Sidebar` to `Page.Sidebar`

--- a/packages/picasso-codemod/src/v52.2.0/non-compound-forms/__testfixtures__/aliased.input.tsx
+++ b/packages/picasso-codemod/src/v52.2.0/non-compound-forms/__testfixtures__/aliased.input.tsx
@@ -1,0 +1,24 @@
+import { Form as PicassoForm } from '@toptal/picasso-forms'
+import React from 'react'
+
+const Example = () => {
+  return (
+    <PicassoForm autoComplete='off' onSubmit={values => () => values}>
+      <PicassoForm.Input
+        enableReset
+        onResetClick={(set: (value: string) => void) => {
+          set('')
+        }}
+        required
+        name='default-firstName'
+        label='First name'
+        placeholder='e.g. Bruce'
+      />
+      <PicassoForm.Rating.Thumbs
+        name='default-thumbs'
+        label='Would you recommend picasso?'
+        required
+      />
+    </PicassoForm>
+  )
+}

--- a/packages/picasso-codemod/src/v52.2.0/non-compound-forms/__testfixtures__/aliased.output.tsx
+++ b/packages/picasso-codemod/src/v52.2.0/non-compound-forms/__testfixtures__/aliased.output.tsx
@@ -1,0 +1,24 @@
+import { FormNonCompound, Input, Rating } from '@toptal/picasso-forms';
+import React from 'react'
+
+const Example = () => {
+  return (
+    <FormNonCompound autoComplete='off' onSubmit={values => () => values}>
+      <Input
+        enableReset
+        onResetClick={(set: (value: string) => void) => {
+          set('')
+        }}
+        required
+        name='default-firstName'
+        label='First name'
+        placeholder='e.g. Bruce'
+      />
+      <Rating.Thumbs
+        name='default-thumbs'
+        label='Would you recommend picasso?'
+        required
+      />
+    </FormNonCompound>
+  );
+}

--- a/packages/picasso-codemod/src/v52.2.0/non-compound-forms/__testfixtures__/basic.input.tsx
+++ b/packages/picasso-codemod/src/v52.2.0/non-compound-forms/__testfixtures__/basic.input.tsx
@@ -1,0 +1,123 @@
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-nocheck
+import { Form } from '@toptal/picasso-forms'
+import React from 'react'
+
+const Example = () => {
+  return (
+    <Form autoComplete='off' onSubmit={values => () => values}>
+      <Form.Input
+        enableReset
+        onResetClick={(set: (value: string) => void) => {
+          set('')
+        }}
+        required
+        name='default-firstName'
+        label='First name'
+        placeholder='e.g. Bruce'
+      />
+      <Form.Input
+        required
+        name='default-lastName'
+        label='Last name'
+        placeholder='e.g. Wayne'
+      />
+      <Form.NumberInput
+        enableReset
+        required
+        name='default-age'
+        label="What's your age?"
+        placeholder='e.g. 25'
+      />
+      <Form.RadioGroup name='default-gender' label='Gender'>
+        <Form.Radio label='Male' value='male' />
+        <Form.Radio label='Female' value='female' />
+      </Form.RadioGroup>
+      <Form.RadioGroup
+        name='default-gender'
+        label='Gender'
+        horizontal
+        spacing={8}
+      >
+        <Form.ButtonRadio value='male'>Male</Form.ButtonRadio>
+        <Form.ButtonRadio value='female'>Female</Form.ButtonRadio>
+      </Form.RadioGroup>
+      <Form.DatePicker name='default-dateOfBirth' label='Date of birth' />
+      <Form.TimePicker name='default-timeOfBirth' label='Time of birth' />
+      <Form.TagSelector name='default-skills' label='Skills' />
+      <Form.CheckboxGroup name='default-hobbies' label='Hobbies'>
+        <Form.Checkbox label='Skiing' value='skiing' />
+        <Form.Checkbox label='Free diving' value='freeDiving' />
+        <Form.Checkbox label='Dancing' value='dancing' />
+      </Form.CheckboxGroup>
+      <Form.CheckboxGroup
+        name='default-hobbies'
+        label='Hobbies'
+        horizontal
+        spacing={8}
+      >
+        <Form.ButtonCheckbox value='skiing'>Skiing</Form.ButtonCheckbox>
+        <Form.ButtonCheckbox value='freeDiving'>
+          Free diving
+        </Form.ButtonCheckbox>
+        <Form.ButtonCheckbox value='dancing'>Dancing</Form.ButtonCheckbox>
+      </Form.CheckboxGroup>
+      <Form.Select
+        enableReset
+        required
+        name='default-businessType'
+        label='Business type'
+        width='auto'
+        options={[
+          { value: 0, text: 'Company' },
+          { value: 1, text: 'Individual' },
+        ]}
+      />
+      <Form.Select
+        name='default-origin_country'
+        label='Origin country'
+        width='auto'
+      />
+      <Form.Autocomplete
+        name='default-current_country'
+        label='Current country'
+        placeholder='Start typing country...'
+        width='auto'
+      />
+      <Form.Rating.Stars
+        name='default-rating'
+        label='How much do you love Picasso?'
+        required
+      />
+      <Form.Rating.Thumbs
+        name='default-thumbs'
+        label='Would you recommend picasso?'
+        required
+      />
+      <Form.FileInput
+        required
+        name='default-resume'
+        label='Resume'
+        status='No file selected.'
+      />
+      <Form.Dropzone label='Attachments' required name='default-attachments' />
+      <Form.AvatarUpload
+        label='Profile photo'
+        required
+        name='default-avatarUpload'
+      />
+      <Form.Checkbox
+        required
+        name='default-legal'
+        label='I confirm that I have legal permission from the client to feature this project.'
+      />
+      <Form.Switch
+        name='default-publicProfile'
+        label='Public Profile'
+        width='auto'
+      />
+
+      <Form.SubmitButton>Submit</Form.SubmitButton>
+    </Form>
+  )
+}

--- a/packages/picasso-codemod/src/v52.2.0/non-compound-forms/__testfixtures__/basic.output.tsx
+++ b/packages/picasso-codemod/src/v52.2.0/non-compound-forms/__testfixtures__/basic.output.tsx
@@ -1,0 +1,144 @@
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-nocheck
+import {
+  FormNonCompound,
+  Input,
+  NumberInput,
+  RadioGroup,
+  Radio,
+  ButtonRadio,
+  DatePicker,
+  TimePicker,
+  TagSelector,
+  CheckboxGroup,
+  Checkbox,
+  ButtonCheckbox,
+  Select,
+  Autocomplete,
+  Rating,
+  FileInput,
+  Dropzone,
+  AvatarUpload,
+  Switch,
+  SubmitButton,
+} from '@toptal/picasso-forms';
+import React from 'react'
+
+const Example = () => {
+  return (
+    <FormNonCompound autoComplete='off' onSubmit={values => () => values}>
+      <Input
+        enableReset
+        onResetClick={(set: (value: string) => void) => {
+          set('')
+        }}
+        required
+        name='default-firstName'
+        label='First name'
+        placeholder='e.g. Bruce'
+      />
+      <Input
+        required
+        name='default-lastName'
+        label='Last name'
+        placeholder='e.g. Wayne'
+      />
+      <NumberInput
+        enableReset
+        required
+        name='default-age'
+        label="What's your age?"
+        placeholder='e.g. 25'
+      />
+      <RadioGroup name='default-gender' label='Gender'>
+        <Radio label='Male' value='male' />
+        <Radio label='Female' value='female' />
+      </RadioGroup>
+      <RadioGroup
+        name='default-gender'
+        label='Gender'
+        horizontal
+        spacing={8}
+      >
+        <ButtonRadio value='male'>Male</ButtonRadio>
+        <ButtonRadio value='female'>Female</ButtonRadio>
+      </RadioGroup>
+      <DatePicker name='default-dateOfBirth' label='Date of birth' />
+      <TimePicker name='default-timeOfBirth' label='Time of birth' />
+      <TagSelector name='default-skills' label='Skills' />
+      <CheckboxGroup name='default-hobbies' label='Hobbies'>
+        <Checkbox label='Skiing' value='skiing' />
+        <Checkbox label='Free diving' value='freeDiving' />
+        <Checkbox label='Dancing' value='dancing' />
+      </CheckboxGroup>
+      <CheckboxGroup
+        name='default-hobbies'
+        label='Hobbies'
+        horizontal
+        spacing={8}
+      >
+        <ButtonCheckbox value='skiing'>Skiing</ButtonCheckbox>
+        <ButtonCheckbox value='freeDiving'>
+          Free diving
+        </ButtonCheckbox>
+        <ButtonCheckbox value='dancing'>Dancing</ButtonCheckbox>
+      </CheckboxGroup>
+      <Select
+        enableReset
+        required
+        name='default-businessType'
+        label='Business type'
+        width='auto'
+        options={[
+          { value: 0, text: 'Company' },
+          { value: 1, text: 'Individual' },
+        ]}
+      />
+      <Select
+        name='default-origin_country'
+        label='Origin country'
+        width='auto'
+      />
+      <Autocomplete
+        name='default-current_country'
+        label='Current country'
+        placeholder='Start typing country...'
+        width='auto'
+      />
+      <Rating.Stars
+        name='default-rating'
+        label='How much do you love Picasso?'
+        required
+      />
+      <Rating.Thumbs
+        name='default-thumbs'
+        label='Would you recommend picasso?'
+        required
+      />
+      <FileInput
+        required
+        name='default-resume'
+        label='Resume'
+        status='No file selected.'
+      />
+      <Dropzone label='Attachments' required name='default-attachments' />
+      <AvatarUpload
+        label='Profile photo'
+        required
+        name='default-avatarUpload'
+      />
+      <Checkbox
+        required
+        name='default-legal'
+        label='I confirm that I have legal permission from the client to feature this project.'
+      />
+      <Switch
+        name='default-publicProfile'
+        label='Public Profile'
+        width='auto'
+      />
+
+      <SubmitButton>Submit</SubmitButton>
+    </FormNonCompound>
+  );
+}

--- a/packages/picasso-codemod/src/v52.2.0/non-compound-forms/__tests__/test.ts
+++ b/packages/picasso-codemod/src/v52.2.0/non-compound-forms/__tests__/test.ts
@@ -1,0 +1,4 @@
+import { defineTest } from 'jscodeshift/src/testUtils'
+
+defineTest(__dirname, 'non-compound-forms', {}, 'basic', { parser: 'tsx' })
+defineTest(__dirname, 'non-compound-forms', {}, 'aliased', { parser: 'tsx' })

--- a/packages/picasso-codemod/src/v52.2.0/non-compound-forms/index.ts
+++ b/packages/picasso-codemod/src/v52.2.0/non-compound-forms/index.ts
@@ -1,0 +1,1 @@
+export { default } from './non-compound-forms'

--- a/packages/picasso-codemod/src/v52.2.0/non-compound-forms/non-compound-forms.ts
+++ b/packages/picasso-codemod/src/v52.2.0/non-compound-forms/non-compound-forms.ts
@@ -1,0 +1,100 @@
+import core, { Transform, Collection } from 'jscodeshift'
+
+import {
+  addImportMember,
+  findSpecifierForImport,
+  isImportFor,
+  isSpecifierFor,
+} from '../../utils'
+import { PackageMember } from '../../utils/types'
+
+const PICASSO_FORMS_PACKAGE = '@toptal/picasso-forms'
+
+const OLD_PICASSO_FORM: PackageMember = {
+  packageName: PICASSO_FORMS_PACKAGE,
+  exportedName: 'Form',
+}
+
+const NEW_PICASSO_FORM: PackageMember = {
+  packageName: PICASSO_FORMS_PACKAGE,
+  exportedName: 'FormNonCompound',
+}
+
+const transformMainImports = (root: Collection) => {
+  const picassoFormsIdentifier = findSpecifierForImport(NEW_PICASSO_FORM, root)
+
+  if (picassoFormsIdentifier == null) {
+    addImportMember(NEW_PICASSO_FORM, root)
+  }
+
+  root
+    .find(core.ImportDeclaration, decl => isImportFor(OLD_PICASSO_FORM, decl))
+    .forEach(({ node }) => {
+      node.specifiers = node.specifiers?.filter(
+        spec => !isSpecifierFor(OLD_PICASSO_FORM.exportedName, spec)
+      )
+    })
+
+  return {
+    picassoFormsIdentifier: picassoFormsIdentifier?.imported.name,
+  }
+}
+
+const transformComponents = (
+  formsPackageIdentifier: string,
+  newPackageIdentifier: string,
+  root: Collection
+) => {
+  const transformedComponents: string[] = []
+
+  // Find all core.JSXMemberExpression for nested components
+  root
+    .find(core.JSXMemberExpression, {
+      object: { name: formsPackageIdentifier },
+    })
+    .replaceWith(node => {
+      const name = node.value.property.name
+
+      transformedComponents.push(name)
+
+      return core.jsxIdentifier(name)
+    })
+
+  // Find all core.JSXIdentifier for main `Form` components
+  root
+    .find(core.JSXIdentifier, { name: formsPackageIdentifier })
+    .replaceWith(() => core.jsxIdentifier(newPackageIdentifier))
+
+  transformedComponents.forEach(exportedName => {
+    addImportMember({ packageName: PICASSO_FORMS_PACKAGE, exportedName }, root)
+  })
+}
+
+const transform: Transform = (file, api) => {
+  const j = api.jscodeshift
+  const root = j(file.source)
+
+  const formImports = root.find(j.ImportDeclaration, decl =>
+    isImportFor(OLD_PICASSO_FORM, decl)
+  )
+
+  if (formImports.size() > 0) {
+    const formsPackageIdentifier =
+      findSpecifierForImport(OLD_PICASSO_FORM, root)?.local?.name ??
+      OLD_PICASSO_FORM.exportedName
+
+    // Get current import declaration for the case of aliased imports
+    // Transform the main `Form` imports to be `FormNonCompound`
+    const { picassoFormsIdentifier } = transformMainImports(root)
+
+    transformComponents(
+      formsPackageIdentifier,
+      picassoFormsIdentifier ?? NEW_PICASSO_FORM.exportedName,
+      root
+    )
+  }
+
+  return root.toSource()
+}
+
+export default transform

--- a/packages/picasso-forms/src/Form/story/AutoSave.example.tsx
+++ b/packages/picasso-forms/src/Form/story/AutoSave.example.tsx
@@ -1,6 +1,13 @@
 import React, { useCallback, useState } from 'react'
 import { Container, FormAutoSaveIndicator, Typography } from '@toptal/picasso'
-import { Form, ChangedFields, useFormAutoSave } from '@toptal/picasso-forms'
+import {
+  FormNonCompound as Form,
+  ChangedFields,
+  useFormAutoSave,
+  Input,
+  RichTextEditor,
+  SubmitButton,
+} from '@toptal/picasso-forms'
 
 // the emulation of the api call
 const saveWithDelay = async () =>
@@ -47,19 +54,19 @@ const Example = () => {
     >
       <Container flex direction='row' gap='medium'>
         <Container>
-          <Form.Input
+          <Input
             required
             name='autoSave-firstName'
             label='First name'
             placeholder='e.g. Bruce'
           />
-          <Form.Input
+          <Input
             required
             name='autoSave-lastName'
             label='Last name'
             placeholder='e.g. Wayne'
           />
-          <Form.Input
+          <Input
             required
             name='autoSave-about'
             multiline
@@ -74,7 +81,7 @@ const Example = () => {
               />
             }
           />
-          <Form.RichTextEditor
+          <RichTextEditor
             id='autoSave-rich-text-editor'
             label='Bio'
             required
@@ -103,7 +110,7 @@ const Example = () => {
       </Container>
 
       <Container top='small'>
-        <Form.SubmitButton>Submit</Form.SubmitButton>
+        <SubmitButton>Submit</SubmitButton>
       </Container>
     </Form>
   )

--- a/packages/picasso-forms/src/Form/story/AvatarUpload.example.tsx
+++ b/packages/picasso-forms/src/Form/story/AvatarUpload.example.tsx
@@ -4,7 +4,12 @@ import {
   AvatarUploadFileRejection,
   Container,
 } from '@toptal/picasso'
-import { Form, useForm } from '@toptal/picasso-forms'
+import {
+  FormNonCompound as Form,
+  useForm,
+  AvatarUpload,
+  SubmitButton,
+} from '@toptal/picasso-forms'
 
 type FormType = {
   avatarUpload: AvatarUploadFileUpload
@@ -46,7 +51,7 @@ const FormRenderer = () => {
 
   return (
     <>
-      <Form.AvatarUpload
+      <AvatarUpload
         required
         name='avatarUpload'
         onDrop={handleDrop}
@@ -54,7 +59,7 @@ const FormRenderer = () => {
       />
 
       <Container top='small'>
-        <Form.SubmitButton>Submit</Form.SubmitButton>
+        <SubmitButton>Submit</SubmitButton>
       </Container>
     </>
   )

--- a/packages/picasso-forms/src/Form/story/BackendCommunication.example.tsx
+++ b/packages/picasso-forms/src/Form/story/BackendCommunication.example.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback } from 'react'
 import { Container } from '@toptal/picasso'
-import { Form } from '@toptal/picasso-forms'
+import { FormNonCompound, Input, SubmitButton } from '@toptal/picasso-forms'
 
 const BackendCommunicationExample = () => {
   const handleSuccessSubmit = useCallback(
@@ -24,18 +24,18 @@ const BackendCommunicationExample = () => {
         gridTemplateColumns: 'repeat(auto-fit, minmax(300px, 1fr))',
       }}
     >
-      <Form
+      <FormNonCompound
         onSubmit={handleSuccessSubmit}
         successSubmitMessage='Login successful!'
       >
-        <Form.Input
+        <Input
           required
           name='backendCommunication-successName'
           label='First name'
           placeholder='e.g. Bruce'
           width='full'
         />
-        <Form.Input
+        <Input
           required
           name='backendCommunication-successSurname'
           label='Last name'
@@ -44,27 +44,24 @@ const BackendCommunicationExample = () => {
         />
 
         <Container top='small'>
-          <Form.SubmitButton
-            variant='positive'
-            data-testid='success-submit-button'
-          >
+          <SubmitButton variant='positive' data-testid='success-submit-button'>
             Login Success
-          </Form.SubmitButton>
+          </SubmitButton>
         </Container>
-      </Form>
+      </FormNonCompound>
 
-      <Form
+      <FormNonCompound
         onSubmit={handleSubmitWithInlineError}
         failedSubmitMessage='Login failed! Please try another combination of first and last names.'
       >
-        <Form.Input
+        <Input
           required
           name='backendCommunication-inlineErrorName'
           label='First name'
           placeholder='e.g. Bruce'
           width='full'
         />
-        <Form.Input
+        <Input
           required
           name='backendCommunication-inlineErrorSurname'
           label='Last name'
@@ -73,24 +70,24 @@ const BackendCommunicationExample = () => {
         />
 
         <Container top='small'>
-          <Form.SubmitButton
+          <SubmitButton
             variant='negative'
             data-testid='submit-with-inline-error-button'
           >
             Login with Inline Error
-          </Form.SubmitButton>
+          </SubmitButton>
         </Container>
-      </Form>
+      </FormNonCompound>
 
-      <Form onSubmit={handleSubmitWithCustomNotificationError}>
-        <Form.Input
+      <FormNonCompound onSubmit={handleSubmitWithCustomNotificationError}>
+        <Input
           required
           name='backendCommunication-customNotificationErrorName'
           label='First name'
           placeholder='e.g. Bruce'
           width='full'
         />
-        <Form.Input
+        <Input
           required
           name='backendCommunication-customNotificationErrorSurname'
           label='Last name'
@@ -99,14 +96,14 @@ const BackendCommunicationExample = () => {
         />
 
         <Container top='small'>
-          <Form.SubmitButton
+          <SubmitButton
             variant='negative'
             data-testid='submit-with-custom-notification-button'
           >
             Login with Custom Notification Error
-          </Form.SubmitButton>
+          </SubmitButton>
         </Container>
-      </Form>
+      </FormNonCompound>
     </Container>
   )
 }

--- a/packages/picasso-forms/src/Form/story/CustomFormLevelConfiguration.example.tsx
+++ b/packages/picasso-forms/src/Form/story/CustomFormLevelConfiguration.example.tsx
@@ -1,17 +1,23 @@
 import React from 'react'
 import { Container } from '@toptal/picasso'
-import { Form, FormConfigProps } from '@toptal/picasso-forms'
+import {
+  FormConfigProps,
+  FormNonCompound,
+  ConfigProvider,
+  Input,
+  SubmitButton,
+} from '@toptal/picasso-forms'
 
 const formConfig: FormConfigProps = {
   requiredVariant: 'asterisk',
 }
 
 const Example = () => (
-  <Form.ConfigProvider value={formConfig}>
-    <Form
+  <ConfigProvider value={formConfig}>
+    <FormNonCompound
       onSubmit={values => window.alert(JSON.stringify(values, undefined, 2))}
     >
-      <Form.Input
+      <Input
         required
         name='formConfig-firstName'
         label='First name'
@@ -19,10 +25,10 @@ const Example = () => (
       />
 
       <Container top='small'>
-        <Form.SubmitButton>Submit</Form.SubmitButton>
+        <SubmitButton>Submit</SubmitButton>
       </Container>
-    </Form>
-  </Form.ConfigProvider>
+    </FormNonCompound>
+  </ConfigProvider>
 )
 
 export default Example

--- a/packages/picasso-forms/src/Form/story/CustomValidator.example.tsx
+++ b/packages/picasso-forms/src/Form/story/CustomValidator.example.tsx
@@ -1,6 +1,11 @@
 import React from 'react'
 import { Container } from '@toptal/picasso'
-import { Form } from '@toptal/picasso-forms'
+import {
+  FormNonCompound,
+  Input,
+  NumberInput,
+  SubmitButton,
+} from '@toptal/picasso-forms'
 
 const minMaxValidator = (value?: string | number) => {
   if (value === undefined) {
@@ -21,14 +26,16 @@ const minMaxValidator = (value?: string | number) => {
 }
 
 const CustomValidatorExample = () => (
-  <Form onSubmit={values => window.alert(JSON.stringify(values, undefined, 2))}>
-    <Form.Input
+  <FormNonCompound
+    onSubmit={values => window.alert(JSON.stringify(values, undefined, 2))}
+  >
+    <Input
       required
       name='customValidator-userName'
       label='First name'
       placeholder='e.g. Bruce'
     />
-    <Form.NumberInput
+    <NumberInput
       required
       validate={minMaxValidator}
       name='customValidator-userAge'
@@ -37,9 +44,9 @@ const CustomValidatorExample = () => (
     />
 
     <Container top='small'>
-      <Form.SubmitButton>Submit</Form.SubmitButton>
+      <SubmitButton>Submit</SubmitButton>
     </Container>
-  </Form>
+  </FormNonCompound>
 )
 
 export default CustomValidatorExample

--- a/packages/picasso-forms/src/Form/story/Default.example.tsx
+++ b/packages/picasso-forms/src/Form/story/Default.example.tsx
@@ -2,7 +2,28 @@ import React, { useState } from 'react'
 import { Container } from '@toptal/picasso'
 import { Item } from '@toptal/picasso/Autocomplete'
 import { isSubstring } from '@toptal/picasso/utils'
-import { Form } from '@toptal/picasso-forms'
+import {
+  FormNonCompound as Form,
+  NumberInput,
+  Input,
+  RadioGroup,
+  Radio,
+  SubmitButton,
+  ButtonRadio,
+  CheckboxGroup,
+  Checkbox,
+  DatePicker,
+  TimePicker,
+  ButtonCheckbox,
+  Autocomplete,
+  FileInput,
+  Dropzone,
+  AvatarUpload,
+  Rating,
+  TagSelector,
+  Select,
+  Switch,
+} from '@toptal/picasso-forms'
 
 const countries = [
   { value: 'Afghanistan', text: 'Afghanistan' },
@@ -58,7 +79,7 @@ const Example = () => {
       onSubmit={values => window.alert(JSON.stringify(values, undefined, 2))}
       initialValues={initialValues}
     >
-      <Form.Input
+      <Input
         enableReset
         onResetClick={(set: (value: string) => void) => {
           set('')
@@ -68,59 +89,52 @@ const Example = () => {
         label='First name'
         placeholder='e.g. Bruce'
       />
-      <Form.Input
+      <Input
         required
         name='default-lastName'
         label='Last name'
         placeholder='e.g. Wayne'
       />
-      <Form.NumberInput
+      <NumberInput
         enableReset
         required
         name='default-age'
         label="What's your age?"
         placeholder='e.g. 25'
       />
-      <Form.RadioGroup name='default-gender' label='Gender'>
-        <Form.Radio label='Male' value='male' />
-        <Form.Radio label='Female' value='female' />
-      </Form.RadioGroup>
-      <Form.RadioGroup
-        name='default-gender'
-        label='Gender'
-        horizontal
-        spacing={8}
-      >
-        <Form.ButtonRadio value='male'>Male</Form.ButtonRadio>
-        <Form.ButtonRadio value='female'>Female</Form.ButtonRadio>
-      </Form.RadioGroup>
-      <Form.DatePicker name='default-dateOfBirth' label='Date of birth' />
-      <Form.TimePicker name='default-timeOfBirth' label='Time of birth' />
-      <Form.TagSelector
+      <RadioGroup name='default-gender' label='Gender'>
+        <Radio label='Male' value='male' />
+        <Radio label='Female' value='female' />
+      </RadioGroup>
+      <RadioGroup name='default-gender' label='Gender' horizontal spacing={8}>
+        <ButtonRadio value='male'>Male</ButtonRadio>
+        <ButtonRadio value='female'>Female</ButtonRadio>
+      </RadioGroup>
+      <DatePicker name='default-dateOfBirth' label='Date of birth' />
+      <TimePicker name='default-timeOfBirth' label='Time of birth' />
+      <TagSelector
         name='default-skills'
         label='Skills'
         inputValue={skillInputValue}
         options={skillOptions}
         onInputChange={setSkillInputValue}
       />
-      <Form.CheckboxGroup name='default-hobbies' label='Hobbies'>
-        <Form.Checkbox label='Skiing' value='skiing' />
-        <Form.Checkbox label='Free diving' value='freeDiving' />
-        <Form.Checkbox label='Dancing' value='dancing' />
-      </Form.CheckboxGroup>
-      <Form.CheckboxGroup
+      <CheckboxGroup name='default-hobbies' label='Hobbies'>
+        <Checkbox label='Skiing' value='skiing' />
+        <Checkbox label='Free diving' value='freeDiving' />
+        <Checkbox label='Dancing' value='dancing' />
+      </CheckboxGroup>
+      <CheckboxGroup
         name='default-hobbies'
         label='Hobbies'
         horizontal
         spacing={8}
       >
-        <Form.ButtonCheckbox value='skiing'>Skiing</Form.ButtonCheckbox>
-        <Form.ButtonCheckbox value='freeDiving'>
-          Free diving
-        </Form.ButtonCheckbox>
-        <Form.ButtonCheckbox value='dancing'>Dancing</Form.ButtonCheckbox>
-      </Form.CheckboxGroup>
-      <Form.Select
+        <ButtonCheckbox value='skiing'>Skiing</ButtonCheckbox>
+        <ButtonCheckbox value='freeDiving'>Free diving</ButtonCheckbox>
+        <ButtonCheckbox value='dancing'>Dancing</ButtonCheckbox>
+      </CheckboxGroup>
+      <Select
         enableReset
         required
         name='default-businessType'
@@ -131,13 +145,13 @@ const Example = () => {
           { value: 1, text: 'Individual' },
         ]}
       />
-      <Form.Select
+      <Select
         name='default-origin_country'
         label='Origin country'
         width='auto'
         options={countries}
       />
-      <Form.Autocomplete
+      <Autocomplete
         name='default-current_country'
         label='Current country'
         placeholder='Start typing country...'
@@ -161,41 +175,41 @@ const Example = () => {
         }}
         getDisplayValue={getAutocompleteDisplayValue}
       />
-      <Form.Rating.Stars
+      <Rating.Stars
         name='default-rating'
         label='How much do you love Picasso?'
         required
       />
-      <Form.Rating.Thumbs
+      <Rating.Thumbs
         name='default-thumbs'
         label='Would you recommend picasso?'
         required
       />
-      <Form.FileInput
+      <FileInput
         required
         name='default-resume'
         label='Resume'
         status='No file selected.'
       />
-      <Form.Dropzone label='Attachments' required name='default-attachments' />
-      <Form.AvatarUpload
+      <Dropzone label='Attachments' required name='default-attachments' />
+      <AvatarUpload
         label='Profile photo'
         required
         name='default-avatarUpload'
       />
-      <Form.Checkbox
+      <Checkbox
         required
         name='default-legal'
         label='I confirm that I have legal permission from the client to feature this project.'
       />
-      <Form.Switch
+      <Switch
         name='default-publicProfile'
         label='Public Profile'
         width='auto'
       />
 
       <Container top='small'>
-        <Form.SubmitButton>Submit</Form.SubmitButton>
+        <SubmitButton>Submit</SubmitButton>
       </Container>
     </Form>
   )

--- a/packages/picasso-forms/src/Form/story/Dropzone.example.tsx
+++ b/packages/picasso-forms/src/Form/story/Dropzone.example.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { Container } from '@toptal/picasso'
-import { Form } from '@toptal/picasso-forms'
+import { FormNonCompound, Dropzone, SubmitButton } from '@toptal/picasso-forms'
 import { FileUpload } from '@toptal/picasso/FileInput'
 
 type FormType = {
@@ -18,23 +18,23 @@ const Example = () => {
   }
 
   return (
-    <Form<FormType>
+    <FormNonCompound<FormType>
       autoComplete='off'
       onSubmit={handleSubmit}
       initialValues={{
         'dropzone-attachments': initialAttachments,
       }}
     >
-      <Form.Dropzone
+      <Dropzone
         required
         name='dropzone-attachments'
         dropzoneHint={`Max file size: ${MAX_SIZE}MB.`}
         hint='These documents will be used to analyze and identify your potential.'
       />
       <Container top='small'>
-        <Form.SubmitButton>Submit</Form.SubmitButton>
+        <SubmitButton>Submit</SubmitButton>
       </Container>
-    </Form>
+    </FormNonCompound>
   )
 }
 

--- a/packages/picasso-forms/src/Form/story/FieldRequirements.example.tsx
+++ b/packages/picasso-forms/src/Form/story/FieldRequirements.example.tsx
@@ -1,6 +1,10 @@
 import React from 'react'
 import { Container } from '@toptal/picasso'
-import { Form } from '@toptal/picasso-forms'
+import {
+  FormNonCompound,
+  PasswordInput,
+  SubmitButton,
+} from '@toptal/picasso-forms'
 
 type FormType = {
   'fieldRequirements-password': string
@@ -16,7 +20,7 @@ const Example = () => {
   }
 
   return (
-    <Form<FormType>
+    <FormNonCompound<FormType>
       autoComplete='off'
       onSubmit={handleSubmit}
       initialValues={{
@@ -24,12 +28,12 @@ const Example = () => {
         'fieldRequirements-confirmPassword': '',
       }}
     >
-      <Form.PasswordInput
+      <PasswordInput
         label='Password'
         name='fieldRequirements-password'
         required
       />
-      <Form.PasswordInput
+      <PasswordInput
         label='Confirm password'
         name='fieldRequirements-confirmPassword'
         hideRequirements
@@ -44,9 +48,9 @@ const Example = () => {
         }}
       />
       <Container top='small'>
-        <Form.SubmitButton>Submit</Form.SubmitButton>
+        <SubmitButton>Submit</SubmitButton>
       </Container>
-    </Form>
+    </FormNonCompound>
   )
 }
 

--- a/packages/picasso-forms/src/Form/story/FileInput.example.tsx
+++ b/packages/picasso-forms/src/Form/story/FileInput.example.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { Container } from '@toptal/picasso'
-import { Form } from '@toptal/picasso-forms'
+import { FormNonCompound, FileInput, SubmitButton } from '@toptal/picasso-forms'
 import { FileUpload } from '@toptal/picasso/FileInput'
 
 type FormType = {
@@ -21,21 +21,21 @@ const Example = () => {
   }
 
   return (
-    <Form<FormType>
+    <FormNonCompound<FormType>
       autoComplete='off'
       onSubmit={handleSubmit}
       initialValues={{
         'fileInput-attachments': initialAttachments,
       }}
     >
-      <Form.FileInput
+      <FileInput
         name='fileInput-attachments'
         hint={`Max file size: ${MAX_SIZE}MB.`}
       />
       <Container top='small'>
-        <Form.SubmitButton>Submit</Form.SubmitButton>
+        <SubmitButton>Submit</SubmitButton>
       </Container>
-    </Form>
+    </FormNonCompound>
   )
 }
 

--- a/packages/picasso-forms/src/Form/story/NoScrolling.example.tsx
+++ b/packages/picasso-forms/src/Form/story/NoScrolling.example.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { Container } from '@toptal/picasso'
-import { Form } from '@toptal/picasso-forms'
+import { FormNonCompound, Input, SubmitButton } from '@toptal/picasso-forms'
 
 const failWithAnError = () => ({
   fieldName: 'This form will always blame on a wrong user name',
@@ -9,31 +9,31 @@ const failWithAnError = () => ({
 const NoScrollingExample = () => (
   <Container>
     <Container top='small'>
-      <Form onSubmit={failWithAnError}>
-        <Form.Input
+      <FormNonCompound onSubmit={failWithAnError}>
+        <Input
           required
           name='noScrollingDefault-fieldName'
           label='With scrolling'
           placeholder='Some field'
         />
         <Container top='small'>
-          <Form.SubmitButton>Submit</Form.SubmitButton>
+          <SubmitButton>Submit</SubmitButton>
         </Container>
-      </Form>
+      </FormNonCompound>
     </Container>
 
     <Container top='small'>
-      <Form disableScrollOnError onSubmit={failWithAnError}>
-        <Form.Input
+      <FormNonCompound disableScrollOnError onSubmit={failWithAnError}>
+        <Input
           required
           name='noScrollingDisableScroll-fieldName'
           label='No scrolling'
           placeholder='Some field'
         />
         <Container top='small'>
-          <Form.SubmitButton>Submit</Form.SubmitButton>
+          <SubmitButton>Submit</SubmitButton>
         </Container>
-      </Form>
+      </FormNonCompound>
     </Container>
   </Container>
 )

--- a/packages/picasso-forms/src/Form/story/ParseInput.example.tsx
+++ b/packages/picasso-forms/src/Form/story/ParseInput.example.tsx
@@ -1,16 +1,18 @@
 import React from 'react'
 import { Container, Typography } from '@toptal/picasso'
-import { Form } from '@toptal/picasso-forms'
+import { FormNonCompound, Input, SubmitButton } from '@toptal/picasso-forms'
 
 const ParseInputExample = () => (
-  <Form onSubmit={values => window.alert(JSON.stringify(values, undefined, 2))}>
+  <FormNonCompound
+    onSubmit={values => window.alert(JSON.stringify(values, undefined, 2))}
+  >
     <Container bottom='small'>
       <Typography size='medium'>
         I want to trim my first name from the empty spaces:
       </Typography>
     </Container>
     <Container flex alignItems='flex-end'>
-      <Form.Input
+      <Input
         name='parseInput-firstName'
         label='First name'
         placeholder='e.g. Bruce'
@@ -19,10 +21,10 @@ const ParseInputExample = () => (
       />
 
       <Container left='small'>
-        <Form.SubmitButton>Submit</Form.SubmitButton>
+        <SubmitButton>Submit</SubmitButton>
       </Container>
     </Container>
-  </Form>
+  </FormNonCompound>
 )
 
 export default ParseInputExample

--- a/packages/picasso-forms/src/Form/story/RichTextEditor.example.tsx
+++ b/packages/picasso-forms/src/Form/story/RichTextEditor.example.tsx
@@ -1,6 +1,10 @@
 import React from 'react'
 import { Container, ASTType } from '@toptal/picasso'
-import { Form } from '@toptal/picasso-forms'
+import {
+  FormNonCompound,
+  RichTextEditor,
+  SubmitButton,
+} from '@toptal/picasso-forms'
 
 const DEFAULT_EXAMPLE: ASTType = {
   type: 'root',
@@ -8,9 +12,9 @@ const DEFAULT_EXAMPLE: ASTType = {
 }
 
 const RichTextEditorExample = () => (
-  <Form onSubmit={data => window.alert(JSON.stringify(data))}>
+  <FormNonCompound onSubmit={data => window.alert(JSON.stringify(data))}>
     <Container bottom='small'>
-      <Form.RichTextEditor
+      <RichTextEditor
         required
         defaultValue={DEFAULT_EXAMPLE}
         label='Text editor'
@@ -19,8 +23,8 @@ const RichTextEditorExample = () => (
       />
     </Container>
 
-    <Form.SubmitButton>Submit</Form.SubmitButton>
-  </Form>
+    <SubmitButton>Submit</SubmitButton>
+  </FormNonCompound>
 )
 
 export default RichTextEditorExample

--- a/packages/picasso-forms/src/Form/story/Status.example.tsx
+++ b/packages/picasso-forms/src/Form/story/Status.example.tsx
@@ -1,17 +1,23 @@
 import React from 'react'
 import { Container } from '@toptal/picasso'
-import { Form, FormConfigProps } from '@toptal/picasso-forms'
+import {
+  FormConfigProps,
+  FormNonCompound,
+  ConfigProvider,
+  Input,
+  SubmitButton,
+} from '@toptal/picasso-forms'
 
 const formConfig: FormConfigProps = {
   showValidState: true,
 }
 
 const Example = () => (
-  <Form.ConfigProvider value={formConfig}>
-    <Form
+  <ConfigProvider value={formConfig}>
+    <FormNonCompound
       onSubmit={values => window.alert(JSON.stringify(values, undefined, 2))}
     >
-      <Form.Input
+      <Input
         required
         name='status-firstName'
         label='First name'
@@ -19,10 +25,10 @@ const Example = () => (
       />
 
       <Container top='small'>
-        <Form.SubmitButton>Submit</Form.SubmitButton>
+        <SubmitButton>Submit</SubmitButton>
       </Container>
-    </Form>
-  </Form.ConfigProvider>
+    </FormNonCompound>
+  </ConfigProvider>
 )
 
 export default Example

--- a/packages/picasso-forms/src/Form/story/TitleCase.example.tsx
+++ b/packages/picasso-forms/src/Form/story/TitleCase.example.tsx
@@ -2,7 +2,24 @@ import React, { useState } from 'react'
 import { Container } from '@toptal/picasso'
 import { Item } from '@toptal/picasso/Autocomplete'
 import { isSubstring } from '@toptal/picasso/utils'
-import { Form } from '@toptal/picasso-forms'
+import {
+  FormNonCompound,
+  Input,
+  NumberInput,
+  RadioGroup,
+  Radio,
+  DatePicker,
+  TimePicker,
+  TagSelector,
+  CheckboxGroup,
+  Checkbox,
+  Select,
+  Autocomplete,
+  Rating,
+  FileInput,
+  Switch,
+  SubmitButton,
+} from '@toptal/picasso-forms'
 
 const countries = [
   { value: 'Afghanistan', text: 'Afghanistan' },
@@ -49,12 +66,12 @@ const Example = () => {
   )
 
   return (
-    <Form
+    <FormNonCompound
       autoComplete='off'
       onSubmit={values => window.alert(JSON.stringify(values, undefined, 2))}
       initialValues={{ 'titleCase-gender': 'female' }}
     >
-      <Form.Input
+      <Input
         titleCase
         enableReset
         onResetClick={(set: (value: string) => void) => {
@@ -65,7 +82,7 @@ const Example = () => {
         label='First name'
         placeholder='e.g. Bruce'
       />
-      <Form.NumberInput
+      <NumberInput
         titleCase
         enableReset
         required
@@ -73,21 +90,21 @@ const Example = () => {
         label="What's your age?"
         placeholder='e.g. 25'
       />
-      <Form.RadioGroup titleCase name='titleCase-gender' label='Select gender'>
-        <Form.Radio label='Male' value='male' />
-        <Form.Radio label='Female' value='female' />
-      </Form.RadioGroup>
-      <Form.DatePicker
+      <RadioGroup titleCase name='titleCase-gender' label='Select gender'>
+        <Radio label='Male' value='male' />
+        <Radio label='Female' value='female' />
+      </RadioGroup>
+      <DatePicker
         titleCase
         name='titleCase-dateOfBirth'
         label='Date of birth'
       />
-      <Form.TimePicker
+      <TimePicker
         titleCase
         name='titleCase-timeOfBirth'
         label='Time of birth'
       />
-      <Form.TagSelector
+      <TagSelector
         titleCase
         name='titleCase-skills'
         label='Your skills'
@@ -95,16 +112,12 @@ const Example = () => {
         options={skillOptions}
         onInputChange={setSkillInputValue}
       />
-      <Form.CheckboxGroup
-        titleCase
-        name='titleCase-hobbies'
-        label='Your hobbies'
-      >
-        <Form.Checkbox label='Skiing' value='skiing' />
-        <Form.Checkbox titleCase label='Free diving' value='freeDiving' />
-        <Form.Checkbox label='Dancing' value='dancing' />
-      </Form.CheckboxGroup>
-      <Form.Select
+      <CheckboxGroup titleCase name='titleCase-hobbies' label='Your hobbies'>
+        <Checkbox label='Skiing' value='skiing' />
+        <Checkbox titleCase label='Free diving' value='freeDiving' />
+        <Checkbox label='Dancing' value='dancing' />
+      </CheckboxGroup>
+      <Select
         titleCase
         enableReset
         required
@@ -116,7 +129,7 @@ const Example = () => {
           { value: 1, text: 'Individual' },
         ]}
       />
-      <Form.Autocomplete
+      <Autocomplete
         titleCase
         name='titleCase-current_country'
         label='Current country'
@@ -141,30 +154,30 @@ const Example = () => {
         }}
         getDisplayValue={getAutocompleteDisplayValue}
       />
-      <Form.Rating.Stars
+      <Rating.Stars
         name='titleCase-rating'
         label='How much do you love Picasso?'
         required
       />
-      <Form.Rating.Thumbs
+      <Rating.Thumbs
         name='titleCase-thumbs'
         label='Would you recommend picasso?'
         required
       />
-      <Form.FileInput
+      <FileInput
         titleCase
         required
         name='titleCase-resume'
         label='Your resume'
         status='No file selected.'
       />
-      <Form.Checkbox
+      <Checkbox
         titleCase
         required
         name='titleCase-legal'
         label='I confirm that I have legal permission from the client to feature this project.'
       />
-      <Form.Switch
+      <Switch
         titleCase
         name='titleCase-publicProfile'
         label='Public profile'
@@ -172,9 +185,9 @@ const Example = () => {
       />
 
       <Container top='small'>
-        <Form.SubmitButton>Submit</Form.SubmitButton>
+        <SubmitButton>Submit</SubmitButton>
       </Container>
-    </Form>
+    </FormNonCompound>
   )
 }
 

--- a/packages/picasso-forms/src/Form/story/ValidateOnSubmit.example.tsx
+++ b/packages/picasso-forms/src/Form/story/ValidateOnSubmit.example.tsx
@@ -1,7 +1,14 @@
 import React, { useCallback } from 'react'
 import { useField } from 'react-final-form'
 import { Container } from '@toptal/picasso'
-import { Form } from '@toptal/picasso-forms'
+import {
+  FormNonCompound,
+  Checkbox,
+  Input,
+  DatePicker,
+  ConfigProvider,
+  SubmitButton,
+} from '@toptal/picasso-forms'
 
 type FormType = {
   'validateOnSubmit-hide': boolean
@@ -19,28 +26,28 @@ const FormContent = () => {
 
   return (
     <>
-      <Form.Checkbox
+      <Checkbox
         name='validateOnSubmit-hide'
         label='Check to hide fields below'
       />
 
       {!hide && (
         <>
-          <Form.Input
+          <Input
             enableReset
             required
             name='validateOnSubmit-name.first'
             label='Your first name'
             placeholder='e.g. Bruce'
           />
-          <Form.Input
+          <Input
             enableReset
             required
             name='validateOnSubmit-name.last'
             label='Your last name'
             placeholder='e.g. Wayne'
           />
-          <Form.DatePicker required name='validateOnSubmit-dob' label='DOB' />
+          <DatePicker required name='validateOnSubmit-dob' label='DOB' />
         </>
       )}
     </>
@@ -51,8 +58,8 @@ const Example = () => {
   const handleSubmit = useCallback((values: FormType) => api.submit(values), [])
 
   return (
-    <Form.ConfigProvider value={{ validateOnSubmit: true }}>
-      <Form<FormType>
+    <ConfigProvider value={{ validateOnSubmit: true }}>
+      <FormNonCompound<FormType>
         onSubmit={handleSubmit}
         successSubmitMessage='Success!'
         failedSubmitMessage='Failure!'
@@ -60,10 +67,10 @@ const Example = () => {
         <FormContent />
 
         <Container top='small'>
-          <Form.SubmitButton>Submit</Form.SubmitButton>
+          <SubmitButton>Submit</SubmitButton>
         </Container>
-      </Form>
-    </Form.ConfigProvider>
+      </FormNonCompound>
+    </ConfigProvider>
   )
 }
 

--- a/packages/picasso-forms/src/Form/story/index.jsx
+++ b/packages/picasso-forms/src/Form/story/index.jsx
@@ -143,8 +143,8 @@ page
   .createChapter()
   .addTextSection(
     `
-Form is a wrapper for 'react-final-form' Form component. It also
-provides inside all the necessary input components types.
+Form is a wrapper for 'react-final-form' Form component.
+The rest of the form components can be imported from \`@toptal/picasso-forms\`
     `
   )
   .addExample(

--- a/packages/picasso-forms/src/FormConfig/FormConfig.ts
+++ b/packages/picasso-forms/src/FormConfig/FormConfig.ts
@@ -27,5 +27,6 @@ export type FormConfigProps = (
 }
 
 export const FormConfigContext = createContext<FormConfigProps>({})
+export const FormConfigProvider = FormConfigContext.Provider
 
 export const useFormConfig = () => useContext(FormConfigContext)

--- a/packages/picasso-forms/src/SubmitButton/story/ButtonTypes.example.tsx
+++ b/packages/picasso-forms/src/SubmitButton/story/ButtonTypes.example.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { Check16, Container, Typography } from '@toptal/picasso'
-import { Form } from '@toptal/picasso-forms'
+import { FormNonCompound, SubmitButton } from '@toptal/picasso-forms';
 
 const onSubmit = () => new Promise(resolve => setTimeout(resolve, 1000))
 
@@ -10,35 +10,35 @@ const Example = () => (
       Rectangular (Default)
     </Typography>
     <Container top='small' bottom='large'>
-      <Form onSubmit={onSubmit}>
+      <FormNonCompound onSubmit={onSubmit}>
         <Container top='small'>
-          <Form.SubmitButton buttonType='rectangular'>
+          <SubmitButton buttonType='rectangular'>
             Rectangular
-          </Form.SubmitButton>
+          </SubmitButton>
         </Container>
-      </Form>
+      </FormNonCompound>
     </Container>
 
     <Typography variant='heading' size='small'>
       Circular
     </Typography>
     <Container top='small' bottom='large'>
-      <Form onSubmit={onSubmit}>
+      <FormNonCompound onSubmit={onSubmit}>
         <Container top='small'>
-          <Form.SubmitButton buttonType='circular' icon={<Check16 />} />
+          <SubmitButton buttonType='circular' icon={<Check16 />} />
         </Container>
-      </Form>
+      </FormNonCompound>
     </Container>
 
     <Typography variant='heading' size='small'>
       Action
     </Typography>
     <Container top='small' bottom='large'>
-      <Form onSubmit={onSubmit}>
+      <FormNonCompound onSubmit={onSubmit}>
         <Container top='small'>
-          <Form.SubmitButton buttonType='action'>Action</Form.SubmitButton>
+          <SubmitButton buttonType='action'>Action</SubmitButton>
         </Container>
-      </Form>
+      </FormNonCompound>
     </Container>
   </>
 )

--- a/packages/picasso-forms/src/SubmitButton/story/ButtonTypes.example.tsx
+++ b/packages/picasso-forms/src/SubmitButton/story/ButtonTypes.example.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { Check16, Container, Typography } from '@toptal/picasso'
-import { FormNonCompound, SubmitButton } from '@toptal/picasso-forms';
+import { FormNonCompound, SubmitButton } from '@toptal/picasso-forms'
 
 const onSubmit = () => new Promise(resolve => setTimeout(resolve, 1000))
 
@@ -12,9 +12,7 @@ const Example = () => (
     <Container top='small' bottom='large'>
       <FormNonCompound onSubmit={onSubmit}>
         <Container top='small'>
-          <SubmitButton buttonType='rectangular'>
-            Rectangular
-          </SubmitButton>
+          <SubmitButton buttonType='rectangular'>Rectangular</SubmitButton>
         </Container>
       </FormNonCompound>
     </Container>

--- a/packages/picasso-forms/src/SubmitButton/story/Default.example.tsx
+++ b/packages/picasso-forms/src/SubmitButton/story/Default.example.tsx
@@ -1,15 +1,15 @@
 import React from 'react'
 import { Container } from '@toptal/picasso'
-import { Form } from '@toptal/picasso-forms'
+import { FormNonCompound, SubmitButton } from '@toptal/picasso-forms';
 
 const onSubmit = () => new Promise(resolve => setTimeout(resolve, 1000))
 
 const Example = () => (
-  <Form onSubmit={onSubmit}>
+  <FormNonCompound onSubmit={onSubmit}>
     <Container top='small'>
-      <Form.SubmitButton>Submit form</Form.SubmitButton>
+      <SubmitButton>Submit form</SubmitButton>
     </Container>
-  </Form>
+  </FormNonCompound>
 )
 
 export default Example

--- a/packages/picasso-forms/src/SubmitButton/story/Default.example.tsx
+++ b/packages/picasso-forms/src/SubmitButton/story/Default.example.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { Container } from '@toptal/picasso'
-import { FormNonCompound, SubmitButton } from '@toptal/picasso-forms';
+import { FormNonCompound, SubmitButton } from '@toptal/picasso-forms'
 
 const onSubmit = () => new Promise(resolve => setTimeout(resolve, 1000))
 

--- a/packages/picasso-forms/src/index.ts
+++ b/packages/picasso-forms/src/index.ts
@@ -38,10 +38,37 @@ export {
   ExternallyChanged,
   OnBlur,
 } from 'react-final-form-listeners'
+export { FieldRequirements } from '@toptal/picasso'
 
 // Picasso Forms exports
+/** @deprecated Use FormNonCompound instead for better tree-shaking */
 export { FormCompound as Form } from './FormCompound'
+
+export { Form as FormNonCompound } from './Form'
 export { default as FieldWrapper } from './FieldWrapper'
+export { default as Autocomplete } from './Autocomplete'
+export { default as Input } from './Input'
+export { default as Select } from './Select'
+export { default as Radio } from './Radio'
+export { default as ButtonRadio } from './ButtonRadio'
+export { default as RadioGroup } from './RadioGroup'
+export { default as Checkbox } from './Checkbox'
+export { default as ButtonCheckbox } from './ButtonCheckbox'
+export { default as CheckboxGroup } from './CheckboxGroup'
+export { default as NumberInput } from './NumberInput'
+export { default as FileInput } from './FileInput'
+export { default as DatePicker } from './DatePicker'
+export { default as TimePicker } from './TimePicker'
+export { default as TagSelector } from './TagSelector'
+export { default as SubmitButton } from './SubmitButton'
+export { FormConfigProvider as ConfigProvider } from './FormConfig'
+export { default as Switch } from './Switch'
+export { default as Rating } from './Rating'
+export { default as Dropzone } from './Dropzone'
+export { default as PasswordInput } from './PasswordInput'
+export { default as RichTextEditor } from './RichTextEditor'
+export { default as AvatarUpload } from './AvatarUpload'
+
 export type { FieldProps } from './Field'
 export type { FormConfigProps, RequiredVariant } from './FormConfig'
 export { default as createFormValuesChangeDecorator } from './utils/form-values-change-decorator'

--- a/packages/picasso-forms/src/story/Deserialization.example.tsx
+++ b/packages/picasso-forms/src/story/Deserialization.example.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { Container } from '@toptal/picasso'
-import { Form } from '@toptal/picasso-forms'
+import { FormNonCompound, RadioGroup, Radio, SubmitButton } from '@toptal/picasso-forms';
 
 const deserializeValue = (value: unknown) => {
   if (value === 'true') {
@@ -14,21 +14,21 @@ const deserializeValue = (value: unknown) => {
 }
 
 const Example = () => (
-  <Form
+  <FormNonCompound
     onSubmit={values => {
       console.log('Raw: ', { foo: values.foo })
       console.log('Deserialized: ', { foo: deserializeValue(values.foo) })
     }}
     initialValues={{ foo: 'true' }}
   >
-    <Form.RadioGroup name='foo' label='Foo'>
-      <Form.Radio label='yes' value='true' />
-      <Form.Radio label='no' value='false' />
-    </Form.RadioGroup>
+    <RadioGroup name='foo' label='Foo'>
+      <Radio label='yes' value='true' />
+      <Radio label='no' value='false' />
+    </RadioGroup>
     <Container top='small'>
-      <Form.SubmitButton>Submit</Form.SubmitButton>
+      <SubmitButton>Submit</SubmitButton>
     </Container>
-  </Form>
+  </FormNonCompound>
 )
 
 export default Example

--- a/packages/picasso-forms/src/story/Deserialization.example.tsx
+++ b/packages/picasso-forms/src/story/Deserialization.example.tsx
@@ -1,6 +1,11 @@
 import React from 'react'
 import { Container } from '@toptal/picasso'
-import { FormNonCompound, RadioGroup, Radio, SubmitButton } from '@toptal/picasso-forms';
+import {
+  FormNonCompound,
+  RadioGroup,
+  Radio,
+  SubmitButton,
+} from '@toptal/picasso-forms'
 
 const deserializeValue = (value: unknown) => {
   if (value === 'true') {

--- a/packages/picasso-forms/src/story/FormSpy.example.tsx
+++ b/packages/picasso-forms/src/story/FormSpy.example.tsx
@@ -1,9 +1,16 @@
 import React from 'react'
 import { Container } from '@toptal/picasso'
-import { FormSpy, FormNonCompound, Input, SubmitButton } from '@toptal/picasso-forms';
+import {
+  FormSpy,
+  FormNonCompound,
+  Input,
+  SubmitButton,
+} from '@toptal/picasso-forms'
 
 const Example = () => (
-  <FormNonCompound onSubmit={values => window.alert(JSON.stringify(values, undefined, 2))}>
+  <FormNonCompound
+    onSubmit={values => window.alert(JSON.stringify(values, undefined, 2))}
+  >
     <Input
       required
       name='firstName'
@@ -32,7 +39,7 @@ const Example = () => (
             <SubmitButton disabled={isDisabled}>
               {isDisabled ? 'Fill out form to enable' : 'Submit'}
             </SubmitButton>
-          );
+          )
         }}
       </FormSpy>
     </Container>

--- a/packages/picasso-forms/src/story/FormSpy.example.tsx
+++ b/packages/picasso-forms/src/story/FormSpy.example.tsx
@@ -1,10 +1,10 @@
 import React from 'react'
 import { Container } from '@toptal/picasso'
-import { Form, FormSpy } from '@toptal/picasso-forms'
+import { FormSpy, FormNonCompound, Input, SubmitButton } from '@toptal/picasso-forms';
 
 const Example = () => (
-  <Form onSubmit={values => window.alert(JSON.stringify(values, undefined, 2))}>
-    <Form.Input
+  <FormNonCompound onSubmit={values => window.alert(JSON.stringify(values, undefined, 2))}>
+    <Input
       required
       name='firstName'
       label='First name'
@@ -13,7 +13,7 @@ const Example = () => (
 
     <FormSpy>
       {({ values }) => (
-        <Form.Input
+        <Input
           required
           name='lastName'
           disabled={!values?.firstName}
@@ -29,14 +29,14 @@ const Example = () => (
           const isDisabled = pristine || !values?.lastName
 
           return (
-            <Form.SubmitButton disabled={isDisabled}>
+            <SubmitButton disabled={isDisabled}>
               {isDisabled ? 'Fill out form to enable' : 'Submit'}
-            </Form.SubmitButton>
-          )
+            </SubmitButton>
+          );
         }}
       </FormSpy>
     </Container>
-  </Form>
+  </FormNonCompound>
 )
 
 export default Example

--- a/packages/picasso/src/RichTextEditor/story/Disabled.example.tsx
+++ b/packages/picasso/src/RichTextEditor/story/Disabled.example.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { ASTType } from '@toptal/picasso'
-import { FormNonCompound, RichTextEditor } from '@toptal/picasso-forms';
+import { FormNonCompound, RichTextEditor } from '@toptal/picasso-forms'
 import { noop } from '@toptal/picasso/utils'
 
 const ast: ASTType = {
@@ -38,7 +38,7 @@ const Example = () => {
         disabled
       />
     </FormNonCompound>
-  );
+  )
 }
 
 export default Example

--- a/packages/picasso/src/RichTextEditor/story/Disabled.example.tsx
+++ b/packages/picasso/src/RichTextEditor/story/Disabled.example.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { ASTType } from '@toptal/picasso'
-import { Form } from '@toptal/picasso-forms'
+import { FormNonCompound, RichTextEditor } from '@toptal/picasso-forms';
 import { noop } from '@toptal/picasso/utils'
 
 const ast: ASTType = {
@@ -19,9 +19,9 @@ const ast: ASTType = {
 
 const Example = () => {
   return (
-    <Form onSubmit={() => {}}>
+    <FormNonCompound onSubmit={() => {}}>
       {' '}
-      <Form.RichTextEditor
+      <RichTextEditor
         id='disabled-no-value'
         name='disabledWithNoValue'
         label='disabled without value'
@@ -29,7 +29,7 @@ const Example = () => {
         placeholder='Write some cool rich text'
         disabled
       />
-      <Form.RichTextEditor
+      <RichTextEditor
         id='disabled-with-value'
         name='disabledWithValue'
         label='disabled with default value'
@@ -37,8 +37,8 @@ const Example = () => {
         defaultValue={ast}
         disabled
       />
-    </Form>
-  )
+    </FormNonCompound>
+  );
 }
 
 export default Example

--- a/packages/picasso/src/RichTextEditor/story/Status.example.tsx
+++ b/packages/picasso/src/RichTextEditor/story/Status.example.tsx
@@ -1,24 +1,24 @@
 import React from 'react'
-import { Form } from '@toptal/picasso-forms'
+import { FormNonCompound, RichTextEditor } from '@toptal/picasso-forms';
 
 const Example = () => {
   return (
-    <Form onSubmit={() => {}}>
-      <Form.RichTextEditor
+    <FormNonCompound onSubmit={() => {}}>
+      <RichTextEditor
         label='Default'
         id='editor-default'
         placeholder='Write some cool rich text'
         name='default'
       />
-      <Form.RichTextEditor
+      <RichTextEditor
         label='Error'
         id='editor-error'
         placeholder='Write some cool rich text'
         status='error'
         name='error'
       />
-    </Form>
-  )
+    </FormNonCompound>
+  );
 }
 
 export default Example

--- a/packages/picasso/src/RichTextEditor/story/Status.example.tsx
+++ b/packages/picasso/src/RichTextEditor/story/Status.example.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { FormNonCompound, RichTextEditor } from '@toptal/picasso-forms';
+import { FormNonCompound, RichTextEditor } from '@toptal/picasso-forms'
 
 const Example = () => {
   return (
@@ -18,7 +18,7 @@ const Example = () => {
         name='error'
       />
     </FormNonCompound>
-  );
+  )
 }
 
 export default Example


### PR DESCRIPTION
[FX-3590](https://toptal-core.atlassian.net/browse/FX-3590)

### Description

The PR adds exported members for all Form components in Picasso Forms to be available directly from entry point as non-compound components.

note: the root picasso package does not require a changeset, only has imports updated in a story

### How to test

- See if all the components are exported properly
- Try the codemod on any codebase that uses compound components `npx @toptal/picasso-codemod@5.3.2-alpha-fx-3590-compound-components-are-increasing-bundle-size-c57a541d.467 v52.2.0/non-compound-forms src/**/*.tsx`
- Verify codemod produces working code and no leftover compound imports are left
- See if there are any remaining examples / documentation still recommending to use compound components


### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests


> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-3590]: https://toptal-core.atlassian.net/browse/FX-3590?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ