### PR TITLE
fix: set static date for visual tests

### DIFF
--- a/packages/picasso-forms/src/Form/story/HighlightAutofill.example.tsx
+++ b/packages/picasso-forms/src/Form/story/HighlightAutofill.example.tsx
@@ -20,6 +20,8 @@ const formConfig: FormConfigProps = {
   highlightAutofill: true,
 }
 
+const april2nd = new Date(2023, 3, 2)
+
 const Example = () => (
   <ConfigProvider value={formConfig}>
     <FormNonCompound
@@ -27,13 +29,13 @@ const Example = () => (
       initialValues={{
         'highlight-firstName': 'Bruce',
         'highlight-autocomplete': 'foo',
-        'highlight-datepicker': new Date(),
+        'highlight-datepicker': april2nd,
         'highlight-numberinput': 1,
         'highlight-passwordinput': 'password',
         'highlight-rte': '<p>Rich Text Editor</p>',
         'highlight-select': 'foo',
         'highlight-tagselector': 'foo',
-        'highlight-timepicker': new Date(),
+        'highlight-timepicker': april2nd,
       }}
     >
       <Input


### PR DESCRIPTION
[FX-NNNN]

### Description

We have flaky test, because of `new Date()`

### How to test

- CI should be green

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| Insert screenshots or screen recordings | Insert screenshots or screen recordings |

### Development checks

- `N/A` Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- `N/A` Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- `N/A` Make sure that additions and changes on design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- `N/A` Annotate all `props` in component with documentation
- `N/A` Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- `N/A` Covered with tests

**Breaking change**

- `N/A` codemod is created and showcased in the changeset
- `N/A` test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>
