### PR TITLE
chore(ci): update changeset config to handle new lines

### DIFF
--- a/.changeset/changelog.config.js
+++ b/.changeset/changelog.config.js
@@ -1,0 +1,101 @@
+const { changelogFunctions } = require('@changesets/changelog-github')
+const getGithubInfo = require('@changesets/get-github-info')
+
+const { getDependencyReleaseLine } = changelogFunctions
+
+// Modified copy of getReleaseLine from @changesets/changelog-github
+const getReleaseLine = async (changeset, type, options) => {
+  if (!options || !options.repo) {
+    throw new Error(
+      'Please provide a repo to this changelog generator like this:\n"changelog": ["@changesets/changelog-github", { "repo": "org/repo" }]'
+    )
+  }
+
+  let prFromSummary
+  let commitFromSummary
+  const usersFromSummary = []
+  const replacedChangelog = changeset.summary
+    .replace(/^\s*(?:pr|pull|pull\s+request):\s*#?(\d+)/im, (_, pr) => {
+      const num = Number(pr)
+
+      if (!isNaN(num)) {
+        prFromSummary = num
+      }
+
+      return ''
+    })
+    .replace(/^\s*commit:\s*([^\s]+)/im, (_, commit) => {
+      commitFromSummary = commit
+
+      return ''
+    })
+    .replace(/^\s*(?:author|user):\s*@?([^\s]+)/gim, (_, user) => {
+      usersFromSummary.push(user)
+
+      return ''
+    })
+    .trim()
+  const [firstLine, ...futureLines] = replacedChangelog
+    .split('\n')
+    .map(line => line.trimRight())
+  const links = await (async () => {
+    if (prFromSummary !== undefined) {
+      let { links } = await getGithubInfo.getInfoFromPullRequest({
+        repo: options.repo,
+        pull: prFromSummary,
+      })
+
+      if (commitFromSummary) {
+        links = {
+          ...links,
+          commit: `[\`${commitFromSummary}\`](https://github.com/${options.repo}/commit/${commitFromSummary})`,
+        }
+      }
+
+      return links
+    }
+
+    const commitToFetchFrom = commitFromSummary || changeset.commit
+
+    if (commitToFetchFrom) {
+      const { links } = await getGithubInfo.getInfo({
+        repo: options.repo,
+        commit: commitToFetchFrom,
+      })
+
+      return links
+    }
+
+    return {
+      commit: null,
+      pull: null,
+      user: null,
+    }
+  })()
+  const users = usersFromSummary.length
+    ? usersFromSummary
+        .map(
+          userFromSummary =>
+            `[@${userFromSummary}](https://github.com/${userFromSummary})`
+        )
+        .join(', ')
+    : links.user
+  const prefix = [
+    links.pull === null ? '' : ` ${links.pull}`,
+    links.commit === null ? '' : ` ${links.commit}`,
+    users === null ? '' : ` Thanks ${users}!`,
+  ].join('')
+
+  // This is the only change from the original getReleaseLine,
+  // we make sure that the changelog description always starts with a new line
+  return `\n\n-${prefix ? prefix : ''}\n${firstLine}\n${futureLines
+    .map(line => `  ${line}`)
+    .join('\n')}`
+}
+
+module.exports = {
+  // Override the default getReleaseLine
+  getReleaseLine,
+  // Use original getDependencyReleaseLine from @changesets/changelog-github
+  getDependencyReleaseLine,
+}

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://unpkg.com/@changesets/config@1.6.1/schema.json",
-  "changelog": ["@changesets/changelog-github", { "repo": "toptal/picasso" }],
+  "changelog": ["./changelog.config.js", { "repo": "toptal/picasso" }],
   "commit": false,
   "linked": [],
   "access": "public",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "@babel/standalone": "^7.19.6",
     "@changesets/changelog-github": "^0.4.7",
     "@changesets/cli": "^2.22.0",
+    "@changesets/get-github-info": "^0.5.1",
     "@cypress/skip-test": "^2.6.1",
     "@storybook/addon-a11y": "^6.5.15",
     "@storybook/addon-viewport": "^6.5.15",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1323,9 +1323,9 @@
     semver "^5.4.1"
 
 "@changesets/get-github-info@^0.5.1":
-  version "0.5.1"
-  resolved "https://registry.yarnpkg.com/@changesets/get-github-info/-/get-github-info-0.5.1.tgz#5a20328b26f301b2193717abb32e73651e8811b7"
-  integrity sha512-w2yl3AuG+hFuEEmT6j1zDlg7GQLM/J2UxTmk0uJBMdRqHni4zXGe/vUlPfLom5KfX3cRfHc0hzGvloDPjWFNZw==
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/@changesets/get-github-info/-/get-github-info-0.5.2.tgz#0cde2cadba57db85c714dc303c077da919a574e5"
+  integrity sha512-JppheLu7S114aEs157fOZDjFqUDpm7eHdq5E8SSR0gUBTEK0cNSHsrSR5a66xs0z3RWuo46QvA3vawp8BxDHvg==
   dependencies:
     dataloader "^1.4.0"
     node-fetch "^2.5.0"


### PR DESCRIPTION
[FX-2779](https://toptal-core.atlassian.net/browse/FX-2779)

### Description

Updated changeset to use the custom changeset formatter to properly handle newlines in the changelog.

### How to test

There is no good way to test this, however, there are some steps to verify the changes:

- Take a look at the code
- Go to https://github.com/mkrl/changesets/commit/432e788243e37f120c396b0cb508594ea97da6a2 - this is a fork of changeset repo with the desired function updated
- Take a look at the changes made for the accurate comparison
- Run ` y test packages/changelog-github/src/index.test.ts`, you can play around with different changeset formats in the `getPicassoStyleChangeset` function

After merging, we should no longer see `---` in the changelog + lint rule for having extra line in the changelog can be disabled.

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| Insert screenshots or screen recordings | Insert screenshots or screen recordings |

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-2779]: https://toptal-core.atlassian.net/browse/FX-2779?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ