### PR TITLE
feat: add support for multi-month display to DatePicker

### DIFF
--- a/packages/picasso/src/Calendar/Calendar.tsx
+++ b/packages/picasso/src/Calendar/Calendar.tsx
@@ -33,6 +33,8 @@ import type {
 import type { RenderRoot } from '../CalendarContainer'
 import CalendarContainer from '../CalendarContainer'
 
+export type CalendarMonthsAmount = 1 | 2
+
 export interface Props
   extends BaseProps,
     Omit<React.HTMLAttributes<HTMLDivElement>, 'onChange' | 'onBlur'> {
@@ -50,7 +52,7 @@ export interface Props
   indicatedIntervals?: CalendarDateRange[]
   weekStartsOn?: WeekStart
   hasFooter?: boolean
-  showTwoMonths?: boolean
+  numberOfMonths?: CalendarMonthsAmount
 }
 
 const useStyles = makeStyles<Theme>(styles, { name: 'PicassoCalendar' })
@@ -84,7 +86,7 @@ export const Calendar = forwardRef<HTMLDivElement, Props>(function Calendar(
     weekStartsOn = 1,
     hasFooter = false,
     renderRoot,
-    showTwoMonths = false,
+    numberOfMonths = 1,
     ...rest
   } = props
 
@@ -189,7 +191,7 @@ export const Calendar = forwardRef<HTMLDivElement, Props>(function Calendar(
   )
 
   const mobileScreen = useBreakpoint(['xs', 'sm'])
-  const shouldRenderTwoMonths = showTwoMonths && !mobileScreen
+  const shouldRenderMultipleMonths = numberOfMonths > 1 && !mobileScreen
 
   return (
     <div ref={ref} {...rest} tabIndex={0}>
@@ -203,7 +205,7 @@ export const Calendar = forwardRef<HTMLDivElement, Props>(function Calendar(
       >
         <CalendarContainer
           hasFooter={hasFooter}
-          showTwoMonths={shouldRenderTwoMonths}
+          showTwoMonths={shouldRenderMultipleMonths}
         >
           <DayPicker
             required
@@ -219,7 +221,7 @@ export const Calendar = forwardRef<HTMLDivElement, Props>(function Calendar(
             fromDate={minDate}
             onMonthChange={month => setNavigationMonth(month)}
             toDate={maxDate}
-            numberOfMonths={shouldRenderTwoMonths ? 2 : 1}
+            numberOfMonths={shouldRenderMultipleMonths ? numberOfMonths : 1}
             disabled={disabledIntervalsFormatted}
             weekStartsOn={weekStartsOn}
             formatters={{ formatWeekdayName: date => format(date, 'EEE') }}

--- a/packages/picasso/src/Calendar/Calendar.tsx
+++ b/packages/picasso/src/Calendar/Calendar.tsx
@@ -16,6 +16,7 @@ import type {
 import { DayPicker } from 'react-day-picker'
 import isWeekend from 'date-fns/isWeekend'
 import { format, isEqual } from 'date-fns'
+import { useBreakpoint } from '@toptal/picasso-provider'
 
 import styles from './styles'
 import type { RenderDay } from '../CalendarDay'
@@ -49,6 +50,7 @@ export interface Props
   indicatedIntervals?: CalendarDateRange[]
   weekStartsOn?: WeekStart
   hasFooter?: boolean
+  showTwoMonths?: boolean
 }
 
 const useStyles = makeStyles<Theme>(styles, { name: 'PicassoCalendar' })
@@ -82,6 +84,7 @@ export const Calendar = forwardRef<HTMLDivElement, Props>(function Calendar(
     weekStartsOn = 1,
     hasFooter = false,
     renderRoot,
+    showTwoMonths = false,
     ...rest
   } = props
 
@@ -185,6 +188,9 @@ export const Calendar = forwardRef<HTMLDivElement, Props>(function Calendar(
     [isWeekend, isIndicated, isTemporaryRangeMiddle, isTemporaryRangeEnd]
   )
 
+  const mobileScreen = useBreakpoint(['xs', 'sm'])
+  const shouldRenderTwoMonths = showTwoMonths && !mobileScreen
+
   return (
     <div ref={ref} {...rest} tabIndex={0}>
       <CalendarContext.Provider
@@ -195,7 +201,10 @@ export const Calendar = forwardRef<HTMLDivElement, Props>(function Calendar(
           renderMonthHeader,
         }}
       >
-        <CalendarContainer hasFooter={hasFooter}>
+        <CalendarContainer
+          hasFooter={hasFooter}
+          showTwoMonths={shouldRenderTwoMonths}
+        >
           <DayPicker
             required
             showOutsideDays
@@ -210,6 +219,7 @@ export const Calendar = forwardRef<HTMLDivElement, Props>(function Calendar(
             fromDate={minDate}
             onMonthChange={month => setNavigationMonth(month)}
             toDate={maxDate}
+            numberOfMonths={shouldRenderTwoMonths ? 2 : 1}
             disabled={disabledIntervalsFormatted}
             weekStartsOn={weekStartsOn}
             formatters={{ formatWeekdayName: date => format(date, 'EEE') }}
@@ -219,6 +229,7 @@ export const Calendar = forwardRef<HTMLDivElement, Props>(function Calendar(
               Day: CalendarDay,
             }}
             classNames={{
+              months: classes.months,
               head: classes.head,
               table: classes.table,
               head_row: classes.head_row,

--- a/packages/picasso/src/Calendar/Calendar.tsx
+++ b/packages/picasso/src/Calendar/Calendar.tsx
@@ -231,7 +231,7 @@ export const Calendar = forwardRef<HTMLDivElement, Props>(function Calendar(
               Day: CalendarDay,
             }}
             classNames={{
-              months: classes.months,
+              months: shouldRenderMultipleMonths ? classes.months : undefined,
               head: classes.head,
               table: classes.table,
               head_row: classes.head_row,

--- a/packages/picasso/src/Calendar/Calendar.tsx
+++ b/packages/picasso/src/Calendar/Calendar.tsx
@@ -205,7 +205,7 @@ export const Calendar = forwardRef<HTMLDivElement, Props>(function Calendar(
       >
         <CalendarContainer
           hasFooter={hasFooter}
-          showTwoMonths={shouldRenderMultipleMonths}
+          isFlexible={shouldRenderMultipleMonths}
         >
           <DayPicker
             required

--- a/packages/picasso/src/Calendar/__snapshots__/test.tsx.snap
+++ b/packages/picasso/src/Calendar/__snapshots__/test.tsx.snap
@@ -15,7 +15,7 @@ exports[`Calendar renders 1`] = `
           class="rdp"
         >
           <div
-            class="rdp-months"
+            class="PicassoCalendar-months"
           >
             <div
               class="rdp-month rdp-caption_start rdp-caption_end"

--- a/packages/picasso/src/Calendar/__snapshots__/test.tsx.snap
+++ b/packages/picasso/src/Calendar/__snapshots__/test.tsx.snap
@@ -14,9 +14,7 @@ exports[`Calendar renders 1`] = `
         <div
           class="rdp"
         >
-          <div
-            class="PicassoCalendar-months"
-          >
+          <div>
             <div
               class="rdp-month rdp-caption_start rdp-caption_end"
             >

--- a/packages/picasso/src/Calendar/styles.ts
+++ b/packages/picasso/src/Calendar/styles.ts
@@ -38,4 +38,8 @@ export default ({ palette }: Theme) =>
     vhidden: {
       display: 'none',
     },
+    months: {
+      display: 'flex',
+      gap: rem('24px'),
+    },
   })

--- a/packages/picasso/src/CalendarContainer/CalendarContainer.tsx
+++ b/packages/picasso/src/CalendarContainer/CalendarContainer.tsx
@@ -14,7 +14,7 @@ const useStyles = makeStyles<Theme>(styles, {
 export type CalendarContainerProps = {
   children?: ReactNode
   hasFooter?: boolean
-  showTwoMonths?: boolean
+  isFlexible?: boolean
 }
 
 export type RenderRoot = (args: CalendarContainerProps) => JSX.Element
@@ -22,7 +22,7 @@ export type RenderRoot = (args: CalendarContainerProps) => JSX.Element
 const CalendarContainer = ({
   children,
   hasFooter,
-  showTwoMonths,
+  isFlexible,
 }: CalendarContainerProps) => {
   const classes = useStyles()
   const { renderRoot } = useCalendar()
@@ -33,7 +33,7 @@ const CalendarContainer = ({
     <div
       className={cx(classes.root, {
         [classes.hasFooter]: hasFooter,
-        [classes.wide]: showTwoMonths,
+        [classes.flexible]: isFlexible,
       })}
     >
       {children}

--- a/packages/picasso/src/CalendarContainer/CalendarContainer.tsx
+++ b/packages/picasso/src/CalendarContainer/CalendarContainer.tsx
@@ -14,11 +14,16 @@ const useStyles = makeStyles<Theme>(styles, {
 export type CalendarContainerProps = {
   children?: ReactNode
   hasFooter?: boolean
+  showTwoMonths?: boolean
 }
 
 export type RenderRoot = (args: CalendarContainerProps) => JSX.Element
 
-const CalendarContainer = ({ children, hasFooter }: CalendarContainerProps) => {
+const CalendarContainer = ({
+  children,
+  hasFooter,
+  showTwoMonths,
+}: CalendarContainerProps) => {
   const classes = useStyles()
   const { renderRoot } = useCalendar()
 
@@ -28,6 +33,7 @@ const CalendarContainer = ({ children, hasFooter }: CalendarContainerProps) => {
     <div
       className={cx(classes.root, {
         [classes.hasFooter]: hasFooter,
+        [classes.wide]: showTwoMonths,
       })}
     >
       {children}

--- a/packages/picasso/src/CalendarContainer/styles.ts
+++ b/packages/picasso/src/CalendarContainer/styles.ts
@@ -18,7 +18,7 @@ export default ({ palette, shadows, sizes }: Theme) =>
     hasFooter: {
       borderRadius: `${sizes.borderRadius.small} ${sizes.borderRadius.small} 0 0`,
     },
-    wide: {
-      maxWidth: '41rem',
+    flexible: {
+      maxWidth: 'unset',
     },
   })

--- a/packages/picasso/src/CalendarContainer/styles.ts
+++ b/packages/picasso/src/CalendarContainer/styles.ts
@@ -18,4 +18,7 @@ export default ({ palette, shadows, sizes }: Theme) =>
     hasFooter: {
       borderRadius: `${sizes.borderRadius.small} ${sizes.borderRadius.small} 0 0`,
     },
+    wide: {
+      maxWidth: '41rem',
+    },
   })

--- a/packages/picasso/src/CalendarMonthHeader/CalendarMonthHeader.tsx
+++ b/packages/picasso/src/CalendarMonthHeader/CalendarMonthHeader.tsx
@@ -83,7 +83,9 @@ const CalendarMonthHeader = (props: RenderMonthHeaderProps) => {
 
   const defaultComponent = (
     <Container flex justifyContent='space-between' bottom='medium'>
-      {!hidePrevious && (
+      {hidePrevious ? (
+        <div />
+      ) : (
         <ButtonCircular
           title='Previous month'
           aria-label='Previous month'
@@ -100,7 +102,9 @@ const CalendarMonthHeader = (props: RenderMonthHeaderProps) => {
       >
         {formatCaption(props.displayMonth, { locale })}
       </Typography>
-      {!hideNext && (
+      {hideNext ? (
+        <div />
+      ) : (
         <ButtonCircular
           title='Next month'
           aria-label='Next month'

--- a/packages/picasso/src/DatePicker/DatePicker.tsx
+++ b/packages/picasso/src/DatePicker/DatePicker.tsx
@@ -114,6 +114,8 @@ export interface Props
   /** Shows orange dot indicator in days between a date range */
   indicatedIntervals?: CalendarDateRange[]
   highlight?: 'autofill'
+  /** Display two months at the same time */
+  showTwoMonths?: boolean
 }
 
 export const DatePicker = (props: Props) => {
@@ -146,6 +148,7 @@ export const DatePicker = (props: Props) => {
     indicatedIntervals,
     footerBackgroundColor,
     highlight,
+    showTwoMonths,
     ...rest
   } = props
   const classes = useStyles()
@@ -440,6 +443,7 @@ export const DatePicker = (props: Props) => {
             className={classes.calendar}
             hasFooter={Boolean(footer)}
             weekStartsOn={weekStartsOn}
+            showTwoMonths={showTwoMonths}
           />
           {footer && (
             <div
@@ -463,6 +467,7 @@ DatePicker.defaultProps = {
   displayDateFormat: 'MMM d, yyyy',
   autoComplete: 'off',
   status: 'default',
+  showTwoMonths: false,
 }
 
 DatePicker.displayName = 'DatePicker'

--- a/packages/picasso/src/DatePicker/DatePicker.tsx
+++ b/packages/picasso/src/DatePicker/DatePicker.tsx
@@ -20,6 +20,7 @@ import type {
   DateOrDateRangeType,
   DateRangeType,
   WeekStart,
+  CalendarMonthsAmount,
 } from '../Calendar'
 import Calendar from '../Calendar'
 import {
@@ -114,8 +115,8 @@ export interface Props
   /** Shows orange dot indicator in days between a date range */
   indicatedIntervals?: CalendarDateRange[]
   highlight?: 'autofill'
-  /** Display two months at the same time */
-  showTwoMonths?: boolean
+  /** Display more than one month at the same time */
+  numberOfMonths?: CalendarMonthsAmount
 }
 
 export const DatePicker = (props: Props) => {
@@ -148,7 +149,7 @@ export const DatePicker = (props: Props) => {
     indicatedIntervals,
     footerBackgroundColor,
     highlight,
-    showTwoMonths,
+    numberOfMonths,
     ...rest
   } = props
   const classes = useStyles()
@@ -443,7 +444,7 @@ export const DatePicker = (props: Props) => {
             className={classes.calendar}
             hasFooter={Boolean(footer)}
             weekStartsOn={weekStartsOn}
-            showTwoMonths={showTwoMonths}
+            numberOfMonths={numberOfMonths}
           />
           {footer && (
             <div

--- a/packages/picasso/src/DatePicker/story/WithTwoMonths.example.tsx
+++ b/packages/picasso/src/DatePicker/story/WithTwoMonths.example.tsx
@@ -8,7 +8,7 @@ const TwoMonthsExample = () => {
     <div style={{ height: '50vh' }}>
       <DatePicker
         value={datepickerValue}
-        showTwoMonths
+        numberOfMonths={2}
         onChange={date => {
           setDatepickerValue(date as Date)
         }}

--- a/packages/picasso/src/DatePicker/story/WithTwoMonths.example.tsx
+++ b/packages/picasso/src/DatePicker/story/WithTwoMonths.example.tsx
@@ -1,0 +1,20 @@
+import React, { useState } from 'react'
+import { DatePicker } from '@toptal/picasso'
+
+const TwoMonthsExample = () => {
+  const [datepickerValue, setDatepickerValue] = useState<Date>()
+
+  return (
+    <div style={{ height: '50vh' }}>
+      <DatePicker
+        value={datepickerValue}
+        showTwoMonths
+        onChange={date => {
+          setDatepickerValue(date as Date)
+        }}
+      />
+    </div>
+  )
+}
+
+export default TwoMonthsExample

--- a/packages/picasso/src/DatePicker/story/index.jsx
+++ b/packages/picasso/src/DatePicker/story/index.jsx
@@ -91,3 +91,9 @@ page
     description: 'Show a custom color footer at the bottom of the calendar',
     takeScreenshot: false,
   })
+  .addExample('DatePicker/story/WithTwoMonths.example.tsx', {
+    title: 'With two months',
+    description:
+      'Display two months at the same time (not applicable to screens below SM size)',
+    takeScreenshot: false,
+  })


### PR DESCRIPTION
[FX-3963](https://toptal-core.atlassian.net/browse/FX-3963)

### Description

Add support for rendering two months at the same time to DatePicker.
This is only available on screens > `sm` range.

### How to test

- Take a look at the [deployed storybook](https://picasso.toptal.net/fx-3963-support-two-month-calendar-visualization-in-the-datepicker-component/?path=/story/forms-datepicker--datepicker#with-two-months)
- Check if the code looks good
- Check if combinations of other props work well with two month view.

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| ![image](https://github.com/toptal/picasso/assets/18409292/4ff5797a-cedf-43e8-9274-f1ca6a050130) | ![image](https://github.com/toptal/picasso/assets/18409292/3f20ae8f-a30c-46cd-aa12-27876b234605) |

### Development checks

- [n/a] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests


> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-3963]: https://toptal-core.atlassian.net/browse/FX-3963?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ