### PR TITLE
test: update BarChart visual test to remove flaky test

### DIFF
--- a/cypress/component/BarChart.spec.tsx
+++ b/cypress/component/BarChart.spec.tsx
@@ -105,7 +105,9 @@ describe('BarChart', () => {
   })
 
   it('renders chart with vertical layout', () => {
-    cy.mount(<TestBarChart layout='vertical' />)
+    cy.mount(
+      <TestBarChart layout='vertical' showBarLabel={false} tooltip={false} />
+    )
 
     cy.get('body').happoScreenshot({
       component,


### PR DESCRIPTION
[FX-NNNN]

### Description

More and more we start seeing flaky test of BarChart
![image](https://user-images.githubusercontent.com/6830426/232712220-e596e8f3-f979-41c5-98ee-5853d9dedc06.png)

I have removed the tooltip and labels from the test as it is already tested in different scenario.

### How to test

- Check and Approve the Happo change

### Screenshots

`n/a`

### Development checks

- `n/a` Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- `n/a` Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- `n/a` Make sure that additions and changes on design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- `n/a` Annotate all `props` in component with documentation
- `n/a` Create `examples` for component
- `n/a` Ensure that deployed demo has expected results and good examples
- `n/a` Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests

**Breaking change**

- `n/a` codemod is created and showcased in the changeset
- `n/a` test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>
