### PR TITLE
feat: add new Picasso breakpoints

### DIFF
--- a/.storybook/public/ico-breakpoint-extra-small.svg
+++ b/.storybook/public/ico-breakpoint-extra-small.svg
@@ -1,0 +1,6 @@
+<svg width="63" height="62" viewBox="0 0 63 62" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path opacity="0.1" d="M24 18H39V45H24V18Z" fill="#204ECF"/>
+<path d="M38.0972 47H24.8368C23.2535 47 22 45.9052 22 44.5223V18.4777C22 17.0948 23.2535 16 24.8368 16H38.1632C39.7465 16 41 17.0948 41 18.4777V44.5223C40.934 45.9052 39.6806 47 38.0972 47Z" stroke="#204ECF" stroke-width="0.5" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M24 18H39V45H24V18Z" stroke="#204ECF" stroke-width="0.5" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M26.4551 24.3901H36.0207M26.4551 26.7795H31.2379M26.4551 22.0006H33.662M26.4551 40.937H28.8793" stroke="#204ECF" stroke-width="0.5" stroke-miterlimit="10" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/packages/picasso-provider/src/Picasso/config/breakpoints.ts
+++ b/packages/picasso-provider/src/Picasso/config/breakpoints.ts
@@ -5,7 +5,12 @@ import useMediaQuery from '@material-ui/core/useMediaQuery'
 
 import { isBrowser } from '../../utils'
 
-type BreakpointKeys = 'small' | 'medium' | 'large' | 'extra-large'
+type BreakpointKeys =
+  | 'extra-small'
+  | 'small'
+  | 'medium'
+  | 'large'
+  | 'extra-large'
 
 type BreakpointsList = {
   [key: string]: number
@@ -15,10 +20,10 @@ class BreakpointProvider {
   breakpoints: Record<'values', BreakpointValues> = {
     values: {
       xs: 0,
-      sm: 576,
+      sm: 480,
       md: 768,
-      lg: 992,
-      xl: 1920,
+      lg: 1024,
+      xl: 1440,
     },
   }
 
@@ -27,13 +32,14 @@ class BreakpointProvider {
   }
 
   constructor() {
-    const { sm, md, lg } = this.breakpoints.values
+    const { sm, md, lg, xl } = this.breakpoints.values
 
     this.mediaQueries = {
-      small: `(max-width: ${sm}px)`,
-      medium: `(min-width: ${sm}px) and (max-width: ${md}px)`,
-      large: `(min-width: ${md}px) and (max-width: ${lg}px)`,
-      'extra-large': `(min-width: ${lg}px)`,
+      'extra-small': `(max-width: ${sm}px)`,
+      small: `(min-width: ${sm}px) and (max-width: ${md}px)`,
+      medium: `(min-width: ${md}px) and (max-width: ${lg}px)`,
+      large: `(min-width: ${lg}px) and (max-width: ${xl}px)`,
+      'extra-large': `(min-width: ${xl}px)`,
     }
   }
 
@@ -41,6 +47,7 @@ class BreakpointProvider {
     this.breakpoints.values.xs = 768
     this.breakpoints.values.sm = 768
 
+    this.mediaQueries['extra-small'] = ''
     this.mediaQueries.small = ''
     this.mediaQueries.medium = ''
   }
@@ -49,6 +56,7 @@ class BreakpointProvider {
 export const PicassoBreakpoints = new BreakpointProvider()
 
 export const breakpointsList: BreakpointsList = {
+  'extra-small': PicassoBreakpoints.breakpoints.values.xs,
   small: PicassoBreakpoints.breakpoints.values.sm,
   medium: PicassoBreakpoints.breakpoints.values.md,
   large: PicassoBreakpoints.breakpoints.values.lg,
@@ -74,18 +82,20 @@ const screenSizeToBreakpointKey = (size: number): BreakpointKeys => {
    * Gets a screen size nickname that corresponds to the given screen size.
    *
    * For the list of breakpoint names and pixel-values we use in designs, check
-   * https://picasso.toptal.net/?path=/story/utils-folder--breakpoints
+   * https://picasso.toptal.net/?path=/story/utils-breakpoints--breakpoints
    *
    * @param {number} size Screen size
    */
 
-  const { sm, md, lg } = PicassoBreakpoints.breakpoints.values
+  const { sm, md, lg, xl } = PicassoBreakpoints.breakpoints.values
 
   if (size < sm) {
-    return 'small'
+    return 'extra-small'
   } else if (size >= sm && size < md) {
-    return 'medium'
+    return 'small'
   } else if (size >= md && size < lg) {
+    return 'medium'
+  } else if (size >= lg && size < xl) {
     return 'large'
   }
 

--- a/packages/picasso-provider/src/Picasso/config/test.ts
+++ b/packages/picasso-provider/src/Picasso/config/test.ts
@@ -2,24 +2,31 @@ import { isScreenSize, screens, PicassoBreakpoints } from './'
 
 const SCREEN_SIZES = {
   small: 500,
-  medium: 750,
-  large: 990,
-  extraLarge: 1000,
+  medium: 800,
+  large: 1060,
+  extraLarge: 1500,
 }
 
 describe('responsive breakpoint utils', () => {
   describe('media query generation', () => {
+    it('extra-small', () => {
+      const mediaQuery = screens('extra-small')
+
+      expect(mediaQuery).toBe('@media (max-width: 480px)')
+    })
     it('small', () => {
       const mediaQuery = screens('small')
 
-      expect(mediaQuery).toBe('@media (max-width: 576px)')
+      expect(mediaQuery).toBe(
+        '@media (min-width: 480px) and (max-width: 768px)'
+      )
     })
 
     it('small medium', () => {
       const mediaQuery = screens('small', 'medium')
 
       expect(mediaQuery).toBe(
-        '@media (max-width: 576px), (min-width: 576px) and (max-width: 768px)'
+        '@media (min-width: 480px) and (max-width: 768px), (min-width: 768px) and (max-width: 1024px)'
       )
     })
 
@@ -27,7 +34,7 @@ describe('responsive breakpoint utils', () => {
       const mediaQuery = screens('small', 'medium', 'large')
 
       expect(mediaQuery).toBe(
-        '@media (max-width: 576px), (min-width: 576px) and (max-width: 768px), (min-width: 768px) and (max-width: 992px)'
+        '@media (min-width: 480px) and (max-width: 768px), (min-width: 768px) and (max-width: 1024px), (min-width: 1024px) and (max-width: 1440px)'
       )
     })
   })
@@ -107,6 +114,12 @@ describe('non-responsive breakpoint utils', () => {
   })
 
   describe('media query generation', () => {
+    it('extra-small', () => {
+      const mediaQuery = screens('extra-small')
+
+      expect(mediaQuery).toBe('')
+    })
+
     it('small', () => {
       const mediaQuery = screens('small')
 
@@ -123,7 +136,7 @@ describe('non-responsive breakpoint utils', () => {
       const mediaQuery = screens('small', 'medium', 'large')
 
       expect(mediaQuery).toBe(
-        '@media (min-width: 768px) and (max-width: 992px)'
+        '@media (min-width: 1024px) and (max-width: 1440px)'
       )
     })
   })
@@ -138,7 +151,7 @@ describe('non-responsive breakpoint utils', () => {
     it('small breakpoint on a small screen', () => {
       const isSmall = isScreenSize('small', SCREEN_SIZES.small)
 
-      expect(isSmall).toBeTruthy()
+      expect(isSmall).toBeFalsy()
     })
 
     it('small breakpoint on a large screen', () => {
@@ -162,7 +175,7 @@ describe('non-responsive breakpoint utils', () => {
     it('medium breakpoint on a medium screen', () => {
       const isMedium = isScreenSize('medium', SCREEN_SIZES.medium)
 
-      expect(isMedium).toBeFalsy()
+      expect(isMedium).toBeTruthy()
     })
 
     it('medium breakpoint on a large screen', () => {

--- a/packages/picasso/src/utils/Breakpoints/story/Breakpoints.example.tsx
+++ b/packages/picasso/src/utils/Breakpoints/story/Breakpoints.example.tsx
@@ -5,31 +5,31 @@ import { Grid, Paper, Image, Typography, Container } from '@toptal/picasso'
 const breakpointsList = Object.entries(breakpoints)
 
 const Example = () => (
-  <Grid spacing={16}>
+  <Grid justifyContent='center' spacing={16}>
     {breakpointsList.map(([breakpointName, breakpointValue], index) => {
-      const prevBreakpoint = breakpointsList[index - 1]
-      let prevBreakpointValue
+      const nextBreakpoint = breakpointsList[index + 1]
+      let nextBreakpointValue
 
-      if (prevBreakpoint) {
-        prevBreakpointValue = prevBreakpoint[1]
+      if (nextBreakpoint) {
+        nextBreakpointValue = nextBreakpoint[1]
       }
 
       const isSmallestBreakpoint = index === 0
       const isLargestBreakpoint = index === breakpointsList.length - 1
 
       return (
-        <Grid.Item key={breakpointName} medium={3}>
+        <Grid.Item key={breakpointName} medium={2}>
           <Paper style={{ padding: '2rem' }}>
             <Container flex direction='column' alignItems='center'>
               <Typography variant='heading' size='large'>
                 {breakpointName}
               </Typography>
               <Typography size='xsmall'>
-                {isSmallestBreakpoint && `< ${breakpointValue} px`}
-                {isLargestBreakpoint && `> ${prevBreakpointValue} px`}
+                {isSmallestBreakpoint && `< ${nextBreakpointValue} px`}
+                {isLargestBreakpoint && `> ${breakpointValue} px`}
                 {!isSmallestBreakpoint &&
                   !isLargestBreakpoint &&
-                  `${prevBreakpointValue} px < ... < ${breakpointValue} px`}
+                  `${breakpointValue} px < ... < ${nextBreakpointValue} px`}
               </Typography>
               <Container top={1}>
                 <Image

--- a/packages/picasso/src/utils/Breakpoints/story/index.jsx
+++ b/packages/picasso/src/utils/Breakpoints/story/index.jsx
@@ -11,20 +11,20 @@ const page = PicassoBook.section('Utils').createPage(
 
 page
   .createChapter()
-  .addExample('utils/Breakpoints/story/MediaQueries.example.tsx', {
-    title: 'Media queries',
-    description: `
-    Picasso provides a function 'screens' to be able to 
-    easily create media queries based on the given breakpoints
-  `,
-    takeScreenshot: false,
-  })
   .addExample('utils/Breakpoints/story/Breakpoints.example.tsx', {
     title: 'Breakpoints',
     description: `
     The list of breakpoint names and pixel-values we use while we design and do layouts
   `,
     showEditCode: false,
+    takeScreenshot: false,
+  })
+  .addExample('utils/Breakpoints/story/MediaQueries.example.tsx', {
+    title: 'Media queries',
+    description: `
+    Picasso provides a function 'screens' to be able to 
+    easily create media queries based on the given breakpoints
+  `,
     takeScreenshot: false,
   })
   .addExample('utils/Breakpoints/story/useBreakpoint.example.tsx', {

--- a/packages/picasso/src/utils/Breakpoints/story/useScreens.example.tsx
+++ b/packages/picasso/src/utils/Breakpoints/story/useScreens.example.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { useScreens } from '@toptal/picasso/utils'
 import type { ButtonVariantType } from '@toptal/picasso'
-import { Typography, Button } from '@toptal/picasso'
+import { Typography, Button, Container } from '@toptal/picasso'
 
 const Example = () => {
   const screens = useScreens<ButtonVariantType>()
@@ -9,6 +9,18 @@ const Example = () => {
 
   return (
     <>
+      <Container bottom={2}>
+        <Typography variant='heading' size='medium'>
+          Current screen breakpoint:{' '}
+          {screenTexts({
+            'extra-small': 'extra-small',
+            small: 'small',
+            medium: 'medium',
+            large: 'large',
+            'extra-large': 'extra-large',
+          })}
+        </Typography>
+      </Container>
       <Typography as='span'>
         The button below will use:
         <ul>


### PR DESCRIPTION
[FX-3923](https://toptal-core.atlassian.net/browse/FX-3923)

### Description

This PR adjusts Picasso breakpoint values to be aligned with the [new BASE standards](https://github.com/toptal/picasso/blob/master/docs/decisions/13-breakpoints.md).


### How to test

- Take a look at the code
- Compare breakpoints stories in [master](https://picasso.toptal.net/?path=/story/utils-breakpoints--breakpoints) vs temploy (pending)
- New breakpoints should be visible on the page
- `useScreens` showcase at the bottom of the showcase should reflect new screen sizes
- Tests should pass

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| ![image](https://user-images.githubusercontent.com/18409292/235444816-2b06fd14-5a1d-44bc-a39e-0f2984836b42.png) | ![image](https://user-images.githubusercontent.com/18409292/235444926-65e86d2e-2f88-45b4-861e-4a2390ea02e7.png) |

### Development checks

- [ ] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [ ] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [ ] Make sure that additions and changes on design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [ ] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [ ] Self reviewed
- [ ] Covered with tests

**Breaking change**

- [ ] codemod is created and showcased in the changeset
- [ ] test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>
