### PR TITLE
fix: version in RichTextEditor codemod

### DIFF
--- a/.changeset/khaki-experts-tan.md
+++ b/.changeset/khaki-experts-tan.md
@@ -1,0 +1,7 @@
+---
+'@toptal/picasso-codemod': patch
+---
+
+---
+
+- fix version in RichTextEditor codemod

--- a/packages/picasso-codemod/src/v36.0.0/rich-text-editor-replacement.ts
+++ b/packages/picasso-codemod/src/v36.0.0/rich-text-editor-replacement.ts
@@ -13,7 +13,7 @@ const specificModules = [
 ]
 const picassoVersion = '36.0.0'
 const picassoFormsVersion = '58.0.0'
-const picassoRichTextEditorVersion = '1.0.1'
+const picassoRichTextEditorVersion = '2.0.0'
 
 // Get current execution directory
 const execDir = process.cwd()


### PR DESCRIPTION
### Description

Need to set up a proper version of RTE package

### How to test

- use alpha version of codemod v36.0.0

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Self reviewed

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>
