### PR TITLE
fix: update toolbar when formatted word is deleted

### DIFF
--- a/.changeset/sweet-emus-punch.md
+++ b/.changeset/sweet-emus-punch.md
@@ -1,0 +1,9 @@
+---
+'@toptal/picasso': patch
+---
+
+---
+
+### RichTextEditor
+
+- fix bug when removing formatted word, it should also update the toolbar

--- a/cypress/component/RichTextEditor.spec.tsx
+++ b/cypress/component/RichTextEditor.spec.tsx
@@ -329,6 +329,22 @@ describe('RichTextEditor', () => {
       buttonShouldNotBeActive(cy.get('@boldButton'))
     })
   })
+  describe('when we delete inline formatted word in the middle of sentense', () => {
+    it('updates the toolbar state correctly', () => {
+      cy.mount(renderEditor(defaultProps))
+      setAliases()
+
+      cy.get('@editor').realClick()
+      cy.get('@editor').type('a ')
+
+      cy.get('@boldButton').realClick()
+      buttonShouldBeActive(cy.get('@boldButton'))
+      cy.get('@editor').type('b')
+      buttonShouldBeActive(cy.get('@boldButton'))
+      cy.get('@editor').type('{backspace}')
+      buttonShouldNotBeActive(cy.get('@boldButton'))
+    })
+  })
 
   describe('Form.RichTextEditor', () => {
     it('focuses editor on label click', () => {

--- a/cypress/component/RichTextEditor.spec.tsx
+++ b/cypress/component/RichTextEditor.spec.tsx
@@ -314,6 +314,22 @@ describe('RichTextEditor', () => {
     })
   })
 
+  describe('when we delete inline formatted word', () => {
+    it('updates the toolbar state correctly', () => {
+      cy.mount(renderEditor(defaultProps))
+      setAliases()
+
+      cy.get('@editor').realClick()
+      cy.get('@boldButton').realClick()
+
+      buttonShouldBeActive(cy.get('@boldButton'))
+      cy.get('@editor').type('b')
+      buttonShouldBeActive(cy.get('@boldButton'))
+      cy.get('@editor').type('{backspace}')
+      buttonShouldNotBeActive(cy.get('@boldButton'))
+    })
+  })
+
   describe('Form.RichTextEditor', () => {
     it('focuses editor on label click', () => {
       cy.mount(renderEditorInForm())

--- a/packages/picasso/src/QuillEditor/hooks/useDefaultValue/test.ts
+++ b/packages/picasso/src/QuillEditor/hooks/useDefaultValue/test.ts
@@ -42,7 +42,7 @@ describe('useDefaultValue', () => {
 
     expect(quill.clipboard.convert).toHaveBeenCalledWith(defaultValue)
     expect(quill.clipboard.convert).toHaveBeenCalledTimes(1)
-    expect(quill.setContents).toHaveBeenCalledWith(deltaMock, 'user')
+    expect(quill.setContents).toHaveBeenCalledWith(deltaMock, 'api')
     expect(quill.setContents).toHaveBeenCalledTimes(1)
     rerender()
     expect(quill.clipboard.convert).toHaveBeenCalledTimes(1)

--- a/packages/picasso/src/QuillEditor/hooks/useDefaultValue/useDefaultValue.tsx
+++ b/packages/picasso/src/QuillEditor/hooks/useDefaultValue/useDefaultValue.tsx
@@ -13,10 +13,9 @@ const useDefaultValue = ({ defaultValue, quill }: Props) => {
     if (!defaultValue || !quill || hasBeenCalled.current) {
       return
     }
-
     const delta = quill.clipboard.convert(defaultValue)
 
-    quill.setContents(delta, 'user')
+    quill.setContents(delta, 'api')
     hasBeenCalled.current = true
   }, [defaultValue, quill])
 }

--- a/packages/picasso/src/QuillEditor/hooks/useDisabledEditor/test.ts
+++ b/packages/picasso/src/QuillEditor/hooks/useDisabledEditor/test.ts
@@ -65,7 +65,7 @@ describe('useDisabledEditor', () => {
 
       expect(quill.clipboard.convert).toHaveBeenCalledWith(defaultValue)
       expect(quill.clipboard.convert).toHaveBeenCalledTimes(1)
-      expect(quill.setContents).toHaveBeenCalledWith(deltaMock, 'user')
+      expect(quill.setContents).toHaveBeenCalledWith(deltaMock, 'api')
       expect(quill.setContents).toHaveBeenCalledTimes(1)
       rerender()
       expect(quill.clipboard.convert).toHaveBeenCalledTimes(1)

--- a/packages/picasso/src/QuillEditor/utils/getEditorChangeHandler/getEditorChangeHandler.tsx
+++ b/packages/picasso/src/QuillEditor/utils/getEditorChangeHandler/getEditorChangeHandler.tsx
@@ -32,9 +32,7 @@ const handleNewLineAfterBlock = ({
 }
 
 const isDeleteOperation = (delta: DeltaStatic) => {
-  const delOperation = delta.ops?.[0].delete
-
-  return Boolean(delOperation)
+  return delta.ops?.some(obj => obj.delete)
 }
 
 const getEditorChangeHandler = (
@@ -58,9 +56,13 @@ const getEditorChangeHandler = (
       } else if (isFromUser) {
         handleNewLineAfterBlock({ latestDelta, quill, onSelectionChange })
 
+        console.log(latestDelta, false)
+
         // when removing formatted text, we automatically remove the format,
         // so we need to update the toolbar
         if (isDeleteOperation(latestDelta)) {
+          console.log(latestDelta)
+
           onSelectionChange(quill.getFormat() as FormatType)
         }
       }

--- a/packages/picasso/src/QuillEditor/utils/getEditorChangeHandler/getEditorChangeHandler.tsx
+++ b/packages/picasso/src/QuillEditor/utils/getEditorChangeHandler/getEditorChangeHandler.tsx
@@ -56,13 +56,9 @@ const getEditorChangeHandler = (
       } else if (isFromUser) {
         handleNewLineAfterBlock({ latestDelta, quill, onSelectionChange })
 
-        console.log(latestDelta, false)
-
         // when removing formatted text, we automatically remove the format,
         // so we need to update the toolbar
         if (isDeleteOperation(latestDelta)) {
-          console.log(latestDelta)
-
           onSelectionChange(quill.getFormat() as FormatType)
         }
       }

--- a/packages/picasso/src/QuillEditor/utils/getEditorChangeHandler/getEditorChangeHandler.tsx
+++ b/packages/picasso/src/QuillEditor/utils/getEditorChangeHandler/getEditorChangeHandler.tsx
@@ -31,10 +31,10 @@ const handleNewLineAfterBlock = ({
   }
 }
 
-const isDeleteOperationOfSelection = (delta: DeltaStatic) => {
+const isDeleteOperation = (delta: DeltaStatic) => {
   const delOperation = delta.ops?.[0].delete
 
-  return delOperation && delOperation > 1
+  return Boolean(delOperation)
 }
 
 const getEditorChangeHandler = (
@@ -58,7 +58,9 @@ const getEditorChangeHandler = (
       } else if (isFromUser) {
         handleNewLineAfterBlock({ latestDelta, quill, onSelectionChange })
 
-        if (isDeleteOperationOfSelection(latestDelta)) {
+        // when removing formatted text, we automatically remove the format,
+        // so we need to update the toolbar
+        if (isDeleteOperation(latestDelta)) {
           onSelectionChange(quill.getFormat() as FormatType)
         }
       }

--- a/packages/picasso/src/QuillEditor/utils/getEditorChangeHandler/getEditorChangeHandler.tsx
+++ b/packages/picasso/src/QuillEditor/utils/getEditorChangeHandler/getEditorChangeHandler.tsx
@@ -52,7 +52,9 @@ const getEditorChangeHandler = (
       if (isFromApi) {
         // this event is triggered when format of block element is changed
         // for example from p > h3 | h3 > ol
-        onSelectionChange(quill.getFormat() as FormatType)
+        if (!latestDelta.ops?.[latestDelta.ops.length - 1].delete) {
+          onSelectionChange(quill.getFormat() as FormatType)
+        }
       } else if (isFromUser) {
         handleNewLineAfterBlock({ latestDelta, quill, onSelectionChange })
 


### PR DESCRIPTION
[FX-2895]

### Description

Bug fix

**Steps to reproduce:**

- write “test bold” into the RichTextEditor
- bold icon in the toolbar is active
- manually remove the “bold” text
- write “this should not be bold”


**expected:**

- text is not bold
- bold button in toolbar is not active

### How to test

- apply the reproducing steps in the storybook

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests

**Breaking change**

- [x] codemod is created and showcased in the changeset
- [x] test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-2895]: https://toptal-core.atlassian.net/browse/FX-2895?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ