### PR TITLE
fix: typings for Tabs onChange callback

### DIFF
--- a/.changeset/twelve-shrimps-obey.md
+++ b/.changeset/twelve-shrimps-obey.md
@@ -1,0 +1,9 @@
+---
+'@toptal/picasso': patch
+---
+
+---
+
+### Tabs
+
+- fix typings for the `onChange` handler

--- a/packages/picasso/src/Tabs/Tabs.tsx
+++ b/packages/picasso/src/Tabs/Tabs.tsx
@@ -14,7 +14,7 @@ export interface Props
   children: ReactNode
 
   /** Callback fired when the value changes. */
-  onChange?: (event: React.ChangeEvent<{}>, value: number) => void
+  onChange?: (event: React.ChangeEvent<{}>, value: TabsProps['value']) => void
 
   /** The value of the currently selected Tab. If you don't want any selected Tab, you can set this property to false. */
   value: TabsProps['value']

--- a/packages/picasso/src/Tabs/test.tsx
+++ b/packages/picasso/src/Tabs/test.tsx
@@ -122,6 +122,24 @@ describe('Tabs', () => {
     expect(onChange).toHaveBeenCalledTimes(1)
   })
 
+  it('fires onChange with custom value when clicked', () => {
+    const onChange = jest.fn()
+    const { getByTestId } = renderTabs(
+      [
+        { label: 'Tab 1', value: 'first' },
+        { label: 'Tab 2', value: 'second' },
+      ],
+      {
+        value: 'first',
+        onChange,
+      }
+    )
+
+    fireEvent.click(getByTestId('tab-2'))
+    expect(onChange).toHaveBeenCalledTimes(1)
+    expect(onChange).toHaveBeenCalledWith(expect.anything(), 'second')
+  })
+
   it('doesnt fire onChange when disabled', () => {
     const onChange = jest.fn()
     const { getByTestId } = renderTabs(


### PR DESCRIPTION
[TDESKAPP-1168]

### Description

Tabs have wrong typings on their `onChange` handler. The `value` returned equals the `value` given when creating a Tab, so if you do not use `index` values, it does not return a `number` type.

### How to test

- Create Tabs with custom values
- trigger the `onChange` handler
- notice that the second value in the callback is not of type `number` (not an index)

I also created a test that mimicks this behavior to make it clear what is happening.

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[TDESKAPP-1168]: https://toptal-core.atlassian.net/browse/TDESKAPP-1168?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ