### PR TITLE
fix: [FX-3823] class names creator in Picasso

### DIFF
--- a/.changeset/calm-kiwis-taste.md
+++ b/.changeset/calm-kiwis-taste.md
@@ -1,0 +1,7 @@
+---
+'@toptal/picasso-provider': patch
+---
+
+---
+
+- memoize class names creator in Picasso provider

--- a/packages/picasso-provider/src/Picasso/Picasso.tsx
+++ b/packages/picasso-provider/src/Picasso/Picasso.tsx
@@ -4,7 +4,7 @@ import {
   StylesProvider,
   createGenerateClassName,
 } from '@material-ui/core/styles'
-import React, { ReactNode } from 'react'
+import React, { ReactNode, useMemo } from 'react'
 
 import CssBaseline from '../CssBaseline'
 import FontsLoader from './FontsLoader'
@@ -80,11 +80,17 @@ const Picasso = ({
     PicassoBreakpoints.disableMobileBreakpoints()
   }
 
-  const generateClassName = createGenerateClassName({
-    // if there are multiples instances of Picasso
-    // on the page we want each set of styles to be unique
-    seed: disableClassNamePrefix ? '' : generateRandomStringOrGetEmptyInTest(),
-  })
+  const generateClassName = useMemo(
+    () =>
+      createGenerateClassName({
+        // if there are multiples instances of Picasso
+        // on the page we want each set of styles to be unique
+        seed: disableClassNamePrefix
+          ? ''
+          : generateRandomStringOrGetEmptyInTest(),
+      }),
+    [disableClassNamePrefix]
+  )
 
   return (
     <StylesProvider


### PR DESCRIPTION
[FX-3823]

### Description

Picasso + Next.js has a significant issue.
The initial load of Picasso components on a page is fine. 
But when we walk across pages, the same page with the same components becames broken in context of styles.
It happens, because of broken counter in `StylesProvider`. the `StylesProvider` uses `generateClassName` function that generate class name for each component and increases the counter after class name generation.

`generateClassName` function is created via `createGenerateClassName`. It happens inside a `Picasso` component.
For some reason, after switching a page, the `createGenerateClassName` is called again, therefore the counter is becoming 0 again.

### How to test

- Use https://github.com/toptal/next-and-picasso-isuue branch
- Add an alpha version of picasso-provider
- Repeat the pages walk
- Expected: the appearance of components still the same


### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Make sure that additions and changes on design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-3823]: https://toptal-core.atlassian.net/browse/FX-3823?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ