### PR TITLE
fix: focus editor on label click

### DIFF
--- a/cypress/component/RichTextEditor.spec.tsx
+++ b/cypress/component/RichTextEditor.spec.tsx
@@ -394,14 +394,13 @@ describe('RichTextEditor', () => {
     })
   })
 
-  describe('Form.RichTextEditor', () => {
-    // TODO: https://toptal-core.atlassian.net/browse/FX-4130
-    it.skip('focuses editor on label click', () => {
+  describe.only('Form.RichTextEditor', () => {
+    it('focuses editor on label click', () => {
       cy.mount(renderEditorInForm())
       setAliases()
 
-      cy.get('label').click()
-      cy.getByRole('textbox').should('be.focused')
+      cy.get('label').realClick().type('foo')
+      cy.contains('foo').should('be.visible')
       cy.get('@wrapper').should('have.attr', 'class').and('include', 'focused')
     })
   })

--- a/cypress/component/RichTextEditor.spec.tsx
+++ b/cypress/component/RichTextEditor.spec.tsx
@@ -394,7 +394,7 @@ describe('RichTextEditor', () => {
     })
   })
 
-  describe.only('Form.RichTextEditor', () => {
+  describe('Form.RichTextEditor', () => {
     it('focuses editor on label click', () => {
       cy.mount(renderEditorInForm())
       setAliases()

--- a/packages/picasso-rich-text-editor/src/FocusOnLabelClickPlugin/FocusOnLabelClickPlugin.tsx
+++ b/packages/picasso-rich-text-editor/src/FocusOnLabelClickPlugin/FocusOnLabelClickPlugin.tsx
@@ -1,0 +1,39 @@
+import React, { useCallback } from 'react'
+import { makeStyles } from '@material-ui/core/styles'
+import type { Theme } from '@material-ui/core/styles'
+import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext'
+
+import styles from './styles'
+
+type Props = {
+  hiddenInputId: string
+}
+
+const useStyles = makeStyles<Theme>(styles, {
+  name: 'HiddenInput',
+})
+
+const FocusOnLabelClickPlugin = ({ hiddenInputId }: Props) => {
+  const classes = useStyles()
+  const [editor] = useLexicalComposerContext()
+
+  const handleFocus = useCallback(() => {
+    editor.focus()
+  }, [editor])
+
+  const handleBlur = useCallback((event: React.FocusEvent) => {
+    event.stopPropagation()
+  }, [])
+
+  return (
+    <input
+      type='text'
+      id={hiddenInputId}
+      onFocus={handleFocus}
+      onBlur={handleBlur}
+      className={classes.hiddenInput}
+    />
+  )
+}
+
+export default FocusOnLabelClickPlugin

--- a/packages/picasso-rich-text-editor/src/FocusOnLabelClickPlugin/index.ts
+++ b/packages/picasso-rich-text-editor/src/FocusOnLabelClickPlugin/index.ts
@@ -1,0 +1,1 @@
+export { default } from './FocusOnLabelClickPlugin'

--- a/packages/picasso-rich-text-editor/src/FocusOnLabelClickPlugin/styles.ts
+++ b/packages/picasso-rich-text-editor/src/FocusOnLabelClickPlugin/styles.ts
@@ -1,0 +1,11 @@
+import { createStyles } from '@material-ui/core/styles'
+
+export default () => {
+  return createStyles({
+    hiddenInput: {
+      position: 'absolute',
+      opacity: 0,
+      zIndex: -1,
+    },
+  })
+}

--- a/packages/picasso-rich-text-editor/src/LexicalEditor/LexicalEditor.tsx
+++ b/packages/picasso-rich-text-editor/src/LexicalEditor/LexicalEditor.tsx
@@ -37,6 +37,7 @@ import type { ASTType } from '../RichText'
 import { CustomEmojiNode } from '../LexicalEmojiPlugin/nodes/CustomEmojiNode'
 import LexicalEmojiPlugin from '../LexicalEmojiPlugin'
 import { LexicalLinkPlugin } from '../LexicalLinkPlugin'
+import FocusOnLabelClickPlugin from '../FocusOnLabelClickPlugin/FocusOnLabelClickPlugin'
 
 const useStyles = makeStyles<Theme>(styles, {
   name: 'LexicalEditor',
@@ -89,6 +90,7 @@ export type Props = BaseProps & {
   customEmojis?: CustomEmojiGroup[]
   /** List of plugins to enable on the editor */
   plugins?: EditorPlugin[]
+  hiddenInputId?: string
 }
 
 const LexicalEditor = forwardRef<HTMLDivElement, Props>(function LexicalEditor(
@@ -106,26 +108,14 @@ const LexicalEditor = forwardRef<HTMLDivElement, Props>(function LexicalEditor(
     onFocus = noop,
     onBlur = noop,
     placeholder,
-    // minLength,
-    // maxLength,
-    // minLengthMessage,
-    // maxLengthMessage,
-
-    // status,
     testIds,
-    // hiddenInputId,
-    // setHasMultilineCounter,
-    // @todo don't know what to do with NAME prop
-    // name,
-    // highlight,
     customEmojis,
+    hiddenInputId,
   } = props
 
   const classes = useStyles()
 
   const toolbarRef = useRef<HTMLDivElement | null>(null)
-  // const editorRef = useRef<HTMLDivElement | null>(ref)
-  // Possibly use useRef for synchronous updates but no re-rendering effect
 
   const typographyClassNames = useTypographyClasses({
     variant: 'body',
@@ -208,6 +198,9 @@ const LexicalEditor = forwardRef<HTMLDivElement, Props>(function LexicalEditor(
         <LexicalEmojiPlugin />
         <HistoryPlugin />
         <LexicalLinkPlugin />
+        {hiddenInputId && (
+          <FocusOnLabelClickPlugin hiddenInputId={hiddenInputId} />
+        )}
 
         <div className={classes.editorContainer} id={id} ref={ref}>
           <RichTextPlugin

--- a/packages/picasso-rich-text-editor/src/RichTextEditor/RichTextEditor.tsx
+++ b/packages/picasso-rich-text-editor/src/RichTextEditor/RichTextEditor.tsx
@@ -192,15 +192,8 @@ export const RichTextEditor = forwardRef<HTMLDivElement, Props>(
             defaultValue={defaultValue}
             plugins={plugins}
             customEmojis={customEmojis}
+            hiddenInputId={hiddenInputId}
           />
-          {hiddenInputId && (
-            // Native `for` attribute on label does not work for div target
-            <input
-              type='text'
-              id={hiddenInputId}
-              className={classes.hiddenInput}
-            />
-          )}
         </div>
         {counterMessage && (
           <InputMultilineAdornment error={counterError}>

--- a/packages/picasso-rich-text-editor/src/RichTextEditor/styles.ts
+++ b/packages/picasso-rich-text-editor/src/RichTextEditor/styles.ts
@@ -37,12 +37,6 @@ export default (theme: Theme) => {
       ...outline(palette.primary.main),
     },
 
-    hiddenInput: {
-      position: 'absolute',
-      opacity: 0,
-      zIndex: -1,
-    },
-
     ...highlightAutofillStyles(theme),
   })
 }


### PR DESCRIPTION
[FX-4130]

### Description

To simulate native behave of form inputs, when we click on `<label for='id-of-input'>` we expect to focus on related input. As RTE is actually div, we need to replicate this functionality on our own.

### How to test

- try in the [temploy](https://picasso.toptal.net/fx-4130-focus-on-label/?path=/story/picasso-forms-form--form#rich-text-editor)

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| https://github.com/toptal/picasso/assets/6830426/0b9d70b0-bac1-4132-ab5b-522ca0dbdac2 | https://github.com/toptal/picasso/assets/6830426/784f51b6-af99-4ca8-8451-2d408c6c9b4f |




### Development checks

- Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- Make sure that additions and changes on design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- Annotate all `props` in component with documentation
- Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests

**Breaking change**

- codemod is created and showcased in the changeset
- test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-4130]: https://toptal-core.atlassian.net/browse/FX-4130?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ