### PR TITLE
feat(RichTextEditor): add Emoji plugin

### DIFF
--- a/packages/picasso/src/LexicalEditor/LexicalEditor.test.tsx
+++ b/packages/picasso/src/LexicalEditor/LexicalEditor.test.tsx
@@ -9,6 +9,7 @@ import LexicalTextLengthPlugin from '../LexicalTextLengthPlugin'
 import LexicalHeadingsReplacementPlugin from '../LexicalHeadingsReplacementPlugin'
 import ToolbarPlugin from '../LexicalEditorToolbarPlugin'
 import LexicalListPlugin from '../LexicalListPlugin'
+import type { CustomEmojiGroup } from './types'
 
 jest.mock('../LexicalEditorToolbarPlugin', () => ({
   __esModule: true,
@@ -17,6 +18,10 @@ jest.mock('../LexicalEditorToolbarPlugin', () => ({
 jest.mock('../LexicalListPlugin', () => ({
   __esModule: true,
   default: jest.fn(() => <div>LexicalListPlugin</div>),
+}))
+jest.mock('../LexicalEmojiPlugin', () => ({
+  __esModule: true,
+  default: jest.fn(() => <div>LexicalEmojiPlugin</div>),
 }))
 
 jest.mock('@lexical/react/LexicalComposerContext', () => ({
@@ -136,6 +141,8 @@ describe('LexicalEditor', () => {
       expect(mockedToolbarPlugin).toHaveBeenCalledWith(
         {
           disabled: true,
+          customEmojis: undefined,
+          plugins: [],
           toolbarRef: {
             current: null,
           },
@@ -152,6 +159,30 @@ describe('LexicalEditor', () => {
       expect(mockedToolbarPlugin).toHaveBeenCalledWith(
         {
           disabled: true,
+          customEmojis: undefined,
+          plugins: [],
+          toolbarRef: {
+            current: null,
+          },
+        },
+        {}
+      )
+    })
+  })
+
+  describe('when customEmojis and plugins prop is passed', () => {
+    it('renders ToolbarPlugin with correct props', () => {
+      renderLexicalEditor({
+        disabled: true,
+        customEmojis: ['foo' as unknown as CustomEmojiGroup],
+        plugins: ['link'],
+      })
+
+      expect(mockedToolbarPlugin).toHaveBeenCalledWith(
+        {
+          disabled: true,
+          customEmojis: ['foo'],
+          plugins: ['link'],
           toolbarRef: {
             current: null,
           },

--- a/packages/picasso/src/LexicalEditor/LexicalEditor.tsx
+++ b/packages/picasso/src/LexicalEditor/LexicalEditor.tsx
@@ -8,12 +8,12 @@ import { RichTextPlugin } from '@lexical/react/LexicalRichTextPlugin'
 import { AutoFocusPlugin } from '@lexical/react/LexicalAutoFocusPlugin'
 import { ContentEditable } from '@lexical/react/LexicalContentEditable'
 import LexicalErrorBoundary from '@lexical/react/LexicalErrorBoundary'
-import { HeadingNode } from '@lexical/rich-text'
 import { $generateHtmlFromNodes } from '@lexical/html'
-import { ListItemNode, ListNode } from '@lexical/list'
 import { $isRootTextContentEmpty } from '@lexical/text'
 import type { LexicalEditor as LexicalEditorType } from 'lexical'
 import { OnChangePlugin } from '@lexical/react/LexicalOnChangePlugin'
+import { ListItemNode, ListNode } from '@lexical/list'
+import { HeadingNode } from '@lexical/rich-text'
 
 import { TriggerInitialOnChangePlugin } from './plugins'
 import { createLexicalTheme, setEditorValue } from './utils'
@@ -22,12 +22,19 @@ import Container from '../Container'
 import Typography from '../Typography'
 import { useTypographyClasses, useOnFocus } from './hooks'
 import styles from './styles'
-import type { ChangeHandler, TextLengthChangeHandler } from './types'
+import type {
+  ChangeHandler,
+  EditorPlugin,
+  TextLengthChangeHandler,
+  CustomEmojiGroup,
+} from './types'
 import ToolbarPlugin from '../LexicalEditorToolbarPlugin'
 import LexicalTextLengthPlugin from '../LexicalTextLengthPlugin'
 import LexicalListPlugin from '../LexicalListPlugin'
 import LexicalHeadingsReplacementPlugin from '../LexicalHeadingsReplacementPlugin'
 import type { ASTType } from '../RichText'
+import { CustomEmojiNode } from '../LexicalEmojiPlugin/nodes/CustomEmojiNode'
+import LexicalEmojiPlugin from '../LexicalEmojiPlugin'
 
 const useStyles = makeStyles<Theme>(styles, {
   name: 'LexicalEditor',
@@ -68,8 +75,7 @@ export type Props = BaseProps & {
   onTextLengthChange: TextLengthChangeHandler
   /** The placeholder attribute specifies a short hint that describes the expected value of a text editor. */
   placeholder?: string
-  /** List of plugins to enable on the editor */
-  //   plugins?: EditorPlugin[]
+
   testIds?: {
     editor?: string
     // headerSelect?: string
@@ -78,7 +84,9 @@ export type Props = BaseProps & {
     // unorderedListButton?: string
     // orderedListButton?: string
   }
-  //   customEmojis?: CustomEmojiGroup[]
+  customEmojis?: CustomEmojiGroup[]
+  /** List of plugins to enable on the editor */
+  plugins?: EditorPlugin[]
 }
 
 const LexicalEditor = forwardRef<HTMLDivElement, Props>(function LexicalEditor(
@@ -86,7 +94,7 @@ const LexicalEditor = forwardRef<HTMLDivElement, Props>(function LexicalEditor(
   ref
 ) {
   const {
-    // plugins,
+    plugins = [],
     autoFocus = false,
     defaultValue,
     disabled = false,
@@ -108,7 +116,7 @@ const LexicalEditor = forwardRef<HTMLDivElement, Props>(function LexicalEditor(
     // @todo don't know what to do with NAME prop
     // name,
     // highlight,
-    // customEmojis,
+    customEmojis,
   } = props
 
   const classes = useStyles()
@@ -128,7 +136,7 @@ const LexicalEditor = forwardRef<HTMLDivElement, Props>(function LexicalEditor(
         typographyClassNames,
         classes,
       }),
-    [typographyClassNames, classes.paragraph]
+    [typographyClassNames, classes]
   )
 
   const editorConfig: InitialConfigType = useMemo(
@@ -143,7 +151,7 @@ const LexicalEditor = forwardRef<HTMLDivElement, Props>(function LexicalEditor(
         throw error
       },
       namespace: 'editor',
-      nodes: [ListNode, ListItemNode, HeadingNode],
+      nodes: [CustomEmojiNode, ListNode, ListItemNode, HeadingNode],
       editable: !disabled,
     }),
     [defaultValue, theme, disabled]
@@ -178,6 +186,8 @@ const LexicalEditor = forwardRef<HTMLDivElement, Props>(function LexicalEditor(
           toolbarRef={toolbarRef}
           // remount Toolbar when disabled
           key={`${disabled || !isFocused}`}
+          customEmojis={customEmojis}
+          plugins={plugins}
         />
         {defaultValue ? (
           <TriggerInitialOnChangePlugin onChange={handleChange} />
@@ -188,6 +198,7 @@ const LexicalEditor = forwardRef<HTMLDivElement, Props>(function LexicalEditor(
         <LexicalHeadingsReplacementPlugin />
         <LexicalTextLengthPlugin onTextLengthChange={onTextLengthChange} />
         <LexicalListPlugin />
+        <LexicalEmojiPlugin />
 
         <div className={classes.editorContainer} id={id} ref={ref}>
           <RichTextPlugin

--- a/packages/picasso/src/LexicalEditor/styles.ts
+++ b/packages/picasso/src/LexicalEditor/styles.ts
@@ -153,5 +153,12 @@ export default ({ typography }: Theme) => {
     italic: {
       fontStyle: 'italic',
     },
+    customEmoji: {
+      '& > img': {
+        verticalAlign: 'bottom',
+        width: '22px',
+        height: '22px',
+      },
+    },
   })
 }

--- a/packages/picasso/src/LexicalEditor/types.ts
+++ b/packages/picasso/src/LexicalEditor/types.ts
@@ -1,3 +1,35 @@
+export type SettingName = 'link' | 'emoji'
+
 export type ChangeHandler = (html: string) => void
 
 export type { TextLengthChangeHandler } from '../LexicalTextLengthPlugin'
+
+export type EditorPlugin = SettingName
+
+export type CustomEmoji = {
+  id: string
+  name: string
+  keywords: string[]
+  skins: [
+    {
+      src: string
+    }
+  ]
+}
+
+export type CustomEmojiGroup = {
+  id: string
+  name: string
+  emojis: CustomEmoji[]
+}
+
+export type Emoji = {
+  id: string
+  name: string
+  native?: string
+  unified?: string
+  keywords: string[]
+  shortcodes: string
+  emoticons?: string[]
+  src?: string
+}

--- a/packages/picasso/src/LexicalEditor/utils/createLexicalTheme.ts
+++ b/packages/picasso/src/LexicalEditor/utils/createLexicalTheme.ts
@@ -34,6 +34,7 @@ export const createLexicalTheme = ({
       ul: classes.ul,
       ol: classes.ol,
     },
+    customEmoji: classes.customEmoji,
   }
 
   return theme

--- a/packages/picasso/src/LexicalEditorToolbarPlugin/LexicalEditorToolbarPlugin.tsx
+++ b/packages/picasso/src/LexicalEditorToolbarPlugin/LexicalEditorToolbarPlugin.tsx
@@ -21,19 +21,32 @@ import {
   toolbarStateReducer,
 } from '../LexicalEditor/utils'
 import { noop } from '../utils'
+import type {
+  CustomEmojiGroup,
+  EditorPlugin,
+  Emoji,
+} from '../LexicalEditor/types'
+import {
+  INSERT_CUSTOM_EMOJI_COMMAND,
+  INSERT_EMOJI_COMMAND,
+} from '../LexicalEmojiPlugin/commands'
 import type { HeaderValue } from '../RichTextEditorToolbar'
 import RichTextEditorToolbar, {
   ALLOWED_HEADER_TYPE,
 } from '../RichTextEditorToolbar'
 
 type Props = {
+  customEmojis?: CustomEmojiGroup[]
   disabled?: boolean
   toolbarRef: React.RefObject<HTMLDivElement>
+  plugins?: EditorPlugin[]
 }
 
 const LexicalEditorToolbarPlugin = ({
   disabled = false,
   toolbarRef,
+  customEmojis,
+  plugins,
 }: Props) => {
   const [editor] = useLexicalComposerContext()
   const [{ bold, italic, list, header }, dispatch] = useReducer(
@@ -73,6 +86,24 @@ const LexicalEditorToolbarPlugin = ({
     )
   }
 
+  const handleInsertEmoji = (emoji: Emoji) => {
+    const isNativeEmoji = emoji.native
+    const isCustomEmoji = emoji.src
+
+    if (isNativeEmoji) {
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      editor.dispatchCommand(INSERT_EMOJI_COMMAND, emoji.native!)
+    }
+
+    if (isCustomEmoji) {
+      editor.dispatchCommand(INSERT_CUSTOM_EMOJI_COMMAND, {
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        src: emoji.src!,
+        id: emoji.id,
+      })
+    }
+  }
+
   const handleHeaderClick = ({
     target: { value },
   }: ChangeEvent<{
@@ -108,8 +139,10 @@ const LexicalEditorToolbarPlugin = ({
       onLinkClick={noop}
       onHeaderChange={handleHeaderClick}
       disabled={disabled}
-      onInsertEmoji={noop}
+      onInsertEmoji={handleInsertEmoji}
       ref={toolbarRef}
+      customEmojis={customEmojis}
+      plugins={plugins}
     />
   )
 }

--- a/packages/picasso/src/LexicalEmojiPlugin/LexicalEmojiPlugin.test.ts
+++ b/packages/picasso/src/LexicalEmojiPlugin/LexicalEmojiPlugin.test.ts
@@ -1,0 +1,77 @@
+import { renderHook } from '@testing-library/react-hooks'
+import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext'
+import { $createTextNode, $insertNodes, COMMAND_PRIORITY_EDITOR } from 'lexical'
+
+import LexicalEmojiPlugin, {
+  INSERT_CUSTOM_EMOJI_COMMAND,
+  INSERT_EMOJI_COMMAND,
+} from './index'
+import { $createCustomEmojiNode } from './nodes/CustomEmojiNode'
+
+jest.mock('@lexical/react/LexicalComposerContext', () => ({
+  useLexicalComposerContext: jest.fn(() => [{}]),
+}))
+
+jest.mock('@lexical/utils', () => ({
+  mergeRegister: jest.fn(),
+}))
+
+jest.mock('lexical', () => ({
+  $createTextNode: jest.fn(),
+  $insertNodes: jest.fn(),
+  COMMAND_PRIORITY_EDITOR: jest.fn(),
+  createCommand: jest.fn(),
+}))
+
+jest.mock('./nodes/CustomEmojiNode', () => ({
+  $createCustomEmojiNode: jest.fn(),
+}))
+
+describe('LexicalEmojiPlugin', () => {
+  const mockEditor = {
+    registerCommand: jest.fn(),
+  }
+
+  beforeEach(() => {
+    jest.resetAllMocks()
+    ;(useLexicalComposerContext as jest.Mock).mockReturnValue([mockEditor])
+  })
+
+  it('registers commands on mount', () => {
+    renderHook(() => LexicalEmojiPlugin())
+
+    expect(mockEditor.registerCommand).toHaveBeenCalledTimes(2)
+    expect(mockEditor.registerCommand).toHaveBeenCalledWith(
+      INSERT_EMOJI_COMMAND,
+      expect.any(Function),
+      COMMAND_PRIORITY_EDITOR
+    )
+    expect(mockEditor.registerCommand).toHaveBeenCalledWith(
+      INSERT_CUSTOM_EMOJI_COMMAND,
+      expect.any(Function),
+      COMMAND_PRIORITY_EDITOR
+    )
+  })
+
+  it('inserts a text node when the native emoji command is called', () => {
+    renderHook(() => LexicalEmojiPlugin())
+    const nativeEmojiCommand = mockEditor.registerCommand.mock.calls[0][1]
+
+    nativeEmojiCommand('😃')
+
+    expect($createTextNode).toHaveBeenCalledWith('😃')
+    expect($insertNodes).toHaveBeenCalledWith([$createTextNode()])
+  })
+
+  it('inserts a custom emoji node when the custom emoji command is called', () => {
+    const payload = { id: 'custom emoji', src: 'https://example.com/emoji.png' }
+
+    renderHook(() => LexicalEmojiPlugin())
+    const customEmojiCommand = mockEditor.registerCommand.mock.calls[1][1]
+
+    customEmojiCommand(payload)
+
+    expect($createCustomEmojiNode).toHaveBeenCalledWith(payload)
+    expect($insertNodes).toHaveBeenCalledWith([$createCustomEmojiNode(payload)])
+  })
+})

--- a/packages/picasso/src/LexicalEmojiPlugin/LexicalEmojiPlugin.tsx
+++ b/packages/picasso/src/LexicalEmojiPlugin/LexicalEmojiPlugin.tsx
@@ -1,0 +1,41 @@
+import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext'
+import { mergeRegister } from '@lexical/utils'
+import { useEffect } from 'react'
+import { $createTextNode, $insertNodes, COMMAND_PRIORITY_EDITOR } from 'lexical'
+
+import { INSERT_CUSTOM_EMOJI_COMMAND, INSERT_EMOJI_COMMAND } from './commands'
+import { $createCustomEmojiNode } from './nodes/CustomEmojiNode'
+import type { CustomEmojiPayload } from './types'
+
+const LexicalEmojiPlugin = () => {
+  const [editor] = useLexicalComposerContext()
+
+  useEffect(() => {
+    return mergeRegister(
+      editor.registerCommand(
+        INSERT_EMOJI_COMMAND,
+        (nativeEmoji: string) => {
+          $insertNodes([$createTextNode(nativeEmoji)])
+
+          return true
+        },
+        COMMAND_PRIORITY_EDITOR
+      ),
+      editor.registerCommand(
+        INSERT_CUSTOM_EMOJI_COMMAND,
+        (customEmojiPayload: CustomEmojiPayload) => {
+          const emojiNode = $createCustomEmojiNode(customEmojiPayload)
+
+          $insertNodes([emojiNode])
+
+          return true
+        },
+        COMMAND_PRIORITY_EDITOR
+      )
+    )
+  }, [editor])
+
+  return null
+}
+
+export default LexicalEmojiPlugin

--- a/packages/picasso/src/LexicalEmojiPlugin/commands/index.ts
+++ b/packages/picasso/src/LexicalEmojiPlugin/commands/index.ts
@@ -1,0 +1,11 @@
+import { createCommand } from 'lexical'
+import type { LexicalCommand } from 'lexical'
+
+import type { CustomEmojiPayload } from '../nodes/CustomEmojiNode'
+
+export const INSERT_EMOJI_COMMAND: LexicalCommand<string> = createCommand(
+  'INSERT_EMOJI_COMMAND'
+)
+
+export const INSERT_CUSTOM_EMOJI_COMMAND: LexicalCommand<CustomEmojiPayload> =
+  createCommand('INSERT_CUSTOM_EMOJI_COMMAND')

--- a/packages/picasso/src/LexicalEmojiPlugin/index.ts
+++ b/packages/picasso/src/LexicalEmojiPlugin/index.ts
@@ -1,0 +1,3 @@
+export { default } from './LexicalEmojiPlugin'
+export * from './commands'
+export * from './nodes'

--- a/packages/picasso/src/LexicalEmojiPlugin/nodes/CustomEmojiNode.tsx
+++ b/packages/picasso/src/LexicalEmojiPlugin/nodes/CustomEmojiNode.tsx
@@ -1,0 +1,141 @@
+import React from 'react'
+import { $applyNodeReplacement, DecoratorNode } from 'lexical'
+import type {
+  DOMConversionMap,
+  DOMConversionOutput,
+  DOMExportOutput,
+  EditorConfig,
+  LexicalNode,
+  NodeKey,
+  SerializedElementNode,
+  Spread,
+} from 'lexical'
+
+export interface CustomEmojiPayload {
+  src: string
+  id: string
+}
+
+type SerializedCustomEmojiNode = Spread<
+  {
+    src: string
+    id: string
+  },
+  SerializedElementNode
+>
+
+const convertImageElement = (domNode: Node): null | DOMConversionOutput => {
+  if (domNode instanceof HTMLImageElement) {
+    const src = domNode.getAttribute('src')
+    const id = domNode.getAttribute('data-emoji-name')
+
+    if (src && id) {
+      return {
+        node: $createCustomEmojiNode({
+          src,
+          id,
+        }),
+      }
+    }
+
+    return null
+  }
+
+  return null
+}
+
+export class CustomEmojiNode extends DecoratorNode<JSX.Element> {
+  src: string
+  id: string
+
+  static getType() {
+    return 'custom-emoji'
+  }
+
+  static clone(node: CustomEmojiNode): CustomEmojiNode {
+    return new CustomEmojiNode(node.src, node.id)
+  }
+
+  constructor(src: string, id: string, key?: NodeKey) {
+    super(key)
+    this.src = src
+    this.id = id
+  }
+
+  static importJSON(
+    serializedNode: SerializedCustomEmojiNode
+  ): CustomEmojiNode {
+    const { src, id } = serializedNode
+
+    const node = $createCustomEmojiNode({ src, id })
+
+    return node
+  }
+
+  createDOM(config: EditorConfig): HTMLElement {
+    const span = document.createElement('span')
+
+    const theme = config.theme
+    const className = theme.customEmoji
+
+    if (className !== undefined) {
+      span.className = className
+    }
+
+    return span
+  }
+
+  updateDOM() {
+    return false
+  }
+
+  exportDOM(): DOMExportOutput {
+    const element = document.createElement('img')
+
+    element.setAttribute('src', this.src)
+    element.setAttribute('data-src', this.src)
+    element.setAttribute('data-emoji-name', this.id)
+
+    return { element }
+  }
+
+  static importDOM(): DOMConversionMap | null {
+    return {
+      img: () => ({
+        conversion: convertImageElement,
+        priority: 0,
+      }),
+    }
+  }
+
+  exportJSON(): SerializedCustomEmojiNode {
+    return {
+      version: 1,
+      type: 'custom-emoji',
+      src: this.src,
+      id: this.id,
+      children: [],
+      direction: this.__direction,
+      format: '',
+      indent: this.__indent,
+    }
+  }
+
+  decorate() {
+    return <img src={this.src} data-src={this.src} data-emoji-name={this.id} />
+  }
+}
+
+export const $isCustomEmojiNode = (
+  node: LexicalNode | null | undefined
+): node is CustomEmojiNode => {
+  return node instanceof CustomEmojiNode
+}
+
+export const $createCustomEmojiNode = ({
+  src,
+  id,
+}: CustomEmojiPayload): CustomEmojiNode => {
+  // return new CustomEmojiNode(src, id)
+  return $applyNodeReplacement(new CustomEmojiNode(src, id))
+}

--- a/packages/picasso/src/LexicalEmojiPlugin/nodes/index.ts
+++ b/packages/picasso/src/LexicalEmojiPlugin/nodes/index.ts
@@ -1,0 +1,1 @@
+export { CustomEmojiNode } from './CustomEmojiNode'

--- a/packages/picasso/src/LexicalEmojiPlugin/types.ts
+++ b/packages/picasso/src/LexicalEmojiPlugin/types.ts
@@ -1,0 +1,1 @@
+export type { CustomEmojiPayload } from './nodes/CustomEmojiNode'

--- a/packages/picasso/src/RichTextEditor/RichTextEditor.tsx
+++ b/packages/picasso/src/RichTextEditor/RichTextEditor.tsx
@@ -6,8 +6,6 @@ import { useHasMultilineCounter } from '@toptal/picasso-shared'
 import cx from 'classnames'
 
 import noop from '../utils/noop'
-// @todo: remove this import once we remove the old QuillEditor
-import type { CustomEmojiGroup, EditorPlugin } from '../QuillEditor'
 import styles from './styles'
 import { useCounter } from './hooks'
 import type { ASTType } from '../RichText'
@@ -15,7 +13,11 @@ import { usePropDeprecationWarning } from '../utils/use-deprecation-warnings'
 import type { Status } from '../OutlinedInput'
 import type { CounterMessageSetter } from './types'
 import LexicalEditor from '../LexicalEditor'
-import type { ChangeHandler } from '../LexicalEditor'
+import type {
+  ChangeHandler,
+  CustomEmojiGroup,
+  EditorPlugin,
+} from '../LexicalEditor'
 import InputMultilineAdornment from '../InputMultilineAdornment'
 
 export interface Props extends BaseProps {
@@ -96,7 +98,7 @@ export const RichTextEditor = forwardRef<HTMLDivElement, Props>(
   function RichTextEditor(props, ref) {
     const {
       'data-testid': dataTestId,
-      // plugins,
+      plugins,
       autoFocus = false,
       className,
       defaultValue,
@@ -117,7 +119,7 @@ export const RichTextEditor = forwardRef<HTMLDivElement, Props>(
       setHasMultilineCounter,
       name,
       highlight,
-      // customEmojis,
+      customEmojis,
     } = props
 
     const classes = useStyles()
@@ -189,13 +191,15 @@ export const RichTextEditor = forwardRef<HTMLDivElement, Props>(
             disabled={disabled}
             autoFocus={autoFocus}
             defaultValue={defaultValue}
+            plugins={plugins}
+            customEmojis={customEmojis}
           />
           {hiddenInputId && (
             // Native `for` attribute on label does not work for div target
             <input
               type='text'
               id={hiddenInputId}
-              style={{ position: 'absolute', opacity: 0, zIndex: -1 }}
+              className={classes.hiddenInput}
             />
           )}
         </div>

--- a/packages/picasso/src/RichTextEditor/styles.ts
+++ b/packages/picasso/src/RichTextEditor/styles.ts
@@ -38,6 +38,12 @@ export default (theme: Theme) => {
       ...outline(palette.primary.main),
     },
 
+    hiddenInput: {
+      position: 'absolute',
+      opacity: 0,
+      zIndex: -1,
+    },
+
     ...highlightAutofillStyles(theme),
   })
 }

--- a/packages/picasso/src/RichTextEditorEmojiPicker/RichTextEditorEmojiPicker.tsx
+++ b/packages/picasso/src/RichTextEditorEmojiPicker/RichTextEditorEmojiPicker.tsx
@@ -8,12 +8,13 @@ import cx from 'classnames'
 
 import Container from '../Container'
 import TextEditorButton from '../RichTextEditorButton'
-import type { CustomEmojiGroup } from '../QuillEditor'
+import type { CustomEmojiGroup, Emoji } from '../LexicalEditor'
 
 interface Props {
   richEditorId: string
   customEmojis?: CustomEmojiGroup[]
-  onInsertEmoji: (emoji: string) => void
+  onInsertEmoji: (emoji: Emoji) => void
+  disabled?: boolean
 }
 
 const TRIGGER_EMOJI_PICKER_ID = 'trigger-emoji-picker'
@@ -48,6 +49,7 @@ export const RichtTextEditorEmojiPicker = ({
   richEditorId,
   customEmojis,
   onInsertEmoji,
+  disabled,
 }: Props) => {
   const [showEmojiPicker, setShowEmojiPicker] = React.useState(false)
 
@@ -61,7 +63,7 @@ export const RichtTextEditorEmojiPicker = ({
     setShowEmojiPicker(false)
   }
 
-  const handleEmojiInsert = (emoji: string) => {
+  const handleEmojiInsert = (emoji: Emoji) => {
     onInsertEmoji(emoji)
     setShowEmojiPicker(false)
   }
@@ -88,6 +90,7 @@ export const RichtTextEditorEmojiPicker = ({
         onClick={handleEmojiPickerClick}
         icon={<Container style={{ pointerEvents: 'none' }}>🙂</Container>}
         id={TRIGGER_EMOJI_PICKER_ID}
+        disabled={disabled}
       />
       <Container
         className={cx(

--- a/packages/picasso/src/RichTextEditorToolbar/RichTextEditorToolbar.tsx
+++ b/packages/picasso/src/RichTextEditorToolbar/RichTextEditorToolbar.tsx
@@ -19,7 +19,7 @@ import type {
   SelectOnChangeHandler,
   FormatType,
 } from './types'
-import type { CustomEmojiGroup, EditorPlugin } from '../QuillEditor'
+import type { CustomEmojiGroup, EditorPlugin, Emoji } from '../LexicalEditor'
 import { RichtTextEditorEmojiPicker } from '../RichTextEditorEmojiPicker/RichTextEditorEmojiPicker'
 
 type Props = {
@@ -38,7 +38,7 @@ type Props = {
   onBoldClick: ButtonHandlerType
   onItalicClick: ButtonHandlerType
   onLinkClick: ButtonHandlerType
-  onInsertEmoji: (emoji: string) => void
+  onInsertEmoji: (emoji: Emoji) => void
   onHeaderChange: SelectOnChangeHandler
   onUnorderedClick: ButtonHandlerType
   onOrderedClick: ButtonHandlerType
@@ -146,6 +146,7 @@ export const RichTextEditorToolbar = forwardRef<HTMLDivElement, Props>(
             richEditorId={id}
             customEmojis={customEmojis}
             onInsertEmoji={onInsertEmoji}
+            disabled={disabled}
           />
         )}
       </Container>


### PR DESCRIPTION
[FX-4012]

### Description

- Create context to enable/disable optional features
- Add emoji plugin

### How to test

- Play with emojis [in the temploy](https://picasso.toptal.net/FX-4012-emoji)

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| ![image](https://github.com/toptal/picasso/assets/6830426/47ba7341-02d7-4bfe-96ce-6136544cb697) | ![image](https://github.com/toptal/picasso/assets/6830426/8d8b2095-60fd-4c6d-a153-ecf48ea1ce54) |

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests

**Breaking change**

- codemod is created and showcased in the changeset
- test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-4012]: https://toptal-core.atlassian.net/browse/FX-4012?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ