### PR TITLE
style(RichText): update font-size

### DIFF
--- a/.changeset/neat-icons-end.md
+++ b/.changeset/neat-icons-end.md
@@ -1,0 +1,9 @@
+---
+"@toptal/picasso": patch
+---
+
+---
+
+### RichText
+
+- update font-size to follow BASE

--- a/packages/picasso/src/RichText/hooks/useRichText/useRichText.tsx
+++ b/packages/picasso/src/RichText/hooks/useRichText/useRichText.tsx
@@ -26,15 +26,15 @@ const Li = ({ children, ...props }: Props) => (
 
 /* eslint-disable id-length */
 const P = ({ children }: Props) => (
-  <Typography size='small'>{children}</Typography>
+  <Typography size='medium'>{children}</Typography>
 )
 const Strong = ({ children }: Props) => (
-  <Typography size='small' as='strong' weight='semibold'>
+  <Typography size='medium' as='strong' weight='semibold'>
     {children}
   </Typography>
 )
 const Em = ({ children }: Props) => (
-  <Typography size='small' as='em'>
+  <Typography size='medium' as='em'>
     {children}
   </Typography>
 )


### PR DESCRIPTION
[FX-3819]

### Description

RichText should use the same font-size as RichTextEditor, 14px. 

### How to test

- check [the storybook](https://picasso.toptal.net/fx-3819-rte-font-size/?path=/story/components-richtext--richtext)

### Screenshots

![image](https://user-images.githubusercontent.com/6830426/227913261-acafa1a7-88f1-40ce-bd99-139e6aa68108.png)

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- `n/a` Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- `n/a` Annotate all `props` in component with documentation
- `n/a` Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests

**Breaking change**

- `n/a` codemod is created and showcased in the changeset
- `n/a` test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-3819]: https://toptal-core.atlassian.net/browse/FX-3819?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ