### PR TITLE
fix(RichTextEditor): default value not populated

### DIFF
--- a/packages/picasso-forms/src/Form/story/HighlightAutofill.example.tsx
+++ b/packages/picasso-forms/src/Form/story/HighlightAutofill.example.tsx
@@ -68,7 +68,7 @@ const Example = () => (
         id='highlight-rte'
         label='rte'
         name='highlight-rte'
-        defaultValue={htmlToHast(INITIAL_RTE_VALUE)}
+        defaultValue={htmlToHast(INITIAL_RTE_VALUE)} // we expect HAST from BE
       />
       <Select
         options={[{ value: 'foo', text: 'first option ' }]}

--- a/packages/picasso-forms/src/Form/story/HighlightAutofill.example.tsx
+++ b/packages/picasso-forms/src/Form/story/HighlightAutofill.example.tsx
@@ -15,12 +15,15 @@ import {
   TagSelector,
   TimePicker,
 } from '@toptal/picasso-forms'
+import { htmlToHast } from '@toptal/picasso/utils'
 
 const formConfig: FormConfigProps = {
   highlightAutofill: true,
 }
 
 const april2nd = new Date(2023, 3, 2)
+
+const INITIAL_RTE_VALUE = '<p>Rich Text Editor</p>'
 
 const Example = () => (
   <ConfigProvider value={formConfig}>
@@ -32,7 +35,7 @@ const Example = () => (
         'highlight-datepicker': april2nd,
         'highlight-numberinput': 1,
         'highlight-passwordinput': 'password',
-        'highlight-rte': '<p>Rich Text Editor</p>',
+        'highlight-rte': INITIAL_RTE_VALUE,
         'highlight-select': 'foo',
         'highlight-tagselector': 'foo',
         'highlight-timepicker': april2nd,
@@ -61,7 +64,12 @@ const Example = () => (
       <DatePicker label='datepicker' name='highlight-datepicker' />
       <NumberInput label='numberinput' name='highlight-numberinput' />
       <PasswordInput label='passwordinput' name='highlight-passwordinput' />
-      <RichTextEditor id='highlight-rte' label='rte' name='highlight-rte' />
+      <RichTextEditor
+        id='highlight-rte'
+        label='rte'
+        name='highlight-rte'
+        defaultValue={htmlToHast(INITIAL_RTE_VALUE)}
+      />
       <Select
         options={[{ value: 'foo', text: 'first option ' }]}
         label='select'

--- a/packages/picasso/src/QuillEditor/hooks/useDefaultValue/useDefaultValue.tsx
+++ b/packages/picasso/src/QuillEditor/hooks/useDefaultValue/useDefaultValue.tsx
@@ -15,7 +15,7 @@ const useDefaultValue = ({ defaultValue, quill }: Props) => {
     }
     const delta = quill.clipboard.convert(defaultValue)
 
-    quill.setContents(delta, 'api')
+    quill.setContents(delta, 'silent')
     hasBeenCalled.current = true
   }, [defaultValue, quill])
 }

--- a/packages/picasso/src/QuillEditor/hooks/useDefaultValue/useDefaultValue.tsx
+++ b/packages/picasso/src/QuillEditor/hooks/useDefaultValue/useDefaultValue.tsx
@@ -15,7 +15,7 @@ const useDefaultValue = ({ defaultValue, quill }: Props) => {
     }
     const delta = quill.clipboard.convert(defaultValue)
 
-    quill.setContents(delta, 'silent')
+    quill.setContents(delta, 'api')
     hasBeenCalled.current = true
   }, [defaultValue, quill])
 }


### PR DESCRIPTION
[FX-NNNN]

### Description

`Form.RichTextEditor` does not populated `initialValue` at all, you can check it in [this example](https://picasso.toptal.net/?path=/story/picasso-forms-form--form#highlight-fields-with-default-value):
<img width="395" alt="image" src="https://user-images.githubusercontent.com/18625278/235583720-aa2b2e57-d38c-4147-b715-e949cc2c7b57.png">

**Actual:**
Even though the field is highlighted, the value is empty. 

**Expected**
The field got populated with the `initialValues` provided on the `Form` or `initialValue` on the field itself.

BREAKING CHANGES:
Providing `defaultValue` prop won't emit a change event anymore, which is expected IMO.

### How to test

- Go to [this example](https://picasso.toptal.net/?path=/story/picasso-forms-form--form#highlight-fields-with-default-value)
- The rte field should be populated by default, field should also be highlighted.

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| Insert screenshots or screen recordings | Insert screenshots or screen recordings |

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- N/A Make sure that additions and changes on design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- N/A Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests

**Breaking change**

- N/A codemod is created and showcased in the changeset
- [x] test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>
