### PR TITLE
fix: add properties to ignore grammarly

### DIFF
--- a/.changeset/soft-steaks-cheer.md
+++ b/.changeset/soft-steaks-cheer.md
@@ -1,0 +1,5 @@
+---
+'@toptal/picasso-rich-text-editor': patch
+---
+
+- properties were added to block Grammarly from accessing rich text editor fields

--- a/packages/picasso-rich-text-editor/src/QuillEditorView/QuillEditorView.tsx
+++ b/packages/picasso-rich-text-editor/src/QuillEditorView/QuillEditorView.tsx
@@ -26,6 +26,9 @@ const QuillEditorView = forwardRef<HTMLDivElement, QuillEditorViewProps>(
         size='medium'
         className={classes.root}
         data-testid={dataTestId}
+        data-gramm_editor='false'
+        data-enable-grammarly='false'
+        data-gramm='false'
         id={id}
         ref={ref}
       />


### PR DESCRIPTION
[FX-4121]

### Description

Grammarly is still enabled in some clients, probably due to the Grammarly version that does not take into account the already existing `data-gramm="false"` property. Please see more details in https://toptal-core.slack.com/archives/CERF5NHT3/p1687974164415239.

<img width="1043" alt="Screenshot 2023-06-28 at 20 24 29" src="https://github.com/toptal/picasso/assets/1390758/e7003f2c-3b53-4356-9827-ae823d65260a">

### How to test

- Testing does not appear to make sense, as it requires multiple versions of Grammarly for testing

Additional resources:

- https://github.com/quilljs/quill/issues/574
- https://github.com/jinjor/elm-break-dom/issues/27
- https://stackoverflow.com/a/46777787/1860213

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [N/A] Make sure that additions and changes on design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [N/A] Annotate all `props` in component with documentation
- [N/A] Create `examples` for component
- [N/A] Ensure that deployed demo has expected results and good examples
- [N/A] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [N/A] Covered with tests

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-4121]: https://toptal-core.atlassian.net/browse/FX-4121?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ