### PR TITLE
feat: add `highlightAutofill` to input components

### DIFF
--- a/.changeset/lovely-dingos-tease.md
+++ b/.changeset/lovely-dingos-tease.md
@@ -7,3 +7,7 @@
 ### NumberInput
 
 - add `highlightAutofill` property
+
+### Autocomplete
+
+- add `highlightAutofill` property

--- a/.changeset/lovely-dingos-tease.md
+++ b/.changeset/lovely-dingos-tease.md
@@ -11,3 +11,7 @@
 ### Autocomplete
 
 - add `highlightAutofill` property
+
+### PasswordInput
+
+- add `highlightAutofill` property

--- a/.changeset/lovely-dingos-tease.md
+++ b/.changeset/lovely-dingos-tease.md
@@ -1,0 +1,9 @@
+---
+'@toptal/picasso': minor
+---
+
+---
+
+### NumberInput
+
+- add `highlightAutofill` property

--- a/.changeset/lovely-dingos-tease.md
+++ b/.changeset/lovely-dingos-tease.md
@@ -19,3 +19,7 @@
 ### TagSelector
 
 - add `highlightAutofill` property
+
+### Select
+
+- add `highlightAutofill` property

--- a/.changeset/lovely-dingos-tease.md
+++ b/.changeset/lovely-dingos-tease.md
@@ -31,3 +31,7 @@
 ### TimePicker
 
 - add `highlightAutofill` property
+
+### RichTextEditor
+
+- add `highlightAutofill` property

--- a/.changeset/lovely-dingos-tease.md
+++ b/.changeset/lovely-dingos-tease.md
@@ -15,3 +15,7 @@
 ### PasswordInput
 
 - add `highlightAutofill` property
+
+### TagSelector
+
+- add `highlightAutofill` property

--- a/.changeset/lovely-dingos-tease.md
+++ b/.changeset/lovely-dingos-tease.md
@@ -23,3 +23,7 @@
 ### Select
 
 - add `highlightAutofill` property
+
+### DatePicker
+
+- add `highlightAutofill` property

--- a/.changeset/lovely-dingos-tease.md
+++ b/.changeset/lovely-dingos-tease.md
@@ -27,3 +27,7 @@
 ### DatePicker
 
 - add `highlightAutofill` property
+
+### TimePicker
+
+- add `highlightAutofill` property

--- a/cypress/component/InputHiglightAutofill.spec.tsx
+++ b/cypress/component/InputHiglightAutofill.spec.tsx
@@ -1,0 +1,81 @@
+import React from 'react'
+import {
+  Autocomplete,
+  Container,
+  DatePicker,
+  FormLabel,
+  Input,
+  MonthSelect,
+  NumberInput,
+  PasswordInput,
+  RichTextEditor,
+  Select,
+  TagSelector,
+  TimePicker,
+  YearSelect,
+} from '@toptal/picasso'
+
+const component = 'HiglightAutofill'
+
+describe('Highlight Autofill', () => {
+  describe('when highlightAutofill prop is true', () => {
+    it('renders inputs with correct background color', () => {
+      cy.mount(
+        <Container padded='small' gap='small' flex direction='column'>
+          <Container>
+            <FormLabel>Autocomplete</FormLabel>
+            <Autocomplete value='' highlightAutofill />
+          </Container>
+          <Container>
+            <FormLabel>DatePicker</FormLabel>
+            <DatePicker onChange={() => {}} highlightAutofill />
+          </Container>
+          <Container>
+            <FormLabel>MonthSelect</FormLabel>
+            <MonthSelect highlightAutofill />
+          </Container>
+          <Container>
+            <FormLabel>NumberInput</FormLabel>
+            <NumberInput highlightAutofill />
+          </Container>
+          <Container>
+            <FormLabel>PasswordInput</FormLabel>
+            <PasswordInput highlightAutofill />
+          </Container>
+          <Container>
+            <FormLabel>RichTextEditor</FormLabel>
+            <RichTextEditor id='foo' highlightAutofill />
+          </Container>
+          <Container>
+            <FormLabel>Select</FormLabel>
+            <Select
+              options={[{ text: 'foo', value: 'bar' }]}
+              highlightAutofill
+            />
+          </Container>
+          <Container>
+            <FormLabel>TagSelector</FormLabel>
+            <TagSelector highlightAutofill />
+          </Container>
+          <Container>
+            <FormLabel>TimePicker</FormLabel>
+            <TimePicker highlightAutofill />
+          </Container>
+          <Container>
+            <FormLabel>YearSelect</FormLabel>
+            <YearSelect from={2000} to={2010} highlightAutofill />
+          </Container>
+          <Container>
+            <FormLabel>Input</FormLabel>
+            <Input highlightAutofill />
+          </Container>
+        </Container>
+      )
+
+      cy.get('body').happoScreenshot({
+        component,
+        variant: 'default',
+      })
+    })
+  })
+})

--- a/packages/picasso/src/Autocomplete/Autocomplete.tsx
+++ b/packages/picasso/src/Autocomplete/Autocomplete.tsx
@@ -128,6 +128,7 @@ export interface Props
     input?: string
     disableAutofillInput?: string
   }
+  highlightAutofill?: boolean
 }
 
 const useStyles = makeStyles<Theme>(styles, {
@@ -177,6 +178,7 @@ export const Autocomplete = forwardRef<HTMLInputElement, Props>(
       value,
       width = 'auto',
       disabled = false,
+      highlightAutofill,
       ...rest
     } = props
 
@@ -338,6 +340,7 @@ export const Autocomplete = forwardRef<HTMLInputElement, Props>(
             autoComplete={enableAutofill ? autoComplete : autoComplete || 'off'}
             testIds={testIds}
             data-testid={testIds?.input}
+            highlightAutofill={highlightAutofill}
           />
         </Container>
         <div role='listbox'>
@@ -380,6 +383,7 @@ Autocomplete.defaultProps = {
   poweredByGoogle: false,
   disabled: false,
   status: 'default',
+  highlightAutofill: false,
 }
 
 Autocomplete.displayName = 'Autocomplete'

--- a/packages/picasso/src/AvatarUpload/story/index.jsx
+++ b/packages/picasso/src/AvatarUpload/story/index.jsx
@@ -1,7 +1,7 @@
 import PicassoBook from '~/.storybook/components/PicassoBook'
 import { AvatarUpload } from '../AvatarUpload'
 
-const page = PicassoBook.section('Components').createPage(
+const page = PicassoBook.section('Forms').createPage(
   'AvatarUpload',
   `
     Gets the image from file input and displays it in the Avatar component.

--- a/packages/picasso/src/DatePicker/DatePicker.tsx
+++ b/packages/picasso/src/DatePicker/DatePicker.tsx
@@ -115,6 +115,7 @@ export interface Props
   footerBackgroundColor?: string
   /** Shows orange dot indicator in days between a date range */
   indicatedIntervals?: { start: Date; end: Date }[]
+  highlightAutofill?: boolean
 }
 
 export const DatePicker = (props: Props) => {
@@ -146,6 +147,7 @@ export const DatePicker = (props: Props) => {
     footer,
     indicatedIntervals,
     footerBackgroundColor,
+    highlightAutofill,
     ...rest
   } = props
   const classes = useStyles()
@@ -395,6 +397,7 @@ export const DatePicker = (props: Props) => {
           width={width}
           testIds={testIds}
           data-testid={testIds?.input}
+          highlightAutofill={highlightAutofill}
         />
       </Container>
       {inputWrapperRef.current && (
@@ -448,6 +451,7 @@ DatePicker.defaultProps = {
   displayDateFormat: 'MMM d, yyyy',
   autoComplete: 'off',
   status: 'default',
+  highlightAutofill: false,
 }
 
 DatePicker.displayName = 'DatePicker'

--- a/packages/picasso/src/DatePicker/story/index.jsx
+++ b/packages/picasso/src/DatePicker/story/index.jsx
@@ -1,11 +1,11 @@
 import { DatePicker } from '../DatePicker'
 import PicassoBook from '~/.storybook/components/PicassoBook'
 
-const page = PicassoBook.section('Components').createPage(
+const page = PicassoBook.section('Forms').createPage(
   'DatePicker',
   `
     Date Picker component
-    
+
     ${PicassoBook.createBaseDocsLink(
       'https://share.goabstract.com/cc5f669e-ee2c-4375-946d-93b20db16ecc?collectionLayerId=10d3230f-5c9c-4fed-85b2-5cfda0bcd25f&mode=design&present=true'
     )}

--- a/packages/picasso/src/Dropzone/story/index.jsx
+++ b/packages/picasso/src/Dropzone/story/index.jsx
@@ -1,7 +1,7 @@
 import { Dropzone } from '../Dropzone'
 import PicassoBook from '~/.storybook/components/PicassoBook'
 
-const page = PicassoBook.section('Components').createPage(
+const page = PicassoBook.section('Forms').createPage(
   'Dropzone',
   `
   ${PicassoBook.createBaseDocsLink(

--- a/packages/picasso/src/FieldRequirements/story/index.jsx
+++ b/packages/picasso/src/FieldRequirements/story/index.jsx
@@ -1,10 +1,10 @@
 import { FieldRequirements } from '../FieldRequirements'
 import PicassoBook from '~/.storybook/components/PicassoBook'
 
-const page = PicassoBook.section('Components').createPage(
+const page = PicassoBook.section('Forms').createPage(
   'FieldRequirements',
   `Component to list field requirements to be valid
-  
+
   ${PicassoBook.createSourceLink(__filename)}
   `
 )

--- a/packages/picasso/src/Input/styles.ts
+++ b/packages/picasso/src/Input/styles.ts
@@ -1,26 +1,23 @@
 import { Theme, createStyles } from '@material-ui/core/styles'
-import { alpha } from '@toptal/picasso-shared'
 
+import highlightAutofillStyles from '../InputBase/highlightAutofillStyles'
 import '../InputBase/styles'
 import '../InputLabel/styles'
 import '../OutlinedInput/styles'
 import '../InputAdornment/styles'
 
-export default ({ palette }: Theme) =>
+export default (theme: Theme) =>
   createStyles({
     root: {
       fontSize: '1rem',
-      backgroundColor: palette.common.white,
+      backgroundColor: theme.palette.common.white,
       cursor: 'text',
     },
     rootMultiline: {
       height: 'auto',
     },
-    highlightAutofill: {
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      backgroundColor: alpha(palette.yellow.lighter!, 0.6),
-    },
     inputMultilineResizable: {
       resize: 'vertical',
     },
+    ...highlightAutofillStyles(theme),
   })

--- a/packages/picasso/src/InputBase/highlightAutofillStyles.ts
+++ b/packages/picasso/src/InputBase/highlightAutofillStyles.ts
@@ -1,0 +1,11 @@
+import { Theme } from '@material-ui/core/styles'
+import { alpha } from '@toptal/picasso-shared'
+
+const highlightAutofillStyles = ({ palette }: Theme) => ({
+  highlightAutofill: {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    backgroundColor: alpha(palette.yellow.lighter!, 0.6),
+  },
+})
+
+export default highlightAutofillStyles

--- a/packages/picasso/src/MonthSelect/story/index.jsx
+++ b/packages/picasso/src/MonthSelect/story/index.jsx
@@ -1,10 +1,10 @@
 import { MonthSelect } from '../MonthSelect'
 import PicassoBook from '~/.storybook/components/PicassoBook'
 
-const page = PicassoBook.section('Components').createPage(
+const page = PicassoBook.section('Forms').createPage(
   'MonthSelect',
   `Month selector
-  
+
   ${PicassoBook.createSourceLink(__filename)}
   `
 )

--- a/packages/picasso/src/NativeSelect/NativeSelect.tsx
+++ b/packages/picasso/src/NativeSelect/NativeSelect.tsx
@@ -62,6 +62,7 @@ export const NativeSelect = documentable(
         limit,
         native,
         testIds,
+        highlightAutofill,
         /* eslint-enable @typescript-eslint/no-unused-vars */
         ...rest
       } = props
@@ -130,6 +131,7 @@ export const NativeSelect = documentable(
           classes={{
             root: cx(classes.select, {
               [classes.placeholder]: !selection.isSelected(),
+              [classes.highlightAutofill]: highlightAutofill,
             }),
             select: cx({
               [classes.startAdornmentPadding]:

--- a/packages/picasso/src/NativeSelect/styles.ts
+++ b/packages/picasso/src/NativeSelect/styles.ts
@@ -4,9 +4,12 @@ import '../InputLabel/styles'
 import '../InputBase/styles'
 import '../Input/styles'
 import '../Loader/styles'
+import highlightAutofillStyles from '../InputBase/highlightAutofillStyles'
 
-export default ({ palette }: Theme) =>
-  createStyles({
+export default (theme: Theme) => {
+  const { palette } = theme
+
+  return createStyles({
     root: {
       position: 'relative',
       display: 'inline-flex',
@@ -52,4 +55,6 @@ export default ({ palette }: Theme) =>
     endAdornmentPadding: {
       paddingRight: '3.5625rem',
     },
+    ...highlightAutofillStyles(theme),
   })
+}

--- a/packages/picasso/src/NonNativeSelect/NonNativeSelect.tsx
+++ b/packages/picasso/src/NonNativeSelect/NonNativeSelect.tsx
@@ -75,6 +75,7 @@ export const NonNativeSelect = documentable(
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
         native,
         testIds,
+        highlightAutofill,
         ...rest
       } = props
 
@@ -176,6 +177,9 @@ export const NonNativeSelect = documentable(
               readOnly
               defaultValue={undefined}
               className={classes.outlinedInput}
+              classes={{
+                root: cx({ [classes.highlightAutofill]: highlightAutofill }),
+              }}
               inputProps={{
                 size: 1, // let input to have smallest width by default for width:'shrink'
               }}

--- a/packages/picasso/src/NonNativeSelect/styles.ts
+++ b/packages/picasso/src/NonNativeSelect/styles.ts
@@ -6,9 +6,12 @@ import '../Input/styles'
 import '../Menu/styles'
 import '../MenuItem/styles'
 import '../Loader/styles'
+import highlightAutofillStyles from '../InputBase/highlightAutofillStyles'
 
-export default ({ palette }: Theme) =>
-  createStyles({
+export default (theme: Theme) => {
+  const { palette } = theme
+
+  return createStyles({
     root: {
       position: 'relative',
       display: 'inline-flex',
@@ -53,4 +56,6 @@ export default ({ palette }: Theme) =>
     placeholder: {
       color: palette.grey.main2,
     },
+    ...highlightAutofillStyles(theme),
   })
+}

--- a/packages/picasso/src/NumberInput/NumberInput.tsx
+++ b/packages/picasso/src/NumberInput/NumberInput.tsx
@@ -1,6 +1,7 @@
 import React, { forwardRef, useRef, ReactNode } from 'react'
 import { makeStyles, Theme } from '@material-ui/core/styles'
 import { BaseProps, OmitInternalProps } from '@toptal/picasso-shared'
+import cx from 'classnames'
 
 import OutlinedInput, { Props as OutlinedInputProps } from '../OutlinedInput'
 import InputAdornment from '../InputAdornment'
@@ -31,6 +32,7 @@ export interface Props
   disabled?: boolean
   /** Callback invoked when `NumberInput` changes its state. */
   onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void
+  highlightAutofill?: boolean
 }
 
 const useStyles = makeStyles<Theme, Props>(styles, {
@@ -55,6 +57,7 @@ export const NumberInput = forwardRef<HTMLInputElement, Props>(
       icon,
       size,
       testIds,
+      highlightAutofill,
       ...rest
     } = props
 
@@ -94,7 +97,9 @@ export const NumberInput = forwardRef<HTMLInputElement, Props>(
     return (
       <OutlinedInput
         classes={{
-          root: classes.root,
+          root: cx(classes.root, {
+            [classes.highlightAutofill]: highlightAutofill,
+          }),
           input: classes.input,
         }}
         inputProps={{
@@ -128,6 +133,7 @@ NumberInput.defaultProps = {
   min: -Infinity,
   max: Infinity,
   hideControls: false,
+  highlightAutofill: false,
   size: 'medium',
   status: 'default',
 }

--- a/packages/picasso/src/NumberInput/styles.ts
+++ b/packages/picasso/src/NumberInput/styles.ts
@@ -1,6 +1,8 @@
-import { createStyles } from '@material-ui/core/styles'
+import { createStyles, Theme } from '@material-ui/core/styles'
 
-export default () =>
+import highlightAutofillStyles from '../InputBase/highlightAutofillStyles'
+
+export default (theme: Theme) =>
   createStyles({
     root: {
       paddingRight: 0,
@@ -14,4 +16,5 @@ export default () =>
       },
       '-moz-appearance': 'textfield',
     },
+    ...highlightAutofillStyles(theme),
   })

--- a/packages/picasso/src/PasswordInput/PasswordInput.tsx
+++ b/packages/picasso/src/PasswordInput/PasswordInput.tsx
@@ -33,6 +33,7 @@ export interface Props
     input?: string
     toggle?: string
   }
+  highlightAutofill?: boolean
 }
 
 const useStyles = makeStyles<Theme>(styles, {
@@ -53,6 +54,7 @@ export const PasswordInput = forwardRef<HTMLInputElement, Props>(
       testIds,
       enableReset,
       onResetClick,
+      highlightAutofill,
       ...rest
     } = props
 
@@ -89,6 +91,7 @@ export const PasswordInput = forwardRef<HTMLInputElement, Props>(
         style={style}
         className={cx(classes.root, className)}
         classes={{
+          root: cx({ [classes.highlightAutofill]: highlightAutofill }),
           input: classes.input,
         }}
         inputProps={{

--- a/packages/picasso/src/PasswordInput/styles.ts
+++ b/packages/picasso/src/PasswordInput/styles.ts
@@ -1,7 +1,11 @@
 import { createStyles, Theme } from '@material-ui/core/styles'
 
-export default ({ spacing }: Theme) =>
-  createStyles({
+import highlightAutofillStyles from '../InputBase/highlightAutofillStyles'
+
+export default (theme: Theme) => {
+  const { spacing } = theme
+
+  return createStyles({
     root: {
       paddingRight: 0,
       cursor: 'text',
@@ -14,7 +18,10 @@ export default ({ spacing }: Theme) =>
       },
     },
 
+    ...highlightAutofillStyles(theme),
+
     toggle: {
       marginRight: spacing(1),
     },
   })
+}

--- a/packages/picasso/src/RatingStars/story/index.jsx
+++ b/packages/picasso/src/RatingStars/story/index.jsx
@@ -2,12 +2,12 @@ import ratingThumbsStory from '../../RatingThumbs/story'
 import RatingStars from '../RatingStars'
 import PicassoBook from '~/.storybook/components/PicassoBook'
 
-const page = PicassoBook.section('Components').createPage(
+const page = PicassoBook.section('Forms').createPage(
   'Rating',
   `
     Ratings provide a way for users to express their opinion
     and experience about features or services.
-    
+
     ${PicassoBook.createBaseDocsLink(
       'https://share.goabstract.com/39a488dc-44bc-4b37-b3c8-d14ca483b7b8?collectionLayerId=7df019cf-ec27-4ce9-af5b-76b5921644d5&mode=build'
     )}

--- a/packages/picasso/src/RichTextEditor/RichTextEditor.tsx
+++ b/packages/picasso/src/RichTextEditor/RichTextEditor.tsx
@@ -90,6 +90,7 @@ export interface Props extends BaseProps {
     unorderedListButton?: string
     orderedListButton?: string
   }
+  highlightAutofill?: boolean
 }
 
 const useStyles = makeStyles<Theme>(styles, {
@@ -120,6 +121,7 @@ export const RichTextEditor = forwardRef<HTMLDivElement, Props>(
       hiddenInputId,
       setHasMultilineCounter,
       name,
+      highlightAutofill,
     } = props
 
     const classes = useStyles()
@@ -189,6 +191,7 @@ export const RichTextEditor = forwardRef<HTMLDivElement, Props>(
               [classes.disabled]: disabled,
               [classes.focused]: isEditorFocused,
               [classes.error]: status === 'error',
+              [classes.highlightAutofill]: highlightAutofill,
             },
             className
           )}
@@ -270,6 +273,7 @@ RichTextEditor.defaultProps = {
   onBlur: noop,
   disabled: false,
   status: 'default',
+  highlightAutofill: false,
 }
 
 RichTextEditor.displayName = 'RichTextEditor'

--- a/packages/picasso/src/RichTextEditor/story/index.jsx
+++ b/packages/picasso/src/RichTextEditor/story/index.jsx
@@ -1,7 +1,7 @@
 import PicassoBook from '~/.storybook/components/PicassoBook'
 import RichTextEditor from '../RichTextEditor'
 
-const page = PicassoBook.section('Components').createPage(
+const page = PicassoBook.section('Forms').createPage(
   'RichTextEditor',
   `
   ${PicassoBook.createBaseDocsLink(

--- a/packages/picasso/src/RichTextEditor/styles.ts
+++ b/packages/picasso/src/RichTextEditor/styles.ts
@@ -1,8 +1,12 @@
 import { outline } from '@toptal/picasso-shared'
 import { createStyles, Theme } from '@material-ui/core/styles'
 
-export default ({ palette, sizes }: Theme) =>
-  createStyles({
+import highlightAutofillStyles from '../InputBase/highlightAutofillStyles'
+
+export default (theme: Theme) => {
+  const { palette, sizes } = theme
+
+  return createStyles({
     editorWrapper: {
       position: 'relative',
       borderRadius: sizes.borderRadius.small,
@@ -32,4 +36,7 @@ export default ({ palette, sizes }: Theme) =>
       borderColor: palette.grey.main2,
       ...outline(palette.primary.main),
     },
+
+    ...highlightAutofillStyles(theme),
   })
+}

--- a/packages/picasso/src/SelectBase/types.ts
+++ b/packages/picasso/src/SelectBase/types.ts
@@ -104,6 +104,7 @@ export interface SelectProps<
     limitFooter?: string
     searchInput?: string
   }
+  highlightAutofill?: boolean
 }
 
 export type ValueType = string | number

--- a/packages/picasso/src/Switch/story/index.jsx
+++ b/packages/picasso/src/Switch/story/index.jsx
@@ -1,11 +1,11 @@
 import { Switch } from '../Switch'
 import PicassoBook from '~/.storybook/components/PicassoBook'
 
-const page = PicassoBook.section('Components').createPage(
+const page = PicassoBook.section('Forms').createPage(
   'Switch',
   `
     Switches are used to toggle the state of an element on or off.
-    
+
     ${PicassoBook.createBaseDocsLink(
       'https://share.goabstract.com/07bda3d7-0417-47ca-a4cd-9dbb7a9dfcd1?collectionLayerId=1992e79b-f871-4077-a72c-2f9a237da809&mode=design&present=true'
     )}

--- a/packages/picasso/src/TagSelector/TagSelector.tsx
+++ b/packages/picasso/src/TagSelector/TagSelector.tsx
@@ -110,6 +110,7 @@ export interface Props
   /** Options provided to the popper.js instance */
   popperOptions?: PopperOptions
   testIds?: AutocompleteProps['testIds']
+  highlightAutofill?: boolean
 }
 
 export const TagSelector = forwardRef<HTMLInputElement, Props>(
@@ -140,6 +141,7 @@ export const TagSelector = forwardRef<HTMLInputElement, Props>(
       error,
       status,
       testIds,
+      highlightAutofill,
       ...rest
     } = props
 
@@ -258,6 +260,7 @@ export const TagSelector = forwardRef<HTMLInputElement, Props>(
         popperContainer={popperContainer}
         popperOptions={popperOptions}
         testIds={testIds}
+        highlightAutofill={highlightAutofill}
       />
     )
   }
@@ -277,6 +280,7 @@ TagSelector.defaultProps = {
   placeholder: '',
   showOtherOption: false,
   status: 'default',
+  highlightAutofill: false,
 }
 
 TagSelector.displayName = 'TagSelector'

--- a/packages/picasso/src/TagSelectorInput/TagSelectorInput.tsx
+++ b/packages/picasso/src/TagSelectorInput/TagSelectorInput.tsx
@@ -40,6 +40,7 @@ export const TagSelectorInput = forwardRef<HTMLInputElement, InputProps>(
       enableReset,
       inputProps,
       testIds,
+      highlightAutofill,
       ...rest
     } = props
 
@@ -67,6 +68,9 @@ export const TagSelectorInput = forwardRef<HTMLInputElement, InputProps>(
         className={cx(classes.inputBase, {
           [classes.withEndAdornment]: Boolean(endAdornment),
         })}
+        classes={{
+          root: cx({ [classes.highlightAutofill]: highlightAutofill }),
+        }}
         id={id}
         name={name}
         defaultValue={defaultValue}
@@ -101,6 +105,7 @@ TagSelectorInput.defaultProps = {
   multiline: false,
   width: 'auto',
   status: 'default',
+  highlightAutofill: false,
 }
 
 TagSelectorInput.displayName = 'TagSelectorInput'

--- a/packages/picasso/src/TagSelectorInput/styles.ts
+++ b/packages/picasso/src/TagSelectorInput/styles.ts
@@ -1,11 +1,13 @@
-import { createStyles } from '@material-ui/core/styles'
+import { createStyles, Theme } from '@material-ui/core/styles'
 import { rem } from '@toptal/picasso-shared'
+
+import highlightAutofillStyles from '../InputBase/highlightAutofillStyles'
 
 export const TAG_SELECTOR_INPUT_GUTTER_SIZE = rem('4px')
 const END_ADORNMENT_PADDING = '0.625em'
 const END_ADORNMENT_HEIGHT = '1em'
 
-export default () =>
+export default (theme: Theme) =>
   createStyles({
     inputBase: {
       display: 'flex',
@@ -26,6 +28,7 @@ export default () =>
         marginBottom: 0,
       },
     },
+    ...highlightAutofillStyles(theme),
     withEndAdornment: {
       paddingRight: `calc(2*${END_ADORNMENT_PADDING} + ${END_ADORNMENT_HEIGHT})`,
     },

--- a/packages/picasso/src/TimePicker/TimePicker.tsx
+++ b/packages/picasso/src/TimePicker/TimePicker.tsx
@@ -45,7 +45,16 @@ export interface Props
 }
 
 export const TimePicker = (props: Props) => {
-  const { onChange, value, width, className, error, status, ...rest } = props
+  const {
+    onChange,
+    value,
+    width,
+    className,
+    error,
+    status,
+    highlightAutofill,
+    ...rest
+  } = props
 
   usePropDeprecationWarning({
     props,
@@ -80,6 +89,7 @@ export const TimePicker = (props: Props) => {
         width={width}
         status={error ? 'error' : status}
         className={cx(classes.root, className)}
+        highlightAutofill={highlightAutofill}
         inputProps={{
           className: classes.inputBase,
           ...rest,
@@ -88,8 +98,6 @@ export const TimePicker = (props: Props) => {
           <InputMask
             mask={inputMask}
             alwaysShowMask
-            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-            // @ts-ignore
             maskPlaceholder='-'
             value={value}
             onChange={onChange}
@@ -107,6 +115,7 @@ export const TimePicker = (props: Props) => {
       className={cx(classes.root, className)}
       onChange={onChange}
       iconPosition='end'
+      highlightAutofill={highlightAutofill}
       icon={icon}
       width={width}
       status={error ? 'error' : status}

--- a/packages/picasso/src/TimePicker/story/index.jsx
+++ b/packages/picasso/src/TimePicker/story/index.jsx
@@ -1,10 +1,10 @@
 import { TimePicker } from '../TimePicker'
 import PicassoBook from '~/.storybook/components/PicassoBook'
 
-const page = PicassoBook.section('Components').createPage(
+const page = PicassoBook.section('Forms').createPage(
   'TimePicker',
   `Time Picker component
-  
+
   ${PicassoBook.createSourceLink(__filename)}
   `
 )

--- a/packages/picasso/src/YearSelect/story/index.jsx
+++ b/packages/picasso/src/YearSelect/story/index.jsx
@@ -1,10 +1,10 @@
 import { YearSelect } from '../YearSelect'
 import PicassoBook from '~/.storybook/components/PicassoBook'
 
-const page = PicassoBook.section('Components').createPage(
+const page = PicassoBook.section('Forms').createPage(
   'YearSelect',
   `Year select
-  
+
   ${PicassoBook.createSourceLink(__filename)}
   `
 )


### PR DESCRIPTION
[FX-3779]

### Description

This PR is a follow-up for https://github.com/toptal/picasso/pull/3421, where we discussed the main idea. In this PR we use the same technique for the rest of the input components that we have in Picasso. `highlightAutofill` will be used only by `@toptal/picasso-forms` which will be done in next PR.

Also as part of this PR I decided to move all input components in Picasso to correct section in the storybook 
![image](https://user-images.githubusercontent.com/6830426/226577139-89d0688b-e363-496a-8aac-3e0d8a9d8724.png)


### How to test

- you can play with [the storybook](https://picasso.toptal.net/fx-3779-autohighlight/?path=/story/forms-input--input) and add manually `highlightAutofill` to any input component in `@toptal/picasso` (They are all in section "FORMS" in the storybook)
- check new visual test with all inputs in the visual state

### Screenshots

![image](https://user-images.githubusercontent.com/6830426/226576956-9af4383e-c045-45d9-9117-11022e5c185e.png)

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests

**Breaking change**

- [x] codemod is created and showcased in the changeset
- [x] test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-3779]: https://toptal-core.atlassian.net/browse/FX-3779?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ