### PR TITLE
feat: add Toolbar for LexicalEditor

### DIFF
--- a/packages/picasso/package.json
+++ b/packages/picasso/package.json
@@ -35,6 +35,7 @@
     "@emoji-mart/react": "^1.1.1",
     "@lexical/html": "^0.9.1",
     "@lexical/react": "^0.9.1",
+    "@lexical/utils": "^0.9.2",
     "@toptal/picasso-shared": "12.0.0",
     "ap-style-title-case": "^1.1.2",
     "classnames": "^2.3.1",

--- a/packages/picasso/src/LexicalEditor/LexicalEditor.tsx
+++ b/packages/picasso/src/LexicalEditor/LexicalEditor.tsx
@@ -17,6 +17,7 @@ import Typography from '../Typography'
 import { useTypographyClasses } from './hooks'
 import styles from './styles'
 import type { ChangeHandler } from './types'
+import ToolbarPlugin from './plugins/LexicalEditorToolbar'
 
 const useStyles = makeStyles<Theme>(styles, {
   name: 'LexicalEditor',
@@ -34,7 +35,7 @@ export type Props = BaseProps & {
   /**
    * This Boolean attribute indicates that the user cannot interact with the control.
    */
-  //   disabled?: boolean
+  disabled?: boolean
   /** unique identifier */
   id: string
   /**
@@ -95,7 +96,7 @@ const LexicalEditor = forwardRef<HTMLDivElement, Props>(function LexicalEditor(
     // plugins,
     // autoFocus = false,
     // defaultValue,
-    // disabled,
+    disabled,
     id,
     onChange = noop,
     // onFocus = noop,
@@ -158,28 +159,7 @@ const LexicalEditor = forwardRef<HTMLDivElement, Props>(function LexicalEditor(
 
   return (
     <LexicalComposer initialConfig={editorConfig}>
-      {/* <Toolbar
-                ref={toolbarRef}
-                disabled={disabled || state.toolbar.disabled}
-                id={id}
-                format={state.toolbar.format}
-                onBoldClick={handleBold}
-                onItalicClick={handleItalic}
-                onUnorderedClick={handleUnordered}
-                onOrderedClick={handleOrdered}
-                onHeaderChange={handleHeader}
-                onLinkClick={handleLink}
-                onInsertEmoji={insertEmoji}
-                plugins={memoizedPlugins}
-                customEmojis={memoizedCustomEmojis}
-                testIds={{
-                headerSelect: testIds?.headerSelect,
-                boldButton: testIds?.boldButton,
-                italicButton: testIds?.italicButton,
-                unorderedListButton: testIds?.unorderedListButton,
-                orderedListButton: testIds?.orderedListButton,
-                }}
-            /> */}
+      <ToolbarPlugin disabled={disabled} />
       <OnChangePlugin ignoreSelectionChange onChange={handleChange} />
       <div className={classes.editorContainer} id={id} ref={ref}>
         <RichTextPlugin

--- a/packages/picasso/src/LexicalEditor/LexicalEditor.tsx
+++ b/packages/picasso/src/LexicalEditor/LexicalEditor.tsx
@@ -17,7 +17,7 @@ import Typography from '../Typography'
 import { useTypographyClasses } from './hooks'
 import styles from './styles'
 import type { ChangeHandler } from './types'
-import ToolbarPlugin from './plugins/LexicalEditorToolbar'
+import ToolbarPlugin from '../LexicalEditorToolbarPlugin'
 
 const useStyles = makeStyles<Theme>(styles, {
   name: 'LexicalEditor',

--- a/packages/picasso/src/LexicalEditor/plugins/LexicalEditorToolbar.tsx
+++ b/packages/picasso/src/LexicalEditor/plugins/LexicalEditorToolbar.tsx
@@ -1,0 +1,79 @@
+import React, { useCallback, useEffect, useReducer } from 'react'
+import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext'
+import { FORMAT_TEXT_COMMAND } from 'lexical'
+
+import {
+  registerLexicalEvents,
+  synchronizeToolbarState,
+  toolbarStateReducer,
+} from '../utils'
+import { noop } from '../../utils'
+import type { FormatType } from '../../RichTextEditorToolbar'
+import RichTextEditorToolbar from '../../RichTextEditorToolbar'
+
+type Props = {
+  disabled?: boolean
+}
+
+const LexicalEditorToolbar = ({ disabled = false }: Props) => {
+  const [editor] = useLexicalComposerContext()
+  const [{ isBold, isItalic, isEditable, activeEditor }, dispatch] = useReducer(
+    toolbarStateReducer,
+    {
+      isBold: false,
+      isItalic: false,
+      isEditable: editor.isEditable(),
+      list: false,
+      header: '',
+      link: '',
+      activeEditor: editor,
+    }
+  )
+
+  const updateToolbar = useCallback(
+    () => synchronizeToolbarState(dispatch),
+    [activeEditor]
+  )
+
+  useEffect(() => {
+    return registerLexicalEvents({
+      editor,
+      activeEditor,
+      updateToolbar,
+      dispatch,
+    })
+  }, [updateToolbar, activeEditor, editor])
+
+  const handleBoldClick = () => {
+    activeEditor.dispatchCommand(FORMAT_TEXT_COMMAND, 'bold')
+  }
+  const handleItalicClick = () => {
+    activeEditor.dispatchCommand(FORMAT_TEXT_COMMAND, 'italic')
+  }
+
+  // Convert toolbar state to format that is compatible with old RichTextEditorToolbar
+  const format: FormatType = {
+    bold: isBold,
+    italic: isItalic,
+    list: false,
+    header: '',
+    link: '',
+  }
+
+  return (
+    <RichTextEditorToolbar
+      format={format}
+      id='toolbar'
+      onUnorderedClick={noop}
+      onOrderedClick={noop}
+      onBoldClick={handleBoldClick}
+      onItalicClick={handleItalicClick}
+      onLinkClick={noop}
+      onHeaderChange={noop}
+      disabled={!isEditable || disabled}
+      onInsertEmoji={noop}
+    />
+  )
+}
+
+export default LexicalEditorToolbar

--- a/packages/picasso/src/LexicalEditor/utils/index.ts
+++ b/packages/picasso/src/LexicalEditor/utils/index.ts
@@ -1,0 +1,3 @@
+export { registerLexicalEvents } from './registerLexicalEvents'
+export { synchronizeToolbarState } from './synchronizeToolbarState'
+export { toolbarStateReducer } from './toolbarState'

--- a/packages/picasso/src/LexicalEditor/utils/registerLexicalEvents.test.ts
+++ b/packages/picasso/src/LexicalEditor/utils/registerLexicalEvents.test.ts
@@ -13,8 +13,8 @@ const mockUpdateToolbar = jest.fn()
 const mockMergeRegister = mergeRegister as jest.MockedFunction<
   typeof mergeRegister
 >
-const mockEditorListenerCleanup = jest.fn()
-const mockEditorCommandsCleanup = jest.fn()
+const mockedEditorListenerCleanup = jest.fn()
+const mockedEditorCommandsCleanup = jest.fn()
 
 describe('registerLexicalEvents', () => {
   beforeEach(() => {
@@ -27,7 +27,7 @@ describe('registerLexicalEvents', () => {
       registerUpdateListener: jest.fn().mockReturnValueOnce(() => {}),
       registerCommand: jest
         .fn()
-        .mockReturnValueOnce(() => mockEditorCommandsCleanup),
+        .mockReturnValueOnce(() => mockedEditorCommandsCleanup),
     }
     const mockActiveEditor = {
       registerUpdateListener: jest.fn().mockReturnValueOnce(() => {}),
@@ -38,7 +38,7 @@ describe('registerLexicalEvents', () => {
         mockEditor.registerEditableListener()
         mockActiveEditor.registerUpdateListener()
       })
-      .mockReturnValueOnce(() => mockEditorListenerCleanup)
+      .mockReturnValueOnce(() => mockedEditorListenerCleanup)
 
     const params = {
       editor: mockEditor,
@@ -65,7 +65,7 @@ describe('registerLexicalEvents', () => {
     cleanup()
 
     // Assert cleanup
-    expect(mockEditorCommandsCleanup).toHaveBeenCalledTimes(1)
-    expect(mockEditorListenerCleanup).toHaveBeenCalledTimes(1)
+    expect(mockedEditorCommandsCleanup).toHaveBeenCalledTimes(1)
+    expect(mockedEditorListenerCleanup).toHaveBeenCalledTimes(1)
   })
 })

--- a/packages/picasso/src/LexicalEditor/utils/registerLexicalEvents.test.ts
+++ b/packages/picasso/src/LexicalEditor/utils/registerLexicalEvents.test.ts
@@ -1,0 +1,71 @@
+import { mergeRegister } from '@lexical/utils'
+import { COMMAND_PRIORITY_CRITICAL, SELECTION_CHANGE_COMMAND } from 'lexical'
+
+import { registerLexicalEvents } from './registerLexicalEvents'
+import type { LexicalRegisterParams } from './registerLexicalEvents'
+
+jest.mock('@lexical/utils', () => ({
+  mergeRegister: jest.fn(),
+}))
+
+const mockDispatch = jest.fn()
+const mockUpdateToolbar = jest.fn()
+const mockMergeRegister = mergeRegister as jest.MockedFunction<
+  typeof mergeRegister
+>
+const mockEditorListenerCleanup = jest.fn()
+const mockEditorCommandsCleanup = jest.fn()
+
+describe('registerLexicalEvents', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('should register listeners and commands correctly and return a cleanup function', () => {
+    const mockEditor = {
+      registerEditableListener: jest.fn().mockReturnValueOnce(() => {}),
+      registerUpdateListener: jest.fn().mockReturnValueOnce(() => {}),
+      registerCommand: jest
+        .fn()
+        .mockReturnValueOnce(() => mockEditorCommandsCleanup),
+    }
+    const mockActiveEditor = {
+      registerUpdateListener: jest.fn().mockReturnValueOnce(() => {}),
+    }
+
+    mockMergeRegister
+      .mockImplementation(() => () => {
+        mockEditor.registerEditableListener()
+        mockActiveEditor.registerUpdateListener()
+      })
+      .mockReturnValueOnce(() => mockEditorListenerCleanup)
+
+    const params = {
+      editor: mockEditor,
+      activeEditor: mockActiveEditor,
+      updateToolbar: mockUpdateToolbar,
+      dispatch: mockDispatch,
+    }
+
+    const cleanup = registerLexicalEvents(
+      params as unknown as LexicalRegisterParams
+    )
+
+    expect(mockEditor.registerEditableListener).toHaveBeenCalledTimes(1)
+    expect(mockActiveEditor.registerUpdateListener).toHaveBeenCalledTimes(1)
+    expect(mockEditor.registerCommand).toHaveBeenCalledTimes(1)
+    expect(mockEditor.registerCommand).toHaveBeenCalledWith(
+      SELECTION_CHANGE_COMMAND,
+      expect.any(Function),
+      COMMAND_PRIORITY_CRITICAL
+    )
+    expect(mergeRegister).toHaveBeenCalledTimes(1)
+
+    // Simulate invoking the cleanup function
+    cleanup()
+
+    // Assert cleanup
+    expect(mockEditorCommandsCleanup).toHaveBeenCalledTimes(1)
+    expect(mockEditorListenerCleanup).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/picasso/src/LexicalEditor/utils/registerLexicalEvents.ts
+++ b/packages/picasso/src/LexicalEditor/utils/registerLexicalEvents.ts
@@ -1,0 +1,54 @@
+import type { LexicalEditor } from 'lexical'
+import { mergeRegister } from '@lexical/utils'
+import { COMMAND_PRIORITY_CRITICAL, SELECTION_CHANGE_COMMAND } from 'lexical'
+
+import type { ToolbarAction } from './toolbarState'
+import { ToolbarActions } from './toolbarState'
+
+export type LexicalRegisterParams = {
+  editor: LexicalEditor
+  activeEditor: LexicalEditor
+  updateToolbar: () => void
+  dispatch: (value: ToolbarAction) => void
+}
+
+// Subscribes to Lexical editor events and updates the toolbar state accordingly
+export const registerLexicalEvents = ({
+  editor,
+  activeEditor,
+  updateToolbar,
+  dispatch,
+}: LexicalRegisterParams) => {
+  const editorListenerCleanup = mergeRegister(
+    editor.registerEditableListener(editable => {
+      dispatch({
+        type: ToolbarActions.UPDATE_IS_EDITABLE,
+        value: editable,
+      })
+    }),
+    activeEditor.registerUpdateListener(({ editorState }) => {
+      editorState.read(() => {
+        updateToolbar()
+      })
+    })
+  )
+  const editorCommandsCleanup = editor.registerCommand(
+    SELECTION_CHANGE_COMMAND,
+    (_payload, newEditor) => {
+      updateToolbar()
+      dispatch({
+        type: ToolbarActions.UPDATE_ACTIVE_EDITOR,
+        value: newEditor,
+      })
+
+      return false
+    },
+    COMMAND_PRIORITY_CRITICAL
+  )
+
+  // Cleanup is necessary to avoid listeners piling up with useEffect
+  return () => {
+    editorListenerCleanup()
+    editorCommandsCleanup()
+  }
+}

--- a/packages/picasso/src/LexicalEditor/utils/synchronizeToolbarState.test.ts
+++ b/packages/picasso/src/LexicalEditor/utils/synchronizeToolbarState.test.ts
@@ -1,0 +1,70 @@
+import type { RangeSelection } from 'lexical'
+import { $getSelection, $isRangeSelection } from 'lexical'
+
+import { ToolbarActions } from './toolbarState'
+import { synchronizeToolbarState } from './synchronizeToolbarState'
+
+jest.mock('lexical', () => ({
+  $getSelection: jest.fn(),
+  $isRangeSelection: jest.fn(),
+}))
+
+const mockGetSelection = $getSelection as jest.MockedFunction<
+  typeof $getSelection
+>
+const mockIsRangeSelection = $isRangeSelection as jest.MockedFunction<
+  typeof $isRangeSelection
+>
+
+describe('synchronizeToolbarState', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('should dispatch an action with the correct values when range selection has bold and italic format', () => {
+    // Arrange
+    const dispatchMock = jest.fn()
+    const hasFormatMock = jest
+      .fn()
+      .mockReturnValueOnce(true)
+      .mockReturnValueOnce(true)
+
+    mockGetSelection.mockReturnValueOnce({
+      hasFormat: hasFormatMock,
+    } as unknown as RangeSelection)
+    mockIsRangeSelection.mockReturnValueOnce(true)
+
+    // Act
+    synchronizeToolbarState(dispatchMock)
+
+    // Assert
+    expect(dispatchMock).toHaveBeenCalledTimes(1)
+    expect(dispatchMock).toHaveBeenCalledWith({
+      type: ToolbarActions.UPDATE_VISUAL_STATE,
+      value: {
+        isBold: true,
+        isItalic: true,
+      },
+    })
+    expect(mockGetSelection).toHaveBeenCalledTimes(1)
+    expect(mockIsRangeSelection).toHaveBeenCalledTimes(1)
+    expect(hasFormatMock).toHaveBeenCalledTimes(2)
+    expect(hasFormatMock).toHaveBeenCalledWith('bold')
+    expect(hasFormatMock).toHaveBeenCalledWith('italic')
+  })
+
+  it('should not dispatch any action when selection is not a range selection', () => {
+    // Arrange
+    const dispatchMock = jest.fn()
+
+    mockIsRangeSelection.mockReturnValueOnce(false)
+
+    // Act
+    synchronizeToolbarState(dispatchMock)
+
+    // Assert
+    expect(dispatchMock).not.toHaveBeenCalled()
+    expect(mockGetSelection).toHaveBeenCalledTimes(1)
+    expect(mockIsRangeSelection).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/picasso/src/LexicalEditor/utils/synchronizeToolbarState.test.ts
+++ b/packages/picasso/src/LexicalEditor/utils/synchronizeToolbarState.test.ts
@@ -9,10 +9,10 @@ jest.mock('lexical', () => ({
   $isRangeSelection: jest.fn(),
 }))
 
-const mockGetSelection = $getSelection as jest.MockedFunction<
+const mockedGetSelection = $getSelection as jest.MockedFunction<
   typeof $getSelection
 >
-const mockIsRangeSelection = $isRangeSelection as jest.MockedFunction<
+const mockedIsRangeSelection = $isRangeSelection as jest.MockedFunction<
   typeof $isRangeSelection
 >
 
@@ -21,50 +21,46 @@ describe('synchronizeToolbarState', () => {
     jest.clearAllMocks()
   })
 
-  it('should dispatch an action with the correct values when range selection has bold and italic format', () => {
-    // Arrange
-    const dispatchMock = jest.fn()
-    const hasFormatMock = jest
-      .fn()
-      .mockReturnValueOnce(true)
-      .mockReturnValueOnce(true)
+  describe('when range selection has bold and italic format', () => {
+    it('should dispatch an action with the correct values', () => {
+      const dispatchMock = jest.fn()
+      const hasFormatMock = jest
+        .fn()
+        .mockReturnValueOnce(true)
+        .mockReturnValueOnce(true)
 
-    mockGetSelection.mockReturnValueOnce({
-      hasFormat: hasFormatMock,
-    } as unknown as RangeSelection)
-    mockIsRangeSelection.mockReturnValueOnce(true)
+      mockedGetSelection.mockReturnValueOnce({
+        hasFormat: hasFormatMock,
+      } as unknown as RangeSelection)
+      mockedIsRangeSelection.mockReturnValueOnce(true)
 
-    // Act
-    synchronizeToolbarState(dispatchMock)
+      synchronizeToolbarState(dispatchMock)
 
-    // Assert
-    expect(dispatchMock).toHaveBeenCalledTimes(1)
-    expect(dispatchMock).toHaveBeenCalledWith({
-      type: ToolbarActions.UPDATE_VISUAL_STATE,
-      value: {
-        isBold: true,
-        isItalic: true,
-      },
+      expect(dispatchMock).toHaveBeenCalledTimes(1)
+      expect(dispatchMock).toHaveBeenCalledWith({
+        type: ToolbarActions.UPDATE_VISUAL_STATE,
+        value: {
+          isBold: true,
+          isItalic: true,
+        },
+      })
+      expect(mockedGetSelection).toHaveBeenCalledTimes(1)
+      expect(mockedIsRangeSelection).toHaveBeenCalledTimes(1)
+      expect(hasFormatMock).toHaveBeenCalledTimes(2)
+      expect(hasFormatMock).toHaveBeenCalledWith('bold')
+      expect(hasFormatMock).toHaveBeenCalledWith('italic')
     })
-    expect(mockGetSelection).toHaveBeenCalledTimes(1)
-    expect(mockIsRangeSelection).toHaveBeenCalledTimes(1)
-    expect(hasFormatMock).toHaveBeenCalledTimes(2)
-    expect(hasFormatMock).toHaveBeenCalledWith('bold')
-    expect(hasFormatMock).toHaveBeenCalledWith('italic')
   })
 
   it('should not dispatch any action when selection is not a range selection', () => {
-    // Arrange
     const dispatchMock = jest.fn()
 
-    mockIsRangeSelection.mockReturnValueOnce(false)
+    mockedIsRangeSelection.mockReturnValueOnce(false)
 
-    // Act
     synchronizeToolbarState(dispatchMock)
 
-    // Assert
     expect(dispatchMock).not.toHaveBeenCalled()
-    expect(mockGetSelection).toHaveBeenCalledTimes(1)
-    expect(mockIsRangeSelection).toHaveBeenCalledTimes(1)
+    expect(mockedGetSelection).toHaveBeenCalledTimes(1)
+    expect(mockedIsRangeSelection).toHaveBeenCalledTimes(1)
   })
 })

--- a/packages/picasso/src/LexicalEditor/utils/synchronizeToolbarState.ts
+++ b/packages/picasso/src/LexicalEditor/utils/synchronizeToolbarState.ts
@@ -1,0 +1,22 @@
+import { $getSelection, $isRangeSelection } from 'lexical'
+
+import type { ToolbarAction } from './toolbarState'
+import { ToolbarActions } from './toolbarState'
+
+// Transfers updated Lexical selection state to the toolbar state
+// This takes care of highlighting the necessary buttons depending on the selection contents
+export const synchronizeToolbarState = (
+  dispatch: (value: ToolbarAction) => void
+) => {
+  const selection = $getSelection()
+
+  if ($isRangeSelection(selection)) {
+    dispatch({
+      type: ToolbarActions.UPDATE_VISUAL_STATE,
+      value: {
+        isBold: selection.hasFormat('bold'),
+        isItalic: selection.hasFormat('italic'),
+      },
+    })
+  }
+}

--- a/packages/picasso/src/LexicalEditor/utils/toolbarState.ts
+++ b/packages/picasso/src/LexicalEditor/utils/toolbarState.ts
@@ -1,0 +1,69 @@
+import type { LexicalEditor } from 'lexical'
+
+// Currently, not all the types are used, but it's a foundation for the future code
+// based on states present in the original PoC https://github.com/toptal/picasso/pull/3505/files
+export type ToolbarState = {
+  isBold: boolean
+  isItalic: boolean
+  isEditable: boolean
+  list: 'bullet' | 'ordered' | false
+  header: '3' | ''
+  link: string
+  activeEditor: LexicalEditor
+}
+
+export enum ToolbarActions {
+  UPDATE_VISUAL_STATE,
+  UPDATE_ACTIVE_EDITOR,
+  UPDATE_IS_EDITABLE,
+}
+
+// When adding a new action type, make sure to add it to the ToolbarAction union type
+type ToolbarVisualStateUpdateAction = {
+  type: ToolbarActions.UPDATE_VISUAL_STATE
+  value: {
+    isBold: boolean
+    isItalic: boolean
+  }
+}
+type ToolbarUpdateEditorAction = {
+  type: ToolbarActions.UPDATE_ACTIVE_EDITOR
+  value: LexicalEditor
+}
+type ToolbarUpdateEditableAction = {
+  type: ToolbarActions.UPDATE_IS_EDITABLE
+  value: boolean
+}
+
+export type ToolbarAction =
+  | ToolbarVisualStateUpdateAction
+  | ToolbarUpdateEditorAction
+  | ToolbarUpdateEditableAction
+
+export const toolbarStateReducer = (
+  state: ToolbarState,
+  action: ToolbarAction
+): ToolbarState => {
+  switch (action.type) {
+    // Update the visual state of the toolbar all at once (bold, italic, etc.)
+    // Since this is called when updating toolbar state on selection change, we can do all updates in one action
+    case ToolbarActions.UPDATE_VISUAL_STATE:
+      return {
+        ...state,
+        isBold: action.value.isBold,
+        isItalic: action.value.isItalic,
+      }
+    case ToolbarActions.UPDATE_ACTIVE_EDITOR:
+      return {
+        ...state,
+        activeEditor: action.value,
+      }
+    case ToolbarActions.UPDATE_IS_EDITABLE:
+      return {
+        ...state,
+        isEditable: action.value,
+      }
+    default:
+      return state
+  }
+}

--- a/packages/picasso/src/LexicalEditorToolbarPlugin/LexicalEditorToolbarPlugin.tsx
+++ b/packages/picasso/src/LexicalEditorToolbarPlugin/LexicalEditorToolbarPlugin.tsx
@@ -6,16 +6,16 @@ import {
   registerLexicalEvents,
   synchronizeToolbarState,
   toolbarStateReducer,
-} from '../utils'
-import { noop } from '../../utils'
-import type { FormatType } from '../../RichTextEditorToolbar'
-import RichTextEditorToolbar from '../../RichTextEditorToolbar'
+} from '../LexicalEditor/utils'
+import { noop } from '../utils'
+import type { FormatType } from '../RichTextEditorToolbar'
+import RichTextEditorToolbar from '../RichTextEditorToolbar'
 
 type Props = {
   disabled?: boolean
 }
 
-const LexicalEditorToolbar = ({ disabled = false }: Props) => {
+const LexicalEditorToolbarPlugin = ({ disabled = false }: Props) => {
   const [editor] = useLexicalComposerContext()
   const [{ isBold, isItalic, isEditable, activeEditor }, dispatch] = useReducer(
     toolbarStateReducer,
@@ -76,4 +76,4 @@ const LexicalEditorToolbar = ({ disabled = false }: Props) => {
   )
 }
 
-export default LexicalEditorToolbar
+export default LexicalEditorToolbarPlugin

--- a/packages/picasso/src/LexicalEditorToolbarPlugin/index.ts
+++ b/packages/picasso/src/LexicalEditorToolbarPlugin/index.ts
@@ -1,0 +1,1 @@
+export { default } from './LexicalEditorToolbarPlugin'

--- a/yarn.lock
+++ b/yarn.lock
@@ -2471,7 +2471,7 @@
   resolved "https://registry.yarnpkg.com/@lexical/text/-/text-0.9.2.tgz#5627eb02fed69b40ecca9507894f067bc6798522"
   integrity sha512-mD9aAOTfewgvpS1P8tMl16cpf4tXHqlxy00NjFZxoH5bQVRRdVCT/Kr7YimD6UVgjPOvlD9s0mKTKoiTm12lXg==
 
-"@lexical/utils@0.9.2":
+"@lexical/utils@0.9.2", "@lexical/utils@^0.9.2":
   version "0.9.2"
   resolved "https://registry.yarnpkg.com/@lexical/utils/-/utils-0.9.2.tgz#fab457648fa60f01975f1a2aaa722e0be6f9dcb6"
   integrity sha512-+azMSHG6/FgRVmg9Bh68DyJuqXDYcI/jrAXYRELT6TJrZaC/04ZyU3IQk3UGw9iyh6hTQjPPQuUDtoFfL9nBzg==


### PR DESCRIPTION
[FX-4006](https://toptal-core.atlassian.net/browse/FX-4006)

### Description

Add a functional toolbar to Lexical implementation of the rich text editor.
Bold and italic formatting is supported, with some foundation for future formatters.

### How to test

- Take a look at the [deployed storybook](https://picasso.toptal.net/fx-4006-integrate-inline-plugins/?path=/story/components-richtext--richtext)
- Most importantly, see if the code makes sense and it's clear where to add future features
- The toolbar should look identical to the [original RTE](https://picasso.toptal.net/?path=/story/components-richtext--richtext)

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| (same as before) | (looks exactly the same, but with a different library) |

### Development checks

- [n/a] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-4006]: https://toptal-core.atlassian.net/browse/FX-4006?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ