### PR TITLE
fix: inconsistency in Rich Text Editor appearance

### DIFF
--- a/packages/picasso/src/LexicalEditor/styles.ts
+++ b/packages/picasso/src/LexicalEditor/styles.ts
@@ -8,6 +8,7 @@ export default () => {
       overflowY: 'hidden',
       resize: 'vertical',
       position: 'relative',
+      fontSize: '14px',
       // ...listStyles,
       // ...margins,
       // ...quillSpecificStyles(theme),


### PR DESCRIPTION
### Description

there is an inconsistency between the current appearance of RTE and new one.

### Screenshots

<img width="1657" alt="Picasso | RichTextEditor 🔊 2023-06-09 12-38-51" src="https://github.com/toptal/picasso/assets/1824723/88102cc4-174e-4e7e-916e-42f7b4f2aeff">



### Development checks

- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Self reviewed


> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>
