### PR TITLE
fix(Drawer): close button and standard title overlap

### DIFF
--- a/.changeset/shiny-files-peel.md
+++ b/.changeset/shiny-files-peel.md
@@ -1,0 +1,7 @@
+---
+'@toptal/picasso': patch
+---
+
+### Drawer
+
+- fix close button and standard title overlap

--- a/packages/picasso/src/DrawerTitle/styles.ts
+++ b/packages/picasso/src/DrawerTitle/styles.ts
@@ -5,7 +5,7 @@ export default ({ palette }: Theme) =>
   createStyles({
     header: {
       borderBottom: `1px solid ${palette.grey.lighter}`,
-      padding: '1rem 1.5rem',
+      padding: '1rem 4rem 1rem 1.5rem',
     },
     title: {
       flexGrow: 1,


### PR DESCRIPTION
[TOP-3211](https://toptal-core.atlassian.net/browse/TOP-3211)

### Description

Fix `Drawer` close button and standard title overlap when the title text is too big.

### How to test

- Go to the [Drawer page](http://localhost:9001/?path=/story/components-drawer--drawer)
- Go to the **Default** example and edit the code by adding a bigger title
- Click on `Show drawer` and make sure the title and close button don't overlap

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| ![image](https://github.com/toptal/picasso/assets/82273361/a2f0c2bb-1014-4c32-b859-75205cb08ef9) | ![image](https://github.com/toptal/picasso/assets/82273361/8f8ca6fa-3a9d-4808-b0a3-7c68057572e8) |

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests

**Breaking change**

- [x] codemod is created and showcased in the changeset
- [x] test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[TOP-3211]: https://toptal-core.atlassian.net/browse/TOP-3211?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ