### PR TITLE
chore: [FX-4015] Integrate Rich Text Editor to Forms

### DIFF
--- a/packages/picasso/package.json
+++ b/packages/picasso/package.json
@@ -36,6 +36,7 @@
     "@lexical/html": "^0.9.1",
     "@lexical/react": "^0.9.1",
     "@lexical/utils": "^0.9.2",
+    "@lexical/text": "^0.11.1",
     "@toptal/picasso-shared": "12.0.0",
     "ap-style-title-case": "^1.1.2",
     "classnames": "^2.3.1",

--- a/packages/picasso/src/LexicalEditor/LexicalEditor.tsx
+++ b/packages/picasso/src/LexicalEditor/LexicalEditor.tsx
@@ -10,6 +10,7 @@ import { OnChangePlugin } from '@lexical/react/LexicalOnChangePlugin'
 import { ContentEditable } from '@lexical/react/LexicalContentEditable'
 import LexicalErrorBoundary from '@lexical/react/LexicalErrorBoundary'
 import { $generateHtmlFromNodes } from '@lexical/html'
+import { $isRootTextContentEmpty } from '@lexical/text'
 
 import noop from '../utils/noop'
 import Container from '../Container'
@@ -156,9 +157,13 @@ const LexicalEditor = forwardRef<HTMLDivElement, Props>(function LexicalEditor(
   const handleChange = useCallback(
     (editorState, editor) => {
       editorState.read(() => {
-        const htmlValue = $generateHtmlFromNodes(editor, null)
+        const isEmpty = $isRootTextContentEmpty(editor.isComposing(), false)
 
-        onChange(removeAttributesFromString(htmlValue))
+        const htmlValue = isEmpty
+          ? ''
+          : removeAttributesFromString($generateHtmlFromNodes(editor, null))
+
+        onChange(htmlValue)
       })
     },
     [onChange]

--- a/packages/picasso/src/RichTextEditor/RichTextEditor.tsx
+++ b/packages/picasso/src/RichTextEditor/RichTextEditor.tsx
@@ -189,7 +189,14 @@ export const RichTextEditor = forwardRef<HTMLDivElement, Props>(
             testIds={testIds}
             disabled={disabled}
           />
-          {hiddenInputId && enableFocusOnLabelClick(hiddenInputId)}
+          {hiddenInputId && (
+            // Native `for` attribute on label does not work for div target
+            <input
+              type='text'
+              id={hiddenInputId}
+              style={{ position: 'absolute', opacity: 0, zIndex: -1 }}
+            />
+          )}
         </div>
         {counterMessage && (
           <InputMultilineAdornment error={counterError}>
@@ -199,17 +206,6 @@ export const RichTextEditor = forwardRef<HTMLDivElement, Props>(
       </>
     )
   }
-)
-
-const hiddenInputStyle: React.CSSProperties = {
-  position: 'absolute',
-  opacity: 0,
-  zIndex: -1,
-}
-
-// Native `for` attribute on label does not work for div target
-const enableFocusOnLabelClick = (hiddenInputId: string) => (
-  <input type='text' id={hiddenInputId} style={hiddenInputStyle} />
 )
 
 RichTextEditor.defaultProps = {

--- a/packages/picasso/src/RichTextEditor/RichTextEditor.tsx
+++ b/packages/picasso/src/RichTextEditor/RichTextEditor.tsx
@@ -111,9 +111,9 @@ export const RichTextEditor = forwardRef<HTMLDivElement, Props>(
       minLengthMessage,
       maxLengthMessage,
       style,
-      // status,
+      status,
       testIds,
-      // hiddenInputId,
+      hiddenInputId,
       setHasMultilineCounter,
       name,
       // highlight,
@@ -162,6 +162,7 @@ export const RichTextEditor = forwardRef<HTMLDivElement, Props>(
             {
               [classes.disabled]: disabled,
               [classes.focused]: hasFocus,
+              [classes.error]: status === 'error',
             },
             className
           )}
@@ -187,6 +188,7 @@ export const RichTextEditor = forwardRef<HTMLDivElement, Props>(
             testIds={testIds}
             disabled={disabled}
           />
+          {hiddenInputId && enableFocusOnLabelClick(hiddenInputId)}
         </div>
         {counterMessage && (
           <InputMultilineAdornment error={counterError}>
@@ -196,6 +198,17 @@ export const RichTextEditor = forwardRef<HTMLDivElement, Props>(
       </>
     )
   }
+)
+
+const hiddenInputStyle: React.CSSProperties = {
+  position: 'absolute',
+  opacity: 0,
+  zIndex: -1,
+}
+
+// Native `for` attribute on label does not work for div target
+const enableFocusOnLabelClick = (hiddenInputId: string) => (
+  <input type='text' id={hiddenInputId} style={hiddenInputStyle} />
 )
 
 RichTextEditor.defaultProps = {

--- a/packages/picasso/src/RichTextEditor/RichTextEditor.tsx
+++ b/packages/picasso/src/RichTextEditor/RichTextEditor.tsx
@@ -116,7 +116,7 @@ export const RichTextEditor = forwardRef<HTMLDivElement, Props>(
       hiddenInputId,
       setHasMultilineCounter,
       name,
-      // highlight,
+      highlight,
       // customEmojis,
     } = props
 
@@ -163,6 +163,7 @@ export const RichTextEditor = forwardRef<HTMLDivElement, Props>(
               [classes.disabled]: disabled,
               [classes.focused]: hasFocus,
               [classes.error]: status === 'error',
+              [classes.highlightAutofill]: highlight === 'autofill',
             },
             className
           )}

--- a/packages/picasso/src/RichTextEditor/test.tsx
+++ b/packages/picasso/src/RichTextEditor/test.tsx
@@ -181,24 +181,4 @@ describe('RichTextEditor', () => {
       })
     })
   })
-
-  describe('when status prop is "default"', () => {
-    it('renders editor wrapper without error className', () => {
-      const { getByTestId } = renderRichTextEditor({ status: 'default' })
-
-      expect(getByTestId('wrapper-test-id-1')).toHaveClass(
-        'RichTextEditor-editorWrapper-4'
-      )
-    })
-  })
-
-  describe('when status prop is "error"', () => {
-    it('renders editor wrapper with error className', () => {
-      const { getByTestId } = renderRichTextEditor({ status: 'error' })
-
-      expect(getByTestId('wrapper-test-id-1')).toHaveClass(
-        'RichTextEditor-editorWrapper-4 RichTextEditor-error-6'
-      )
-    })
-  })
 })

--- a/packages/picasso/src/RichTextEditor/test.tsx
+++ b/packages/picasso/src/RichTextEditor/test.tsx
@@ -181,4 +181,24 @@ describe('RichTextEditor', () => {
       })
     })
   })
+
+  describe('when status prop is "default"', () => {
+    it('renders editor wrapper without error className', () => {
+      const { getByTestId } = renderRichTextEditor({ status: 'default' })
+
+      expect(getByTestId('wrapper-test-id-1')).toHaveClass(
+        'RichTextEditor-editorWrapper-4'
+      )
+    })
+  })
+
+  describe('when status prop is "error"', () => {
+    it('renders editor wrapper with error className', () => {
+      const { getByTestId } = renderRichTextEditor({ status: 'error' })
+
+      expect(getByTestId('wrapper-test-id-1')).toHaveClass(
+        'RichTextEditor-editorWrapper-4 RichTextEditor-error-6'
+      )
+    })
+  })
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -2471,6 +2471,11 @@
   resolved "https://registry.yarnpkg.com/@lexical/text/-/text-0.9.2.tgz#5627eb02fed69b40ecca9507894f067bc6798522"
   integrity sha512-mD9aAOTfewgvpS1P8tMl16cpf4tXHqlxy00NjFZxoH5bQVRRdVCT/Kr7YimD6UVgjPOvlD9s0mKTKoiTm12lXg==
 
+"@lexical/text@^0.11.1":
+  version "0.11.1"
+  resolved "https://registry.yarnpkg.com/@lexical/text/-/text-0.11.1.tgz#e8e4573752ddea0b35e59152ae3c7d04400f83e8"
+  integrity sha512-TQ9vb24sStMicnJaGT9U6yUCVXTIVFHAzt5cMPtr7hK6b1CsJPMTRmsM7n5vIo9xnHM9SLLe01AxwL2O7I1QKg==
+
 "@lexical/utils@0.9.2", "@lexical/utils@^0.9.2":
   version "0.9.2"
   resolved "https://registry.yarnpkg.com/@lexical/utils/-/utils-0.9.2.tgz#fab457648fa60f01975f1a2aaa722e0be6f9dcb6"


### PR DESCRIPTION
[FX-4015]

### Description

We need to integrate a new RTE to Picasso Forms.

### How to test

- Check the regress on temploy

### Screenshots

<img width="1267" alt="Picasso | Form 🔊 2023-06-13 13-09-49" src="https://github.com/toptal/picasso/assets/1824723/6bc2b3db-56b6-44a4-bd4d-25e0f5a693a2">



### Development checks

- [x] Make sure that additions and changes on design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [x] Annotate all `props` in component with documentation
- [x] Ensure that deployed demo has expected results and good examples
- [x] Self reviewed
- [x] Covered with tests


> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-4015]: https://toptal-core.atlassian.net/browse/FX-4015?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ