### PR TITLE
fix: broken alpha publishing workflow

### DIFF
--- a/.github/workflows/davinci-alpha-package.yml
+++ b/.github/workflows/davinci-alpha-package.yml
@@ -67,6 +67,7 @@ jobs:
         with:
           npm-token: ${{ env.NPM_TOKEN }}
           branch: ${{ steps.get-branch.outputs.branch }}
+          root-folder: /dist-package
 
       - name: Alpha package — Handle success
         if: ${{ success() }}


### PR DESCRIPTION
### Description

We should pass `root-folder` to `toptal/davinci-github-actions/build-publish-alpha-package@v5.0.0` GH Action to properly publish alpha packages

### How to test

- Merge this PR and check it in a separate PR


### Development checks

- [ ] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Self reviewed

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>
