### PR TITLE
fix: solve inactive deployments for temploy

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -161,9 +161,10 @@ jobs:
           echo "temployURL=$temployURL" >> $GITHUB_OUTPUT
 
       - name: Create Jira Deployment
-        uses: toptal/davinci-github-actions/create-jira-deployment@v7.0.0
+        uses: toptal/davinci-github-actions/create-jira-deployment@chore/add-auto-inactive-parameter
         if: ${{ always() }}
         with:
           token: ${{ env.TOPTAL_DEVBOT_TOKEN }}
           environment: temploy
           environment-url: ${{ steps.temploy.outputs.temployURL }}
+          auto-inactive: false


### PR DESCRIPTION
### Description

Fix inactive temploy deployments: right now, only the latest `temploy` deployment is active. We need to keep them all active.

### How to test

- Create PR
- run temploy deployment several times between this PR and another

Expected:

All `temploy` deployments that are related to this PR must be active.

### Development checks

- [ ] Self reviewed

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>
