### PR TITLE
chore: rename highlightAutofill to highlight

### DIFF
--- a/.changeset/swift-pears-sleep.md
+++ b/.changeset/swift-pears-sleep.md
@@ -1,0 +1,9 @@
+---
+'@toptal/picasso': patch
+---
+
+---
+
+### Picasso inputs
+
+- rename `highlightAutofill` to `highlight`

--- a/cypress/component/InputHiglightAutofill.spec.tsx
+++ b/cypress/component/InputHiglightAutofill.spec.tsx
@@ -18,56 +18,56 @@ import {
 const component = 'HiglightAutofill'
 
 describe('Highlight Autofill', () => {
-  describe('when highlightAutofill prop is true', () => {
+  describe('when highlight prop is true', () => {
     it('renders inputs with correct background color', () => {
       cy.mount(
         <Container padded='small' gap='small' flex direction='column'>
           <Container>
             <FormLabel>Autocomplete</FormLabel>
-            <Autocomplete value='' highlightAutofill />
+            <Autocomplete value='' highlight='autofill' />
           </Container>
           <Container>
             <FormLabel>DatePicker</FormLabel>
-            <DatePicker onChange={() => {}} highlightAutofill />
+            <DatePicker onChange={() => {}} highlight='autofill' />
           </Container>
           <Container>
             <FormLabel>MonthSelect</FormLabel>
-            <MonthSelect highlightAutofill />
+            <MonthSelect highlight='autofill' />
           </Container>
           <Container>
             <FormLabel>NumberInput</FormLabel>
-            <NumberInput highlightAutofill />
+            <NumberInput highlight='autofill' />
           </Container>
           <Container>
             <FormLabel>PasswordInput</FormLabel>
-            <PasswordInput highlightAutofill />
+            <PasswordInput highlight='autofill' />
           </Container>
           <Container>
             <FormLabel>RichTextEditor</FormLabel>
-            <RichTextEditor id='foo' highlightAutofill />
+            <RichTextEditor id='foo' highlight='autofill' />
           </Container>
           <Container>
             <FormLabel>Select</FormLabel>
             <Select
               options={[{ text: 'foo', value: 'bar' }]}
-              highlightAutofill
+              highlight='autofill'
             />
           </Container>
           <Container>
             <FormLabel>TagSelector</FormLabel>
-            <TagSelector highlightAutofill />
+            <TagSelector highlight='autofill' />
           </Container>
           <Container>
             <FormLabel>TimePicker</FormLabel>
-            <TimePicker highlightAutofill />
+            <TimePicker highlight='autofill' />
           </Container>
           <Container>
             <FormLabel>YearSelect</FormLabel>
-            <YearSelect from={2000} to={2010} highlightAutofill />
+            <YearSelect from={2000} to={2010} highlight='autofill' />
           </Container>
           <Container>
             <FormLabel>Input</FormLabel>
-            <Input highlightAutofill />
+            <Input highlight='autofill' />
           </Container>
         </Container>
       )

--- a/packages/picasso/src/Autocomplete/Autocomplete.tsx
+++ b/packages/picasso/src/Autocomplete/Autocomplete.tsx
@@ -128,7 +128,7 @@ export interface Props
     input?: string
     disableAutofillInput?: string
   }
-  highlightAutofill?: boolean
+  highlight?: 'autofill'
 }
 
 const useStyles = makeStyles<Theme>(styles, {
@@ -178,7 +178,7 @@ export const Autocomplete = forwardRef<HTMLInputElement, Props>(
       value,
       width = 'auto',
       disabled = false,
-      highlightAutofill,
+      highlight,
       ...rest
     } = props
 
@@ -340,7 +340,7 @@ export const Autocomplete = forwardRef<HTMLInputElement, Props>(
             autoComplete={enableAutofill ? autoComplete : autoComplete || 'off'}
             testIds={testIds}
             data-testid={testIds?.input}
-            highlightAutofill={highlightAutofill}
+            highlight={highlight}
           />
         </Container>
         <div role='listbox'>
@@ -383,7 +383,6 @@ Autocomplete.defaultProps = {
   poweredByGoogle: false,
   disabled: false,
   status: 'default',
-  highlightAutofill: false,
 }
 
 Autocomplete.displayName = 'Autocomplete'

--- a/packages/picasso/src/DatePicker/DatePicker.tsx
+++ b/packages/picasso/src/DatePicker/DatePicker.tsx
@@ -115,7 +115,7 @@ export interface Props
   footerBackgroundColor?: string
   /** Shows orange dot indicator in days between a date range */
   indicatedIntervals?: { start: Date; end: Date }[]
-  highlightAutofill?: boolean
+  highlight?: 'autofill'
 }
 
 export const DatePicker = (props: Props) => {
@@ -147,7 +147,7 @@ export const DatePicker = (props: Props) => {
     footer,
     indicatedIntervals,
     footerBackgroundColor,
-    highlightAutofill,
+    highlight,
     ...rest
   } = props
   const classes = useStyles()
@@ -397,7 +397,7 @@ export const DatePicker = (props: Props) => {
           width={width}
           testIds={testIds}
           data-testid={testIds?.input}
-          highlightAutofill={highlightAutofill}
+          highlight={highlight}
         />
       </Container>
       {inputWrapperRef.current && (
@@ -451,7 +451,6 @@ DatePicker.defaultProps = {
   displayDateFormat: 'MMM d, yyyy',
   autoComplete: 'off',
   status: 'default',
-  highlightAutofill: false,
 }
 
 DatePicker.displayName = 'DatePicker'

--- a/packages/picasso/src/Input/Input.tsx
+++ b/packages/picasso/src/Input/Input.tsx
@@ -99,7 +99,7 @@ export interface Props
     validIcon?: string
   }
   setHasMultilineCounter?: (name: string, hasCounter: boolean) => void
-  highlightAutofill?: boolean
+  highlight?: 'autofill'
 }
 
 type StartAdornmentProps = Pick<Props, 'icon' | 'iconPosition' | 'disabled'>
@@ -275,7 +275,7 @@ export const Input = forwardRef<HTMLInputElement, Props>(function Input(
     outlineRef,
     testIds,
     setHasMultilineCounter,
-    highlightAutofill,
+    highlight,
     ...rest
   } = purifyProps(props)
 
@@ -305,7 +305,7 @@ export const Input = forwardRef<HTMLInputElement, Props>(function Input(
         classes={{
           root: cx(classes.root, {
             [classes.rootMultiline]: multiline,
-            [classes.highlightAutofill]: highlightAutofill,
+            [classes.highlightAutofill]: highlight === 'autofill',
           }),
           input: cx(classes.input, {
             [classes.inputMultilineResizable]: multiline && multilineResizable,
@@ -386,7 +386,6 @@ Input.defaultProps = {
   autoComplete: 'none',
   counter: 'remaining',
   iconPosition: 'start',
-  highlightAutofill: false,
   multiline: false,
   size: 'medium',
   width: 'auto',

--- a/packages/picasso/src/Input/styles.ts
+++ b/packages/picasso/src/Input/styles.ts
@@ -1,6 +1,6 @@
 import { Theme, createStyles } from '@material-ui/core/styles'
 
-import highlightAutofillStyles from '../InputBase/highlightAutofillStyles'
+import highlightAutofillStyles from '../InputBase/highlightStyles'
 import '../InputBase/styles'
 import '../InputLabel/styles'
 import '../OutlinedInput/styles'

--- a/packages/picasso/src/InputBase/highlightStyles.ts
+++ b/packages/picasso/src/InputBase/highlightStyles.ts
@@ -1,11 +1,11 @@
 import { Theme } from '@material-ui/core/styles'
 import { alpha } from '@toptal/picasso-shared'
 
-const highlightAutofillStyles = ({ palette }: Theme) => ({
+const highlightStyles = ({ palette }: Theme) => ({
   highlightAutofill: {
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     backgroundColor: alpha(palette.yellow.lighter!, 0.6),
   },
 })
 
-export default highlightAutofillStyles
+export default highlightStyles

--- a/packages/picasso/src/NativeSelect/NativeSelect.tsx
+++ b/packages/picasso/src/NativeSelect/NativeSelect.tsx
@@ -62,7 +62,7 @@ export const NativeSelect = documentable(
         limit,
         native,
         testIds,
-        highlightAutofill,
+        highlight,
         /* eslint-enable @typescript-eslint/no-unused-vars */
         ...rest
       } = props
@@ -131,7 +131,7 @@ export const NativeSelect = documentable(
           classes={{
             root: cx(classes.select, {
               [classes.placeholder]: !selection.isSelected(),
-              [classes.highlightAutofill]: highlightAutofill,
+              [classes.highlightAutofill]: highlight === 'autofill',
             }),
             select: cx({
               [classes.startAdornmentPadding]:

--- a/packages/picasso/src/NativeSelect/styles.ts
+++ b/packages/picasso/src/NativeSelect/styles.ts
@@ -4,7 +4,7 @@ import '../InputLabel/styles'
 import '../InputBase/styles'
 import '../Input/styles'
 import '../Loader/styles'
-import highlightAutofillStyles from '../InputBase/highlightAutofillStyles'
+import highlightAutofillStyles from '../InputBase/highlightStyles'
 
 export default (theme: Theme) => {
   const { palette } = theme

--- a/packages/picasso/src/NonNativeSelect/NonNativeSelect.tsx
+++ b/packages/picasso/src/NonNativeSelect/NonNativeSelect.tsx
@@ -75,7 +75,7 @@ export const NonNativeSelect = documentable(
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
         native,
         testIds,
-        highlightAutofill,
+        highlight,
         ...rest
       } = props
 
@@ -178,7 +178,7 @@ export const NonNativeSelect = documentable(
               defaultValue={undefined}
               className={classes.outlinedInput}
               classes={{
-                root: cx({ [classes.highlightAutofill]: highlightAutofill }),
+                root: cx({ [classes.highlightAutofill]: highlight === 'autofill' }),
               }}
               inputProps={{
                 size: 1, // let input to have smallest width by default for width:'shrink'

--- a/packages/picasso/src/NonNativeSelect/styles.ts
+++ b/packages/picasso/src/NonNativeSelect/styles.ts
@@ -6,7 +6,7 @@ import '../Input/styles'
 import '../Menu/styles'
 import '../MenuItem/styles'
 import '../Loader/styles'
-import highlightAutofillStyles from '../InputBase/highlightAutofillStyles'
+import highlightAutofillStyles from '../InputBase/highlightStyles'
 
 export default (theme: Theme) => {
   const { palette } = theme

--- a/packages/picasso/src/NumberInput/NumberInput.tsx
+++ b/packages/picasso/src/NumberInput/NumberInput.tsx
@@ -32,7 +32,7 @@ export interface Props
   disabled?: boolean
   /** Callback invoked when `NumberInput` changes its state. */
   onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void
-  highlightAutofill?: boolean
+  highlight?: 'autofill'
 }
 
 const useStyles = makeStyles<Theme, Props>(styles, {
@@ -57,7 +57,7 @@ export const NumberInput = forwardRef<HTMLInputElement, Props>(
       icon,
       size,
       testIds,
-      highlightAutofill,
+      highlight,
       ...rest
     } = props
 
@@ -98,7 +98,7 @@ export const NumberInput = forwardRef<HTMLInputElement, Props>(
       <OutlinedInput
         classes={{
           root: cx(classes.root, {
-            [classes.highlightAutofill]: highlightAutofill,
+            [classes.highlightAutofill]: highlight === 'autofill',
           }),
           input: classes.input,
         }}
@@ -133,7 +133,6 @@ NumberInput.defaultProps = {
   min: -Infinity,
   max: Infinity,
   hideControls: false,
-  highlightAutofill: false,
   size: 'medium',
   status: 'default',
 }

--- a/packages/picasso/src/NumberInput/styles.ts
+++ b/packages/picasso/src/NumberInput/styles.ts
@@ -1,6 +1,6 @@
 import { createStyles, Theme } from '@material-ui/core/styles'
 
-import highlightAutofillStyles from '../InputBase/highlightAutofillStyles'
+import highlightAutofillStyles from '../InputBase/highlightStyles'
 
 export default (theme: Theme) =>
   createStyles({

--- a/packages/picasso/src/PasswordInput/PasswordInput.tsx
+++ b/packages/picasso/src/PasswordInput/PasswordInput.tsx
@@ -33,7 +33,7 @@ export interface Props
     input?: string
     toggle?: string
   }
-  highlightAutofill?: boolean
+  highlight?: 'autofill'
 }
 
 const useStyles = makeStyles<Theme>(styles, {
@@ -54,7 +54,7 @@ export const PasswordInput = forwardRef<HTMLInputElement, Props>(
       testIds,
       enableReset,
       onResetClick,
-      highlightAutofill,
+      highlight,
       ...rest
     } = props
 
@@ -91,7 +91,7 @@ export const PasswordInput = forwardRef<HTMLInputElement, Props>(
         style={style}
         className={cx(classes.root, className)}
         classes={{
-          root: cx({ [classes.highlightAutofill]: highlightAutofill }),
+          root: cx({ [classes.highlightAutofill]: highlight === 'autofill' }),
           input: classes.input,
         }}
         inputProps={{

--- a/packages/picasso/src/PasswordInput/styles.ts
+++ b/packages/picasso/src/PasswordInput/styles.ts
@@ -1,6 +1,6 @@
 import { createStyles, Theme } from '@material-ui/core/styles'
 
-import highlightAutofillStyles from '../InputBase/highlightAutofillStyles'
+import highlightAutofillStyles from '../InputBase/highlightStyles'
 
 export default (theme: Theme) => {
   const { spacing } = theme

--- a/packages/picasso/src/RichTextEditor/RichTextEditor.tsx
+++ b/packages/picasso/src/RichTextEditor/RichTextEditor.tsx
@@ -90,7 +90,7 @@ export interface Props extends BaseProps {
     unorderedListButton?: string
     orderedListButton?: string
   }
-  highlightAutofill?: boolean
+  highlight?: 'autofill'
 }
 
 const useStyles = makeStyles<Theme>(styles, {
@@ -121,7 +121,7 @@ export const RichTextEditor = forwardRef<HTMLDivElement, Props>(
       hiddenInputId,
       setHasMultilineCounter,
       name,
-      highlightAutofill,
+      highlight,
     } = props
 
     const classes = useStyles()
@@ -191,7 +191,7 @@ export const RichTextEditor = forwardRef<HTMLDivElement, Props>(
               [classes.disabled]: disabled,
               [classes.focused]: isEditorFocused,
               [classes.error]: status === 'error',
-              [classes.highlightAutofill]: highlightAutofill,
+              [classes.highlightAutofill]: highlight === 'autofill',
             },
             className
           )}
@@ -273,7 +273,6 @@ RichTextEditor.defaultProps = {
   onBlur: noop,
   disabled: false,
   status: 'default',
-  highlightAutofill: false,
 }
 
 RichTextEditor.displayName = 'RichTextEditor'

--- a/packages/picasso/src/RichTextEditor/styles.ts
+++ b/packages/picasso/src/RichTextEditor/styles.ts
@@ -1,7 +1,7 @@
 import { outline } from '@toptal/picasso-shared'
 import { createStyles, Theme } from '@material-ui/core/styles'
 
-import highlightAutofillStyles from '../InputBase/highlightAutofillStyles'
+import highlightAutofillStyles from '../InputBase/highlightStyles'
 
 export default (theme: Theme) => {
   const { palette, sizes } = theme

--- a/packages/picasso/src/SelectBase/types.ts
+++ b/packages/picasso/src/SelectBase/types.ts
@@ -104,7 +104,7 @@ export interface SelectProps<
     limitFooter?: string
     searchInput?: string
   }
-  highlightAutofill?: boolean
+  highlight?: 'autofill'
 }
 
 export type ValueType = string | number

--- a/packages/picasso/src/TagSelector/TagSelector.tsx
+++ b/packages/picasso/src/TagSelector/TagSelector.tsx
@@ -110,7 +110,7 @@ export interface Props
   /** Options provided to the popper.js instance */
   popperOptions?: PopperOptions
   testIds?: AutocompleteProps['testIds']
-  highlightAutofill?: boolean
+  highlight?: 'autofill'
 }
 
 export const TagSelector = forwardRef<HTMLInputElement, Props>(
@@ -141,7 +141,7 @@ export const TagSelector = forwardRef<HTMLInputElement, Props>(
       error,
       status,
       testIds,
-      highlightAutofill,
+      highlight,
       ...rest
     } = props
 
@@ -260,7 +260,7 @@ export const TagSelector = forwardRef<HTMLInputElement, Props>(
         popperContainer={popperContainer}
         popperOptions={popperOptions}
         testIds={testIds}
-        highlightAutofill={highlightAutofill}
+        highlight={highlight}
       />
     )
   }
@@ -280,7 +280,6 @@ TagSelector.defaultProps = {
   placeholder: '',
   showOtherOption: false,
   status: 'default',
-  highlightAutofill: false,
 }
 
 TagSelector.displayName = 'TagSelector'

--- a/packages/picasso/src/TagSelectorInput/TagSelectorInput.tsx
+++ b/packages/picasso/src/TagSelectorInput/TagSelectorInput.tsx
@@ -40,7 +40,7 @@ export const TagSelectorInput = forwardRef<HTMLInputElement, InputProps>(
       enableReset,
       inputProps,
       testIds,
-      highlightAutofill,
+      highlight,
       ...rest
     } = props
 
@@ -69,7 +69,7 @@ export const TagSelectorInput = forwardRef<HTMLInputElement, InputProps>(
           [classes.withEndAdornment]: Boolean(endAdornment),
         })}
         classes={{
-          root: cx({ [classes.highlightAutofill]: highlightAutofill }),
+          root: cx({ [classes.highlightAutofill]: highlight === 'autofill' }),
         }}
         id={id}
         name={name}
@@ -105,7 +105,6 @@ TagSelectorInput.defaultProps = {
   multiline: false,
   width: 'auto',
   status: 'default',
-  highlightAutofill: false,
 }
 
 TagSelectorInput.displayName = 'TagSelectorInput'

--- a/packages/picasso/src/TagSelectorInput/styles.ts
+++ b/packages/picasso/src/TagSelectorInput/styles.ts
@@ -1,7 +1,7 @@
 import { createStyles, Theme } from '@material-ui/core/styles'
 import { rem } from '@toptal/picasso-shared'
 
-import highlightAutofillStyles from '../InputBase/highlightAutofillStyles'
+import highlightAutofillStyles from '../InputBase/highlightStyles'
 
 export const TAG_SELECTOR_INPUT_GUTTER_SIZE = rem('4px')
 const END_ADORNMENT_PADDING = '0.625em'

--- a/packages/picasso/src/TimePicker/TimePicker.tsx
+++ b/packages/picasso/src/TimePicker/TimePicker.tsx
@@ -52,7 +52,7 @@ export const TimePicker = (props: Props) => {
     className,
     error,
     status,
-    highlightAutofill,
+    highlight,
     ...rest
   } = props
 
@@ -89,7 +89,7 @@ export const TimePicker = (props: Props) => {
         width={width}
         status={error ? 'error' : status}
         className={cx(classes.root, className)}
-        highlightAutofill={highlightAutofill}
+        highlight={highlight}
         inputProps={{
           className: classes.inputBase,
           ...rest,
@@ -115,7 +115,7 @@ export const TimePicker = (props: Props) => {
       className={cx(classes.root, className)}
       onChange={onChange}
       iconPosition='end'
-      highlightAutofill={highlightAutofill}
+      highlight={highlight}
       icon={icon}
       width={width}
       status={error ? 'error' : status}


### PR DESCRIPTION
[FX-3780]

### Description

@OleksandrNechai had a good point, that basic Picasso input components should not need to know anything about why they are highlighted. So before we release the main update in [Picasso forms](https://github.com/toptal/picasso/pull/3444), we want to update the name `highlightAutofill` 👉 `highlight` for better design

### How to test

- CI should be green

### Screenshots

`N/A`

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- `N/A` Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- `N/A` Annotate all `props` in component with documentation
- `N/A` Create `examples` for component
- `N/A` Ensure that deployed demo has expected results and good examples
- `N/A` Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- `N/A` Covered with tests

**Breaking change**

- `N/A` codemod is created and showcased in the changeset
- `N/A` test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-3780]: https://toptal-core.atlassian.net/browse/FX-3780?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ