### PR TITLE
style(Calendar): highlight weekends

### DIFF
--- a/.changeset/happy-humans-repair.md
+++ b/.changeset/happy-humans-repair.md
@@ -1,0 +1,10 @@
+---
+'@toptal/picasso': patch
+---
+
+---
+
+### Calendar
+
+- highlight weekends
+- remove border-radius on selected items between the start and end date

--- a/packages/picasso/src/Calendar/Calendar.tsx
+++ b/packages/picasso/src/Calendar/Calendar.tsx
@@ -5,6 +5,7 @@ import SimpleReactCalendar from 'simple-react-calendar'
 import cx from 'classnames'
 import { Theme, makeStyles } from '@material-ui/core/styles'
 import { BaseProps } from '@toptal/picasso-shared'
+import isWeekend from 'date-fns/isWeekend'
 
 import {
   CalendarProps,
@@ -138,6 +139,7 @@ export const Calendar = forwardRef<HTMLDivElement, Props>(function Calendar(
               tabIndex={isDisabled || !isSelectable ? -1 : undefined}
               className={cx(classes.day, {
                 [classes.selected]: isSelected,
+                [classes.weekend]: isWeekend(date),
                 [classes.selectable]: isSelectable,
                 [classes.grayed]:
                   (isMonthPrev || isMonthNext) && !isSelected && !isDisabled,

--- a/packages/picasso/src/Calendar/__snapshots__/test.tsx.snap
+++ b/packages/picasso/src/Calendar/__snapshots__/test.tsx.snap
@@ -155,7 +155,7 @@ exports[`Calendar renders 1`] = `
               1
             </button>
             <button
-              class="PicassoCalendar-day PicassoCalendar-selectable"
+              class="PicassoCalendar-day PicassoCalendar-weekend PicassoCalendar-selectable"
               data-simple-react-calendar-day="2019-02-02"
               data-testid="day-button-2"
               type="button"
@@ -164,7 +164,7 @@ exports[`Calendar renders 1`] = `
               2
             </button>
             <button
-              class="PicassoCalendar-day PicassoCalendar-selectable"
+              class="PicassoCalendar-day PicassoCalendar-weekend PicassoCalendar-selectable"
               data-simple-react-calendar-day="2019-02-03"
               data-testid="day-button-3"
               type="button"
@@ -222,7 +222,7 @@ exports[`Calendar renders 1`] = `
               8
             </button>
             <button
-              class="PicassoCalendar-day PicassoCalendar-selectable"
+              class="PicassoCalendar-day PicassoCalendar-weekend PicassoCalendar-selectable"
               data-simple-react-calendar-day="2019-02-09"
               data-testid="day-button-9"
               type="button"
@@ -231,7 +231,7 @@ exports[`Calendar renders 1`] = `
               9
             </button>
             <button
-              class="PicassoCalendar-day PicassoCalendar-selectable"
+              class="PicassoCalendar-day PicassoCalendar-weekend PicassoCalendar-selectable"
               data-simple-react-calendar-day="2019-02-10"
               data-testid="day-button-10"
               type="button"
@@ -289,7 +289,7 @@ exports[`Calendar renders 1`] = `
               15
             </button>
             <button
-              class="PicassoCalendar-day PicassoCalendar-selectable"
+              class="PicassoCalendar-day PicassoCalendar-weekend PicassoCalendar-selectable"
               data-simple-react-calendar-day="2019-02-16"
               data-testid="day-button-16"
               type="button"
@@ -298,7 +298,7 @@ exports[`Calendar renders 1`] = `
               16
             </button>
             <button
-              class="PicassoCalendar-day PicassoCalendar-selectable"
+              class="PicassoCalendar-day PicassoCalendar-weekend PicassoCalendar-selectable"
               data-simple-react-calendar-day="2019-02-17"
               data-testid="day-button-17"
               type="button"
@@ -356,7 +356,7 @@ exports[`Calendar renders 1`] = `
               22
             </button>
             <button
-              class="PicassoCalendar-day PicassoCalendar-selectable"
+              class="PicassoCalendar-day PicassoCalendar-weekend PicassoCalendar-selectable"
               data-simple-react-calendar-day="2019-02-23"
               data-testid="day-button-23"
               type="button"
@@ -365,7 +365,7 @@ exports[`Calendar renders 1`] = `
               23
             </button>
             <button
-              class="PicassoCalendar-day PicassoCalendar-selectable"
+              class="PicassoCalendar-day PicassoCalendar-weekend PicassoCalendar-selectable"
               data-simple-react-calendar-day="2019-02-24"
               data-testid="day-button-24"
               type="button"
@@ -423,7 +423,7 @@ exports[`Calendar renders 1`] = `
               1
             </button>
             <button
-              class="PicassoCalendar-day PicassoCalendar-selectable PicassoCalendar-grayed"
+              class="PicassoCalendar-day PicassoCalendar-weekend PicassoCalendar-selectable PicassoCalendar-grayed"
               data-simple-react-calendar-day="2019-03-02"
               data-testid="day-button-2"
               type="button"
@@ -432,7 +432,7 @@ exports[`Calendar renders 1`] = `
               2
             </button>
             <button
-              class="PicassoCalendar-day PicassoCalendar-selectable PicassoCalendar-grayed"
+              class="PicassoCalendar-day PicassoCalendar-weekend PicassoCalendar-selectable PicassoCalendar-grayed"
               data-simple-react-calendar-day="2019-03-03"
               data-testid="day-button-3"
               type="button"

--- a/packages/picasso/src/Calendar/styles.ts
+++ b/packages/picasso/src/Calendar/styles.ts
@@ -49,13 +49,23 @@ export default ({ palette, sizes }: Theme) =>
       justifyContent: 'space-between',
       marginBottom: '1.5rem',
     },
+    weekend: {
+      background: palette.grey.lighter,
+      '&:not(:hover):not($selected)': {
+        border: '4px solid white',
+        borderRadius: sizes.borderRadius.medium,
+      },
+    },
     selected: {
       background: palette.blue.lighter,
+      '&:not($startSelection):not($endSelection)': {
+        borderRadius: 0,
+      },
     },
     selectable: {
       cursor: 'pointer',
 
-      '&:hover, &:focus': {
+      '&:hover': {
         backgroundColor: alpha(palette.blue.main, 0.24),
       },
 
@@ -85,6 +95,6 @@ export default ({ palette, sizes }: Theme) =>
     },
     disabled: {
       color: palette.grey.main,
-      cursor: 'default'
-    }
+      cursor: 'default',
+    },
   })


### PR DESCRIPTION
[FX-2885]

### Description

BASE updated [design](https://www.figma.com/file/5SCTOPrCDcHuk5We091GBn/Product-Library?node-id=1941%3A15847&t=lnPVM0FD5VVXHlN5-0) of Calendar. We need to highlight weekends. Also, I found out that we were having some discrepancies between BASE and Picasso so also fixed these small issues.

### How to test

- Compare [the storybook](https://picasso.toptal.net/fx-2885-calendar/?path=/story/components-datepicker--datepicker) example with [BASE design](https://www.figma.com/file/5SCTOPrCDcHuk5We091GBn/Product-Library?node-id=1941%3A15847&t=lnPVM0FD5VVXHlN5-0)
- Check new screenshots in Happo

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| ![image](https://user-images.githubusercontent.com/6830426/222706949-8257c3f1-0500-4e9a-ad8b-fe1c3338953c.png) | ![image](https://user-images.githubusercontent.com/6830426/222706841-43cdb0fb-b648-478c-b0f4-db5f13f867ea.png) |

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- Annotate all `props` in component with documentation
- Create `examples` for component
- Ensure that deployed demo has expected results and good examples
- Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- Covered with tests

**Breaking change**

- codemod is created and showcased in the changeset
- test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-2885]: https://toptal-core.atlassian.net/browse/FX-2885?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ