### PR TITLE
fix: [FX-4118] incorrect output for custom emoji

### DIFF
--- a/packages/picasso-rich-text-editor/src/LexicalEditor/LexicalEditor.tsx
+++ b/packages/picasso-rich-text-editor/src/LexicalEditor/LexicalEditor.tsx
@@ -162,7 +162,11 @@ const LexicalEditor = forwardRef<HTMLDivElement, Props>(function LexicalEditor(
         const root = $getRoot()
         const topLevelChildren = root.getChildren()
 
-        if (topLevelChildren.length === 0) {
+        const hasNoChildren = topLevelChildren.length === 0
+        const hasOneEmptyChild =
+          topLevelChildren.length === 1 && topLevelChildren[0].isEmpty()
+
+        if (hasNoChildren || hasOneEmptyChild) {
           onChange('')
 
           return

--- a/packages/picasso-rich-text-editor/src/LexicalEditor/LexicalEditor.tsx
+++ b/packages/picasso-rich-text-editor/src/LexicalEditor/LexicalEditor.tsx
@@ -1,3 +1,4 @@
+import React, { forwardRef, useCallback, useMemo, useRef } from 'react'
 import { $generateHtmlFromNodes } from '@lexical/html'
 import { ListItemNode, ListNode } from '@lexical/list'
 import { AutoFocusPlugin } from '@lexical/react/LexicalAutoFocusPlugin'
@@ -9,14 +10,13 @@ import { HistoryPlugin } from '@lexical/react/LexicalHistoryPlugin'
 import { OnChangePlugin } from '@lexical/react/LexicalOnChangePlugin'
 import { RichTextPlugin } from '@lexical/react/LexicalRichTextPlugin'
 import { HeadingNode } from '@lexical/rich-text'
-import { $isRootTextContentEmpty } from '@lexical/text'
 import type { Theme } from '@material-ui/core/styles'
 import { makeStyles } from '@material-ui/core/styles'
 import { Container, Typography } from '@toptal/picasso'
 import type { BaseProps } from '@toptal/picasso-shared'
 import { noop } from '@toptal/picasso/utils'
 import type { LexicalEditor as LexicalEditorType } from 'lexical'
-import React, { forwardRef, useCallback, useMemo, useRef } from 'react'
+import { $getRoot } from 'lexical'
 
 import ToolbarPlugin from '../LexicalEditorToolbarPlugin'
 import { RTEPluginContextProvider } from '../plugins/api'
@@ -159,9 +159,10 @@ const LexicalEditor = forwardRef<HTMLDivElement, Props>(function LexicalEditor(
   const handleChange = useCallback(
     (editorState, editor) => {
       editorState.read(() => {
-        const isEmpty = $isRootTextContentEmpty(editor.isComposing(), false)
+        const root = $getRoot()
+        const topLevelChildren = root.getChildren()
 
-        if (isEmpty) {
+        if (topLevelChildren.length === 0) {
           onChange('')
 
           return


### PR DESCRIPTION
[FX-4118]

### Description

Incorrect output when inserting custom emoji to an empty editor
Expected: '<img ...'
Actual: ''

### How to test

- use temploy to check


### Development checks

- [x] Ensure that deployed demo has expected results and good examples
- [x] Self reviewed

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-4118]: https://toptal-core.atlassian.net/browse/FX-4118?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ