### PR TITLE
chore: make prop table responsive in Picasso Storybook

### DIFF
--- a/.storybook/components/PicassoBook/components/PropsTable/styles.ts
+++ b/.storybook/components/PicassoBook/components/PropsTable/styles.ts
@@ -3,58 +3,59 @@ import { Theme, createStyles } from '@material-ui/core/styles'
 export default ({ palette }: Theme) =>
   createStyles({
     root: {
-      width: '100%'
+      width: '100%',
+      overflowX: 'auto',
     },
     table: {
-      width: '100%'
+      width: '100%',
     },
     name: {
-      width: '100px'
+      width: '100px',
     },
     type: {
-      width: '1%'
+      width: '1%',
     },
     description: {
-      width: '100%'
+      width: '100%',
     },
     defaultValue: {
-      width: '1%'
+      width: '1%',
     },
     tooltipTarget: {
       borderBottom: '1px dotted',
       fontWeight: 600,
-      cursor: 'help'
+      cursor: 'help',
     },
     highlight: {
       backgroundColor: 'rgb(236, 236, 236, 0.5)',
       borderRadius: '0.4em',
       padding: '0.3em 0.7em',
-      fontWeight: 600
+      fontWeight: 600,
     },
     typeCell: {
-      whiteSpace: 'nowrap'
+      whiteSpace: 'nowrap',
     },
     defaultValueCell: {
-      whiteSpace: 'nowrap'
+      whiteSpace: 'nowrap',
     },
     descriptionCell: {
       paddingTop: '1em',
-      paddingBottom: '1em'
+      paddingBottom: '1em',
     },
     enums: {
       marginTop: '1em',
       display: 'flex',
       flexWrap: 'wrap',
-      alignItems: 'center'
+      alignItems: 'center',
     },
     enumLabel: {
       marginRight: '0.2em',
-      marginBottom: '0.2em'
+      marginBottom: '0.2em',
     },
     enum: {
       fontSize: '0.8rem',
       marginRight: '0.2em',
-      marginBottom: '0.2em'
+      marginBottom: '0.2em',
     },
     markdown: {
       '& code': {
@@ -64,21 +65,21 @@ export default ({ palette }: Theme) =>
         fontWeight: 400,
         fontSize: '0.8em',
         fontFamily:
-          "'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace"
+          "'Monaco', 'Menlo', 'Ubuntu Mono', 'Consolas', 'source-code-pro', monospace",
       },
       '& p:first-child': {
-        marginTop: 0
+        marginTop: 0,
       },
       '& p:last-child': {
-        marginBottom: 0
+        marginBottom: 0,
       },
       '& pre': {
         backgroundColor: 'rgb(236, 236, 236, 0.5)',
 
         '& code': {
           padding: '0em',
-          backgroundColor: 'initial'
-        }
-      }
-    }
+          backgroundColor: 'initial',
+        },
+      },
+    },
   })

--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -5,6 +5,7 @@
   }
   #root {
     padding: 0;
+    flex-direction: column;
   }
   .story {
     padding: 20px;


### PR DESCRIPTION
[FX-NNNN]

### Description

Added `overflow-x: auto` to the table that is used to display props in Picasso Storybook. `flex-direction` on the root node was also necessary to prevent overflow of the rest of the content.

Previously it was forcing the entire content (including stories) to be the width of the prop table.

### How to test

- Open any page and switch to small/large mobile view (or resize the browser window)
- Compare with master

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| ![image](https://user-images.githubusercontent.com/18409292/233626347-773a59b6-ddd5-4f07-9ca8-00d72fc5c42d.png) | ![image](https://user-images.githubusercontent.com/18409292/233626541-4d98d04f-1c12-4a83-b010-8b2b9188e528.png) |
| ![image](https://user-images.githubusercontent.com/18409292/233626863-b31cb0e5-d30d-4579-ad98-92e5e8314ada.png) | ![image](https://user-images.githubusercontent.com/18409292/233626952-e90176af-a31c-4383-9dec-1aee8b26e00d.png) |

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Self reviewed
- [x] Covered with tests

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>
