### PR TITLE
fix: overlap in breakpoints

### DIFF
--- a/.changeset/calm-students-refuse.md
+++ b/.changeset/calm-students-refuse.md
@@ -1,0 +1,5 @@
+---
+'@toptal/picasso-provider': minor
+---
+
+- remove media queries overlap for breakpoint range detection

--- a/packages/picasso-provider/src/Picasso/config/breakpoints.ts
+++ b/packages/picasso-provider/src/Picasso/config/breakpoints.ts
@@ -11,8 +11,6 @@ type BreakpointsList = {
   [key: string]: number
 }
 
-const decreaseByOne = (value: number) => value - 1
-
 class BreakpointProvider {
   breakpoints: Record<'values', BreakpointValues> = {
     values: {
@@ -32,10 +30,10 @@ class BreakpointProvider {
     const { sm, md, lg, xl } = this.breakpoints.values
 
     this.mediaQueries = {
-      xs: `(max-width: ${decreaseByOne(sm)}px)`,
-      sm: `(min-width: ${sm}px) and (max-width: ${decreaseByOne(md)}px)`,
-      md: `(min-width: ${md}px) and (max-width: ${decreaseByOne(lg)}px)`,
-      lg: `(min-width: ${lg}px) and (max-width: ${decreaseByOne(xl)}px)`,
+      xs: `(max-width: ${sm - 1}px)`,
+      sm: `(min-width: ${sm}px) and (max-width: ${md - 1}px)`,
+      md: `(min-width: ${md}px) and (max-width: ${lg - 1}px)`,
+      lg: `(min-width: ${lg}px) and (max-width: ${xl - 1}px)`,
       xl: `(min-width: ${xl}px)`,
     }
   }

--- a/packages/picasso-provider/src/Picasso/config/breakpoints.ts
+++ b/packages/picasso-provider/src/Picasso/config/breakpoints.ts
@@ -11,6 +11,8 @@ type BreakpointsList = {
   [key: string]: number
 }
 
+const decreaseByOne = (value: number) => value - 1
+
 class BreakpointProvider {
   breakpoints: Record<'values', BreakpointValues> = {
     values: {
@@ -30,10 +32,10 @@ class BreakpointProvider {
     const { sm, md, lg, xl } = this.breakpoints.values
 
     this.mediaQueries = {
-      xs: `(max-width: ${sm}px)`,
-      sm: `(min-width: ${sm}px) and (max-width: ${md}px)`,
-      md: `(min-width: ${md}px) and (max-width: ${lg}px)`,
-      lg: `(min-width: ${lg}px) and (max-width: ${xl}px)`,
+      xs: `(max-width: ${decreaseByOne(sm)}px)`,
+      sm: `(min-width: ${sm}px) and (max-width: ${decreaseByOne(md)}px)`,
+      md: `(min-width: ${md}px) and (max-width: ${decreaseByOne(lg)}px)`,
+      lg: `(min-width: ${lg}px) and (max-width: ${decreaseByOne(xl)}px)`,
       xl: `(min-width: ${xl}px)`,
     }
   }

--- a/packages/picasso-provider/src/Picasso/config/test.ts
+++ b/packages/picasso-provider/src/Picasso/config/test.ts
@@ -12,13 +12,13 @@ describe('responsive breakpoint utils', () => {
     it('xs', () => {
       const mediaQuery = screens('xs')
 
-      expect(mediaQuery).toBe('@media (max-width: 480px)')
+      expect(mediaQuery).toBe('@media (max-width: 479px)')
     })
     it('sm', () => {
       const mediaQuery = screens('sm')
 
       expect(mediaQuery).toBe(
-        '@media (min-width: 480px) and (max-width: 768px)'
+        '@media (min-width: 480px) and (max-width: 767px)'
       )
     })
 
@@ -26,7 +26,7 @@ describe('responsive breakpoint utils', () => {
       const mediaQuery = screens('sm', 'md')
 
       expect(mediaQuery).toBe(
-        '@media (min-width: 480px) and (max-width: 768px), (min-width: 768px) and (max-width: 1024px)'
+        '@media (min-width: 480px) and (max-width: 767px), (min-width: 768px) and (max-width: 1023px)'
       )
     })
 
@@ -34,7 +34,7 @@ describe('responsive breakpoint utils', () => {
       const mediaQuery = screens('sm', 'md', 'lg')
 
       expect(mediaQuery).toBe(
-        '@media (min-width: 480px) and (max-width: 768px), (min-width: 768px) and (max-width: 1024px), (min-width: 1024px) and (max-width: 1440px)'
+        '@media (min-width: 480px) and (max-width: 767px), (min-width: 768px) and (max-width: 1023px), (min-width: 1024px) and (max-width: 1439px)'
       )
     })
   })
@@ -136,7 +136,7 @@ describe('non-responsive breakpoint utils', () => {
       const mediaQuery = screens('sm', 'md', 'lg')
 
       expect(mediaQuery).toBe(
-        '@media (min-width: 1024px) and (max-width: 1440px)'
+        '@media (min-width: 1024px) and (max-width: 1439px)'
       )
     })
   })


### PR DESCRIPTION
[FX-3999]

### Description

This pull request fixes the overlap in breakpoints media queries that was causing ambiguity when detecting breakpoint ranges.

Taken from https://github.com/toptal/picasso/blob/a9e8c9189dc7a11ddb159f3c08eddffa081a1e2f/docs/decisions/13-breakpoints.md#proposal:

```
...
// Breakpoint ranges
xs:  0-479px
sm:  480-767px
md:  768-1023px
lg:  1024-1439px
xl:  1440px+
...
```

### How to test

- All checks should pass

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [N/A] Make sure that additions and changes on design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [x] Annotate all `props` in component with documentation
- [N/A] Create `examples` for component
- [N/A] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-3999]: https://toptal-core.atlassian.net/browse/FX-3999?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ