### PR TITLE
feat(ButtonGroup): [SDE-1090] Add disabled appearance

### DIFF
--- a/.changeset/lazy-poets-change.md
+++ b/.changeset/lazy-poets-change.md
@@ -1,0 +1,5 @@
+---
+'@toptal/picasso': patch
+---
+
+- add disabled appearance to ButtonGroup

--- a/.changeset/lazy-poets-change.md
+++ b/.changeset/lazy-poets-change.md
@@ -2,4 +2,10 @@
 '@toptal/picasso': patch
 ---
 
-- add disabled appearance to ButtonGroup
+### ButtonGroup
+
+- add disabled appearance
+
+### PaginationButton
+
+- add disabled appearance

--- a/packages/picasso/src/Button/styles.ts
+++ b/packages/picasso/src/Button/styles.ts
@@ -30,6 +30,12 @@ export const activeGroup = ({ palette }: Theme) => ({
   color: palette.common.white,
 })
 
+export const disabledGroup = ({ palette }: Theme) => ({
+  color: palette.grey.main,
+  cursor: 'not-allowed',
+  pointerEvents: 'all',
+})
+
 export const createVariant = (mainColor: string, { palette }: Theme) => ({
   border: 'none',
   color: palette.common.white,

--- a/packages/picasso/src/ButtonGroup/story/ButtonGroupDisabled.example.tsx
+++ b/packages/picasso/src/ButtonGroup/story/ButtonGroupDisabled.example.tsx
@@ -1,0 +1,43 @@
+import React, { useState } from 'react'
+import { Button } from '@toptal/picasso'
+
+const Example = () => {
+  const [active, setActive] = useState(1)
+
+  return (
+    <div>
+      <Button.Group>
+        <Button.Group.Item
+          active={active === 0}
+          onClick={() => setActive(0)}
+          disabled
+        >
+          First
+        </Button.Group.Item>
+        <Button.Group.Item
+          active={active === 1}
+          onClick={() => setActive(1)}
+          disabled
+        >
+          Second
+        </Button.Group.Item>
+        <Button.Group.Item
+          active={active === 2}
+          onClick={() => setActive(2)}
+          disabled
+        >
+          Third
+        </Button.Group.Item>
+        <Button.Group.Item
+          active={active === 3}
+          onClick={() => setActive(3)}
+          disabled
+        >
+          Fourth
+        </Button.Group.Item>
+      </Button.Group>
+    </div>
+  )
+}
+
+export default Example

--- a/packages/picasso/src/ButtonGroup/story/index.jsx
+++ b/packages/picasso/src/ButtonGroup/story/index.jsx
@@ -9,6 +9,10 @@ const chapter = PicassoBook.connectToPage(page =>
     )
     .addExample('ButtonGroup/story/ButtonGroup.example.tsx', 'Button group')
     .addExample(
+      'ButtonGroup/story/ButtonGroupDisabled.example.tsx',
+      'Button group disabled'
+    )
+    .addExample(
       'ButtonGroup/story/ButtonGroupNested.example.tsx',
       'Nested Button Group'
     )

--- a/packages/picasso/src/ButtonGroupItem/ButtonGroupItem.tsx
+++ b/packages/picasso/src/ButtonGroupItem/ButtonGroupItem.tsx
@@ -21,6 +21,7 @@ const ButtonGroupItem = (props: Props) => {
       {...props}
       className={cx(props.className, classes.root, classes.group, {
         [classes.active]: props.active,
+        [classes.disabled]: props.disabled,
       })}
       variant='secondary'
     />

--- a/packages/picasso/src/ButtonGroupItem/styles.ts
+++ b/packages/picasso/src/ButtonGroupItem/styles.ts
@@ -1,19 +1,25 @@
 import type { Theme } from '@material-ui/core/styles'
 import { createStyles } from '@material-ui/core/styles'
 
-import { createOutlineCommons, activeGroup } from '../Button/styles'
+import {
+  createOutlineCommons,
+  activeGroup,
+  disabledGroup,
+} from '../Button/styles'
 
 export default (theme: Theme) =>
   createStyles({
     root: {
-      '&:active, &$active, &:hover, &$hovered, &:focus, &$focused': {
-        // border overlap to keep proper border width, but on state change
-        // we need to move up overlapped border
-        zIndex: 1,
-      },
+      '&:active, &$active, &:hover, &$hovered, &:focus, &$focused, &:disabled, &$disabled':
+        {
+          // border overlap to keep proper border width, but on state change
+          // we need to move up overlapped border
+          zIndex: 1,
+        },
       '&$group': {
         ...createOutlineCommons(theme),
         '&:active, &$active': activeGroup(theme),
+        '&:disabled, &$disabled': disabledGroup(theme),
       },
     },
     active: {},

--- a/packages/picasso/src/PaginationButton/styles.ts
+++ b/packages/picasso/src/PaginationButton/styles.ts
@@ -1,7 +1,11 @@
 import type { Theme } from '@material-ui/core/styles'
 import { createStyles } from '@material-ui/core/styles'
 
-import { createOutlineCommons, activeGroup } from '../Button/styles'
+import {
+  createOutlineCommons,
+  activeGroup,
+  disabledGroup,
+} from '../Button/styles'
 
 export default (theme: Theme) =>
   createStyles({
@@ -11,6 +15,7 @@ export default (theme: Theme) =>
 
       ...createOutlineCommons(theme),
       '&:active, &$active': activeGroup(theme),
+      '&:disabled, &$disabled': disabledGroup(theme),
     },
     active: {},
     hovered: {},


### PR DESCRIPTION
[SDE-1090](https://toptal-core.atlassian.net/browse/SDE-1090)

### Description

Add support for disabled appearance to `ButtonGroup`.

### How to test

- Take a look at the [deployed storybook](https://picasso.toptal.net/sde-1090-add-disabled-appearance-button-group/?path=/story/components-button--button#group-of-buttons-button-group-disabled)
- Check if the code looks good
- Compare implementation with ticket requirements.

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| ![image](https://github.com/toptal/picasso/assets/5639968/5fcc4a03-b512-4302-8b62-99ae9813f1bd) | ![image](https://github.com/toptal/picasso/assets/5639968/4b56b2ba-558f-48c7-8e3e-77b36a48c949) |

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests

**Breaking change**

- [n/a] codemod is created and showcased in the changeset
- [n/a] test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[SDE-1090]: https://toptal-core.atlassian.net/browse/SDE-1090?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ