### PR TITLE
fix: editor state initialization

### DIFF
--- a/cypress/component/RichTextEditor.spec.tsx
+++ b/cypress/component/RichTextEditor.spec.tsx
@@ -449,6 +449,10 @@ describe('RichTextEditor', () => {
         expect(error.message).to.include('prevents user mouse interaction')
       })
 
+      // need for editor to loose focus
+      cy.get('body').click(0, 0)
+
+      cy.get('@headerSelect').find('input').should('have.attr', 'disabled')
       cy.get('@headerSelect').click({ timeout: 100 })
       // the click should not open select but just simply trigger focus on whole editor
       cy.get('@headerSelect').find('input').should('not.have.attr', 'disabled')

--- a/cypress/component/RichTextEditor.spec.tsx
+++ b/cypress/component/RichTextEditor.spec.tsx
@@ -232,7 +232,7 @@ describe('RichTextEditor', () => {
   })
 
   describe('select all and delete', () => {
-    it('removes header format', () => {
+    const removeHeaderFormat = (removalKey: string) => {
       // render editor
       cy.mount(renderEditor(defaultProps))
       setAliases()
@@ -243,13 +243,12 @@ describe('RichTextEditor', () => {
       cy.get('@editor').type('Head{enter}')
 
       // remove all
-      cy.get('@editor').type('{selectall}{del}')
+      cy.get('@editor').type(`{selectall}${removalKey}`)
       cy.get('@placeholder').should('be.visible')
       selectShouldHaveValue(cy.get('@headerSelect'), 'normal')
-    })
+    }
 
-    // TODO: https://toptal-core.atlassian.net/browse/FX-4129
-    it.skip('removes lists', () => {
+    const removeLists = (removalKey: string) => {
       // render editor
       cy.mount(renderEditor(defaultProps))
       setAliases()
@@ -262,11 +261,22 @@ describe('RichTextEditor', () => {
       cy.get('@editor').type('ol{enter}')
 
       // remove all
-      cy.get('@editor').type('{selectall}{del}')
+      cy.get('@editor').type(`{selectall}${removalKey}`)
 
       cy.get('@placeholder').should('be.visible')
       buttonShouldNotBeActive(cy.get('@olButton'))
       buttonShouldNotBeActive(cy.get('@boldButton'))
+    }
+
+    describe('using delete key', () => {
+      // TODO: restore in https://toptal-core.atlassian.net/browse/FX-4138
+      it.skip('removes header format', () => removeHeaderFormat('{del}'))
+      it('removes lists', () => removeLists('{del}'))
+    })
+
+    describe('using backspace key', () => {
+      it('removes header format', () => removeHeaderFormat('{backspace}'))
+      it('removes lists', () => removeLists('{del}'))
     })
   })
 
@@ -284,8 +294,8 @@ describe('RichTextEditor', () => {
       // on new line we have unformatted text
       selectShouldHaveValue(cy.get('@headerSelect'), 'normal')
     })
-    // TODO: https://toptal-core.atlassian.net/browse/FX-4129
-    it.skip('removes list', () => {
+
+    it('removes list', () => {
       // render editor
       cy.mount(renderEditor(defaultProps))
       setAliases()
@@ -320,8 +330,7 @@ describe('RichTextEditor', () => {
   })
 
   describe('switching between block formats', () => {
-    // TODO: https://toptal-core.atlassian.net/browse/FX-4129
-    it.skip('keeps only one block element active', () => {
+    it('keeps only one block element active', () => {
       // render editor
       cy.mount(renderEditor(defaultProps))
       setAliases()
@@ -440,10 +449,19 @@ describe('RichTextEditor', () => {
         expect(error.message).to.include('prevents user mouse interaction')
       })
 
-      cy.get('@headerSelect').find('input').should('have.attr', 'disabled')
       cy.get('@headerSelect').click({ timeout: 100 })
       // the click should not open select but just simply trigger focus on whole editor
       cy.get('@headerSelect').find('input').should('not.have.attr', 'disabled')
+    })
+
+    it('creates list from scratch', () => {
+      cy.mount(renderEditor(defaultProps))
+      setAliases()
+
+      cy.get('@editor').realClick()
+      cy.get('@ulButton').realClick()
+      buttonShouldBeActive(cy.get('@ulButton'))
+      cy.get('body').happoScreenshot({ component, variant: 'focused' })
     })
   })
 })

--- a/packages/picasso-rich-text-editor/src/LexicalEditor/LexicalEditor.tsx
+++ b/packages/picasso-rich-text-editor/src/LexicalEditor/LexicalEditor.tsx
@@ -143,11 +143,8 @@ const LexicalEditor = forwardRef<HTMLDivElement, Props>(function LexicalEditor(
 
   const editorConfig: InitialConfigType = useMemo(
     () => ({
-      editorState: (editor: LexicalEditorType) => {
-        if (defaultValue) {
-          setEditorValue(editor, defaultValue)
-        }
-      },
+      editorState: (editor: LexicalEditorType) =>
+        setEditorValue(editor, defaultValue),
       theme,
       onError(error: Error) {
         throw error

--- a/packages/picasso-rich-text-editor/src/LexicalEditor/utils/setEditorValue.ts
+++ b/packages/picasso-rich-text-editor/src/LexicalEditor/utils/setEditorValue.ts
@@ -18,20 +18,16 @@ export const setEditorValue = (editor: LexicalEditorType, value?: ASTType) => {
     const lexicalValueNodes = $generateNodesFromDOM(editor, domValue)
 
     lexicalValueNodes.forEach(node => {
-      if ($isElementNode(node) || $isDecoratorNode(node)) {
-        root.append(node)
-      } else {
-        const paragraphNode = $createParagraphNode()
+      const nodeToAppend =
+        $isElementNode(node) || $isDecoratorNode(node)
+          ? node
+          : $createParagraphNode().append(node)
 
-        paragraphNode.append(node)
-        root.append(paragraphNode)
-      }
+      root.append(nodeToAppend)
     })
   } else {
     if (root.isEmpty()) {
-      const paragraphNode = $createParagraphNode()
-
-      root.append(paragraphNode)
+      root.append($createParagraphNode())
     }
 
     root.getLastChild()?.select()

--- a/packages/picasso-rich-text-editor/src/LexicalEditor/utils/setEditorValue.ts
+++ b/packages/picasso-rich-text-editor/src/LexicalEditor/utils/setEditorValue.ts
@@ -10,20 +10,30 @@ import { $generateNodesFromDOM } from '@lexical/html'
 import type { ASTType } from '../../RichText'
 import { getDomValue } from './getDomValue'
 
-export const setEditorValue = (editor: LexicalEditorType, value: ASTType) => {
-  const domValue = getDomValue(value)
-
+export const setEditorValue = (editor: LexicalEditorType, value?: ASTType) => {
   const root = $getRoot()
-  const lexicalValueNodes = $generateNodesFromDOM(editor, domValue)
 
-  lexicalValueNodes.forEach(node => {
-    if ($isElementNode(node) || $isDecoratorNode(node)) {
-      root.append(node)
-    } else {
+  if (value) {
+    const domValue = getDomValue(value)
+    const lexicalValueNodes = $generateNodesFromDOM(editor, domValue)
+
+    lexicalValueNodes.forEach(node => {
+      if ($isElementNode(node) || $isDecoratorNode(node)) {
+        root.append(node)
+      } else {
+        const paragraphNode = $createParagraphNode()
+
+        paragraphNode.append(node)
+        root.append(paragraphNode)
+      }
+    })
+  } else {
+    if (root.isEmpty()) {
       const paragraphNode = $createParagraphNode()
 
-      paragraphNode.append(node)
       root.append(paragraphNode)
     }
-  })
+
+    root.getLastChild()?.select()
+  }
 }

--- a/packages/picasso-rich-text-editor/src/LexicalEditorToolbarPlugin/LexicalEditorToolbarPlugin.tsx
+++ b/packages/picasso-rich-text-editor/src/LexicalEditorToolbarPlugin/LexicalEditorToolbarPlugin.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useReducer } from 'react'
 import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext'
+// eslint-disable-next-line unused-imports/no-unused-imports, @typescript-eslint/no-unused-vars
 import { noop } from '@toptal/picasso/utils'
 import {
   INSERT_ORDERED_LIST_COMMAND,

--- a/packages/picasso-rich-text-editor/src/LexicalEditorToolbarPlugin/LexicalEditorToolbarPlugin.tsx
+++ b/packages/picasso-rich-text-editor/src/LexicalEditorToolbarPlugin/LexicalEditorToolbarPlugin.tsx
@@ -1,7 +1,5 @@
 import React, { useEffect, useReducer } from 'react'
 import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext'
-// eslint-disable-next-line unused-imports/no-unused-imports, @typescript-eslint/no-unused-vars
-import { noop } from '@toptal/picasso/utils'
 import {
   INSERT_ORDERED_LIST_COMMAND,
   INSERT_UNORDERED_LIST_COMMAND,


### PR DESCRIPTION
[FX-4129]

### Description

This pull request fixes the editor state initialization.

According to the source code (https://github.com/facebook/lexical/blob/2bcf11bec944cd3bd69b7e7b40903e593b716a06/packages/lexical-react/src/LexicalComposer.tsx#L119), the editor state needs to be initialized either by Lexical itself or inside of the `editorConfig` if it is a function. This pull request removes the case when the function is provided, but the state is not initialized by anybody.
 
### How to test

- Navigate to https://picasso.toptal.net/fx-4129-insert-list-to-empty-editor-2/?path=/story/forms-richtexteditor--richtexteditor

### Screenshots

https://github.com/toptal/picasso/assets/1390758/0a0a72a8-d276-4bb5-a6dd-5a4d89044d0c

### Development checks

- [N/A] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [N/A] Make sure that additions and changes on design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [N/A] Annotate all `props` in component with documentation
- [N/A] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [N/A] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-4129]: https://toptal-core.atlassian.net/browse/FX-4129?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ