### PR TITLE
feat: skip ticks for x and y axes

### DIFF
--- a/.changeset/moody-cooks-walk.md
+++ b/.changeset/moody-cooks-walk.md
@@ -1,0 +1,7 @@
+---
+'@toptal/picasso-charts': minor
+---
+
+### BarChart
+
+- add `showEveryNthTickOnXAxis` and `showEveryNthTickOnYAxis` properties to `BarChart`, so X and Y axes ticks can be skipped

--- a/packages/picasso-charts/src/BarChart/BarChart.tsx
+++ b/packages/picasso-charts/src/BarChart/BarChart.tsx
@@ -37,6 +37,8 @@ export type BarChartDataItem<K extends string | number | symbol> = {
   }
 }
 
+type ShowEverytNthTickValue = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10
+
 export interface Props<K extends string | number | symbol>
   extends BaseChartProps {
   /**
@@ -64,6 +66,10 @@ export interface Props<K extends string | number | symbol>
   showBarLabel?: boolean
   /** If set false, animation of bar will be disabled */
   isAnimationActive?: boolean
+  /** Makes X-axis show only every Nth tick. `0` hides all ticks, `1` shows all ticks (default behavior), `2` shows every 2nd tick, and so on */
+  showEveryNthTickOnXAxis?: ShowEverytNthTickValue
+  /** Makes Y-axis show only every Nth tick. `0` hides all ticks, `1` shows all ticks (default behavior), `2` shows every 2nd tick, and so on */
+  showEveryNthTickOnYAxis?: ShowEverytNthTickValue
 }
 
 const StyleOverrides = () => (
@@ -106,6 +112,8 @@ const BarChart = <K extends string>({
   showBarLabel,
   isAnimationActive,
   layout,
+  showEveryNthTickOnXAxis = 1,
+  showEveryNthTickOnYAxis = 1,
   ...rest
 }: Props<K>) => {
   const horizontal = layout === 'horizontal'
@@ -171,6 +179,7 @@ const BarChart = <K extends string>({
             axisLine={AXIS_LINE}
             minTickGap={MIN_TICK_GAP}
             tickMargin={TICK_MARGIN}
+            interval={showEveryNthTickOnXAxis - 1}
           />
           <YAxis
             {...yAxisProps}
@@ -179,6 +188,7 @@ const BarChart = <K extends string>({
             axisLine={AXIS_LINE}
             minTickGap={MIN_TICK_GAP}
             tickMargin={TICK_MARGIN}
+            interval={showEveryNthTickOnYAxis - 1}
           />
           {tooltipElement}
           {dataKeys.map(dataKey => (

--- a/packages/picasso-charts/src/BarChart/story/ShowEveryNthTick.example.tsx
+++ b/packages/picasso-charts/src/BarChart/story/ShowEveryNthTick.example.tsx
@@ -1,0 +1,55 @@
+import React from 'react'
+import { BarChart } from '@toptal/picasso-charts'
+import { palette } from '@toptal/picasso/utils'
+
+const CHART_DATA = [
+  {
+    name: 'Jan',
+    value: { recovered: 2400 },
+  },
+  {
+    name: 'Feb',
+    value: { recovered: 1398 },
+  },
+  {
+    name: 'Mar',
+    value: { recovered: 9800 },
+  },
+  {
+    name: 'Apr',
+    value: { recovered: 3908 },
+  },
+  {
+    name: 'May',
+    value: { recovered: 3900 },
+  },
+  {
+    name: 'Jun',
+    value: { recovered: 4200 },
+  },
+  {
+    name: 'Jul',
+    value: { recovered: 4500 },
+  },
+]
+
+const COLORS_MAPPING: Record<string, string> = {
+  infected: palette.blue.main,
+  recovered: palette.green.dark,
+}
+
+const Example = () => (
+  <div style={{ width: 720 }}>
+    <BarChart
+      data={CHART_DATA}
+      width='100%'
+      height={300}
+      getBarColor={({ dataKey }) => COLORS_MAPPING[dataKey]}
+      getBarLabelColor={({ dataKey }) => COLORS_MAPPING[dataKey]}
+      showEveryNthTickOnXAxis={3}
+      showEveryNthTickOnYAxis={0}
+    />
+  </div>
+)
+
+export default Example

--- a/packages/picasso-charts/src/BarChart/story/index.jsx
+++ b/packages/picasso-charts/src/BarChart/story/index.jsx
@@ -43,3 +43,8 @@ page
       'You can hide label of each bar via `showBarLabel` prop being set to `false`.',
     takeScreenshot: false,
   })
+  .addExample('BarChart/story/ShowEveryNthTick.example.tsx', {
+    title: 'Show every Nth tick on X or Y-axis',
+    description: `You can show every Nth tick for X-axis or Y-axis. "0" hides all ticks, "1" shows all ticks (default behavior). The example below has "showEveryNthTickOnXAxis={3}" (every third tick is shown on X-axis) and "showEveryNthTickOnYAxis={0}" (no ticks are shown on Y-axis).`,
+    takeScreenshot: false,
+  })


### PR DESCRIPTION
[FX-3957](https://toptal-core.atlassian.net/browse/FX-3957)

### Description

This pull request adds the `showEveryNthTickOnXAxis` and `showEveryNthTickOnYAxis` properties to `BarChart`, so ticks can be skipped on both axes.

### How to test

- Navigate to https://picasso.toptal.net/fx-3957-provide-an-option-to-show-or-hide-x-axis-ticks-in-picasso-barchart/?path=/story/picasso-charts-barchart--barchart and check out the `Show every Nth tick on X or Y-axis` section

### Screenshots

<img width="847" alt="Screenshot 2023-05-10 at 18 31 12" src="https://github.com/toptal/picasso/assets/1390758/653c8c0a-46a5-40fb-ba55-5295d7c27682">

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [N/A] Covered with tests

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-3957]: https://toptal-core.atlassian.net/browse/FX-3957?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ