### PR TITLE
fix(ModalContent): [TOP-3334] proper bottom edge detection for scrolling shades

### DIFF
--- a/.changeset/curly-rice-cough.md
+++ b/.changeset/curly-rice-cough.md
@@ -1,0 +1,9 @@
+---
+'@toptal/picasso': patch
+---
+
+---
+
+### Modal
+
+- Fix scrollable shade at the bottom to properly disappear on different screen sizes

--- a/packages/picasso/src/ModalContent/hooks/use-scrollable-shades.ts
+++ b/packages/picasso/src/ModalContent/hooks/use-scrollable-shades.ts
@@ -19,7 +19,7 @@ const useScrollableShades = (ref: React.RefObject<HTMLDivElement>) => {
       }
 
       setTop(el.scrollTop > 0)
-      setBottom(Math.round(el.scrollTop) + el.clientHeight < el.scrollHeight)
+      setBottom(Math.ceil(el.scrollTop) + el.clientHeight < el.scrollHeight)
     }, 20)
 
     updateShades()


### PR DESCRIPTION
[TOP-3334]

### Description

On some screen sizes el.scrollTop is rounder in wrong direction which results in shade not disappearing even though user scrolled to the very bottom of the content. This definitely reproduces on Chrome/Windows. This PR aims to fix this. 

### How to test

- Ensure scrolling shade at the bottom properly disappears once you scroll to the end of the container
- [Temploy link](https://picasso.toptal.net/TOP-3334-fix-scrollable-shades-on-screens-of-fractional-size/?path=/story/overlays-modal--modal)
 
### Screenshots

https://github.com/toptal/picasso/assets/903437/9be16563-d0f9-4405-9ca7-44b8f9b17a1c

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- ~Annotate all `props` in component with documentation~
- ~Create `examples` for component~
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- ~Covered with tests~

**Breaking change**

- ~codemod is created and showcased in the changeset~
- ~test alpha package of Picasso in StaffPortal~

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[TOP-3334]: https://toptal-core.atlassian.net/browse/TOP-3334?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ