### PR TITLE
chore: use local state istead of global context

### DIFF
--- a/.changeset/stupid-rice-shop.md
+++ b/.changeset/stupid-rice-shop.md
@@ -1,0 +1,7 @@
+---
+'@toptal/picasso': patch
+---
+
+### Page.TopBar
+
+- fix responsivnes when running on react@16

--- a/.changeset/stupid-rice-shop.md
+++ b/.changeset/stupid-rice-shop.md
@@ -4,4 +4,4 @@
 
 ### Page.TopBar
 
-- fix responsivnes when running on react@16
+- fix responsiveness when running on react@16

--- a/packages/picasso/src/PageHamburger/PageHamburger.tsx
+++ b/packages/picasso/src/PageHamburger/PageHamburger.tsx
@@ -18,7 +18,7 @@ const useStyles = makeStyles<Theme>(styles, {
 })
 
 const PageHamburger = ({ id }: Props) => {
-  const { isHamburgerVisible } = useHamburgerContext()
+  const { isHamburgerVisible, hamburgerRef } = useHamburgerContext()
   const [showContent, setShowContent] = useState<boolean>(false)
   const classes = useStyles()
 
@@ -27,7 +27,7 @@ const PageHamburger = ({ id }: Props) => {
 
   return (
     <Dropdown
-      content={<div id={id} />}
+      content={<div id={id} ref={hamburgerRef} />}
       className={cx(classes.root, {
         [classes.hidden]: !isHamburgerVisible,
       })}

--- a/packages/picasso/src/PageHamburger/PageHamburgerContext.tsx
+++ b/packages/picasso/src/PageHamburger/PageHamburgerContext.tsx
@@ -1,12 +1,13 @@
 import type { ReactNode } from 'react'
 import React, { createContext, useContext, useState } from 'react'
 
+type BooleanStateSetter = React.Dispatch<React.SetStateAction<boolean>>
 export interface HamburgerContextProps {
   hamburgerId: string
   isHamburgerVisible: boolean
-  setIsHamburgerVisible: React.Dispatch<React.SetStateAction<boolean>>
+  setIsHamburgerVisible: BooleanStateSetter
   hasTopBar: boolean
-  setHasTopBar: React.Dispatch<React.SetStateAction<boolean>>
+  setHasTopBar: BooleanStateSetter
 }
 
 const PageHamburgerContext = createContext<HamburgerContextProps>({

--- a/packages/picasso/src/PageHamburger/PageHamburgerContext.tsx
+++ b/packages/picasso/src/PageHamburger/PageHamburgerContext.tsx
@@ -1,13 +1,12 @@
 import type { ReactNode } from 'react'
 import React, { createContext, useContext, useState } from 'react'
 
-type BooleanStateSetter = React.Dispatch<React.SetStateAction<boolean>>
 export interface HamburgerContextProps {
   hamburgerId: string
   isHamburgerVisible: boolean
-  setIsHamburgerVisible: BooleanStateSetter
+  setIsHamburgerVisible: (val: boolean) => void
   hasTopBar: boolean
-  setHasTopBar: BooleanStateSetter
+  setHasTopBar: (val: boolean) => void
 }
 
 const PageHamburgerContext = createContext<HamburgerContextProps>({

--- a/packages/picasso/src/PageHamburger/PageHamburgerContext.tsx
+++ b/packages/picasso/src/PageHamburger/PageHamburgerContext.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from 'react'
-import React, { createContext, useContext, useState } from 'react'
+import React, { createContext, useContext, useRef, useState } from 'react'
 
 export interface HamburgerContextProps {
   hamburgerId: string
@@ -7,6 +7,7 @@ export interface HamburgerContextProps {
   setIsHamburgerVisible: (val: boolean) => void
   hasTopBar: boolean
   setHasTopBar: (val: boolean) => void
+  hamburgerRef?: React.RefObject<HTMLDivElement>
 }
 
 const PageHamburgerContext = createContext<HamburgerContextProps>({
@@ -28,6 +29,7 @@ export const PageHamburgerContextProvider = ({
 }: Props) => {
   const [isHamburgerVisible, setIsHamburgerVisible] = useState<boolean>(false)
   const [hasTopBar, setHasTopBar] = useState(true)
+  const hamburgerRef = useRef<HTMLDivElement>(null)
 
   const context = {
     hamburgerId,
@@ -35,6 +37,7 @@ export const PageHamburgerContextProvider = ({
     setIsHamburgerVisible,
     hasTopBar,
     setHasTopBar,
+    hamburgerRef,
   }
 
   return (

--- a/packages/picasso/src/PageHamburger/PageHamburgerContext.tsx
+++ b/packages/picasso/src/PageHamburger/PageHamburgerContext.tsx
@@ -27,7 +27,7 @@ export const PageHamburgerContextProvider = ({
   hamburgerId,
 }: Props) => {
   const [isHamburgerVisible, setIsHamburgerVisible] = useState<boolean>(false)
-  const [hasTopBar, setHasTopBar] = useState(false)
+  const [hasTopBar, setHasTopBar] = useState(true)
 
   const context = {
     hamburgerId,

--- a/packages/picasso/src/PageHamburger/PageHamburgerContext.tsx
+++ b/packages/picasso/src/PageHamburger/PageHamburgerContext.tsx
@@ -5,12 +5,16 @@ export interface HamburgerContextProps {
   hamburgerId: string
   isHamburgerVisible: boolean
   setIsHamburgerVisible: React.Dispatch<React.SetStateAction<boolean>>
+  hasTopBar: boolean
+  setHasTopBar: React.Dispatch<React.SetStateAction<boolean>>
 }
 
 const PageHamburgerContext = createContext<HamburgerContextProps>({
   hamburgerId: 'hamburger',
   isHamburgerVisible: false,
   setIsHamburgerVisible: () => {},
+  hasTopBar: false,
+  setHasTopBar: () => {},
 })
 
 interface Props {
@@ -23,11 +27,14 @@ export const PageHamburgerContextProvider = ({
   hamburgerId,
 }: Props) => {
   const [isHamburgerVisible, setIsHamburgerVisible] = useState<boolean>(false)
+  const [hasTopBar, setHasTopBar] = useState(false)
 
   const context = {
     hamburgerId,
     isHamburgerVisible,
     setIsHamburgerVisible,
+    hasTopBar,
+    setHasTopBar,
   }
 
   return (

--- a/packages/picasso/src/PageHamburger/PageHamburgerPortal.tsx
+++ b/packages/picasso/src/PageHamburger/PageHamburgerPortal.tsx
@@ -1,5 +1,5 @@
-import React from 'react'
-import Portal from '@material-ui/core/Portal'
+import React, { useEffect } from 'react'
+import { createPortal } from 'react-dom'
 
 import { useHamburgerContext } from './PageHamburgerContext'
 
@@ -9,12 +9,22 @@ interface Props {
 
 const PageHamburgerPortal = ({ children }: Props) => {
   const { isHamburgerVisible, hamburgerRef } = useHamburgerContext()
+  const [container, setContainer] = React.useState<HTMLElement | null>(null)
+  const [isMounted, setIsMounted] = React.useState<boolean>(false)
 
-  if (!hamburgerRef?.current || !isHamburgerVisible) {
+  useEffect(() => {
+    setIsMounted(true)
+
+    if (hamburgerRef?.current) {
+      setContainer(hamburgerRef.current)
+    }
+  }, [hamburgerRef, isMounted])
+
+  if (!container || !isHamburgerVisible) {
     return null
   }
 
-  return <Portal container={hamburgerRef.current}>{children}</Portal>
+  return createPortal(children, container)
 }
 
 export default PageHamburgerPortal

--- a/packages/picasso/src/PageHamburger/PageHamburgerPortal.tsx
+++ b/packages/picasso/src/PageHamburger/PageHamburgerPortal.tsx
@@ -1,6 +1,5 @@
-import React, { useEffect, useState } from 'react'
+import React from 'react'
 import Portal from '@material-ui/core/Portal'
-import { getElementById } from '@toptal/picasso-shared'
 
 import { useHamburgerContext } from './PageHamburgerContext'
 
@@ -9,30 +8,13 @@ interface Props {
 }
 
 const PageHamburgerPortal = ({ children }: Props) => {
-  const { hamburgerId, isHamburgerVisible } = useHamburgerContext()
-  const [container, setContainer] = useState<HTMLElement | null>(null)
+  const { isHamburgerVisible, hamburgerRef } = useHamburgerContext()
 
-  useEffect(() => {
-    const handleSetContainer = () => setContainer(getElementById(hamburgerId))
-
-    handleSetContainer()
-
-    // If the container doesn't exist on the first render, try again once the whole page has loaded
-    if (!container) {
-      window.addEventListener('load', handleSetContainer)
-    }
-
-    // Clean up event listener on component unmount
-    return () => {
-      window.removeEventListener('load', handleSetContainer)
-    }
-  }, [container, hamburgerId])
-
-  if (!container || !isHamburgerVisible) {
+  if (!hamburgerRef?.current || !isHamburgerVisible) {
     return null
   }
 
-  return <Portal container={container}>{children}</Portal>
+  return <Portal container={hamburgerRef.current}>{children}</Portal>
 }
 
 export default PageHamburgerPortal

--- a/packages/picasso/src/PageHamburger/PageHamburgerPortal.tsx
+++ b/packages/picasso/src/PageHamburger/PageHamburgerPortal.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useCallback } from 'react'
 import Portal from '@material-ui/core/Portal'
 import { getElementById } from '@toptal/picasso-shared'
 
@@ -9,13 +9,12 @@ interface Props {
 }
 
 const PageHamburgerPortal = ({ children }: Props) => {
-  const { hamburgerId, hasTopBar } = useHamburgerContext()
+  const { hamburgerId, isHamburgerVisible } = useHamburgerContext()
 
-  const container = getElementById(hamburgerId)
-
-  if (!container || !hasTopBar) {
-    return null
-  }
+  const container = useCallback(
+    () => (isHamburgerVisible ? getElementById(hamburgerId) : null),
+    [hamburgerId, isHamburgerVisible]
+  )
 
   return <Portal container={container}>{children}</Portal>
 }

--- a/packages/picasso/src/PageHamburger/PageHamburgerPortal.tsx
+++ b/packages/picasso/src/PageHamburger/PageHamburgerPortal.tsx
@@ -11,12 +11,12 @@ interface Props {
 const PageHamburgerPortal = ({ children }: Props) => {
   const { hamburgerId, isHamburgerVisible } = useHamburgerContext()
 
-  const container = useCallback(
+  const getContainer = useCallback(
     () => (isHamburgerVisible ? getElementById(hamburgerId) : null),
     [hamburgerId, isHamburgerVisible]
   )
 
-  return <Portal container={container}>{children}</Portal>
+  return <Portal container={getContainer}>{children}</Portal>
 }
 
 export default PageHamburgerPortal

--- a/packages/picasso/src/PageHamburger/PageHamburgerPortal.tsx
+++ b/packages/picasso/src/PageHamburger/PageHamburgerPortal.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react'
+import React, { useEffect, useState } from 'react'
 import Portal from '@material-ui/core/Portal'
 import { getElementById } from '@toptal/picasso-shared'
 
@@ -10,13 +10,20 @@ interface Props {
 
 const PageHamburgerPortal = ({ children }: Props) => {
   const { hamburgerId, isHamburgerVisible } = useHamburgerContext()
+  const [container, setContainer] = useState<HTMLElement | null>(null)
+  const containerElement = getElementById(hamburgerId)
 
-  const getContainer = useCallback(
-    () => (isHamburgerVisible ? getElementById(hamburgerId) : null),
-    [hamburgerId, isHamburgerVisible]
-  )
+  useEffect(() => {
+    if (containerElement !== container) {
+      setContainer(containerElement)
+    }
+  }, [containerElement, container])
 
-  return <Portal container={getContainer}>{children}</Portal>
+  if (!container || !isHamburgerVisible) {
+    return null
+  }
+
+  return <Portal container={container}>{children}</Portal>
 }
 
 export default PageHamburgerPortal

--- a/packages/picasso/src/PageHamburger/PageHamburgerPortal.tsx
+++ b/packages/picasso/src/PageHamburger/PageHamburgerPortal.tsx
@@ -11,13 +11,22 @@ interface Props {
 const PageHamburgerPortal = ({ children }: Props) => {
   const { hamburgerId, isHamburgerVisible } = useHamburgerContext()
   const [container, setContainer] = useState<HTMLElement | null>(null)
-  const containerElement = getElementById(hamburgerId)
 
   useEffect(() => {
-    if (containerElement !== container) {
-      setContainer(containerElement)
+    const handleSetContainer = () => setContainer(getElementById(hamburgerId))
+
+    handleSetContainer()
+
+    // If the container doesn't exist on the first render, try again once the whole page has loaded
+    if (!container) {
+      window.addEventListener('load', handleSetContainer)
     }
-  }, [containerElement, container])
+
+    // Clean up event listener on component unmount
+    return () => {
+      window.removeEventListener('load', handleSetContainer)
+    }
+  }, [container, hamburgerId])
 
   if (!container || !isHamburgerVisible) {
     return null

--- a/packages/picasso/src/PageHamburger/PageHamburgerPortal.tsx
+++ b/packages/picasso/src/PageHamburger/PageHamburgerPortal.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import Portal from '@material-ui/core/Portal'
 import { getElementById } from '@toptal/picasso-shared'
-import { usePageTopBar } from '@toptal/picasso-provider'
 
 import { useHamburgerContext } from './PageHamburgerContext'
 
@@ -10,8 +9,7 @@ interface Props {
 }
 
 const PageHamburgerPortal = ({ children }: Props) => {
-  const { hamburgerId } = useHamburgerContext()
-  const { hasTopBar } = usePageTopBar()
+  const { hamburgerId, hasTopBar } = useHamburgerContext()
 
   const container = getElementById(hamburgerId)
 

--- a/packages/picasso/src/PageHamburger/hooks/use-portal-to-hamburger.ts
+++ b/packages/picasso/src/PageHamburger/hooks/use-portal-to-hamburger.ts
@@ -1,4 +1,3 @@
-import { usePageTopBar } from '@toptal/picasso-provider'
 import { useEffect } from 'react'
 
 import { useHamburgerContext } from '../PageHamburgerContext'
@@ -10,8 +9,7 @@ import { useHamburgerContext } from '../PageHamburgerContext'
  * It sets hamburger menu to be visible in compact screens.
  */
 const usePortalToHamburger = () => {
-  const { setIsHamburgerVisible } = useHamburgerContext()
-  const { hasTopBar } = usePageTopBar()
+  const { setIsHamburgerVisible, hasTopBar } = useHamburgerContext()
 
   useEffect(() => {
     if (hasTopBar) {

--- a/packages/picasso/src/PageSidebar/PageSidebar.tsx
+++ b/packages/picasso/src/PageSidebar/PageSidebar.tsx
@@ -1,6 +1,6 @@
 import type { Theme } from '@material-ui/core/styles'
 import { makeStyles } from '@material-ui/core/styles'
-import { usePageTopBar, useSidebar } from '@toptal/picasso-provider'
+import { useSidebar } from '@toptal/picasso-provider'
 import type { BaseProps, SizeType } from '@toptal/picasso-shared'
 import cx from 'classnames'
 import type { ReactNode } from 'react'
@@ -9,7 +9,11 @@ import React, { forwardRef, useCallback, useEffect, useState } from 'react'
 import ButtonCircular from '../ButtonCircular'
 import Container from '../Container'
 import { BackMinor16, ChevronRight16 } from '../Icon'
-import { PageHamburgerPortal, usePortalToHamburger } from '../PageHamburger'
+import {
+  PageHamburgerPortal,
+  useHamburgerContext,
+  usePortalToHamburger,
+} from '../PageHamburger'
 import SidebarItem from '../SidebarItem'
 import SidebarLogo from '../SidebarLogo'
 import SidebarMenu from '../SidebarMenu'
@@ -68,7 +72,7 @@ export const PageSidebar = forwardRef<HTMLDivElement, Props>(function Sidebar(
   const [isCollapsed, setIsCollapsed] = useState(!!defaultCollapsed)
   const [isHovered, setIsHovered] = useState(false)
   const [expandedItemKey, setExpandedItemKey] = useState<number | null>(null)
-  const { hasTopBar } = usePageTopBar()
+  const { hasTopBar } = useHamburgerContext()
 
   useEffect(() => {
     // Clear expanded submenu on sidebar collapse

--- a/packages/picasso/src/PageTopBar/PageTopBar.tsx
+++ b/packages/picasso/src/PageTopBar/PageTopBar.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable complexity */
 import type { ReactNode, ReactElement, HTMLAttributes } from 'react'
-import React, { useContext, forwardRef } from 'react'
+import React, { useContext, forwardRef, useEffect } from 'react'
 import cx from 'classnames'
 import type { BaseProps } from '@toptal/picasso-shared'
 import { usePageTopBar } from '@toptal/picasso-provider'
@@ -66,7 +66,9 @@ export const PageTopBar = forwardRef<HTMLElement, Props>(function PageTopBar(
   const showEmblemOnly = useBreakpoint(['xs', 'sm'])
   const showTagline = useBreakpoint(['lg', 'xl'])
 
-  const { setHasTopBar, hasTopBar } = usePageTopBar()
+  const { setHasTopBar } = usePageTopBar()
+  const { setHasTopBar: setHasTopBarHamburger, hasTopBar } =
+    useHamburgerContext()
 
   useIsomorphicLayoutEffect(() => {
     setHasTopBar(true)
@@ -74,7 +76,13 @@ export const PageTopBar = forwardRef<HTMLElement, Props>(function PageTopBar(
     return function cleanup() {
       setHasTopBar(false)
     }
-  }, [setHasTopBar, hasTopBar])
+  }, [setHasTopBar])
+
+  useEffect(() => {
+    setHasTopBarHamburger(true)
+
+    return () => setHasTopBarHamburger(false)
+  }, [hasTopBar, setHasTopBarHamburger])
 
   const { width, fullWidth } = useContext<PageContextProps>(PageContext)
   const { hamburgerId } = useHamburgerContext()

--- a/packages/picasso/src/PageTopBar/PageTopBar.tsx
+++ b/packages/picasso/src/PageTopBar/PageTopBar.tsx
@@ -73,9 +73,7 @@ export const PageTopBar = forwardRef<HTMLElement, Props>(function PageTopBar(
   useIsomorphicLayoutEffect(() => {
     setHasTopBar(true)
 
-    return function cleanup() {
-      setHasTopBar(false)
-    }
+    return () => setHasTopBar(false)
   }, [setHasTopBar])
 
   useEffect(() => {


### PR DESCRIPTION
[FX-4033]

### Description

For some reason, when the application is running on react@16, it has not the correct value of `hasTopBar` from the global context. To not break it's usage in the rest of the application, I'm using local context which works exactly as it should.

### How to test

- check this [sandbox](https://codesandbox.io/s/flamboyant-bartik-mrvdlj?file=/package.json&resolutionWidth=1252&resolutionHeight=675)

### Screenshots

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- `n/a` Annotate all `props` in component with documentation
- `n/a` Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- `n/a` Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- `n/a` Covered with tests

**Breaking change**

- `n/a` codemod is created and showcased in the changeset
- `n/a` test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-4033]: https://toptal-core.atlassian.net/browse/FX-4033?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ