### PR TITLE
feat: support emojis and custom emojis in richtexteditor

### DIFF
--- a/.changeset/selfish-kids-boil.md
+++ b/.changeset/selfish-kids-boil.md
@@ -1,0 +1,5 @@
+---
+'@toptal/picasso': minor
+---
+
+- implement emoji picker into RichTextEditor with support for native unicode emojis and custom emojis provided from external source as images

--- a/@types/quill-emoji/index.d.ts
+++ b/@types/quill-emoji/index.d.ts
@@ -1,0 +1,1 @@
+declare module 'quill-emoji'

--- a/package.json
+++ b/package.json
@@ -147,6 +147,6 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-test-renderer": "^18.2.0",
-    "quill-emoji/**/clean-css": "^4"
+    "**/quill-emoji/**/clean-css": "^4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -146,6 +146,7 @@
     "node-fetch": "^2.6.7",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-test-renderer": "^18.2.0"
+    "react-test-renderer": "^18.2.0",
+    "quill-emoji/**/clean-css": "^4"
   }
 }

--- a/packages/picasso/package.json
+++ b/packages/picasso/package.json
@@ -31,6 +31,8 @@
     "typescript": "~4.7.0"
   },
   "dependencies": {
+    "@emoji-mart/data": "^1.1.2",
+    "@emoji-mart/react": "^1.1.1",
     "@toptal/picasso-shared": "11.3.0",
     "ap-style-title-case": "^1.1.2",
     "classnames": "^2.3.1",
@@ -41,12 +43,14 @@
     "date-fns-tz": "^2.0.0",
     "debounce": "^1.2.1",
     "detect-browser": "^5.3.0",
+    "emoji-mart": "^5.5.2",
     "glider-js": "^1.7.8",
     "hast-to-hyperscript": "^9.0.1",
     "hast-util-from-dom": "^3.0.0",
     "hast-util-sanitize": "^3.0.2",
     "hast-util-to-html": "^7.1.3",
     "quill": "^1.3.7",
+    "quill-emoji": "^0.2.0",
     "quill-paste-smart": "^1.4.9",
     "react-content-loader": "^6.2.1",
     "react-dropzone": "^11.4.0",

--- a/packages/picasso/src/QuillEditor/QuillEditor.tsx
+++ b/packages/picasso/src/QuillEditor/QuillEditor.tsx
@@ -52,7 +52,11 @@ const QuillEditor = forwardRef<HTMLDivElement, Props>(function QuillEditor(
   },
   ref
 ) {
-  const quill = useQuillInstance({ id, placeholder, plugins })
+  const quill = useQuillInstance({
+    id,
+    placeholder,
+    plugins,
+  })
   const editorRef = useCombinedRefs<HTMLDivElement>(
     ref,
     useRef<HTMLDivElement>(null)

--- a/packages/picasso/src/QuillEditor/blots/emoji.ts
+++ b/packages/picasso/src/QuillEditor/blots/emoji.ts
@@ -1,0 +1,32 @@
+import Quill from 'quill'
+
+const EmbedBlot = Quill.import('blots/embed')
+
+export class EmojiBlot extends EmbedBlot {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  static create(data: any) {
+    console.log(data)
+    const node = super.create(data)
+
+    node.setAttribute('data-src', data.src)
+    node.setAttribute('data-emoji-name', data.emojiId)
+    node.setAttribute('src', data.src)
+    node.setAttribute('width', data.width)
+    node.setAttribute('height', data.height)
+    node.setAttribute('style', data.style)
+    console.log(node)
+
+    return node
+  }
+  static value(domNode: {
+    dataset: { src: string; width: number; height: number }
+  }) {
+    const { src, width, height } = domNode.dataset
+
+    return { src, width, height }
+  }
+}
+
+EmojiBlot.blotName = 'emojiBlot'
+EmojiBlot.className = 'emoji-blot'
+EmojiBlot.tagName = 'img'

--- a/packages/picasso/src/QuillEditor/blots/emoji.ts
+++ b/packages/picasso/src/QuillEditor/blots/emoji.ts
@@ -5,24 +5,20 @@ const EmbedBlot = Quill.import('blots/embed')
 export class EmojiBlot extends EmbedBlot {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   static create(data: any) {
-    console.log(data)
     const node = super.create(data)
 
     node.setAttribute('data-src', data.src)
     node.setAttribute('data-emoji-name', data.emojiId)
     node.setAttribute('src', data.src)
-    node.setAttribute('width', data.width)
-    node.setAttribute('height', data.height)
     node.setAttribute('class', 'emoji-icon')
 
     return node
   }
-  static value(domNode: {
-    dataset: { src: string; width: number; height: number }
-  }) {
-    const { src, width, height } = domNode.dataset
 
-    return { src, width, height }
+  static value(domNode: { dataset: { src: string } }) {
+    const { src } = domNode.dataset
+
+    return { src }
   }
 }
 

--- a/packages/picasso/src/QuillEditor/blots/emoji.ts
+++ b/packages/picasso/src/QuillEditor/blots/emoji.ts
@@ -13,8 +13,7 @@ export class EmojiBlot extends EmbedBlot {
     node.setAttribute('src', data.src)
     node.setAttribute('width', data.width)
     node.setAttribute('height', data.height)
-    node.setAttribute('style', data.style)
-    console.log(node)
+    node.setAttribute('class', 'emoji-icon')
 
     return node
   }

--- a/packages/picasso/src/QuillEditor/constants.ts
+++ b/packages/picasso/src/QuillEditor/constants.ts
@@ -1,2 +1,3 @@
 export const CUSTOM_QUILL_EDITOR_FORMAT_EVENT = 'quill-editor-format'
 export const INSERT_DEFAULT_LINK_TEXT = 'quill-editor-insert-default-link-text'
+export const INSERT_EMOJI = 'quill-editor-insert-emoji'

--- a/packages/picasso/src/QuillEditor/hooks/useQuillInstance/useQuillInstance.tsx
+++ b/packages/picasso/src/QuillEditor/hooks/useQuillInstance/useQuillInstance.tsx
@@ -10,6 +10,7 @@ import {
   makeLinkFormat,
 } from '../../formats'
 import type { EditorPlugin } from '../../types'
+import { EmojiBlot } from '../../blots/emoji'
 
 export type EditorOptionsType = {
   id: string
@@ -21,6 +22,7 @@ export const getModules = (
   plugins: EditorOptionsType['plugins']
 ): QuillOptionsStatic['modules'] => {
   const allowLinks = plugins?.includes('link')
+  const allowEmojis = plugins?.includes('emoji')
 
   const allowedTags = [
     'b',
@@ -39,6 +41,11 @@ export const getModules = (
   if (allowLinks) {
     allowedTags.push('a')
     allowedAttributes.push('href')
+  }
+
+  if (allowEmojis) {
+    allowedTags.push('img')
+    allowedAttributes.push('src', 'width', 'height', 'style')
   }
 
   return {
@@ -135,6 +142,7 @@ const Inline = Quill.import('blots/inline')
 // Lower index means deeper in the DOM tree, since not found (-1) is for embeds
 Inline.order = [
   'cursor',
+  'emojiBlot',
   'link',
   'inline', // Must be lower
   'underline',
@@ -158,6 +166,13 @@ const useQuillInstance = ({
 
     Quill.register(makeHeaderFormat(typographyClasses), true)
     Quill.register(makeBoldFormat(typographyClasses), true)
+
+    const allowEmojis = plugins?.includes('emoji')
+
+    if (allowEmojis) {
+      Quill.register({ 'formats/emojiBlot': EmojiBlot }, true)
+      extendedFormats.push('image', 'emojiBlot')
+    }
 
     const allowLinks = plugins?.includes('link')
 

--- a/packages/picasso/src/QuillEditor/hooks/useQuillInstance/useQuillInstance.tsx
+++ b/packages/picasso/src/QuillEditor/hooks/useQuillInstance/useQuillInstance.tsx
@@ -45,7 +45,7 @@ export const getModules = (
 
   if (allowEmojis) {
     allowedTags.push('img')
-    allowedAttributes.push('src', 'width', 'height', 'style')
+    allowedAttributes.push('src', 'data-src', 'data-emoji-name', 'class')
   }
 
   return {

--- a/packages/picasso/src/QuillEditor/hooks/useSubscribeToTextEditorEvents/useSubscribeToTextEditorEvents.tsx
+++ b/packages/picasso/src/QuillEditor/hooks/useSubscribeToTextEditorEvents/useSubscribeToTextEditorEvents.tsx
@@ -78,8 +78,6 @@ const useSubscribeToTextEditorEvents = ({
       if (selection.length === 0) {
         quill.insertEmbed(selection.index, 'emojiBlot', {
           src,
-          width: 22,
-          height: 22,
           emojiId: id,
         })
 

--- a/packages/picasso/src/QuillEditor/hooks/useSubscribeToTextEditorEvents/useSubscribeToTextEditorEvents.tsx
+++ b/packages/picasso/src/QuillEditor/hooks/useSubscribeToTextEditorEvents/useSubscribeToTextEditorEvents.tsx
@@ -11,11 +11,12 @@ import getFormatChangeHandler from '../../utils/getFormatChangeHandler'
 type Emoji = {
   id: string
   name: string
-  native: string
+  native: string | undefined
   unified: string
   keywords: string[]
   shortcodes: string
   emoticons: string[]
+  src: string | undefined
 }
 
 const useSubscribeToTextEditorEvents = ({
@@ -60,12 +61,35 @@ const useSubscribeToTextEditorEvents = ({
         return
       }
 
-      const { native } = detail as Emoji
+      console.log({ detail })
+
+      const { native, src, id } = detail as Emoji
+
+      if (native) {
+        const selection = quill.getSelection(true) ?? { index: 0, length: 0 }
+
+        if (selection.length === 0) {
+          quill.insertText(selection.index, native)
+        }
+
+        return
+      }
 
       const selection = quill.getSelection(true) ?? { index: 0, length: 0 }
 
       if (selection.length === 0) {
-        quill.insertText(selection.index, native)
+        console.log({ src })
+
+        quill.insertEmbed(selection.index, 'emojiBlot', {
+          src,
+          width: 22,
+          height: 22,
+          emojiId: id,
+          // In order to preserve the paragraph line height and formatting, we need to set the vertical alignment of the image to be at the bottom:)
+          style: `vertical-align: bottom;`,
+        })
+
+        quill.setSelection(selection.index + 1, selection.length + 1)
       }
     },
     [quill]

--- a/packages/picasso/src/QuillEditor/hooks/useSubscribeToTextEditorEvents/useSubscribeToTextEditorEvents.tsx
+++ b/packages/picasso/src/QuillEditor/hooks/useSubscribeToTextEditorEvents/useSubscribeToTextEditorEvents.tsx
@@ -4,8 +4,19 @@ import type Quill from 'quill'
 import {
   CUSTOM_QUILL_EDITOR_FORMAT_EVENT,
   INSERT_DEFAULT_LINK_TEXT,
+  INSERT_EMOJI,
 } from '../../constants'
 import getFormatChangeHandler from '../../utils/getFormatChangeHandler'
+
+type Emoji = {
+  id: string
+  name: string
+  native: string
+  unified: string
+  keywords: string[]
+  shortcodes: string
+  emoticons: string[]
+}
 
 const useSubscribeToTextEditorEvents = ({
   editorRef,
@@ -43,6 +54,23 @@ const useSubscribeToTextEditorEvents = ({
     [quill]
   )
 
+  const insertEmoji = useCallback(
+    ({ detail }) => {
+      if (!quill) {
+        return
+      }
+
+      const { native } = detail as Emoji
+
+      const selection = quill.getSelection(true) ?? { index: 0, length: 0 }
+
+      if (selection.length === 0) {
+        quill.insertText(selection.index, native)
+      }
+    },
+    [quill]
+  )
+
   useEffect(() => {
     const editor = editorRef.current
 
@@ -62,6 +90,8 @@ const useSubscribeToTextEditorEvents = ({
       false
     )
 
+    editor.addEventListener(INSERT_EMOJI, insertEmoji, false)
+
     return () => {
       editor?.removeEventListener(
         CUSTOM_QUILL_EDITOR_FORMAT_EVENT,
@@ -73,8 +103,9 @@ const useSubscribeToTextEditorEvents = ({
         insertDefaultLinkText,
         false
       )
+      editor?.removeEventListener(INSERT_EMOJI, insertEmoji, false)
     }
-  }, [editorRef, formatChangeHandler, insertDefaultLinkText])
+  }, [editorRef, formatChangeHandler, insertDefaultLinkText, insertEmoji])
 }
 
 export default useSubscribeToTextEditorEvents

--- a/packages/picasso/src/QuillEditor/hooks/useSubscribeToTextEditorEvents/useSubscribeToTextEditorEvents.tsx
+++ b/packages/picasso/src/QuillEditor/hooks/useSubscribeToTextEditorEvents/useSubscribeToTextEditorEvents.tsx
@@ -61,8 +61,6 @@ const useSubscribeToTextEditorEvents = ({
         return
       }
 
-      console.log({ detail })
-
       const { native, src, id } = detail as Emoji
 
       if (native) {
@@ -78,15 +76,11 @@ const useSubscribeToTextEditorEvents = ({
       const selection = quill.getSelection(true) ?? { index: 0, length: 0 }
 
       if (selection.length === 0) {
-        console.log({ src })
-
         quill.insertEmbed(selection.index, 'emojiBlot', {
           src,
           width: 22,
           height: 22,
           emojiId: id,
-          // In order to preserve the paragraph line height and formatting, we need to set the vertical alignment of the image to be at the bottom:)
-          style: `vertical-align: bottom;`,
         })
 
         quill.setSelection(selection.index + 1, selection.length + 1)

--- a/packages/picasso/src/QuillEditor/types.ts
+++ b/packages/picasso/src/QuillEditor/types.ts
@@ -26,3 +26,19 @@ export type ChangeHandler = (html: string) => void
 export type TextLengthChangeHandler = (length: number) => void
 
 export type EditorPlugin = 'link' | 'emoji'
+
+export type CustomEmoji = {
+  id: string
+  name: string
+  keywords: string[]
+  skins: [
+    {
+      src: string
+    }
+  ]
+}
+export type CustomEmojiGroup = {
+  id: string
+  name: string
+  emojis: CustomEmoji[]
+}

--- a/packages/picasso/src/QuillEditor/types.ts
+++ b/packages/picasso/src/QuillEditor/types.ts
@@ -3,6 +3,7 @@ export type ItalicValue = boolean | undefined
 export type ListValue = 'bullet' | 'ordered' | undefined
 export type HeaderValue = 3 | undefined
 export type LinkValue = string | undefined
+export type EmojiValue = string
 
 export type FormatType = {
   bold: BoldValue
@@ -24,4 +25,4 @@ export type SelectionHandler = (format: FormatType) => void
 export type ChangeHandler = (html: string) => void
 export type TextLengthChangeHandler = (length: number) => void
 
-export type EditorPlugin = 'link'
+export type EditorPlugin = 'link' | 'emoji'

--- a/packages/picasso/src/QuillEditorView/styles.ts
+++ b/packages/picasso/src/QuillEditorView/styles.ts
@@ -158,6 +158,8 @@ const clipboard = {
 const emojiIcon = {
   '& .emoji-icon': {
     verticalAlign: 'bottom',
+    width: '22px',
+    height: '22px',
   },
 }
 

--- a/packages/picasso/src/QuillEditorView/styles.ts
+++ b/packages/picasso/src/QuillEditorView/styles.ts
@@ -155,11 +155,18 @@ const clipboard = {
   },
 }
 
+const emojiIcon = {
+  '& .emoji-icon': {
+    verticalAlign: 'bottom',
+  },
+}
+
 const quillSpecificStyles = (theme: Theme) => ({
   ...placeholder(theme),
   ...editor,
   ...hidden,
   ...clipboard,
+  ...emojiIcon,
 })
 
 export default (theme: Theme) => {

--- a/packages/picasso/src/RichText/hooks/useRichText/useRichText.tsx
+++ b/packages/picasso/src/RichText/hooks/useRichText/useRichText.tsx
@@ -1,6 +1,7 @@
 import toH from 'hast-to-hyperscript'
 import type { ReactElement, ReactNode, FC } from 'react'
 import React, { useMemo, createElement, isValidElement } from 'react'
+import { makeStyles } from '@material-ui/core'
 
 import type { ASTType } from '../../types'
 import Typography from '../../../Typography'
@@ -17,6 +18,14 @@ type Props = {
 const Li = ({ children, ...props }: Props) => (
   <ListItem {...props}>{children}</ListItem>
 )
+
+const useStyles = makeStyles({
+  emoji: {
+    width: 24,
+    height: 24,
+    verticalAlign: 'bottom',
+  },
+})
 
 /* eslint-disable id-length */
 const P = ({ children }: Props) => (
@@ -42,6 +51,11 @@ const H3 = ({ children }: Props) => (
 const Ul = ({ children }: Props) => <List variant='unordered'>{children}</List>
 const Ol = ({ children }: Props) => <List variant='ordered'>{children}</List>
 const A = ({ children, ...props }: Props) => <Link {...props}>{children}</Link>
+const Emoji = ({ ...props }: Props) => {
+  const classes = useStyles()
+
+  return <img className={classes.emoji} {...props} />
+}
 
 const componentMap: Record<string, FC> = {
   p: P,
@@ -52,6 +66,7 @@ const componentMap: Record<string, FC> = {
   ol: Ol,
   ul: Ul,
   a: A,
+  img: Emoji,
 } as const
 
 const picassoMapper = (child: ReactNode): ReactNode => {

--- a/packages/picasso/src/RichTextEditor/RichTextEditor.tsx
+++ b/packages/picasso/src/RichTextEditor/RichTextEditor.tsx
@@ -9,7 +9,7 @@ import hastSanitize from 'hast-util-sanitize'
 
 import noop from '../utils/noop'
 import Container from '../Container'
-import type { EditorPlugin } from '../QuillEditor'
+import type { CustomEmojiGroup, EditorPlugin } from '../QuillEditor'
 import QuillEditor from '../QuillEditor'
 import InputMultilineAdornment from '../InputMultilineAdornment'
 import Toolbar from '../RichTextEditorToolbar'
@@ -94,6 +94,7 @@ export interface Props extends BaseProps {
     orderedListButton?: string
   }
   highlight?: 'autofill'
+  customEmojis?: CustomEmojiGroup[]
 }
 
 const useStyles = makeStyles<Theme>(styles, {
@@ -125,6 +126,7 @@ export const RichTextEditor = forwardRef<HTMLDivElement, Props>(
       setHasMultilineCounter,
       name,
       highlight,
+      customEmojis,
     } = props
 
     const classes = useStyles()
@@ -183,6 +185,8 @@ export const RichTextEditor = forwardRef<HTMLDivElement, Props>(
     // declare the array outside the component level
     // eslint-disable-next-line react-hooks/exhaustive-deps
     const memoizedPlugins = useMemo(() => plugins, [])
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    const memoizedCustomEmojis = useMemo(() => customEmojis, [])
 
     useHasMultilineCounter(name, !!counterMessage, setHasMultilineCounter)
 
@@ -226,6 +230,7 @@ export const RichTextEditor = forwardRef<HTMLDivElement, Props>(
             onLinkClick={handleLink}
             onInsertEmoji={insertEmoji}
             plugins={memoizedPlugins}
+            customEmojis={memoizedCustomEmojis}
             testIds={{
               headerSelect: testIds?.headerSelect,
               boldButton: testIds?.boldButton,

--- a/packages/picasso/src/RichTextEditor/RichTextEditor.tsx
+++ b/packages/picasso/src/RichTextEditor/RichTextEditor.tsx
@@ -150,6 +150,7 @@ export const RichTextEditor = forwardRef<HTMLDivElement, Props>(
       handleOrdered,
       handleUnordered,
       handleLink,
+      insertEmoji,
     } = useToolbarHandlers({
       editorRef,
       handleTextFormat,
@@ -223,6 +224,7 @@ export const RichTextEditor = forwardRef<HTMLDivElement, Props>(
             onOrderedClick={handleOrdered}
             onHeaderChange={handleHeader}
             onLinkClick={handleLink}
+            onInsertEmoji={insertEmoji}
             plugins={memoizedPlugins}
             testIds={{
               headerSelect: testIds?.headerSelect,

--- a/packages/picasso/src/RichTextEditor/hooks/useToolbarHandlers/useToolbarHandlers.tsx
+++ b/packages/picasso/src/RichTextEditor/hooks/useToolbarHandlers/useToolbarHandlers.tsx
@@ -5,7 +5,10 @@ import type {
   FormatType as EditorFormatType,
 } from '../../../QuillEditor'
 import { CUSTOM_QUILL_EDITOR_FORMAT_EVENT } from '../../../QuillEditor'
-import { INSERT_DEFAULT_LINK_TEXT } from '../../../QuillEditor/constants'
+import {
+  INSERT_DEFAULT_LINK_TEXT,
+  INSERT_EMOJI,
+} from '../../../QuillEditor/constants'
 import type {
   SelectOnChangeHandler,
   ButtonHandlerType,
@@ -38,6 +41,17 @@ const useToolbarHandlers = ({ editorRef, handleTextFormat, format }: Props) => {
       })
 
       editorRef.current?.dispatchEvent(defaultLinkTextEvent)
+    },
+    [editorRef]
+  )
+
+  const sendInsertEmojiEvent = useCallback(
+    detail => {
+      const insertEmojiEvent = new CustomEvent(INSERT_EMOJI, {
+        detail,
+      })
+
+      editorRef.current?.dispatchEvent(insertEmojiEvent)
     },
     [editorRef]
   )
@@ -116,6 +130,10 @@ const useToolbarHandlers = ({ editorRef, handleTextFormat, format }: Props) => {
     })
   }
 
+  const insertEmoji = (emoji: any) => {
+    sendInsertEmojiEvent(emoji)
+  }
+
   return {
     handleBold,
     handleItalic,
@@ -123,6 +141,7 @@ const useToolbarHandlers = ({ editorRef, handleTextFormat, format }: Props) => {
     handleUnordered,
     handleHeader,
     handleLink,
+    insertEmoji,
   }
 }
 

--- a/packages/picasso/src/RichTextEditor/index.ts
+++ b/packages/picasso/src/RichTextEditor/index.ts
@@ -1,6 +1,7 @@
 import type { OmitInternalProps } from '@toptal/picasso-shared'
 
 import type { Props } from './RichTextEditor'
+export type { CustomEmojiGroup } from './types'
 
 export { default } from './RichTextEditor'
 export type { RichTextEditorChangeHandler } from './types'

--- a/packages/picasso/src/RichTextEditor/story/Emoji.example.tsx
+++ b/packages/picasso/src/RichTextEditor/story/Emoji.example.tsx
@@ -2,6 +2,27 @@ import React, { useState } from 'react'
 import type { RichTextEditorChangeHandler } from '@toptal/picasso'
 import { RichTextEditor, Container } from '@toptal/picasso'
 
+import type { CustomEmojiGroup } from '../types'
+
+const customEmojis = [
+  {
+    id: 'talent-community',
+    name: 'Talent Community',
+    emojis: [
+      {
+        id: 'talent-community',
+        name: 'Talent Community',
+        keywords: ['Toptal', 'Talent Community', 'Community'],
+        skins: [
+          {
+            src: 'https://emoji.slack-edge.com/T01HSMSV622/talent-community/3937b2735bdea8c3.png',
+          },
+        ],
+      },
+    ],
+  },
+] as CustomEmojiGroup[]
+
 const Example = () => {
   const [value, setValue] = useState<string | undefined>()
 
@@ -15,6 +36,7 @@ const Example = () => {
         onChange={handleChange}
         placeholder='Write some cool rich text with emojis!'
         plugins={['emoji']}
+        customEmojis={customEmojis}
       />
       <Container
         padded='small'

--- a/packages/picasso/src/RichTextEditor/story/Emoji.example.tsx
+++ b/packages/picasso/src/RichTextEditor/story/Emoji.example.tsx
@@ -1,0 +1,33 @@
+import React, { useState } from 'react'
+import type { RichTextEditorChangeHandler } from '@toptal/picasso'
+import { RichTextEditor, Container } from '@toptal/picasso'
+
+const Example = () => {
+  const [value, setValue] = useState<string | undefined>()
+
+  const handleChange: RichTextEditorChangeHandler = newValue =>
+    setValue(newValue)
+
+  return (
+    <>
+      <RichTextEditor
+        id='allow-emojis-editor'
+        onChange={handleChange}
+        placeholder='Write some cool rich text with emojis!'
+        plugins={['emoji']}
+      />
+      <Container
+        padded='small'
+        top='large'
+        style={{
+          fontFamily: "Consolas, 'Courier New', monospace",
+          background: 'lightyellow',
+        }}
+      >
+        {value}
+      </Container>
+    </>
+  )
+}
+
+export default Example

--- a/packages/picasso/src/RichTextEditor/story/index.jsx
+++ b/packages/picasso/src/RichTextEditor/story/index.jsx
@@ -33,3 +33,7 @@ page
     title: 'Links',
     takeScreenshot: false,
   })
+  .addExample('RichTextEditor/story/Emoji.example.tsx', {
+    title: 'Emojis',
+    takeScreenshot: false,
+  })

--- a/packages/picasso/src/RichTextEditor/types.ts
+++ b/packages/picasso/src/RichTextEditor/types.ts
@@ -7,3 +7,5 @@ export type CounterMessageSetter = (
   currLength: number,
   isError: boolean
 ) => string
+
+export type { CustomEmojiGroup, CustomEmoji } from '../QuillEditor'

--- a/packages/picasso/src/RichTextEditorButton/RichTextEditorButton.tsx
+++ b/packages/picasso/src/RichTextEditorButton/RichTextEditorButton.tsx
@@ -13,6 +13,7 @@ type Props = BaseProps & {
   disabled: boolean
   icon: ReactElement
   onClick: (e: React.MouseEvent<HTMLButtonElement>) => void
+  id?: string
 }
 
 // Using { index: 10 } to inject CSS generated classes after the button's classes

--- a/packages/picasso/src/RichTextEditorEmojiPicker/RichTextEditorEmojiPicker.tsx
+++ b/packages/picasso/src/RichTextEditorEmojiPicker/RichTextEditorEmojiPicker.tsx
@@ -4,10 +4,10 @@ import data from '@emoji-mart/data'
 import Picker from '@emoji-mart/react'
 import type { Theme } from '@material-ui/core'
 import { makeStyles } from '@material-ui/core'
+import cx from 'classnames'
 
 import Container from '../Container'
 import TextEditorButton from '../RichTextEditorButton'
-import styles from '../Icon/styles'
 import type { CustomEmojiGroup } from '../QuillEditor'
 
 interface Props {
@@ -18,6 +18,23 @@ interface Props {
 
 const TRIGGER_EMOJI_PICKER_ID = 'trigger-emoji-picker'
 
+interface StyleProps {
+  showEmojiPicker: boolean
+}
+
+const useStyles = makeStyles<Theme, StyleProps>({
+  emojiPicker: {
+    position: 'absolute',
+    top: 34,
+    left: 0,
+    zIndex: 10,
+    opacity: 0,
+    pointerEvents: 'none',
+  },
+  activeOpacity: { opacity: 1 },
+  activePointers: { pointerEvents: 'all' },
+})
+
 const handleEmojiPickerEscBehaviour = (
   event: KeyboardEvent,
   setShowEmojiPicker: React.Dispatch<React.SetStateAction<boolean>>
@@ -27,10 +44,6 @@ const handleEmojiPickerEscBehaviour = (
   }
 }
 
-const useStyles = makeStyles<Theme, Omit<Props, 'customEmojis'>>(styles, {
-  name: 'RichTextEditorToolbar',
-})
-
 export const RichtTextEditorEmojiPicker = ({
   richEditorId,
   customEmojis,
@@ -38,10 +51,7 @@ export const RichtTextEditorEmojiPicker = ({
 }: Props) => {
   const [showEmojiPicker, setShowEmojiPicker] = React.useState(false)
 
-  const classes = useStyles({
-    richEditorId,
-    onInsertEmoji,
-  })
+  const classes = useStyles({ showEmojiPicker })
 
   const handleEmojiPickerClick = () => {
     setShowEmojiPicker(!showEmojiPicker)
@@ -73,21 +83,18 @@ export const RichtTextEditorEmojiPicker = ({
   }, [showEmojiPicker, setShowEmojiPicker])
 
   return (
-    <Container className={classes.group} style={{ position: 'relative' }}>
+    <Container style={{ position: 'relative' }}>
       <TextEditorButton
         onClick={handleEmojiPickerClick}
         icon={<Container style={{ pointerEvents: 'none' }}>🙂</Container>}
         id={TRIGGER_EMOJI_PICKER_ID}
       />
       <Container
-        style={{
-          position: 'absolute',
-          top: 34,
-          left: 0,
-          zIndex: 10,
-          opacity: showEmojiPicker ? 1 : 0,
-          pointerEvents: showEmojiPicker ? 'all' : 'none',
-        }}
+        className={cx(
+          classes.emojiPicker,
+          showEmojiPicker && classes.activeOpacity,
+          showEmojiPicker && classes.activePointers
+        )}
       >
         <Picker
           id={`emoji-picker-${richEditorId}`}

--- a/packages/picasso/src/RichTextEditorEmojiPicker/RichTextEditorEmojiPicker.tsx
+++ b/packages/picasso/src/RichTextEditorEmojiPicker/RichTextEditorEmojiPicker.tsx
@@ -1,0 +1,104 @@
+import React, { useEffect } from 'react'
+import data from '@emoji-mart/data'
+import Picker from '@emoji-mart/react'
+import type { Theme } from '@material-ui/core'
+import { makeStyles } from '@material-ui/core'
+
+import Container from '../Container'
+import TextEditorButton from '../RichTextEditorButton'
+import styles from '../Icon/styles'
+
+interface Props {
+  onInsertEmoji: (emoji: string) => void
+}
+
+const EMOJI_PICKER_LOCAL_NAME = 'em-emoji-picker'
+const TRIGGER_EMOJI_PICKER_ID = 'trigger-emoji-picker'
+
+const handleEmojiPickerBehaviour = (
+  event: MouseEvent,
+  showEmojiPicker: boolean,
+  setShowEmojiPicker: React.Dispatch<React.SetStateAction<boolean>>
+) => {
+  if (!showEmojiPicker) {
+    return
+  }
+
+  // If we click on the trigger but the picker is shown, we should do nothing
+  // @ts-ignore
+  if (event.target.offsetParent.id === TRIGGER_EMOJI_PICKER_ID) {
+    return
+  }
+
+  // If we click on the emoji picker custom component, we should keep it open :)
+  // @ts-ignore
+  if (event.target.localName === EMOJI_PICKER_LOCAL_NAME) {
+    return
+  }
+
+  setShowEmojiPicker(false)
+}
+
+const handleEmojiPickerEscBehaviour = (
+  event: KeyboardEvent,
+  setShowEmojiPicker: React.Dispatch<React.SetStateAction<boolean>>
+) => {
+  if (event.key === 'Escape') {
+    setShowEmojiPicker(false)
+  }
+}
+
+const useStyles = makeStyles<Theme, Props>(styles, {
+  name: 'RichTextEditorToolbar',
+})
+
+export const RichtTextEditorEmojiPicker = ({ onInsertEmoji }: Props) => {
+  const [showEmojiPicker, setShowEmojiPicker] = React.useState(false)
+
+  const classes = useStyles({
+    onInsertEmoji,
+  })
+
+  const handleEmojiPickerClick = () => {
+    setShowEmojiPicker(!showEmojiPicker)
+  }
+
+  useEffect(() => {
+    if (!showEmojiPicker) {
+      return
+    }
+
+    document.body.addEventListener('keyup', event => {
+      handleEmojiPickerEscBehaviour(event, setShowEmojiPicker)
+    })
+    document.body.addEventListener('click', event => {
+      handleEmojiPickerBehaviour(event, showEmojiPicker, setShowEmojiPicker)
+    })
+
+    return () => {
+      document.body.removeEventListener('click', event => {
+        handleEmojiPickerBehaviour(event, showEmojiPicker, setShowEmojiPicker)
+      })
+      document.body.removeEventListener('keyup', event => {
+        handleEmojiPickerEscBehaviour(event, setShowEmojiPicker)
+      })
+    }
+  }, [showEmojiPicker, setShowEmojiPicker])
+
+  return (
+    <Container className={classes.group} style={{ position: 'relative' }}>
+      <TextEditorButton
+        onClick={handleEmojiPickerClick}
+        icon={<Container style={{ pointerEvents: 'none' }}>🙂</Container>}
+        id={TRIGGER_EMOJI_PICKER_ID}
+      />
+      {showEmojiPicker && (
+        <Container
+          style={{ position: 'absolute', top: 34, left: 0, zIndex: 10 }}
+        >
+          <Picker data={data} onEmojiSelect={onInsertEmoji} />
+        </Container>
+      )}
+    </Container>
+  )
+}

--- a/packages/picasso/src/RichTextEditorToolbar/RichTextEditorToolbar.tsx
+++ b/packages/picasso/src/RichTextEditorToolbar/RichTextEditorToolbar.tsx
@@ -20,6 +20,7 @@ import type {
   FormatType,
 } from './types'
 import type { EditorPlugin } from '../QuillEditor'
+import { RichtTextEditorEmojiPicker } from '../RichTextEditorEmojiPicker/RichTextEditorEmojiPicker'
 
 type Props = {
   disabled: boolean
@@ -32,10 +33,12 @@ type Props = {
     unorderedListButton?: string
     orderedListButton?: string
     linkButton?: string
+    emojiButton?: string
   }
   onBoldClick: ButtonHandlerType
   onItalicClick: ButtonHandlerType
   onLinkClick: ButtonHandlerType
+  onInsertEmoji: (emoji: string) => void
   onHeaderChange: SelectOnChangeHandler
   onUnorderedClick: ButtonHandlerType
   onOrderedClick: ButtonHandlerType
@@ -55,6 +58,7 @@ export const RichTextEditorToolbar = forwardRef<HTMLDivElement, Props>(
       onBoldClick,
       onItalicClick,
       onLinkClick,
+      onInsertEmoji,
       onHeaderChange,
       onUnorderedClick,
       onOrderedClick,
@@ -66,6 +70,7 @@ export const RichTextEditorToolbar = forwardRef<HTMLDivElement, Props>(
     const isHeadingFormat = format.header === '3'
 
     const allowLinks = plugins?.includes('link')
+    const allowEmojis = plugins?.includes('emoji')
 
     return (
       <Container id={`${id}toolbar`} ref={ref} className={classes.toolbar}>
@@ -130,6 +135,9 @@ export const RichTextEditorToolbar = forwardRef<HTMLDivElement, Props>(
               data-testid={testIds?.linkButton}
             />
           </Container>
+        )}
+        {allowEmojis && (
+          <RichtTextEditorEmojiPicker onInsertEmoji={onInsertEmoji} />
         )}
       </Container>
     )

--- a/packages/picasso/src/RichTextEditorToolbar/RichTextEditorToolbar.tsx
+++ b/packages/picasso/src/RichTextEditorToolbar/RichTextEditorToolbar.tsx
@@ -19,7 +19,7 @@ import type {
   SelectOnChangeHandler,
   FormatType,
 } from './types'
-import type { EditorPlugin } from '../QuillEditor'
+import type { CustomEmojiGroup, EditorPlugin } from '../QuillEditor'
 import { RichtTextEditorEmojiPicker } from '../RichTextEditorEmojiPicker/RichTextEditorEmojiPicker'
 
 type Props = {
@@ -43,6 +43,7 @@ type Props = {
   onUnorderedClick: ButtonHandlerType
   onOrderedClick: ButtonHandlerType
   plugins?: EditorPlugin[]
+  customEmojis?: CustomEmojiGroup[]
 }
 
 const useStyles = makeStyles<Theme, Props>(styles, {
@@ -64,6 +65,7 @@ export const RichTextEditorToolbar = forwardRef<HTMLDivElement, Props>(
       onOrderedClick,
       testIds,
       plugins,
+      customEmojis,
     } = props
 
     const classes = useStyles(props)
@@ -137,7 +139,11 @@ export const RichTextEditorToolbar = forwardRef<HTMLDivElement, Props>(
           </Container>
         )}
         {allowEmojis && (
-          <RichtTextEditorEmojiPicker onInsertEmoji={onInsertEmoji} />
+          <RichtTextEditorEmojiPicker
+            richEditorId={id}
+            customEmojis={customEmojis}
+            onInsertEmoji={onInsertEmoji}
+          />
         )}
       </Container>
     )

--- a/packages/picasso/src/utils/html-to-hast.ts
+++ b/packages/picasso/src/utils/html-to-hast.ts
@@ -13,8 +13,9 @@ export const hastSanitizeSchema: Schema = {
   attributes: {
     '*': [],
     a: ['href'],
+    img: ['src', 'data-src', 'data-emoji-name', 'width', 'height', 'class'],
   },
-  tagNames: ['h3', 'p', 'br', 'strong', 'em', 'ul', 'ol', 'li', 'a'],
+  tagNames: ['h3', 'p', 'br', 'strong', 'em', 'ul', 'ol', 'li', 'a', 'img'],
   strip: ['script'],
 }
 

--- a/packages/picasso/src/utils/html-to-hast.ts
+++ b/packages/picasso/src/utils/html-to-hast.ts
@@ -13,7 +13,7 @@ export const hastSanitizeSchema: Schema = {
   attributes: {
     '*': [],
     a: ['href'],
-    img: ['src', 'data-src', 'data-emoji-name', 'width', 'height', 'class'],
+    img: ['src', 'data-src', 'data-emoji-name', 'class'],
   },
   tagNames: ['h3', 'p', 'br', 'strong', 'em', 'ul', 'ol', 'li', 'a', 'img'],
   strip: ['script'],

--- a/yarn.lock
+++ b/yarn.lock
@@ -1665,6 +1665,16 @@
   resolved "https://registry.yarnpkg.com/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz#1d572bfbbe14b7704e0ba0f39b74815b84870d70"
   integrity sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==
 
+"@emoji-mart/data@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@emoji-mart/data/-/data-1.1.2.tgz#777c976f8f143df47cbb23a7077c9ca9fe5fc513"
+  integrity sha512-1HP8BxD2azjqWJvxIaWAMyTySeZY0Osr83ukYjltPVkNXeJvTz7yDrPLBtnrD5uqJ3tg4CcLuuBW09wahqL/fg==
+
+"@emoji-mart/react@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@emoji-mart/react/-/react-1.1.1.tgz#ddad52f93a25baf31c5383c3e7e4c6e05554312a"
+  integrity sha512-NMlFNeWgv1//uPsvLxvGQoIerPuVdXwK/EUek8OOkJ6wVOWPUizRBJU0hDqWZCOROVpfBgCemaC3m6jDOXi03g==
+
 "@emotion/cache@^10.0.27":
   version "10.0.29"
   resolved "https://registry.npmjs.org/@emotion/cache/-/cache-10.0.29.tgz"
@@ -6910,6 +6920,11 @@ ally.js@^1.4.1:
     css.escape "^1.5.0"
     platform "1.3.3"
 
+amdefine@>=0.0.4:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/amdefine/-/amdefine-1.0.1.tgz#4a5282ac164729e93619bcfd3ad151f817ce91f5"
+  integrity sha512-S2Hw0TtNkMJhIabBwIojKL9YHO5T0n5eNqWJ7Lrlel/zDbftQpxpapi8tZs3X1HWa+u+QeydGmzzNU0m09+Rcg==
+
 analytics-node@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/analytics-node/-/analytics-node-6.2.0.tgz#8ae2ebc73d85e5b2aac8d366b974ad36996f629d"
@@ -8463,6 +8478,14 @@ clean-css@4.2.x, clean-css@^4.2.3:
   dependencies:
     source-map "~0.6.0"
 
+clean-css@^3.4.20:
+  version "3.4.28"
+  resolved "https://registry.yarnpkg.com/clean-css/-/clean-css-3.4.28.tgz#bf1945e82fc808f55695e6ddeaec01400efd03ff"
+  integrity sha512-aTWyttSdI2mYi07kWqHi24NUU9YlELFKGOAgFzZjDN1064DMAOy2FBuoyGmkKRlXkbpXd0EVHmiVkbKhKoirTw==
+  dependencies:
+    commander "2.8.x"
+    source-map "0.4.x"
+
 clean-css@^5.1.5:
   version "5.2.2"
   resolved "https://registry.npmjs.org/clean-css/-/clean-css-5.2.2.tgz"
@@ -8749,6 +8772,13 @@ commander@10.0.0, commander@^10.0.0:
 commander@2.17.x, commander@~2.17.1:
   version "2.17.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.17.1.tgz#bd77ab7de6de94205ceacc72f1716d29f20a77bf"
+
+commander@2.8.x:
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.8.1.tgz#06be367febfda0c330aa1e2a072d3dc9762425d4"
+  integrity sha512-+pJLBFVk+9ZZdlAOB5WuIElVPPth47hILFkmGym57aq8kwxsowvByvB0DHs1vQAhyMZzdcpTtF0VDKGkSDR4ZQ==
+  dependencies:
+    graceful-readlink ">= 1.0.0"
 
 commander@7, commander@^7.2.0:
   version "7.2.0"
@@ -10554,6 +10584,24 @@ emittery@^0.10.2:
   resolved "https://registry.npmjs.org/emittery/-/emittery-0.10.2.tgz"
   integrity sha512-aITqOwnLanpHLNXZJENbOgjUBeHocD+xsSJmNrjovKBW5HbSpW3d1pEls7GFQPUWXiwG9+0P4GtHfEqC/4M0Iw==
 
+emoji-data-css@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/emoji-data-css/-/emoji-data-css-1.0.1.tgz#4f95b48394b58571ed3284acfa709ea511875f8f"
+  integrity sha512-+fV7z7bDAMx4FrnC1YyIhi3yBURSkNETxwEstw7kl/cmwzF2vGiT0aRWipoWPtmM2fdD9ezvRai9DUEKBlT6YA==
+  dependencies:
+    clean-css "^3.4.20"
+    emoji-datasource "^2.4.4"
+
+emoji-datasource@^2.4.4:
+  version "2.4.4"
+  resolved "https://registry.yarnpkg.com/emoji-datasource/-/emoji-datasource-2.4.4.tgz#b97ac1896bc208ecf1833564a20687a5215d0389"
+  integrity sha512-Uyb23tvxUSlPiRQaK1ot+uOlLv1ivd/gcI8x+cqvLCRRMoan8waXXPrXU6UtASpORzcwCOA9dGlzqzLXw+WL7Q==
+
+emoji-mart@^5.5.2:
+  version "5.5.2"
+  resolved "https://registry.yarnpkg.com/emoji-mart/-/emoji-mart-5.5.2.tgz#3ddbaf053139cf4aa217650078bc1c50ca8381af"
+  integrity sha512-Sqc/nso4cjxhOwWJsp9xkVm8OF5c+mJLZJFoFfzRuKO+yWiN7K8c96xmtughYb0d/fZ8UC6cLIQ/p4BR6Pv3/A==
+
 emoji-regex@^8.0.0:
   version "8.0.0"
   resolved "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz"
@@ -12070,6 +12118,11 @@ functions-have-names@^1.2.2:
   resolved "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.2.tgz"
   integrity sha512-bLgc3asbWdwPbx2mNk2S49kmJCuQeu0nfmaOgbs8WIyzzkw3r4htszdIi9Q9EMezDPTYuJx2wvjZ/EwgAthpnA==
 
+fuse.js@^3.3.0:
+  version "3.6.1"
+  resolved "https://registry.yarnpkg.com/fuse.js/-/fuse.js-3.6.1.tgz#7de85fdd6e1b3377c23ce010892656385fd9b10c"
+  integrity sha512-hT9yh/tiinkmirKrlv4KWOjztdoZo1mx9Qh4KvWqC7isoXwdUY3PNWUxceF4/qO9R6riA2C29jdTOeQOIROjgw==
+
 gauge@^3.0.0:
   version "3.0.1"
   resolved "https://registry.npmjs.org/gauge/-/gauge-3.0.1.tgz"
@@ -12506,6 +12559,11 @@ graceful-fs@4.2.10, graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2
   version "4.2.10"
   resolved "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz"
   integrity sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==
+
+"graceful-readlink@>= 1.0.0":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/graceful-readlink/-/graceful-readlink-1.0.1.tgz#4cafad76bc62f02fa039b2f94e9a3dd3a391a725"
+  integrity sha512-8tLu60LgxF6XpdbK8OW3FA+IfTNBn1ZHGHKF4KQbEeSkajYw5PlYJcKluntgegDPTg8UkHjpet1T82vk6TQ68w==
 
 gradient-string@^2.0.0:
   version "2.0.2"
@@ -18926,6 +18984,14 @@ quill-delta@^3.6.2:
     extend "^3.0.2"
     fast-diff "1.1.2"
 
+quill-emoji@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/quill-emoji/-/quill-emoji-0.2.0.tgz#2d8b830cfd3389a408100f3b7de8d656da74d06f"
+  integrity sha512-0kqHKTFA9hk1Vf5g32KBm/NYZal6n9N/ATmk13Hka/XYsgrEIaShSR84B5VMB7bg5o9+TMeIzc+wey5OP7hv+A==
+  dependencies:
+    emoji-data-css "^1.0.1"
+    fuse.js "^3.3.0"
+
 quill-paste-smart@^1.4.9:
   version "1.4.10"
   resolved "https://registry.yarnpkg.com/quill-paste-smart/-/quill-paste-smart-1.4.10.tgz#c49740b7f5e5a3943da6bd23192382e46daa46d7"
@@ -20856,6 +20922,13 @@ source-map-url@^0.4.0:
   version "0.4.1"
   resolved "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.1.tgz"
   integrity sha512-cPiFOTLUKvJFIg4SKVScy4ilPPW6rFgMgfuZJPNoDuMs3nC1HbMUycBoJw77xFIp6z1UJQJOfx6C9GMH80DiTw==
+
+source-map@0.4.x:
+  version "0.4.4"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.4.4.tgz#eba4f5da9c0dc999de68032d8b4f76173652036b"
+  integrity sha512-Y8nIfcb1s/7DcobUz1yOO1GSp7gyL+D9zLHDehT7iRESqGSxjJ448Sg7rvfgsRJCnKLdSl11uGf0s9X80cH0/A==
+  dependencies:
+    amdefine ">=0.0.4"
 
 source-map@^0.5.0, source-map@^0.5.6, source-map@^0.5.7, source-map@~0.5.0:
   version "0.5.7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8471,7 +8471,7 @@ classnames@*, classnames@^2.2.5, classnames@^2.3.1:
   resolved "https://registry.npmjs.org/classnames/-/classnames-2.3.1.tgz"
   integrity sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA==
 
-clean-css@4.2.x, clean-css@^4.2.3:
+clean-css@4.2.x, clean-css@^4, clean-css@^4.2.3:
   version "4.2.4"
   resolved "https://registry.npmjs.org/clean-css/-/clean-css-4.2.4.tgz"
   integrity sha512-EJUDT7nDVFDvaQgAo2G/PJvxmp1o/c6iXLbswsBbUFXi1Nr+AjA2cKmfbKDMjMvzEe75g3P6JkaDDAKk96A85A==

--- a/yarn.lock
+++ b/yarn.lock
@@ -6920,11 +6920,6 @@ ally.js@^1.4.1:
     css.escape "^1.5.0"
     platform "1.3.3"
 
-amdefine@>=0.0.4:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/amdefine/-/amdefine-1.0.1.tgz#4a5282ac164729e93619bcfd3ad151f817ce91f5"
-  integrity sha512-S2Hw0TtNkMJhIabBwIojKL9YHO5T0n5eNqWJ7Lrlel/zDbftQpxpapi8tZs3X1HWa+u+QeydGmzzNU0m09+Rcg==
-
 analytics-node@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/analytics-node/-/analytics-node-6.2.0.tgz#8ae2ebc73d85e5b2aac8d366b974ad36996f629d"
@@ -8471,20 +8466,12 @@ classnames@*, classnames@^2.2.5, classnames@^2.3.1:
   resolved "https://registry.npmjs.org/classnames/-/classnames-2.3.1.tgz"
   integrity sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA==
 
-clean-css@4.2.x, clean-css@^4, clean-css@^4.2.3:
+clean-css@4.2.x, clean-css@^3.4.20, clean-css@^4, clean-css@^4.2.3:
   version "4.2.4"
   resolved "https://registry.npmjs.org/clean-css/-/clean-css-4.2.4.tgz"
   integrity sha512-EJUDT7nDVFDvaQgAo2G/PJvxmp1o/c6iXLbswsBbUFXi1Nr+AjA2cKmfbKDMjMvzEe75g3P6JkaDDAKk96A85A==
   dependencies:
     source-map "~0.6.0"
-
-clean-css@^3.4.20:
-  version "3.4.28"
-  resolved "https://registry.yarnpkg.com/clean-css/-/clean-css-3.4.28.tgz#bf1945e82fc808f55695e6ddeaec01400efd03ff"
-  integrity sha512-aTWyttSdI2mYi07kWqHi24NUU9YlELFKGOAgFzZjDN1064DMAOy2FBuoyGmkKRlXkbpXd0EVHmiVkbKhKoirTw==
-  dependencies:
-    commander "2.8.x"
-    source-map "0.4.x"
 
 clean-css@^5.1.5:
   version "5.2.2"
@@ -8772,13 +8759,6 @@ commander@10.0.0, commander@^10.0.0:
 commander@2.17.x, commander@~2.17.1:
   version "2.17.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.17.1.tgz#bd77ab7de6de94205ceacc72f1716d29f20a77bf"
-
-commander@2.8.x:
-  version "2.8.1"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-2.8.1.tgz#06be367febfda0c330aa1e2a072d3dc9762425d4"
-  integrity sha512-+pJLBFVk+9ZZdlAOB5WuIElVPPth47hILFkmGym57aq8kwxsowvByvB0DHs1vQAhyMZzdcpTtF0VDKGkSDR4ZQ==
-  dependencies:
-    graceful-readlink ">= 1.0.0"
 
 commander@7, commander@^7.2.0:
   version "7.2.0"
@@ -12559,11 +12539,6 @@ graceful-fs@4.2.10, graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2
   version "4.2.10"
   resolved "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz"
   integrity sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==
-
-"graceful-readlink@>= 1.0.0":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/graceful-readlink/-/graceful-readlink-1.0.1.tgz#4cafad76bc62f02fa039b2f94e9a3dd3a391a725"
-  integrity sha512-8tLu60LgxF6XpdbK8OW3FA+IfTNBn1ZHGHKF4KQbEeSkajYw5PlYJcKluntgegDPTg8UkHjpet1T82vk6TQ68w==
 
 gradient-string@^2.0.0:
   version "2.0.2"
@@ -20922,13 +20897,6 @@ source-map-url@^0.4.0:
   version "0.4.1"
   resolved "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.1.tgz"
   integrity sha512-cPiFOTLUKvJFIg4SKVScy4ilPPW6rFgMgfuZJPNoDuMs3nC1HbMUycBoJw77xFIp6z1UJQJOfx6C9GMH80DiTw==
-
-source-map@0.4.x:
-  version "0.4.4"
-  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.4.4.tgz#eba4f5da9c0dc999de68032d8b4f76173652036b"
-  integrity sha512-Y8nIfcb1s/7DcobUz1yOO1GSp7gyL+D9zLHDehT7iRESqGSxjJ448Sg7rvfgsRJCnKLdSl11uGf0s9X80cH0/A==
-  dependencies:
-    amdefine ">=0.0.4"
 
 source-map@^0.5.0, source-map@^0.5.6, source-map@^0.5.7, source-map@~0.5.0:
   version "0.5.7"


### PR DESCRIPTION
[COMM-2200]

### Description

Our product team has the need of sending Slack mass messages that include emojis and custom Toptal emojis and they would like to do it via a specific Staff Portal page. We would need to extend RichTextEditor to support emojis and also custom emojis. This PR implements such a feature into Quill Editor as an opt-in feature that won't break existing RichTextEditor instances

### How to test

- Access the Storybook
- Navigate to RichTextEditor
- ScrollDown to "Emojis" example
- Play around with adding the emojis, searching them, and inserting them into the editor.
- CI should be 💚 

### Screenshots

![image](https://user-images.githubusercontent.com/9496960/232036877-9cb0ca5f-acaf-4b45-8309-036a188b86f9.png)
![image](https://user-images.githubusercontent.com/9496960/232036934-eb348c84-c1b9-4de5-8681-ae68e1c0649c.png)
![image](https://user-images.githubusercontent.com/9496960/232037013-1eb88542-956f-4634-b48a-e1f7ead518f4.png)
![image](https://user-images.githubusercontent.com/9496960/232037072-5bfeebc9-2d39-47ed-8696-d6e0446ad529.png)
![image](https://user-images.githubusercontent.com/9496960/232037122-768db260-bb88-4a42-af35-9e79f0d485db.png)
![image](https://user-images.githubusercontent.com/9496960/232037169-aee7ea86-d1fa-4e44-8a13-a8b36ae500a0.png)
![image](https://user-images.githubusercontent.com/9496960/232037223-9b0fc49a-6411-446d-a31b-0ff44417d119.png)

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests

**Breaking change**

- [x] codemod is created and showcased in the changeset
- [x] test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[COMM-2200]: https://toptal-core.atlassian.net/browse/COMM-2200?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ