### PR TITLE
fix: remove unused group separator from toolbar

### DIFF
--- a/packages/picasso-rich-text-editor/src/RichTextEditorToolbar/styles.ts
+++ b/packages/picasso-rich-text-editor/src/RichTextEditorToolbar/styles.ts
@@ -14,7 +14,7 @@ export default ({ palette }: Theme) =>
       position: 'relative',
       pointerEvents: 'unset',
 
-      '&:not(:last-child)::after': {
+      '&:not(:last-child):not(:empty)::after': {
         content: '""',
         height: '1em',
         width: '1px',


### PR DESCRIPTION
[FX-4142](https://toptal-core.atlassian.net/browse/FX-4142)

### Description

Hides the empty group divider in the toolbar.

### How to test

- Compare to the Storybook on the base branch
- When link plugin is disabled and emojis are enabled, empty group should not be visible in the toolbar

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| ![image](https://github.com/toptal/picasso/assets/18409292/86418f9b-b941-4b8c-adff-e0216891ac49) | ![image](https://github.com/toptal/picasso/assets/18409292/f462da64-402d-490d-85f9-85c230285f34) |

### Development checks

- [n/a] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [n/a] Annotate all `props` in component with documentation
- [n/a] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [n/a] Covered with tests

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-4142]: https://toptal-core.atlassian.net/browse/FX-4142?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ