### PR TITLE
feat(BarChart): add option to format the value axis

### DIFF
--- a/.changeset/cyan-plums-cheat.md
+++ b/.changeset/cyan-plums-cheat.md
@@ -1,0 +1,5 @@
+---
+'@toptal/picasso-charts': minor
+---
+
+- add `valueAxisTickFormatter` option to format value axis ticks

--- a/packages/picasso-charts/src/BarChart/BarChart.tsx
+++ b/packages/picasso-charts/src/BarChart/BarChart.tsx
@@ -76,6 +76,8 @@ export interface Props<K extends string | number | symbol>
   autoSize?: boolean
   /** Maximum size for the bar */
   maxBarSize?: number
+  /** Function to format ticks of the value axis */
+  valueAxisTickFormatter?: ((value: any, index: number) => string) | undefined
 }
 
 const StyleOverrides = () => (
@@ -127,6 +129,7 @@ const BarChart = <T extends string>({
   showEveryNthTickOnYAxis = 1,
   autoSize,
   maxBarSize,
+  valueAxisTickFormatter,
   ...rest
 }: Props<T>) => {
   const horizontal = layout === 'horizontal'
@@ -163,6 +166,7 @@ const BarChart = <T extends string>({
     width: Y_AXIS_WIDTH,
     ticks: ticks,
     domain: [ticks[0], ticks[ticks.length - 1]],
+    tickFormatter: valueAxisTickFormatter,
   }
 
   const xAxisProps = horizontal ? categoryAxisProps : valueAxisProps

--- a/packages/picasso-charts/src/BarChart/story/ValueAxisTickFormatter.example.tsx
+++ b/packages/picasso-charts/src/BarChart/story/ValueAxisTickFormatter.example.tsx
@@ -1,0 +1,57 @@
+import React from 'react'
+import { BarChart } from '@toptal/picasso-charts'
+import { palette } from '@toptal/picasso/utils'
+
+const CHART_DATA = [
+  {
+    name: 'Jan',
+    value: { amount: 1000 },
+  },
+  {
+    name: 'Feb',
+    value: { amount: 2000 },
+  },
+  {
+    name: 'Mar',
+    value: { amount: 5000 },
+  },
+  {
+    name: 'Apr',
+    value: { amount: 10000 },
+  },
+  {
+    name: 'May',
+    value: { amount: 9000 },
+  },
+  {
+    name: 'Jun',
+    value: { amount: 3000 },
+  },
+  {
+    name: 'Jul',
+    value: { amount: 1000 },
+  },
+]
+
+const COLORS_MAPPING: Record<string, string> = {
+  amount: palette.green.dark,
+}
+
+const valueAxisFormatter = (value: number) => {
+  return `$${value / 1000}k`
+}
+
+const Example = () => (
+  <div style={{ width: 720 }}>
+    <BarChart
+      data={CHART_DATA}
+      width='100%'
+      height={300}
+      getBarColor={({ dataKey }) => COLORS_MAPPING[dataKey]}
+      getBarLabelColor={({ dataKey }) => COLORS_MAPPING[dataKey]}
+      valueAxisTickFormatter={valueAxisFormatter}
+    />
+  </div>
+)
+
+export default Example

--- a/packages/picasso-charts/src/BarChart/story/index.jsx
+++ b/packages/picasso-charts/src/BarChart/story/index.jsx
@@ -59,3 +59,9 @@ page
     description: `You can show every Nth tick for X-axis or Y-axis. "0" hides all ticks, "1" shows all ticks (default behavior). The example below has "showEveryNthTickOnXAxis={3}" (every third tick is shown on X-axis) and "showEveryNthTickOnYAxis={0}" (no ticks are shown on Y-axis).`,
     takeScreenshot: false,
   })
+  .addExample('BarChart/story/ValueAxisTickFormatter.example.tsx', {
+    title: 'Format the value axis',
+    description:
+      'You can format the ticks on the value axis by providing the format function in the `valueAxisTickFormatter` property.',
+    takeScreenshot: false,
+  })


### PR DESCRIPTION
[SDE-1048]

### Description

This PR adds the `valueAxisTickFormatter` option to the BarChart component, allowing us to format the value axis ticks as needed!

### How to test

- Run the storybook locally (`yarn start`)
- Navigate to the `BarChart` component (http://localhost:9001/?path=/story/picasso-charts-barchart--barchart) and find the example provided

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| N/A | ![image](https://github.com/toptal/picasso/assets/65467711/47122d29-1394-4d39-a556-eefe955540eb) |

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests

**Breaking change**

- [x] codemod is created and showcased in the changeset
- [x] test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[SDE-1048]: https://toptal-core.atlassian.net/browse/SDE-1048?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ