### PR TITLE
fix: quill issue in Safari when editor is hidden

### DIFF
--- a/.changeset/brave-eyes-raise.md
+++ b/.changeset/brave-eyes-raise.md
@@ -1,0 +1,7 @@
+---
+'@toptal/picasso': patch
+---
+
+---
+
+- fix quill issue in Safari when editor is hidden

--- a/packages/picasso/src/QuillEditor/utils/getEditorChangeHandler/getEditorChangeHandler.tsx
+++ b/packages/picasso/src/QuillEditor/utils/getEditorChangeHandler/getEditorChangeHandler.tsx
@@ -54,7 +54,12 @@ const getEditorChangeHandler = (
         // this event is triggered when format of block element is changed
         // for example from p > h3 | h3 > ol
         if (!latestDelta.ops?.[latestDelta.ops.length - 1].delete) {
-          onSelectionChange(quill.getFormat() as FormatType)
+          // we need to set range index manually, because Safari has an issue with it. See: https://github.com/quilljs/quill/issues/3093
+          onSelectionChange(
+            quill.getFormat(
+              (quill as any).selection.savedRange.index
+            ) as FormatType
+          )
         }
       } else if (isFromUser) {
         handleNewLineAfterBlock({ latestDelta, quill, onSelectionChange })

--- a/packages/picasso/src/QuillEditor/utils/getEditorChangeHandler/test.ts
+++ b/packages/picasso/src/QuillEditor/utils/getEditorChangeHandler/test.ts
@@ -28,6 +28,11 @@ describe('getEditorChangeHandler', () => {
       it('calls the callback with quill format', () => {
         const quill = {
           getFormat: jest.fn(() => ({})),
+          selection: {
+            savedRange: {
+              index: 0,
+            },
+          },
         } as unknown as Quill
         const onSelectionChange = jest.fn()
 


### PR DESCRIPTION
[FX-3974]

### Description

Quill has an issue with ranges in Safari: https://github.com/quilljs/quill/issues/3093

We need to handle it on our side by providing the latest range index. So, we need to use an internal `selection` object to do it or provide `0` manually

### How to test

- on Temploy, you need to paste the following code:

```
import React from 'react'
import { Accordion } from '@toptal/picasso'
import {
  FormNonCompound,
  SubmitButton,
  RichTextEditor,
} from '@toptal/picasso-forms'
import { htmlToHast } from '@toptal/picasso/utils'

const defaultValue = '<p>Position Description</p>'

const Example = () => (
  <Accordion content={<DetailsDogDefinitionPanel />}>
    <Accordion.Summary>Job description</Accordion.Summary>
  </Accordion>
)

const RTE = () => {
  return (
    <FormNonCompound
      onSubmit={console.log}
      initialValues={{
        defaultValueEditor: defaultValue,
      }}
    >
      <RichTextEditor
        id='defaultValueEditor'
        name='defaultValueEditor'
        placeholder='Write some cool rich text'
        defaultValue={htmlToHast(defaultValue)}
      />
      <SubmitButton>Submit</SubmitButton>
    </FormNonCompound>
  )
}

const DetailsDogDefinitionPanel = () => (
  <Accordion.Details>
    <RTE />
  </Accordion.Details>
)

export default Example
```

It must work as expected without raising errors.


### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Ensure that deployed demo has expected results and good examples
- [x] Self reviewed


> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-3974]: https://toptal-core.atlassian.net/browse/FX-3974?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ