### PR TITLE
fix: [FX-4028] incorrect associations with jira deployments

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -169,3 +169,13 @@ jobs:
           environment-url: ${{ steps.temploy.outputs.temployURL }}
           transient-environment: false
           auto-inactive: false
+
+      - name: Create Jira Deployment for Alpha-package
+        uses: toptal/davinci-github-actions/create-jira-deployment@v7.1.0
+        if: ${{ always() }}
+        with:
+          token: ${{ env.TOPTAL_DEVBOT_TOKEN }}
+          environment: alpha-package
+          environment-url: ${{ steps.temploy.outputs.temployURL }}
+          transient-environment: false
+          auto-inactive: false

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -160,22 +160,12 @@ jobs:
           temployURL="https://picasso.toptal.net/${targetBranch}/"
           echo "temployURL=$temployURL" >> $GITHUB_OUTPUT
 
-      - name: Create Jira Deployment
-        uses: toptal/davinci-github-actions/create-jira-deployment@v7.1.0
-        if: ${{ always() }}
-        with:
-          token: ${{ env.TOPTAL_DEVBOT_TOKEN }}
-          environment: temploy
-          environment-url: ${{ steps.temploy.outputs.temployURL }}
-          transient-environment: false
-          auto-inactive: false
-
-      - name: Create Jira Deployment for Alpha-package
-        uses: toptal/davinci-github-actions/create-jira-deployment@v7.1.0
-        if: ${{ always() }}
-        with:
-          token: ${{ env.TOPTAL_DEVBOT_TOKEN }}
-          environment: alpha-package
-          environment-url: ${{ steps.temploy.outputs.temployURL }}
-          transient-environment: false
-          auto-inactive: false
+      # - name: Create Jira Deployment
+      #   uses: toptal/davinci-github-actions/create-jira-deployment@v7.1.0
+      #   if: ${{ always() }}
+      #   with:
+      #     token: ${{ env.TOPTAL_DEVBOT_TOKEN }}
+      #     environment: temploy
+      #     environment-url: ${{ steps.temploy.outputs.temployURL }}
+      #     transient-environment: false
+      #     auto-inactive: false

--- a/.github/workflows/test-jira-deployments.yaml
+++ b/.github/workflows/test-jira-deployments.yaml
@@ -91,7 +91,7 @@ jobs:
         uses: chrnorm/deployment-status@v2
         with:
           token: ${{ env.TOPTAL_DEVBOT_TOKEN }}
-          environment-url: ${{ stepsgh-alpha-deployment.outputs.environment_url }}
+          environment-url: ${{ steps.gh-alpha-deployment.outputs.environment_url }}
           environment: 'alpha-package'
           deployment-id: ${{ steps.gh-alpha-deployment.outputs.deployment_id }}
           log-url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/test-jira-deployments.yaml
+++ b/.github/workflows/test-jira-deployments.yaml
@@ -1,0 +1,52 @@
+name: Test JIRA Deployments
+
+on:
+  pull_request:
+    branches:
+      - master # triggers the flow for every PR to master
+      - 'feature/**' # triggers the flow for a PR to a branch like feature/v9
+
+    types:
+      - synchronize # PR was updated
+      - opened # PR was open
+      - reopened # PR was closed and is now open again
+      - ready_for_review # PR was converted from draft to open
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  TOPTAL_DEVBOT_TOKEN: ${{ secrets.TOPTAL_DEVBOT_TOKEN }}
+  NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+  HTTP_PROXY: http://${{ secrets.HTTP_PROXY }}
+  HAPPO_API_KEY: ${{ secrets.HAPPO_API_KEY }}
+  HAPPO_API_SECRET: ${{ secrets.HAPPO_API_SECRET }}
+
+jobs:
+  create-deployments:
+    if: ${{ github.event.pull_request.head.ref != 'changeset-release/master' }}
+    name: Create Jira Deployments
+    runs-on: ubuntu-latest
+    
+    steps:
+      
+      - name: Create Jira Deployment
+        uses: toptal/davinci-github-actions/create-jira-deployment@v7.1.0
+        if: ${{ always() }}
+        with:
+          token: ${{ env.TOPTAL_DEVBOT_TOKEN }}
+          environment: temploy
+          environment-url: http://temploy.toptal.net
+          transient-environment: false
+          auto-inactive: false
+
+      - name: Create Jira Deployment for Alpha-package
+        uses: toptal/davinci-github-actions/create-jira-deployment@v7.1.0
+        if: ${{ always() }}
+        with:
+          token: ${{ env.TOPTAL_DEVBOT_TOKEN }}
+          environment: alpha-package
+          environment-url: https://www.npmjs.com/package/@toptal/picasso?activeTab=dependents
+          transient-environment: false
+          auto-inactive: false

--- a/.github/workflows/test-jira-deployments.yaml
+++ b/.github/workflows/test-jira-deployments.yaml
@@ -57,8 +57,8 @@ jobs:
         uses: chrnorm/deployment-status@v2
         with:
           token: ${{ env.TOPTAL_DEVBOT_TOKEN }}
-          environment-url: http://temploy.toptal.net
-          environment: ${{ steps.gh-temploy-deployment.outputs.environment_url }}
+          environment-url: ${{ steps.gh-temploy-deployment.outputs.environment_url }}
+          environment: 'temploy'
           deployment-id: ${{ steps.gh-temploy-deployment.outputs.deployment_id }}
           log-url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
           state: 'success'
@@ -91,8 +91,8 @@ jobs:
         uses: chrnorm/deployment-status@v2
         with:
           token: ${{ env.TOPTAL_DEVBOT_TOKEN }}
-          environment-url: https://www.npmjs.com/package/@toptal/picasso?activeTab=dependents
-          environment: ${{ steps.gh-alpha-deployment.outputs.environment_url }}
+          environment-url: ${{ stepsgh-alpha-deployment.outputs.environment_url }}
+          environment: 'alpha-package'
           deployment-id: ${{ steps.gh-alpha-deployment.outputs.deployment_id }}
           log-url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
           state: 'success'

--- a/.github/workflows/test-jira-deployments.yaml
+++ b/.github/workflows/test-jira-deployments.yaml
@@ -31,22 +31,69 @@ jobs:
     
     steps:
       
-      - name: Create Jira Deployment
-        uses: toptal/davinci-github-actions/create-jira-deployment@v7.1.0
+      # - name: Create Jira Deployment
+      #   uses: toptal/davinci-github-actions/create-jira-deployment@v7.1.0
+      #   if: ${{ always() }}
+      #   with:
+      #     token: ${{ env.TOPTAL_DEVBOT_TOKEN }}
+      #     environment: temploy
+      #     environment-url: http://temploy.toptal.net
+      #     transient-environment: false
+      #     auto-inactive: false
+
+
+      - uses: chrnorm/deployment-action@v2
+        name: Create Temploy GitHub deployment
+        id: gh-temploy-deployment
         if: ${{ always() }}
         with:
           token: ${{ env.TOPTAL_DEVBOT_TOKEN }}
-          environment: temploy
           environment-url: http://temploy.toptal.net
+          environment: temploy
+          transient-environment: true
+          auto-inactive: false
+
+      - name: Update deployment status on success
+        uses: chrnorm/deployment-status@v2
+        with:
+          token: ${{ env.TOPTAL_DEVBOT_TOKEN }}
+          environment-url: http://temploy.toptal.net
+          environment: ${{ steps.gh-temploy-deployment.outputs.environment_url }}
+          deployment-id: ${{ steps.gh-temploy-deployment.outputs.deployment_id }}
+          log-url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          state: 'success'
+          description: 'Temploy Deployment successful'
+
+
+      # - name: Create Jira Deployment for Alpha-package
+      #   uses: toptal/davinci-github-actions/create-jira-deployment@v7.1.0
+      #   if: ${{ always() }}
+      #   with:
+      #     token: ${{ env.TOPTAL_DEVBOT_TOKEN }}
+      #     environment: alpha-package
+      #     environment-url: https://www.npmjs.com/package/@toptal/picasso?activeTab=dependents
+      #     transient-environment: false
+      #     auto-inactive: false
+
+
+      - uses: chrnorm/deployment-action@v2
+        name: Create Alpha GitHub deployment
+        id: gh-alpha-deployment
+        if: ${{ always() }}
+        with:
+          token: ${{ env.TOPTAL_DEVBOT_TOKEN }}
+          environment-url: https://www.npmjs.com/package/@toptal/picasso?activeTab=dependents
+          environment: alpha-package
           transient-environment: false
           auto-inactive: false
 
-      - name: Create Jira Deployment for Alpha-package
-        uses: toptal/davinci-github-actions/create-jira-deployment@v7.1.0
-        if: ${{ always() }}
+      - name: Update deployment status on success
+        uses: chrnorm/deployment-status@v2
         with:
           token: ${{ env.TOPTAL_DEVBOT_TOKEN }}
-          environment: alpha-package
           environment-url: https://www.npmjs.com/package/@toptal/picasso?activeTab=dependents
-          transient-environment: false
-          auto-inactive: false
+          environment: ${{ steps.gh-alpha-deployment.outputs.environment_url }}
+          deployment-id: ${{ steps.gh-alpha-deployment.outputs.deployment_id }}
+          log-url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          state: 'success'
+          description: 'Alpha Package Deployment successful'

--- a/.jira/config.yml
+++ b/.jira/config.yml
@@ -1,7 +1,7 @@
 deployments:
   environmentMapping:
     testing:
-      - "temploy"
-      - "alpha-package"
+      - "templ*"
+      - "alpha*"
     production:
-      - "production"
+      - "prod*"

--- a/.jira/config.yml
+++ b/.jira/config.yml
@@ -1,7 +1,7 @@
 deployments:
   environmentMapping:
     testing:
-      - "templ*"
+      - "temploy"
       - "alpha*"
     production:
       - "prod*"


### PR DESCRIPTION
[FX-4028]

### Description

GH deployments are associated incorrectly with Jira deployments

### How to test

- Check the alpha-package, temploy and production GH deployments with associated JIRA ticket


### Development checks

- [ ] Self reviewed


> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-4028]: https://toptal-core.atlassian.net/browse/FX-4028?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ