### PR TITLE
feat(Forms): add `highlightAutofill` functionality

### DIFF
--- a/.changeset/hot-ligers-invent.md
+++ b/.changeset/hot-ligers-invent.md
@@ -1,0 +1,13 @@
+---
+'@toptal/picasso-forms': major
+---
+
+---
+
+- add a hint background color on the component field to show preselected fill (automatically filled)
+- this feature is disabled by default, you can turn it on in the form config
+- update `@toptal/picasso@^31.12.1` to support new visual state (**BREAKING CHANGE**)
+
+```
+<ConfigProvider value={{ highlightAutofill: true }}>
+```

--- a/.changeset/many-spies-share.md
+++ b/.changeset/many-spies-share.md
@@ -1,0 +1,9 @@
+---
+'@toptal/picasso': patch
+---
+
+---
+
+### DatePicker
+
+- use passed `onClick` and `onFocus` from the parent component

--- a/packages/picasso-forms/package.json
+++ b/packages/picasso-forms/package.json
@@ -23,7 +23,7 @@
     "url": "https://github.com/toptal/picasso/issues"
   },
   "peerDependencies": {
-    "@toptal/picasso": "^31.0.0",
+    "@toptal/picasso": "^31.12.1",
     "@toptal/picasso-shared": "^11.0.0",
     "react": ">=16.12.0 < 19.0.0",
     "react-dom": ">=16.12.0 < 19.0.0",

--- a/packages/picasso-forms/src/AvatarUpload/AvatarUpload.tsx
+++ b/packages/picasso-forms/src/AvatarUpload/AvatarUpload.tsx
@@ -17,9 +17,14 @@ type FinalFormOnChangeType = FinalFieldInputProps<
 >['onChange']
 
 const AvatarUpload = (props: Props) => {
-  // dropping 'src' value here out from 'rest'. 'src' value should be provided via form context
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const { label, titleCase, src, ...rest } = props
+  const {
+    label,
+    titleCase,
+    // dropping 'src' value here out from 'rest'. 'src' value should be provided via form context
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    src,
+    ...rest
+  } = props
 
   const handleDropAccepted = async ({
     acceptedFile,
@@ -52,7 +57,12 @@ const AvatarUpload = (props: Props) => {
         ) : null
       }
     >
-      {inputProps => (
+      {({
+        // omit 'highlight' as it is used only for classic inputs
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        highlight,
+        ...inputProps
+      }) => (
         <PicassoAvatarUpload
           {...inputProps}
           src={inputProps.value?.src}

--- a/packages/picasso-forms/src/ButtonCheckbox/ButtonCheckbox.tsx
+++ b/packages/picasso-forms/src/ButtonCheckbox/ButtonCheckbox.tsx
@@ -46,7 +46,14 @@ const ButtonCheckbox = ({ name, value, required, ...restProps }: Props) => {
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       name={name!}
     >
-      {(input: ButtonCheckboxProps) => <Button.Checkbox {...input} />}
+      {({
+        // omit 'highlight' as it is used only for classic inputs
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        highlight,
+        ...input
+      }: ButtonCheckboxProps & { highlight?: 'autofill' }) => (
+        <Button.Checkbox {...input} />
+      )}
     </PicassoField>
   )
 }

--- a/packages/picasso-forms/src/Checkbox/Checkbox.tsx
+++ b/packages/picasso-forms/src/Checkbox/Checkbox.tsx
@@ -57,7 +57,12 @@ export const Checkbox = ({
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       name={name!}
     >
-      {(input: CheckboxProps) => (
+      {({
+        // omit 'highlight' as it is used only for classic inputs
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        highlight,
+        ...input
+      }: CheckboxProps & { highlight?: 'autofill' }) => (
         <PicassoCheckbox
           {...input}
           label={label}

--- a/packages/picasso-forms/src/Dropzone/Dropzone.tsx
+++ b/packages/picasso-forms/src/Dropzone/Dropzone.tsx
@@ -64,7 +64,12 @@ const Dropzone = ({ dropzoneHint, ...props }: Props) => {
         />
       }
     >
-      {inputProps => (
+      {({
+        // omit 'highlight' as it is used only for classic inputs
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        highlight,
+        ...inputProps
+      }) => (
         <PicassoDropzone
           {...inputProps}
           hint={dropzoneHint}

--- a/packages/picasso-forms/src/Field/Field.tsx
+++ b/packages/picasso-forms/src/Field/Field.tsx
@@ -89,7 +89,8 @@ const Field = <
     ...rest
   } = props
 
-  const { validateOnSubmit: shouldValidateOnSubmit } = useFormConfig()
+  const { validateOnSubmit: shouldValidateOnSubmit, highlightAutofill } =
+    useFormConfig()
   const validators = useMemo(
     () => getValidators(required, validate),
     [required, validate]
@@ -119,6 +120,9 @@ const Field = <
     validators,
     shouldValidateOnSubmit,
   })
+
+  const shouldHighlightAutofill =
+    highlightAutofill && !meta.visited && meta.pristine && input.value
 
   const childProps: Record<string, unknown> = {
     id,
@@ -162,6 +166,7 @@ const Field = <
         rest.onFocus(event)
       }
     },
+    ...(shouldHighlightAutofill ? { highlight: 'autofill' } : {}),
   }
 
   return (

--- a/packages/picasso-forms/src/FileInput/FileInput.tsx
+++ b/packages/picasso-forms/src/FileInput/FileInput.tsx
@@ -57,7 +57,12 @@ export const FileInput = (props: Props) => {
         ) : null
       }
     >
-      {inputProps => (
+      {({
+        // omit 'highlight' as it is used only for classic inputs
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        highlight,
+        ...inputProps
+      }) => (
         <PicassoFileInput
           {...inputProps}
           onChange={(event: React.ChangeEvent<HTMLInputElement>) => {

--- a/packages/picasso-forms/src/Form/story/HighlightAutofill.example.tsx
+++ b/packages/picasso-forms/src/Form/story/HighlightAutofill.example.tsx
@@ -1,0 +1,74 @@
+import React from 'react'
+import { Container } from '@toptal/picasso'
+import {
+  FormConfigProps,
+  FormNonCompound,
+  ConfigProvider,
+  SubmitButton,
+  Autocomplete,
+  DatePicker,
+  Input,
+  NumberInput,
+  PasswordInput,
+  RichTextEditor,
+  Select,
+  TagSelector,
+  TimePicker,
+} from '@toptal/picasso-forms'
+
+const formConfig: FormConfigProps = {
+  highlightAutofill: true,
+}
+
+const Example = () => (
+  <ConfigProvider value={formConfig}>
+    <FormNonCompound
+      onSubmit={values => window.alert(JSON.stringify(values, undefined, 2))}
+      initialValues={{
+        'highlight-firstName': 'Bruce',
+        'highlight-autocomplete': 'foo',
+        'highlight-datepicker': new Date(),
+        'highlight-numberinput': 1,
+        'highlight-passwordinput': 'password',
+        'highlight-rte': '<p>Rich Text Editor</p>',
+        'highlight-select': 'foo',
+        'highlight-tagselector': 'foo',
+        'highlight-timepicker': new Date(),
+      }}
+    >
+      <Input
+        required
+        name='highlight-firstName'
+        label='textinput'
+        placeholder='e.g. Bruce'
+      />
+
+      <Input
+        required
+        name='highlight-noDefaultValue'
+        label='textinput'
+        placeholder='e.g. Bruce'
+      />
+
+      <Autocomplete
+        label='autocomplete'
+        value='foo'
+        name='highlight-autocomplete'
+      />
+
+      <DatePicker label='datepicker' name='highlight-datepicker' />
+      <NumberInput label='numberinput' name='highlight-numberinput' />
+      <PasswordInput label='passwordinput' name='highlight-passwordinput' />
+      <RichTextEditor id='highlight-rte' label='rte' name='highlight-rte' />
+      <Select label='select' options={[]} name='highlight-select' />
+      <TagSelector label='tagselector' name='highlight-tagselector' />
+      <TimePicker label='timepicker' name='highlight-timepicker' />
+
+      <Container top='small'>
+        <SubmitButton>Submit</SubmitButton>
+      </Container>
+    </FormNonCompound>
+  </ConfigProvider>
+)
+
+export default Example

--- a/packages/picasso-forms/src/Form/story/HighlightAutofill.example.tsx
+++ b/packages/picasso-forms/src/Form/story/HighlightAutofill.example.tsx
@@ -60,8 +60,17 @@ const Example = () => (
       <NumberInput label='numberinput' name='highlight-numberinput' />
       <PasswordInput label='passwordinput' name='highlight-passwordinput' />
       <RichTextEditor id='highlight-rte' label='rte' name='highlight-rte' />
-      <Select label='select' options={[]} name='highlight-select' />
-      <TagSelector label='tagselector' name='highlight-tagselector' />
+      <Select
+        options={[{ value: 'foo', text: 'first option ' }]}
+        label='select'
+        name='highlight-select'
+      />
+      <TagSelector
+        options={[{ value: 'foo', text: 'first option ' }]}
+        label='tagselector'
+        name='highlight-tagselector'
+        inputValue='foo'
+      />
       <TimePicker label='timepicker' name='highlight-timepicker' />
 
       <Container top='small'>

--- a/packages/picasso-forms/src/Form/story/index.jsx
+++ b/packages/picasso-forms/src/Form/story/index.jsx
@@ -263,3 +263,6 @@ however, you may need custom validators for more complex types of fields.
     description: 'Showcase how to use auto-save functionality.',
     takeScreenshot: false,
   })
+  .addExample('Form/story/HighlightAutofill.example.tsx', {
+    title: 'Highlight autofill',
+  })

--- a/packages/picasso-forms/src/Form/story/index.jsx
+++ b/packages/picasso-forms/src/Form/story/index.jsx
@@ -264,5 +264,5 @@ however, you may need custom validators for more complex types of fields.
     takeScreenshot: false,
   })
   .addExample('Form/story/HighlightAutofill.example.tsx', {
-    title: 'Highlight autofill',
+    title: 'Highlight fields with default value',
   })

--- a/packages/picasso-forms/src/FormConfig/FormConfig.ts
+++ b/packages/picasso-forms/src/FormConfig/FormConfig.ts
@@ -24,9 +24,12 @@ export type FormConfigProps = (
   | NoValidationConfig
 ) & {
   requiredVariant?: RequiredVariant
+  highlightAutofill?: boolean
 }
 
-export const FormConfigContext = createContext<FormConfigProps>({})
+export const FormConfigContext = createContext<FormConfigProps>({
+  highlightAutofill: false,
+})
 export const FormConfigProvider = FormConfigContext.Provider
 
 export const useFormConfig = () => useContext(FormConfigContext)

--- a/packages/picasso-forms/src/RadioGroup/RadioGroup.tsx
+++ b/packages/picasso-forms/src/RadioGroup/RadioGroup.tsx
@@ -30,7 +30,12 @@ export const RadioGroup = (props: Props) => {
           ) : null
         }
       >
-        {radioGroupProps => (
+        {({
+          // omit 'highlight' as it is used only for classic inputs
+          // eslint-disable-next-line @typescript-eslint/no-unused-vars
+          highlight,
+          ...radioGroupProps
+        }) => (
           <PicassoRadio.Group {...radioGroupProps}>
             {children}
           </PicassoRadio.Group>

--- a/packages/picasso-forms/src/Rating/Rating.tsx
+++ b/packages/picasso-forms/src/Rating/Rating.tsx
@@ -30,7 +30,12 @@ const Stars = (props: RatingStarsProps) => {
         ) : null
       }
     >
-      {inputProps => <PicassoRating.Stars {...inputProps} />}
+      {({
+        // omit 'highlight' as it is used only for classic inputs
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        highlight,
+        ...inputProps
+      }) => <PicassoRating.Stars {...inputProps} />}
     </PicassoField>
   )
 }

--- a/packages/picasso-forms/src/Switch/Switch.tsx
+++ b/packages/picasso-forms/src/Switch/Switch.tsx
@@ -24,7 +24,12 @@ export const Switch = (props: Props) => (
       ) : null
     }
   >
-    {(inputProps: SwitchProps) => {
+    {({
+      // omitting highlight from inputProps
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      highlight,
+      ...inputProps
+    }: SwitchProps & { highlight?: 'autofill' }) => {
       return <PicassoSwitch {...inputProps} />
     }}
   </PicassoField>

--- a/packages/picasso/src/DatePicker/DatePicker.tsx
+++ b/packages/picasso/src/DatePicker/DatePicker.tsx
@@ -355,10 +355,22 @@ export const DatePicker = (props: Props) => {
     }
   }
 
-  const handleFocusOrClick = () => {
+  const handleClick: React.MouseEventHandler<HTMLInputElement> = event => {
     if (disabled) {
       return
     }
+
+    inputProps?.onClick?.(event)
+    showCalendar()
+    setIsInputFocused(true)
+  }
+
+  const handleFocus: React.FocusEventHandler<HTMLInputElement> = event => {
+    if (disabled) {
+      return
+    }
+
+    inputProps?.onFocus?.(event)
     showCalendar()
     setIsInputFocused(true)
   }
@@ -386,8 +398,8 @@ export const DatePicker = (props: Props) => {
           disabled={disabled}
           ref={inputRef}
           onKeyDown={handleInputKeydown}
-          onClick={handleFocusOrClick}
-          onFocus={handleFocusOrClick}
+          onClick={handleClick}
+          onFocus={handleFocus}
           onBlur={handleBlur}
           onResetClick={handleResetClick}
           value={inputValue}


### PR DESCRIPTION
[FX-3780]

### Description

This is a follow-up to https://github.com/toptal/picasso/pull/3439. In this PR we introduce `highlightAutofill` on final-form level. Users can enable this feature in form config.

### How to test

- check [the new example](https://picasso.toptal.net/fx-3780-highligh-autofill/?path=/story/picasso-forms-form--form#highlight-autofill) in storybook

### Screenshots

![image](https://user-images.githubusercontent.com/6830426/227150496-72c2516c-d5f0-4796-b1b0-a0fdfa2ae7ff.png)

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests

**Breaking change**

- `N/A` codemod is created and showcased in the changeset
- `N/A` test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-3780]: https://toptal-core.atlassian.net/browse/FX-3780?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ