### PR TITLE
fix: reset button when datepicker calendar is closed

### DIFF
--- a/.changeset/chatty-sheep-watch.md
+++ b/.changeset/chatty-sheep-watch.md
@@ -1,0 +1,9 @@
+---
+'@toptal/picasso': patch
+---
+
+---
+
+### DatePicker
+
+- prevent opening the calendar when clicking on the datepicker reset button

--- a/packages/picasso/src/DatePicker/DatePicker.tsx
+++ b/packages/picasso/src/DatePicker/DatePicker.tsx
@@ -372,6 +372,9 @@ export const DatePicker = (props: Props) => {
   ) => {
     setInputValue(EMPTY_INPUT_VALUE)
     onResetClick?.(event)
+
+    // prevent re-opening the calendar popper
+    event.stopPropagation()
   }
 
   const startAdornment =

--- a/packages/picasso/src/DatePicker/test.tsx
+++ b/packages/picasso/src/DatePicker/test.tsx
@@ -515,6 +515,29 @@ describe('DatePicker', () => {
 
         expect(queryByTestId('day-button-selected')).toBeInTheDocument()
       })
+
+      it('should not open calendar on `reset` button click', async () => {
+        const { getByRole, queryByTestId, getByPlaceholderText, getByText } =
+          renderDatePicker({
+            ...defaultProps,
+            enableReset: true,
+          })
+
+        const input = getByPlaceholderText(defaultProps.placeholder)
+
+        fireEvent.focus(input)
+
+        const day15 = getByText(/15/)
+
+        fireEvent.click(day15)
+
+        expect(queryByTestId(testIds.calendar)).not.toBeInTheDocument()
+
+        fireEvent.click(getByRole('reset', { hidden: true }))
+
+        expect(input).toHaveAttribute('value', '')
+        expect(queryByTestId(testIds.calendar)).not.toBeInTheDocument()
+      })
     })
 
     describe('when `footer` option is passed', () => {


### PR DESCRIPTION
[FX-3932](https://toptal-core.atlassian.net/browse/FX-3932)

### Description

Prevent opening the datepicker calendar when clicking on the reset button.



### How to test

- Go to https://picasso.toptal.net/FX-3932-fix-reset-button-for-datepicker/?path=/story/forms-datepicker--datepicker#with-reset-button
- Select a date
- Click the reset button
- The calendar should not be visible
- Click on the datepicker
- The calendar should be visible

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| ![Kapture 2023-04-20 at 08 39 47](https://user-images.githubusercontent.com/2583281/233336041-e9c9f8c1-c1c0-483d-a97a-79b327951124.gif)  | ![Kapture 2023-04-20 at 13 14 16](https://user-images.githubusercontent.com/2583281/233336360-8da15a86-de02-4f2f-a99b-6c218bf2d3a0.gif) |



### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [] Annotate all `props` in component with documentation
- [] Create `examples` for component
- [] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests

**Breaking change**

- [] codemod is created and showcased in the changeset
- [] test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-3932]: https://toptal-core.atlassian.net/browse/FX-3932?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ