### PR TITLE
feat: output proper nested list semantics

### DIFF
--- a/packages/picasso-rich-text-editor/src/LexicalEditor/utils/cleanupHtmlOutput.test.ts
+++ b/packages/picasso-rich-text-editor/src/LexicalEditor/utils/cleanupHtmlOutput.test.ts
@@ -44,4 +44,30 @@ describe('cleanupHtmlOutput', () => {
       '<p><em>test </em><em><strong>test</strong></em> test</p>'
     )
   })
+
+  it('hoists nested lists to previous sibling', () => {
+    const result = cleanupHtmlOutput(`
+      <ul>
+        <li>first</li>
+        <li>
+          <ul>
+            <li>second</li>
+          </ul>
+        </li>
+      </ul>
+    `).replace(/\s/g, '')
+
+    const expected = `
+      <ul>
+        <li>
+          first
+          <ul>
+            <li>second</li>
+          </ul>
+        </li>
+      </ul>
+    `.replace(/\s/g, '')
+
+    expect(result).toBe(expected)
+  })
 })

--- a/packages/picasso-rich-text-editor/src/LexicalEditor/utils/cleanupHtmlOutput.ts
+++ b/packages/picasso-rich-text-editor/src/LexicalEditor/utils/cleanupHtmlOutput.ts
@@ -92,11 +92,35 @@ const replaceItalicTag = (htmlDoc: Document): Document => {
   return htmlDoc
 }
 
+const hoistNestedLists = (htmlDoc: Document): Document => {
+  htmlDoc.querySelectorAll('li>ul,li>ol').forEach(list => {
+    const currentLi = list.parentNode as Element
+
+    if (currentLi?.children.length === 1) {
+      const previousLi = currentLi.previousElementSibling
+
+      if (previousLi) {
+        currentLi.removeChild(list)
+        previousLi.appendChild(list)
+        currentLi?.parentNode?.removeChild(currentLi)
+      }
+    }
+  })
+
+  return htmlDoc
+}
+
 export const cleanupHtmlOutput = (html: string): string => {
   const parser = new DOMParser()
-  let htmlDoc = parser.parseFromString(html, 'text/html')
 
-  htmlDoc = replaceItalicTag(removeExtraTags(htmlDoc))
+  const htmlDoc = parser.parseFromString(html, 'text/html')
 
-  return htmlDoc.body.innerHTML
+  const [newHtml] = [htmlDoc]
+    .map(removeExtraTags)
+    .map(replaceItalicTag)
+    .map(hoistNestedLists)
+
+  const result = newHtml.body.innerHTML
+
+  return result
 }


### PR DESCRIPTION
[FX-4136]

### Description

After discussion with Augusto, we decided that it is much simpler to output old HTML for nested lists as it is more complex to play with AST and also we would need to extend List component to work new structure.

### How to test

- check [temploy](https://picasso.toptal.net/fx-4136-lists/?path=/story/components-richtext--richtext#html-from-fe-for-live-editing-preview) and play with nested lists, they should look nice in the RichText component
- we noticed that currently ordered list does not look as it should in RichText and I will create ticket to fix it in List component.

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| ![image](https://github.com/toptal/picasso/assets/6830426/b82cbd58-e127-4646-893c-0a2c83f272c9) | ![image](https://github.com/toptal/picasso/assets/6830426/82529b86-5b4f-44f3-822f-bce5b18650e1) |

### Development checks

- Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- Make sure that additions and changes on design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- Annotate all `props` in component with documentation
- Create `examples` for component
- Ensure that deployed demo has expected results and good examples
- Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests

**Breaking change**

- codemod is created and showcased in the changeset
- test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-4136]: https://toptal-core.atlassian.net/browse/FX-4136?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ