### PR TITLE
fix(Stepper): always show active Step's StepLabel

### DIFF
--- a/.changeset/little-pillows-clean.md
+++ b/.changeset/little-pillows-clean.md
@@ -1,0 +1,9 @@
+---
+'@toptal/picasso': patch
+---
+
+---
+
+### Stepper
+
+- always show active Step's StepLabel

--- a/packages/picasso/src/StepLabel/StepLabel.tsx
+++ b/packages/picasso/src/StepLabel/StepLabel.tsx
@@ -57,6 +57,7 @@ export const StepLabel = (props: Props) => {
         }),
         label: cx({
           [classes.hidden]: hideLabel && !active,
+          [classes.hiddenOnMobile]: !active,
           [classes.labelOverflowEllipsis]: withOverflowEllipsis,
         }),
       }}

--- a/packages/picasso/src/StepLabel/styles.ts
+++ b/packages/picasso/src/StepLabel/styles.ts
@@ -26,6 +26,11 @@ export default ({ palette, breakpoints: { down } }: Theme) =>
     hidden: {
       display: 'none',
     },
+    hiddenOnMobile: {
+      [down(breakpoints.small)]: {
+        display: 'none',
+      },
+    },
     labelContainerOverflowEllipsis: {
       display: 'grid',
     },
@@ -40,8 +45,5 @@ export default ({ palette, breakpoints: { down } }: Theme) =>
       fontWeight: 600,
       lineHeight: '1em',
       color: palette.grey.dark,
-      [down(breakpoints.small)]: {
-        display: 'none',
-      },
     },
   })

--- a/packages/picasso/src/Stepper/__snapshots__/test.tsx.snap
+++ b/packages/picasso/src/Stepper/__snapshots__/test.tsx.snap
@@ -35,7 +35,7 @@ exports[`Stepper render with all steps completed 1`] = `
             class="MuiStepLabel-labelContainer PicassoStepLabel-root"
           >
             <span
-              class="MuiTypography-root MuiStepLabel-label MuiTypography-body2 MuiTypography-displayBlock"
+              class="MuiTypography-root MuiStepLabel-label PicassoStepLabel-hiddenOnMobile MuiTypography-body2 MuiTypography-displayBlock"
             >
               <span
                 class="PicassoStepLabel-label"
@@ -82,7 +82,7 @@ exports[`Stepper render with all steps completed 1`] = `
             class="MuiStepLabel-labelContainer PicassoStepLabel-root"
           >
             <span
-              class="MuiTypography-root MuiStepLabel-label MuiTypography-body2 MuiTypography-displayBlock"
+              class="MuiTypography-root MuiStepLabel-label PicassoStepLabel-hiddenOnMobile MuiTypography-body2 MuiTypography-displayBlock"
             >
               <span
                 class="PicassoStepLabel-label"
@@ -129,7 +129,7 @@ exports[`Stepper render with all steps completed 1`] = `
             class="MuiStepLabel-labelContainer PicassoStepLabel-root"
           >
             <span
-              class="MuiTypography-root MuiStepLabel-label MuiTypography-body2 MuiTypography-displayBlock"
+              class="MuiTypography-root MuiStepLabel-label PicassoStepLabel-hiddenOnMobile MuiTypography-body2 MuiTypography-displayBlock"
             >
               <span
                 class="PicassoStepLabel-label"
@@ -176,7 +176,7 @@ exports[`Stepper render with all steps completed 1`] = `
             class="MuiStepLabel-labelContainer PicassoStepLabel-root"
           >
             <span
-              class="MuiTypography-root MuiStepLabel-label MuiTypography-body2 MuiTypography-displayBlock"
+              class="MuiTypography-root MuiStepLabel-label PicassoStepLabel-hiddenOnMobile MuiTypography-body2 MuiTypography-displayBlock"
             >
               <span
                 class="PicassoStepLabel-label"
@@ -227,7 +227,7 @@ exports[`Stepper render with hidden labels 1`] = `
             class="MuiStepLabel-labelContainer"
           >
             <span
-              class="MuiTypography-root MuiStepLabel-label PicassoStepLabel-hidden MuiTypography-body2 MuiTypography-displayBlock"
+              class="MuiTypography-root MuiStepLabel-label PicassoStepLabel-hidden PicassoStepLabel-hiddenOnMobile MuiTypography-body2 MuiTypography-displayBlock"
             >
               <span
                 class="PicassoStepLabel-label"
@@ -274,7 +274,7 @@ exports[`Stepper render with hidden labels 1`] = `
             class="MuiStepLabel-labelContainer"
           >
             <span
-              class="MuiTypography-root MuiStepLabel-label PicassoStepLabel-hidden MuiTypography-body2 MuiTypography-displayBlock"
+              class="MuiTypography-root MuiStepLabel-label PicassoStepLabel-hidden PicassoStepLabel-hiddenOnMobile MuiTypography-body2 MuiTypography-displayBlock"
             >
               <span
                 class="PicassoStepLabel-label"
@@ -321,7 +321,7 @@ exports[`Stepper render with hidden labels 1`] = `
             class="MuiStepLabel-labelContainer"
           >
             <span
-              class="MuiTypography-root MuiStepLabel-label PicassoStepLabel-hidden MuiTypography-body2 MuiTypography-displayBlock"
+              class="MuiTypography-root MuiStepLabel-label PicassoStepLabel-hidden PicassoStepLabel-hiddenOnMobile MuiTypography-body2 MuiTypography-displayBlock"
             >
               <span
                 class="PicassoStepLabel-label"
@@ -368,7 +368,7 @@ exports[`Stepper render with hidden labels 1`] = `
             class="MuiStepLabel-labelContainer"
           >
             <span
-              class="MuiTypography-root MuiStepLabel-label PicassoStepLabel-hidden MuiTypography-body2 MuiTypography-displayBlock"
+              class="MuiTypography-root MuiStepLabel-label PicassoStepLabel-hidden PicassoStepLabel-hiddenOnMobile MuiTypography-body2 MuiTypography-displayBlock"
             >
               <span
                 class="PicassoStepLabel-label"
@@ -419,7 +419,7 @@ exports[`Stepper renders 1`] = `
             class="MuiStepLabel-labelContainer PicassoStepLabel-root"
           >
             <span
-              class="MuiTypography-root MuiStepLabel-label MuiTypography-body2 MuiTypography-displayBlock"
+              class="MuiTypography-root MuiStepLabel-label PicassoStepLabel-hiddenOnMobile MuiTypography-body2 MuiTypography-displayBlock"
             >
               <span
                 class="PicassoStepLabel-label"
@@ -466,7 +466,7 @@ exports[`Stepper renders 1`] = `
             class="MuiStepLabel-labelContainer PicassoStepLabel-root"
           >
             <span
-              class="MuiTypography-root MuiStepLabel-label MuiTypography-body2 MuiTypography-displayBlock"
+              class="MuiTypography-root MuiStepLabel-label PicassoStepLabel-hiddenOnMobile MuiTypography-body2 MuiTypography-displayBlock"
             >
               <span
                 class="PicassoStepLabel-label"
@@ -540,7 +540,7 @@ exports[`Stepper renders 1`] = `
             class="MuiStepLabel-labelContainer PicassoStepLabel-root"
           >
             <span
-              class="MuiTypography-root MuiStepLabel-label MuiTypography-body2 MuiTypography-displayBlock"
+              class="MuiTypography-root MuiStepLabel-label PicassoStepLabel-hiddenOnMobile MuiTypography-body2 MuiTypography-displayBlock"
             >
               <span
                 class="PicassoStepLabel-label"

--- a/packages/picasso/src/StepperVertical/__snapshots__/test.tsx.snap
+++ b/packages/picasso/src/StepperVertical/__snapshots__/test.tsx.snap
@@ -35,7 +35,7 @@ exports[`StepperVertical render with all steps completed 1`] = `
             class="MuiStepLabel-labelContainer PicassoStepLabel-root"
           >
             <span
-              class="MuiTypography-root MuiStepLabel-label MuiTypography-body2 MuiTypography-displayBlock"
+              class="MuiTypography-root MuiStepLabel-label PicassoStepLabel-hiddenOnMobile MuiTypography-body2 MuiTypography-displayBlock"
             >
               <span
                 class="PicassoStepLabel-label"
@@ -76,7 +76,7 @@ exports[`StepperVertical render with all steps completed 1`] = `
             class="MuiStepLabel-labelContainer PicassoStepLabel-root"
           >
             <span
-              class="MuiTypography-root MuiStepLabel-label MuiTypography-body2 MuiTypography-displayBlock"
+              class="MuiTypography-root MuiStepLabel-label PicassoStepLabel-hiddenOnMobile MuiTypography-body2 MuiTypography-displayBlock"
             >
               <span
                 class="PicassoStepLabel-label"
@@ -117,7 +117,7 @@ exports[`StepperVertical render with all steps completed 1`] = `
             class="MuiStepLabel-labelContainer PicassoStepLabel-root"
           >
             <span
-              class="MuiTypography-root MuiStepLabel-label MuiTypography-body2 MuiTypography-displayBlock"
+              class="MuiTypography-root MuiStepLabel-label PicassoStepLabel-hiddenOnMobile MuiTypography-body2 MuiTypography-displayBlock"
             >
               <span
                 class="PicassoStepLabel-label"
@@ -158,7 +158,7 @@ exports[`StepperVertical render with all steps completed 1`] = `
             class="MuiStepLabel-labelContainer PicassoStepLabel-root"
           >
             <span
-              class="MuiTypography-root MuiStepLabel-label MuiTypography-body2 MuiTypography-displayBlock"
+              class="MuiTypography-root MuiStepLabel-label PicassoStepLabel-hiddenOnMobile MuiTypography-body2 MuiTypography-displayBlock"
             >
               <span
                 class="PicassoStepLabel-label"
@@ -209,7 +209,7 @@ exports[`StepperVertical renders 1`] = `
             class="MuiStepLabel-labelContainer PicassoStepLabel-root"
           >
             <span
-              class="MuiTypography-root MuiStepLabel-label MuiTypography-body2 MuiTypography-displayBlock"
+              class="MuiTypography-root MuiStepLabel-label PicassoStepLabel-hiddenOnMobile MuiTypography-body2 MuiTypography-displayBlock"
             >
               <span
                 class="PicassoStepLabel-label"
@@ -250,7 +250,7 @@ exports[`StepperVertical renders 1`] = `
             class="MuiStepLabel-labelContainer PicassoStepLabel-root"
           >
             <span
-              class="MuiTypography-root MuiStepLabel-label MuiTypography-body2 MuiTypography-displayBlock"
+              class="MuiTypography-root MuiStepLabel-label PicassoStepLabel-hiddenOnMobile MuiTypography-body2 MuiTypography-displayBlock"
             >
               <span
                 class="PicassoStepLabel-label"
@@ -312,7 +312,7 @@ exports[`StepperVertical renders 1`] = `
             class="MuiStepLabel-labelContainer PicassoStepLabel-root"
           >
             <span
-              class="MuiTypography-root MuiStepLabel-label MuiTypography-body2 MuiTypography-displayBlock"
+              class="MuiTypography-root MuiStepLabel-label PicassoStepLabel-hiddenOnMobile MuiTypography-body2 MuiTypography-displayBlock"
             >
               <span
                 class="PicassoStepLabel-label"


### PR DESCRIPTION
[FX-3885]
[EXP-2638]

### Description

This PR fixes the issue where the `StepLabel` of an active `Step` is hidden on mobile resolutions

### How to test

- visit https://picasso.toptal.net/EXP-2638-always-show-active-stepper-label-on-mobile/?path=/story/components-stepper--stepper
- resize the page to a width below 576px
- verify that only the labels for non-active step are hidden

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| ![image](https://user-images.githubusercontent.com/291348/231813978-5936e959-9e57-4706-9c57-84656eae8bbf.png) | ![image](https://user-images.githubusercontent.com/291348/231813431-ed08e28f-15e0-46ba-a6b1-cbd75fbf3c18.png) |

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [n/a] Annotate all `props` in component with documentation
- [n/a] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [n/a] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests

**Breaking change**

- [n/a] codemod is created and showcased in the changeset
- [n/a] test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-3885]: https://toptal-core.atlassian.net/browse/FX-3885?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[EXP-2638]: https://toptal-core.atlassian.net/browse/EXP-2638?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ