### PR TITLE
feat: add responsive grid spacing

### DIFF
--- a/.changeset/red-countries-thank.md
+++ b/.changeset/red-countries-thank.md
@@ -1,0 +1,5 @@
+---
+'@toptal/picasso': major
+---
+
+- grid spacing automatically adjusts to the screen size, unless explicitly specified by consumer. If you want to keep the old behavior, please explicitly set `spacing={32}` for `Grid` components.

--- a/.changeset/red-countries-thank.md
+++ b/.changeset/red-countries-thank.md
@@ -2,4 +2,6 @@
 '@toptal/picasso': major
 ---
 
+### Grid
+
 - grid spacing automatically adjusts to the screen size, unless explicitly specified by consumer. If you want to keep the old behavior, please explicitly set `spacing={32}` for `Grid` components.

--- a/packages/picasso-forms/src/Checkbox/__snapshots__/test.tsx.snap
+++ b/packages/picasso-forms/src/Checkbox/__snapshots__/test.tsx.snap
@@ -29,7 +29,7 @@ exports[`Form.Checkbox default render for checkboxes in a group 1`] = `
             name="checkbox-group"
           >
             <div
-              class="MuiGrid-root PicassoCheckboxGroup-grid MuiGrid-container PicassoGrid-container MuiGrid-direction-xs MuiGrid-align-items-xs-flex"
+              class="MuiGrid-root PicassoCheckboxGroup-grid MuiGrid-container PicassoGrid-container MuiGrid-spacing-xs MuiGrid-direction-xs MuiGrid-align-items-xs-flex"
             >
               <div
                 class="MuiGrid-root PicassoCheckboxGroup-gridItem MuiGrid-item"

--- a/packages/picasso-forms/src/Radio/__snapshots__/test.tsx.snap
+++ b/packages/picasso-forms/src/Radio/__snapshots__/test.tsx.snap
@@ -31,7 +31,7 @@ exports[`FormRadio renders 1`] = `
             type="radio"
           >
             <div
-              class="MuiGrid-root PicassoRadioGroup-grid MuiGrid-container PicassoGrid-container MuiGrid-direction-xs MuiGrid-align-items-xs-flex"
+              class="MuiGrid-root PicassoRadioGroup-grid MuiGrid-container PicassoGrid-container MuiGrid-spacing-xs MuiGrid-direction-xs MuiGrid-align-items-xs-flex"
             >
               <div
                 class="MuiGrid-root PicassoRadioGroup-gridItem MuiGrid-item"
@@ -148,7 +148,7 @@ exports[`FormRadio required with asterisk 1`] = `
             type="radio"
           >
             <div
-              class="MuiGrid-root PicassoRadioGroup-grid MuiGrid-container PicassoGrid-container MuiGrid-direction-xs MuiGrid-align-items-xs-flex"
+              class="MuiGrid-root PicassoRadioGroup-grid MuiGrid-container PicassoGrid-container MuiGrid-spacing-xs MuiGrid-direction-xs MuiGrid-align-items-xs-flex"
             >
               <div
                 class="MuiGrid-root PicassoRadioGroup-gridItem MuiGrid-item"

--- a/packages/picasso-provider/src/Picasso/PicassoGlobalStylesProvider.tsx
+++ b/packages/picasso-provider/src/Picasso/PicassoGlobalStylesProvider.tsx
@@ -1,11 +1,13 @@
 import type { ReactNode, ForwardRefExoticComponent, RefAttributes } from 'react'
-import React, { useRef, useState, useCallback } from 'react'
+import React, { useEffect, useRef, useState, useCallback } from 'react'
 
 import type { RootContextProps } from './RootContext'
 import { RootContext } from './RootContext'
 import type { EnvironmentType, TextLabelProps } from '../types'
 import type { PicassoRootNodeProps } from './PicassoRootNode'
 import { isBrowser } from '../utils'
+import type { BreakpointKeys } from './config/breakpoints'
+import { useScreens } from './config/breakpoints'
 
 export interface PicassoGlobalStylesProviderProps extends TextLabelProps {
   children?: ReactNode
@@ -14,6 +16,14 @@ export interface PicassoGlobalStylesProviderProps extends TextLabelProps {
   >
   environment: EnvironmentType<'test' | 'temploy'>
   disableTransitions?: boolean
+}
+
+const breakpointRangesToKeys: Record<BreakpointKeys, BreakpointKeys> = {
+  xs: 'xs',
+  sm: 'sm',
+  md: 'md',
+  lg: 'lg',
+  xl: 'xl',
 }
 
 const PicassoGlobalStylesProvider = (
@@ -29,8 +39,22 @@ const PicassoGlobalStylesProvider = (
 
   const [picassoRootMounted, setPicassoRootMounted] = useState(false)
   const rootRef = useRef<HTMLDivElement | null>(null)
+
+  const screens = useScreens<BreakpointKeys>()
+  const currentBreakpointRange = screens(breakpointRangesToKeys)
+
+  useEffect(() => {
+    if (contextValue.currentBreakpointRange !== currentBreakpointRange) {
+      setContextValue({
+        ...contextValue,
+        currentBreakpointRange,
+      })
+    }
+  }, [currentBreakpointRange])
+
   const [contextValue, setContextValue] = useState<RootContextProps>({
     rootRef,
+    currentBreakpointRange,
     hasTopBar: false,
     setHasTopBar: (hasTopBar: boolean) => {
       setContextValue({

--- a/packages/picasso-provider/src/Picasso/PicassoGlobalStylesProvider.tsx
+++ b/packages/picasso-provider/src/Picasso/PicassoGlobalStylesProvider.tsx
@@ -18,7 +18,7 @@ export interface PicassoGlobalStylesProviderProps extends TextLabelProps {
   disableTransitions?: boolean
 }
 
-const breakpointRangesToKeys: Record<BreakpointKeys, BreakpointKeys> = {
+const breakpointKeyByRange: Record<BreakpointKeys, BreakpointKeys> = {
   xs: 'xs',
   sm: 'sm',
   md: 'md',
@@ -41,7 +41,7 @@ const PicassoGlobalStylesProvider = (
   const rootRef = useRef<HTMLDivElement | null>(null)
 
   const screens = useScreens<BreakpointKeys>()
-  const currentBreakpointRange = screens(breakpointRangesToKeys)
+  const currentBreakpointRange = screens(breakpointKeyByRange)
 
   useEffect(() => {
     if (contextValue.currentBreakpointRange !== currentBreakpointRange) {

--- a/packages/picasso-provider/src/Picasso/RootContext.ts
+++ b/packages/picasso-provider/src/Picasso/RootContext.ts
@@ -2,6 +2,7 @@ import type { RefObject } from 'react'
 import React, { useContext } from 'react'
 
 import type { TextLabelProps, EnvironmentType } from '../types'
+import type { BreakpointKeys } from './config'
 
 export interface RootContextProps extends TextLabelProps {
   rootRef?: RefObject<HTMLDivElement>
@@ -13,6 +14,7 @@ export interface RootContextProps extends TextLabelProps {
   hasDrawer: boolean
   setHasDrawer: (value: boolean) => void
   disableTransitions?: boolean
+  currentBreakpointRange?: BreakpointKeys
 }
 
 export const RootContext = React.createContext<RootContextProps>({
@@ -25,6 +27,7 @@ export const RootContext = React.createContext<RootContextProps>({
   hasDrawer: false,
   setHasDrawer: () => {},
   disableTransitions: false,
+  currentBreakpointRange: undefined,
 })
 
 export const usePicassoRoot = () => {
@@ -67,5 +70,13 @@ export const useAppConfig = () => {
     environment: context.environment,
     titleCase: context.titleCase,
     disableTransitions: context.disableTransitions,
+  }
+}
+
+export const useCurrentBreakpointRange = () => {
+  const context = useContext(RootContext)
+
+  return {
+    currentBreakpointRange: context.currentBreakpointRange,
   }
 }

--- a/packages/picasso-provider/src/Picasso/config/breakpoints.ts
+++ b/packages/picasso-provider/src/Picasso/config/breakpoints.ts
@@ -5,7 +5,7 @@ import useMediaQuery from '@material-ui/core/useMediaQuery'
 
 import { isBrowser } from '../../utils'
 
-type BreakpointKeys = 'xs' | 'sm' | 'md' | 'lg' | 'xl'
+export type BreakpointKeys = 'xs' | 'sm' | 'md' | 'lg' | 'xl'
 
 type BreakpointsList = {
   [key: string]: number

--- a/packages/picasso-provider/src/Picasso/config/breakpoints.ts
+++ b/packages/picasso-provider/src/Picasso/config/breakpoints.ts
@@ -136,7 +136,7 @@ export const useBreakpoint = (sizes: BreakpointKeys[] | BreakpointKeys) => {
  *
  * The function returned accepts 2 arguments:
  * 1. An object mapping values to screen size nicknames, e.g.
- *   {small: 'secondary', large: 'positive'}
+ *   { sm: 'secondary', lg: 'positive' }
  * 2. A default value to use if no keys match in the object
  *
  * The function returns a value from the first argument that corresponds to the current
@@ -149,16 +149,16 @@ export const useBreakpoint = (sizes: BreakpointKeys[] | BreakpointKeys) => {
  * <Button
  *   variant={screens(
  *     {
- *       small: 'secondary',
- *       large: 'positive'
+ *       sm: 'secondary',
+ *       lg: 'positive'
  *     },
  *     'primary'
  *   )}
  * >
  * {screens(
  *   {
- *     small: 'small (secondary)',
- *     large: 'large (positive)'
+ *     sm: 'small (secondary)',
+ *     lg: 'large (positive)'
  *   },
  *   'default (primary)'
  * )}

--- a/packages/picasso-provider/src/Picasso/config/index.ts
+++ b/packages/picasso-provider/src/Picasso/config/index.ts
@@ -12,6 +12,7 @@ export {
   useScreenSize,
   useBreakpoint,
   useScreens,
+  BreakpointKeys,
 } from './breakpoints'
 export { default as layout } from './layout'
 export { default as shadows } from './shadows'

--- a/packages/picasso-provider/src/index.ts
+++ b/packages/picasso-provider/src/index.ts
@@ -24,6 +24,7 @@ export {
   sizes,
   shadows,
   PicassoBreakpoints,
+  BreakpointKeys,
 } from './Picasso/config'
 
 export { default as PicassoProvider } from './Picasso/PicassoProvider'

--- a/packages/picasso-provider/src/index.ts
+++ b/packages/picasso-provider/src/index.ts
@@ -34,6 +34,7 @@ export {
   useAppConfig,
   useDrawer,
   useSidebar,
+  useCurrentBreakpointRange,
   RootContext,
 } from './Picasso/RootContext'
 

--- a/packages/picasso/src/Grid/Grid.tsx
+++ b/packages/picasso/src/Grid/Grid.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode, HTMLAttributes } from 'react'
-import React, { useMemo, forwardRef } from 'react'
+import React, { forwardRef } from 'react'
 import type { Theme } from '@material-ui/core/styles'
 import { makeStyles } from '@material-ui/core/styles'
 import type {
@@ -11,7 +11,8 @@ import type {
 } from '@material-ui/core'
 import { Grid as MUIGrid } from '@material-ui/core'
 import type { BaseProps } from '@toptal/picasso-shared'
-import { useScreens } from '@toptal/picasso-provider'
+import { useCurrentBreakpointRange } from '@toptal/picasso-provider'
+import type { BreakpointKeys } from '@toptal/picasso-provider/Picasso/config'
 
 import styles from './styles'
 
@@ -42,16 +43,22 @@ const useStyles = makeStyles<Theme>(styles, {
   name: 'PicassoGrid',
 })
 
-const useResponsiveSpacing = () => {
-  const screens = useScreens()
+const responsiveSpacingConfiguration: Record<BreakpointKeys, number> = {
+  xs: 16,
+  sm: 16,
+  md: 24,
+  lg: 32,
+  xl: 32,
+}
 
-  return screens({
-    xs: 16,
-    sm: 16,
-    md: 24,
-    lg: 32,
-    xl: 32,
-  }) as number
+const useResponsiveSpacing = () => {
+  const { currentBreakpointRange } = useCurrentBreakpointRange()
+
+  if (currentBreakpointRange) {
+    return responsiveSpacingConfiguration[currentBreakpointRange]
+  }
+
+  return responsiveSpacingConfiguration.md
 }
 
 // eslint-disable-next-line react/display-name
@@ -71,40 +78,26 @@ export const Grid = forwardRef<HTMLDivElement, Props>(function Grid(
     ...rest
   } = props
   const classes = useStyles()
+
   const responsiveSpacing = useResponsiveSpacing()
   const gridSpacing = humanToMUISpacing(userSpacing || responsiveSpacing)
 
-  return useMemo(
-    () => (
-      <MUIGrid
-        {...rest}
-        ref={ref}
-        container
-        spacing={gridSpacing}
-        direction={direction}
-        alignItems={alignItems}
-        justifyContent={justifyContent}
-        wrap={wrap}
-        classes={classes}
-        className={className}
-        style={style}
-      >
-        {children}
-      </MUIGrid>
-    ),
-    [
-      ref,
-      gridSpacing,
-      direction,
-      alignItems,
-      justifyContent,
-      wrap,
-      classes,
-      className,
-      style,
-      children,
-      ...Object.values(rest),
-    ]
+  return (
+    <MUIGrid
+      {...rest}
+      ref={ref}
+      container
+      spacing={gridSpacing}
+      direction={direction}
+      alignItems={alignItems}
+      justifyContent={justifyContent}
+      wrap={wrap}
+      classes={classes}
+      className={className}
+      style={style}
+    >
+      {children}
+    </MUIGrid>
   )
 })
 

--- a/packages/picasso/src/Grid/Grid.tsx
+++ b/packages/picasso/src/Grid/Grid.tsx
@@ -11,8 +11,8 @@ import type {
 } from '@material-ui/core'
 import { Grid as MUIGrid } from '@material-ui/core'
 import type { BaseProps } from '@toptal/picasso-shared'
+import type { BreakpointKeys } from '@toptal/picasso-provider'
 import { useCurrentBreakpointRange } from '@toptal/picasso-provider'
-import type { BreakpointKeys } from '@toptal/picasso-provider/Picasso/config'
 
 import styles from './styles'
 

--- a/packages/picasso/src/Grid/story/ResponsiveSpacing.example.tsx
+++ b/packages/picasso/src/Grid/story/ResponsiveSpacing.example.tsx
@@ -1,0 +1,35 @@
+import React from 'react'
+import { Grid, Container } from '@toptal/picasso'
+import { useScreens } from '@toptal/picasso-provider'
+
+const BorderedContainer = () => {
+  const screens = useScreens()
+  const currentSpacing = screens({
+    xs: 'extra-small, 16px spacing',
+    sm: 'small, 16px spacing',
+    md: 'medium, 24px spacing',
+    lg: 'large, 32px spacing',
+    xl: 'extra-large, 32px spacing',
+  }) as string
+
+  return (
+    <Container padded='small' bordered rounded>
+      {currentSpacing}
+    </Container>
+  )
+}
+
+const Example = () => {
+  return (
+    <Grid>
+      <Grid.Item small={6}>
+        <BorderedContainer />
+      </Grid.Item>
+      <Grid.Item small={6}>
+        <BorderedContainer />
+      </Grid.Item>
+    </Grid>
+  )
+}
+
+export default Example

--- a/packages/picasso/src/Grid/story/ResponsiveSpacing.example.tsx
+++ b/packages/picasso/src/Grid/story/ResponsiveSpacing.example.tsx
@@ -1,5 +1,5 @@
-import React from 'react'
-import { Grid, Container } from '@toptal/picasso'
+import React, { useState } from 'react'
+import { Grid, Container, Button } from '@toptal/picasso'
 import { useScreens } from '@toptal/picasso-provider'
 
 const BorderedContainer = () => {
@@ -20,15 +20,25 @@ const BorderedContainer = () => {
 }
 
 const Example = () => {
+  const gridItem = (
+    <Grid.Item small={6}>
+      <BorderedContainer />
+    </Grid.Item>
+  )
+
+  const [gridItems, setGridItems] = useState([gridItem, gridItem])
+
   return (
-    <Grid>
-      <Grid.Item small={6}>
-        <BorderedContainer />
-      </Grid.Item>
-      <Grid.Item small={6}>
-        <BorderedContainer />
-      </Grid.Item>
-    </Grid>
+    <>
+      <Container>
+        <Grid>{gridItems}</Grid>
+      </Container>
+      <Container top='small'>
+        <Button onClick={() => setGridItems([...gridItems, gridItem])}>
+          Add another grid item
+        </Button>
+      </Container>
+    </>
   )
 }
 

--- a/packages/picasso/src/Grid/story/index.jsx
+++ b/packages/picasso/src/Grid/story/index.jsx
@@ -1,3 +1,4 @@
+import gridItemStory from '../../GridItem/story'
 import { Grid } from '../Grid'
 import PicassoBook from '~/.storybook/components/PicassoBook'
 
@@ -20,19 +21,17 @@ const page = PicassoBook.section('Layout').createPage(
 page
   .createTabChapter('Props')
   .addComponentDocs({ component: Grid, name: 'Grid' })
-//.addComponentDocs(gridItemStory.componentDocs)
+  .addComponentDocs(gridItemStory.componentDocs)
 
 page
   .createChapter()
-  /*
   .addExample('Grid/story/Alignment.example.tsx', 'Alignment')
   .addExample('Grid/story/Direction.example.tsx', 'Direction')
   .addExample('Grid/story/Wrapping.example.tsx', 'Wrapping')
-  */
   .addExample('Grid/story/ResponsiveSpacing.example.tsx', {
     title: 'Responsive spacing',
     description:
       'When `spacing` is not explicitly specified by consumer, grid adjusts it according to the screen size (please see the property description for details). You can try to resize screen, to see how different spacing is applied.',
   })
 
-//page.connect(gridItemStory.chapter)
+page.connect(gridItemStory.chapter)

--- a/packages/picasso/src/Grid/story/index.jsx
+++ b/packages/picasso/src/Grid/story/index.jsx
@@ -1,4 +1,3 @@
-import gridItemStory from '../../GridItem/story'
 import { Grid } from '../Grid'
 import PicassoBook from '~/.storybook/components/PicassoBook'
 
@@ -21,17 +20,19 @@ const page = PicassoBook.section('Layout').createPage(
 page
   .createTabChapter('Props')
   .addComponentDocs({ component: Grid, name: 'Grid' })
-  .addComponentDocs(gridItemStory.componentDocs)
+//.addComponentDocs(gridItemStory.componentDocs)
 
 page
   .createChapter()
+  /*
   .addExample('Grid/story/Alignment.example.tsx', 'Alignment')
   .addExample('Grid/story/Direction.example.tsx', 'Direction')
   .addExample('Grid/story/Wrapping.example.tsx', 'Wrapping')
+  */
   .addExample('Grid/story/ResponsiveSpacing.example.tsx', {
     title: 'Responsive spacing',
     description:
       'When `spacing` is not explicitly specified by consumer, grid adjusts it according to the screen size (please see the property description for details). You can try to resize screen, to see how different spacing is applied.',
   })
 
-page.connect(gridItemStory.chapter)
+//page.connect(gridItemStory.chapter)

--- a/packages/picasso/src/Grid/story/index.jsx
+++ b/packages/picasso/src/Grid/story/index.jsx
@@ -28,5 +28,10 @@ page
   .addExample('Grid/story/Alignment.example.tsx', 'Alignment')
   .addExample('Grid/story/Direction.example.tsx', 'Direction')
   .addExample('Grid/story/Wrapping.example.tsx', 'Wrapping')
+  .addExample('Grid/story/ResponsiveSpacing.example.tsx', {
+    title: 'Responsive spacing',
+    description:
+      'When `spacing` is not explicitly specified by consumer, grid adjusts it according to the screen size (please see the property description for details). You can try to resize screen, to see how different spacing is applied.',
+  })
 
 page.connect(gridItemStory.chapter)

--- a/packages/picasso/src/Radio/__snapshots__/test.tsx.snap
+++ b/packages/picasso/src/Radio/__snapshots__/test.tsx.snap
@@ -238,7 +238,7 @@ exports[`Radio Radio.Group renders radio in group 1`] = `
       role="radiogroup"
     >
       <div
-        class="MuiGrid-root PicassoRadioGroup-grid MuiGrid-container PicassoGrid-container MuiGrid-direction-xs MuiGrid-align-items-xs-flex"
+        class="MuiGrid-root PicassoRadioGroup-grid MuiGrid-container PicassoGrid-container MuiGrid-spacing-xs MuiGrid-direction-xs MuiGrid-align-items-xs-flex"
       >
         <div
           class="MuiGrid-root PicassoRadioGroup-gridItem MuiGrid-item"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7267,16 +7267,7 @@ array-unique@^0.3.2:
   resolved "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz"
   integrity sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=
 
-array.prototype.flat@^1.2.1, array.prototype.flat@^1.2.5:
-  version "1.2.5"
-  resolved "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.2.5.tgz"
-  integrity sha512-KaYU+S+ndVqyUnignHftkwc58o3uVU1jzczILJ1tN2YaIZpFIKBiP/x/j97E5MVPsaCloPbqWLB/8qCTVvT2qg==
-  dependencies:
-    call-bind "^1.0.2"
-    define-properties "^1.1.3"
-    es-abstract "^1.19.0"
-
-array.prototype.flat@^1.2.3:
+array.prototype.flat@^1.2.1, array.prototype.flat@^1.2.3, array.prototype.flat@^1.2.5:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/array.prototype.flat/-/array.prototype.flat-1.3.1.tgz#ffc6576a7ca3efc2f46a143b9d1dda9b4b3cf5e2"
   integrity sha512-roTU0KWIOmJ4DRLmwKd19Otg0/mT3qPNt0Qb3GWW8iObuZXxrjB/pzn0R3hqpRSWg4HCwqx+0vwOnWnvlOyeIA==
@@ -15269,12 +15260,7 @@ kleur@^3.0.3:
   resolved "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz"
   integrity sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==
 
-kleur@^4.0.3:
-  version "4.1.4"
-  resolved "https://registry.npmjs.org/kleur/-/kleur-4.1.4.tgz"
-  integrity sha512-8QADVssbrFjivHWQU7KkMgptGTl6WAcSdlbBPY4uNF+mWr6DGcKrvY2w4FQJoXch7+fKMjj0dRrL75vk3k23OA==
-
-kleur@^4.1.5:
+kleur@^4.0.3, kleur@^4.1.5:
   version "4.1.5"
   resolved "https://registry.yarnpkg.com/kleur/-/kleur-4.1.5.tgz#95106101795f7050c6c650f350c683febddb1780"
   integrity sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==
@@ -17110,12 +17096,7 @@ mylas@^2.1.9:
   resolved "https://registry.yarnpkg.com/mylas/-/mylas-2.1.13.tgz#1e23b37d58fdcc76e15d8a5ed23f9ae9fc0cbdf4"
   integrity sha512-+MrqnJRtxdF+xngFfUUkIMQrUUL0KsxbADUkn23Z/4ibGg192Q+z+CQyiYwvWTsYjJygmMR8+w3ZDa98Zh6ESg==
 
-nanoid@^3.3.1, nanoid@^3.3.4:
-  version "3.3.4"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.4.tgz#730b67e3cd09e2deacf03c027c81c9d9dbc5e8ab"
-  integrity sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==
-
-nanoid@^3.3.6:
+nanoid@^3.3.1, nanoid@^3.3.4, nanoid@^3.3.6:
   version "3.3.6"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.6.tgz#443380c856d6e9f9824267d960b4236ad583ea4c"
   integrity sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==
@@ -18698,16 +18679,7 @@ postcss@^7.0.14, postcss@^7.0.26, postcss@^7.0.32, postcss@^7.0.36, postcss@^7.0
     picocolors "^0.2.1"
     source-map "^0.6.1"
 
-postcss@^8.1.7, postcss@^8.2.15, postcss@^8.4.19:
-  version "8.4.21"
-  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.21.tgz#c639b719a57efc3187b13a1d765675485f4134f4"
-  integrity sha512-tP7u/Sn/dVxK2NnruI4H9BG+x+Wxz6oeZ1cJ8P6G/PZY0IKk4k/63TDsQf2kQq3+qoJeLm2kIBUNlZe3zgb4Zg==
-  dependencies:
-    nanoid "^3.3.4"
-    picocolors "^1.0.0"
-    source-map-js "^1.0.2"
-
-postcss@^8.4.22:
+postcss@^8.1.7, postcss@^8.2.15, postcss@^8.4.19, postcss@^8.4.22:
   version "8.4.23"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.4.23.tgz#df0aee9ac7c5e53e1075c24a3613496f9e6552ab"
   integrity sha512-bQ3qMcpF6A/YjR55xtoTr0jGOlnPOKAIMdOWiv0EIT6HVPEaJiJB4NLljSbiHoC2RX7DN5Uvjtpbg1NPdwv1oA==


### PR DESCRIPTION
[FX-3930]

### Description

[According to the BASE design](https://www.figma.com/file/q2nvjiyO2CLqBv4DeJnU3i/Product-Library-Documentation?type=design&node-id=4533%3A28468&t=NpdofDozEQJAvCJX-1), grid gutters depend on the screen size. This pull request adjusts gutters depending on the screen size unless spacing is explicitly specified by users.

<img width="794" alt="Screenshot 2023-05-04 at 15 49 25" src="https://user-images.githubusercontent.com/1390758/236209417-a7dffb53-457d-4cb4-b325-b00de66cf78e.png">

### How to test

- Test different screen sizes at https://picasso.toptal.net/FX-3930-make-grid-spacing-responsive/?path=/story/layout-grid--grid

### Screenshots

https://user-images.githubusercontent.com/1390758/236229973-8199a4fa-e35e-46dd-8fad-39771dcb6a1e.mp4

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [N/A] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [N/A] Covered with tests

**Breaking change**

- [N/A] codemod is created and showcased in the changeset
- [x] test alpha package of Picasso in StaffPortal (please see the https://github.com/toptal/staff-portal/pull/10339 and compare pages that have grids, for example, `talents?rate_buffer=0&limit=20&roles%5B%5D=designer&page=1&trigger=FilterUpdate`)

<img width="1016" alt="Screenshot 2023-05-04 at 18 32 59" src="https://user-images.githubusercontent.com/1390758/236256717-7492f3bc-88cb-4722-bd06-0ad5173dadfc.png">



> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-3930]: https://toptal-core.atlassian.net/browse/FX-3930?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ