### PR TITLE
chore: add light blue color in indicator

### DIFF
--- a/.changeset/tender-insects-accept.md
+++ b/.changeset/tender-insects-accept.md
@@ -1,0 +1,9 @@
+---
+'@toptal/picasso': minor
+---
+
+---
+
+### Indicator
+
+- add light-blue color

--- a/packages/picasso/src/Indicator/Indicator.tsx
+++ b/packages/picasso/src/Indicator/Indicator.tsx
@@ -6,7 +6,13 @@ import type { BaseProps } from '@toptal/picasso-shared'
 
 import styles from './styles'
 
-type ColorType = 'red' | 'yellow' | 'blue' | 'green' | 'light-grey'
+type ColorType =
+  | 'red'
+  | 'yellow'
+  | 'blue'
+  | 'green'
+  | 'light-grey'
+  | 'light-blue'
 
 export interface Props extends BaseProps {
   /** Indicator color */

--- a/packages/picasso/src/Indicator/story/Default.example.tsx
+++ b/packages/picasso/src/Indicator/story/Default.example.tsx
@@ -4,6 +4,15 @@ import { Indicator, Typography, Container } from '@toptal/picasso'
 const Example = () => (
   <>
     <Container bottom='medium'>
+      <Container inline right='small'>
+        <Indicator color='light-blue' />
+      </Container>
+      <Typography inline size='medium'>
+        Light blue
+      </Typography>
+    </Container>
+
+    <Container bottom='medium'>
       <Container bottom='medium'>
         <Container inline right='small'>
           <Indicator color='light-grey' />

--- a/packages/picasso/src/Indicator/styles.ts
+++ b/packages/picasso/src/Indicator/styles.ts
@@ -23,4 +23,7 @@ export default ({ palette }: Theme) =>
     'light-grey': {
       background: palette.grey.light2,
     },
+    'light-blue': {
+      background: palette.blue.light,
+    },
   })

--- a/packages/picasso/src/TagRectangular/story/Indicators.example.tsx
+++ b/packages/picasso/src/TagRectangular/story/Indicators.example.tsx
@@ -15,6 +15,9 @@ const Example = () => (
     <Container right='small' top={0.5}>
       <Tag.Rectangular indicator='blue'>Blue</Tag.Rectangular>
     </Container>
+    <Container right='small' top={0.5}>
+      <Tag.Rectangular indicator='light-blue'>Light blue</Tag.Rectangular>
+    </Container>
   </Container>
 )
 


### PR DESCRIPTION
[SDE-1065](https://toptal-core.atlassian.net/browse/SDE-1065)

### Description

Add light blue color in `Indicator` and `TagRectangular`

### How to test

- Go to `Indicator` component page
- Light-blue section should appear 
- Go to `TagRectangular` component page
- Light-blue section should appear 

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| ![Screenshot from 2023-05-23 19-24-12](https://github.com/toptal/picasso/assets/33624918/60080573-3ff4-48b5-b328-7102a3d38e3b) | ![Screenshot from 2023-05-23 19-23-50](https://github.com/toptal/picasso/assets/33624918/166f01e9-1ef0-4b19-ac86-ead1550314fe) |


### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [n/a] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests

**Breaking change**

- [n/a] codemod is created and showcased in the changeset
- [n/a] test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[SDE-1065]: https://toptal-core.atlassian.net/browse/SDE-1065?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ