### PR TITLE
feat: add styles for bold and italic

### DIFF
--- a/packages/picasso/src/LexicalEditor/LexicalEditor.tsx
+++ b/packages/picasso/src/LexicalEditor/LexicalEditor.tsx
@@ -166,6 +166,8 @@ const LexicalEditor = forwardRef<HTMLDivElement, Props>(function LexicalEditor(
         <ToolbarPlugin
           disabled={disabled || !isFocused}
           toolbarRef={toolbarRef}
+          // remount Toolbar when disabled
+          key={`${disabled || !isFocused}`}
         />
         <OnChangePlugin ignoreSelectionChange onChange={handleChange} />
         {autoFocus && <AutoFocusPlugin />}

--- a/packages/picasso/src/LexicalEditor/styles.ts
+++ b/packages/picasso/src/LexicalEditor/styles.ts
@@ -1,4 +1,5 @@
 import { createStyles } from '@material-ui/core/styles'
+import type { Theme } from '@material-ui/core/styles'
 import type { CSSProperties } from '@material-ui/core/styles/withStyles'
 import { rem } from '@toptal/picasso-shared'
 
@@ -78,7 +79,7 @@ const listStyles = {
   ...indentStyles,
 }
 
-export default () => {
+export default ({ typography }: Theme) => {
   return createStyles({
     editorContainer: {
       height: '12.5em',
@@ -145,6 +146,12 @@ export default () => {
           width: '1rem',
         },
       },
+    },
+    bold: {
+      fontWeight: typography.fontWeights.semibold,
+    },
+    italic: {
+      fontStyle: 'italic',
     },
   })
 }

--- a/packages/picasso/src/LexicalEditor/utils/createLexicalTheme.ts
+++ b/packages/picasso/src/LexicalEditor/utils/createLexicalTheme.ts
@@ -19,6 +19,11 @@ export const createLexicalTheme = ({
   const theme: EditorThemeClasses = {
     root: typographyClassNames,
     paragraph: classes.paragraph,
+    text: {
+      italic: classes.italic,
+      bold: classes.bold,
+    },
+
     list: {
       listitem: classes.listItem,
       nested: {

--- a/packages/picasso/src/LexicalEditor/utils/registerLexicalEvents.test.ts
+++ b/packages/picasso/src/LexicalEditor/utils/registerLexicalEvents.test.ts
@@ -1,23 +1,14 @@
-import { mergeRegister } from '@lexical/utils'
 import { COMMAND_PRIORITY_CRITICAL, SELECTION_CHANGE_COMMAND } from 'lexical'
 
 import { registerLexicalEvents } from './registerLexicalEvents'
 import type { LexicalRegisterParams } from './registerLexicalEvents'
-
-jest.mock('@lexical/utils', () => ({
-  mergeRegister: jest.fn(),
-}))
 
 jest.mock('@lexical/react/LexicalComposerContext', () => ({
   useLexicalComposerContext: jest.fn().mockReturnValue([]),
 }))
 
 const mockUpdateToolbar = jest.fn()
-const mockMergeRegister = mergeRegister as jest.MockedFunction<
-  typeof mergeRegister
->
 
-const mockedEditorListenerCleanup = jest.fn()
 const mockedEditorCommandsCleanup = jest.fn()
 
 describe('registerLexicalEvents', () => {
@@ -32,15 +23,6 @@ describe('registerLexicalEvents', () => {
         .fn()
         .mockReturnValueOnce(mockedEditorCommandsCleanup),
     }
-    const mockActiveEditor = {
-      registerUpdateListener: jest.fn().mockReturnValueOnce(() => {}),
-    }
-
-    mockMergeRegister
-      .mockImplementation(() => () => {
-        mockActiveEditor.registerUpdateListener()
-      })
-      .mockReturnValueOnce(mockedEditorListenerCleanup)
 
     const params = {
       editor: mockEditor,
@@ -58,13 +40,11 @@ describe('registerLexicalEvents', () => {
       expect.any(Function),
       COMMAND_PRIORITY_CRITICAL
     )
-    expect(mergeRegister).toHaveBeenCalledTimes(1)
 
     // Simulate invoking the cleanup function
     cleanup()
 
     // Assert cleanup
     expect(mockedEditorCommandsCleanup).toHaveBeenCalledTimes(1)
-    expect(mockedEditorListenerCleanup).toHaveBeenCalledTimes(1)
   })
 })

--- a/packages/picasso/src/RichTextEditorToolbar/RichTextEditorToolbar.tsx
+++ b/packages/picasso/src/RichTextEditorToolbar/RichTextEditorToolbar.tsx
@@ -51,6 +51,7 @@ const useStyles = makeStyles<Theme, Props>(styles, {
 })
 
 export const RichTextEditorToolbar = forwardRef<HTMLDivElement, Props>(
+  // eslint-disable-next-line complexity
   function RichTextEditorToolbar(props: Props, ref) {
     const {
       disabled,
@@ -83,7 +84,7 @@ export const RichTextEditorToolbar = forwardRef<HTMLDivElement, Props>(
         >
           <Select
             onChange={onHeaderChange}
-            value={format.header}
+            value={disabled ? '' : format.header}
             options={[
               { value: '3', text: 'heading' },
               { value: '', text: 'normal' },
@@ -99,14 +100,14 @@ export const RichTextEditorToolbar = forwardRef<HTMLDivElement, Props>(
           <TextEditorButton
             icon={<Bold16 />}
             onClick={onBoldClick}
-            active={isHeadingFormat ? false : format.bold}
+            active={isHeadingFormat || disabled ? false : format.bold}
             disabled={isHeadingFormat || disabled}
             data-testid={testIds?.boldButton}
           />
           <TextEditorButton
             icon={<Italic16 />}
             onClick={onItalicClick}
-            active={isHeadingFormat ? false : format.italic}
+            active={isHeadingFormat || disabled ? false : format.italic}
             disabled={isHeadingFormat || disabled}
             data-testid={testIds?.italicButton}
           />
@@ -115,14 +116,14 @@ export const RichTextEditorToolbar = forwardRef<HTMLDivElement, Props>(
           <TextEditorButton
             icon={<ListUnordered16 />}
             onClick={onUnorderedClick}
-            active={format.list === 'bullet'}
+            active={disabled ? false : format.list === 'bullet'}
             disabled={disabled}
             data-testid={testIds?.unorderedListButton}
           />
           <TextEditorButton
             icon={<ListOrdered16 />}
             onClick={onOrderedClick}
-            active={format.list === 'ordered'}
+            active={disabled ? false : format.list === 'ordered'}
             disabled={disabled}
             data-testid={testIds?.orderedListButton}
           />
@@ -132,7 +133,7 @@ export const RichTextEditorToolbar = forwardRef<HTMLDivElement, Props>(
             <TextEditorButton
               icon={<Link16 />}
               onClick={onLinkClick}
-              active={!!format.link}
+              active={disabled ? false : !!format.link}
               disabled={disabled}
               data-testid={testIds?.linkButton}
             />

--- a/packages/picasso/src/RichTextEditorToolbar/RichTextEditorToolbar.tsx
+++ b/packages/picasso/src/RichTextEditorToolbar/RichTextEditorToolbar.tsx
@@ -100,14 +100,14 @@ export const RichTextEditorToolbar = forwardRef<HTMLDivElement, Props>(
           <TextEditorButton
             icon={<Bold16 />}
             onClick={onBoldClick}
-            active={isHeadingFormat || disabled ? false : format.bold}
+            active={isHeadingFormat ? false : format.bold}
             disabled={isHeadingFormat || disabled}
             data-testid={testIds?.boldButton}
           />
           <TextEditorButton
             icon={<Italic16 />}
             onClick={onItalicClick}
-            active={isHeadingFormat || disabled ? false : format.italic}
+            active={isHeadingFormat ? false : format.italic}
             disabled={isHeadingFormat || disabled}
             data-testid={testIds?.italicButton}
           />
@@ -116,14 +116,14 @@ export const RichTextEditorToolbar = forwardRef<HTMLDivElement, Props>(
           <TextEditorButton
             icon={<ListUnordered16 />}
             onClick={onUnorderedClick}
-            active={disabled ? false : format.list === 'bullet'}
+            active={format.list === 'bullet'}
             disabled={disabled}
             data-testid={testIds?.unorderedListButton}
           />
           <TextEditorButton
             icon={<ListOrdered16 />}
             onClick={onOrderedClick}
-            active={disabled ? false : format.list === 'ordered'}
+            active={format.list === 'ordered'}
             disabled={disabled}
             data-testid={testIds?.orderedListButton}
           />
@@ -133,7 +133,7 @@ export const RichTextEditorToolbar = forwardRef<HTMLDivElement, Props>(
             <TextEditorButton
               icon={<Link16 />}
               onClick={onLinkClick}
-              active={disabled ? false : !!format.link}
+              active={!!format.link}
               disabled={disabled}
               data-testid={testIds?.linkButton}
             />


### PR DESCRIPTION
[FX-4087]

### Description

The only thing that we need to do is to add class to HTML tags in the editor. As you can see from the screenshot from the current feature branch, we have both bold and italic on the output.

### How to test

- play with[ temploy ](https://picasso.toptal.net/fx-4087-italic-bold/?path=/story/forms-richtexteditor--richtexteditor)

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| ![image](https://github.com/toptal/picasso/assets/6830426/e1256b91-74ea-415c-afe4-60dd6dffab1a) | ![image](https://github.com/toptal/picasso/assets/6830426/170ee389-15d2-47ab-b71b-f93a0b50ad09) |

### Development checks

- Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- Make sure that additions and changes on design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- Annotate all `props` in component with documentation
- Create `examples` for component
- Ensure that deployed demo has expected results and good examples
- Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- Covered with tests

**Breaking change**

- codemod is created and showcased in the changeset
- test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-4087]: https://toptal-core.atlassian.net/browse/FX-4087?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ