### PR TITLE
fix: disable link button when editor not focused

### DIFF
--- a/packages/picasso-rich-text-editor/src/LexicalEditor/LexicalEditor.tsx
+++ b/packages/picasso-rich-text-editor/src/LexicalEditor/LexicalEditor.tsx
@@ -183,7 +183,7 @@ const LexicalEditor = forwardRef<HTMLDivElement, Props>(function LexicalEditor(
     [onChange]
   )
 
-  const { isFocused, handleFocus, handleBlur } = useOnFocus({
+  const { focused, handleFocus, handleBlur } = useOnFocus({
     onFocus,
     onBlur,
     internalRefs: [toolbarRef],
@@ -192,12 +192,12 @@ const LexicalEditor = forwardRef<HTMLDivElement, Props>(function LexicalEditor(
   return (
     <LexicalComposer initialConfig={editorConfig}>
       <div onFocus={handleFocus} onBlur={handleBlur} tabIndex={-1}>
-        <RTEPluginContextProvider disabled={disabled} isFocused={isFocused}>
+        <RTEPluginContextProvider disabled={disabled} focused={focused}>
           <ToolbarPlugin
-            disabled={disabled || !isFocused}
+            disabled={disabled || !focused}
             toolbarRef={toolbarRef}
             // remount Toolbar when disabled
-            key={`${disabled || !isFocused}`}
+            key={`${disabled || !focused}`}
             customEmojis={customEmojis}
             plugins={plugins}
             testIds={testIds}

--- a/packages/picasso-rich-text-editor/src/LexicalEditor/LexicalEditor.tsx
+++ b/packages/picasso-rich-text-editor/src/LexicalEditor/LexicalEditor.tsx
@@ -192,7 +192,7 @@ const LexicalEditor = forwardRef<HTMLDivElement, Props>(function LexicalEditor(
   return (
     <LexicalComposer initialConfig={editorConfig}>
       <div onFocus={handleFocus} onBlur={handleBlur} tabIndex={-1}>
-        <RTEPluginContextProvider disabled={disabled}>
+        <RTEPluginContextProvider disabled={disabled} isFocused={isFocused}>
           <ToolbarPlugin
             disabled={disabled || !isFocused}
             toolbarRef={toolbarRef}

--- a/packages/picasso-rich-text-editor/src/LexicalEditor/hooks/useOnFocus/test.ts
+++ b/packages/picasso-rich-text-editor/src/LexicalEditor/hooks/useOnFocus/test.ts
@@ -16,7 +16,7 @@ describe('useOnFocus', () => {
     mockEvent = getFocusEvent()
   })
 
-  it('sets `isFocused` to true when handleFocus is called', () => {
+  it('sets `focused` to true when handleFocus is called', () => {
     const onFocus = jest.fn()
     const { result } = renderHook(() => useOnFocus({ onFocus }))
 
@@ -24,20 +24,20 @@ describe('useOnFocus', () => {
       result.current.handleFocus(mockEvent)
     })
 
-    expect(result.current.isFocused).toBe(true)
+    expect(result.current.focused).toBe(true)
     expect(onFocus).toHaveBeenCalledTimes(1)
   })
 
   describe('when internalRefs is passed', () => {
     describe('when handleBlur is called and the focus is not on an internal element', () => {
-      it('sets `isFocused` to false', () => {
+      it('sets `focused` to false', () => {
         const onBlur = jest.fn()
         const internalRefs = [{ current: document.createElement('div') }]
         const { result } = renderHook(() =>
           useOnFocus({ onBlur, internalRefs })
         )
 
-        // Simulating handleFocus to make isFocused true initially
+        // Simulating handleFocus to make focused true initially
         act(() => {
           result.current.handleFocus(mockEvent)
         })
@@ -46,20 +46,20 @@ describe('useOnFocus', () => {
           result.current.handleBlur(mockEvent)
         })
 
-        expect(result.current.isFocused).toBe(false)
+        expect(result.current.focused).toBe(false)
         expect(onBlur).toHaveBeenCalledTimes(1)
       })
     })
 
     describe('when handleBlur is called and the focus is on an internal element', () => {
-      it('does not set `isFocused` to false', () => {
+      it('does not set `focused` to false', () => {
         const onBlur = jest.fn()
         const internalRefs = [{ current: document.createElement('div') }]
         const { result } = renderHook(() =>
           useOnFocus({ onBlur, internalRefs })
         )
 
-        // Simulating handleFocus to make isFocused true initially
+        // Simulating handleFocus to make focused true initially
         act(() => {
           result.current.handleFocus(mockEvent)
         })
@@ -68,7 +68,7 @@ describe('useOnFocus', () => {
           result.current.handleBlur(getFocusEvent(internalRefs[0].current))
         })
 
-        expect(result.current.isFocused).toBe(true)
+        expect(result.current.focused).toBe(true)
         expect(onBlur).toHaveBeenCalledTimes(0)
       })
     })

--- a/packages/picasso-rich-text-editor/src/LexicalEditor/hooks/useOnFocus/useOnFocus.ts
+++ b/packages/picasso-rich-text-editor/src/LexicalEditor/hooks/useOnFocus/useOnFocus.ts
@@ -8,7 +8,7 @@ export type Props = {
 }
 
 type Result = {
-  isFocused: boolean
+  focused: boolean
   handleFocus: (e: React.FocusEvent<HTMLDivElement>) => void
   handleBlur: (e: React.FocusEvent<HTMLDivElement>) => void
 }
@@ -18,10 +18,10 @@ const useOnFocus = ({
   onBlur = noop,
   internalRefs = [],
 }: Props): Result => {
-  const [isFocused, setIsFocused] = useState(false)
+  const [focused, setFocused] = useState(false)
 
   const handleFocus = useCallback(() => {
-    setIsFocused(true)
+    setFocused(true)
     onFocus()
   }, [onFocus])
 
@@ -36,14 +36,14 @@ const useOnFocus = ({
         return
       }
 
-      setIsFocused(false)
+      setFocused(false)
       onBlur()
     },
     [onBlur]
   )
 
   return {
-    isFocused,
+    focused,
     handleFocus,
     handleBlur,
   }

--- a/packages/picasso-rich-text-editor/src/plugins/LinkPlugin/LinkPluginButton.tsx
+++ b/packages/picasso-rich-text-editor/src/plugins/LinkPlugin/LinkPluginButton.tsx
@@ -16,7 +16,7 @@ export type Props = {
 const LinkPluginButton = ({ 'data-testid': testId }: Props) => {
   const [active, setActive] = useState(false)
   const [editor] = useLexicalComposerContext()
-  const { disabled } = useRTEPluginContext()
+  const { disabled, isFocused } = useRTEPluginContext()
 
   useRTEUpdate(() => {
     const selection = $getSelection()
@@ -50,7 +50,7 @@ const LinkPluginButton = ({ 'data-testid': testId }: Props) => {
       icon={<Link16 />}
       onClick={onLinkClick}
       active={active}
-      disabled={disabled}
+      disabled={disabled || !isFocused}
       data-testid={testId}
     />
   )

--- a/packages/picasso-rich-text-editor/src/plugins/LinkPlugin/LinkPluginButton.tsx
+++ b/packages/picasso-rich-text-editor/src/plugins/LinkPlugin/LinkPluginButton.tsx
@@ -16,7 +16,7 @@ export type Props = {
 const LinkPluginButton = ({ 'data-testid': testId }: Props) => {
   const [active, setActive] = useState(false)
   const [editor] = useLexicalComposerContext()
-  const { disabled, isFocused } = useRTEPluginContext()
+  const { disabled, focused } = useRTEPluginContext()
 
   useRTEUpdate(() => {
     const selection = $getSelection()
@@ -50,7 +50,7 @@ const LinkPluginButton = ({ 'data-testid': testId }: Props) => {
       icon={<Link16 />}
       onClick={onLinkClick}
       active={active}
-      disabled={disabled || !isFocused}
+      disabled={disabled || !focused}
       data-testid={testId}
     />
   )

--- a/packages/picasso-rich-text-editor/src/plugins/api.tsx
+++ b/packages/picasso-rich-text-editor/src/plugins/api.tsx
@@ -34,6 +34,7 @@ export const isRTEPluginElement = (plugin: {}): plugin is ReactElement<
 
 type RTEPluginContextValue = {
   disabled: boolean
+  isFocused: boolean
   toolbarPortalEl?: HTMLElement
   setToolbarPortalEl: (element: HTMLElement | null) => void
 }
@@ -53,22 +54,26 @@ export const useRTEUpdate = (callback: () => void) => {
 
 const RTEPluginContext = createContext<RTEPluginContextValue>({
   disabled: false,
+  isFocused: false,
   setToolbarPortalEl: () => {},
 })
 
 export type ToolbarPortalProviderProps = {
   children: ReactNode
   disabled: boolean
+  isFocused: boolean
 }
 
 export const RTEPluginContextProvider = ({
   children,
   disabled,
+  isFocused,
 }: ToolbarPortalProviderProps) => {
   const [element, setElement] = useState<HTMLElement | null>(null)
 
   const value: RTEPluginContextValue = {
     disabled,
+    isFocused,
     toolbarPortalEl: element ?? undefined,
     setToolbarPortalEl: setElement,
   }
@@ -89,10 +94,11 @@ export const useToolbarPortalRegister = () => {
 }
 
 export const useRTEPluginContext = () => {
-  const { disabled } = useContext(RTEPluginContext)
+  const { disabled, isFocused } = useContext(RTEPluginContext)
 
   return {
     disabled,
+    isFocused,
   }
 }
 

--- a/packages/picasso-rich-text-editor/src/plugins/api.tsx
+++ b/packages/picasso-rich-text-editor/src/plugins/api.tsx
@@ -34,7 +34,7 @@ export const isRTEPluginElement = (plugin: {}): plugin is ReactElement<
 
 type RTEPluginContextValue = {
   disabled: boolean
-  isFocused: boolean
+  focused: boolean
   toolbarPortalEl?: HTMLElement
   setToolbarPortalEl: (element: HTMLElement | null) => void
 }
@@ -54,26 +54,26 @@ export const useRTEUpdate = (callback: () => void) => {
 
 const RTEPluginContext = createContext<RTEPluginContextValue>({
   disabled: false,
-  isFocused: false,
+  focused: false,
   setToolbarPortalEl: () => {},
 })
 
 export type ToolbarPortalProviderProps = {
   children: ReactNode
   disabled: boolean
-  isFocused: boolean
+  focused: boolean
 }
 
 export const RTEPluginContextProvider = ({
   children,
   disabled,
-  isFocused,
+  focused,
 }: ToolbarPortalProviderProps) => {
   const [element, setElement] = useState<HTMLElement | null>(null)
 
   const value: RTEPluginContextValue = {
     disabled,
-    isFocused,
+    focused,
     toolbarPortalEl: element ?? undefined,
     setToolbarPortalEl: setElement,
   }
@@ -94,11 +94,11 @@ export const useToolbarPortalRegister = () => {
 }
 
 export const useRTEPluginContext = () => {
-  const { disabled, isFocused } = useContext(RTEPluginContext)
+  const { disabled, focused } = useContext(RTEPluginContext)
 
   return {
     disabled,
-    isFocused,
+    focused,
   }
 }
 


### PR DESCRIPTION
[FX-4146]

### Description

Buttons in the toolbar need to be disabled even when the editor is not focused

### How to test

- check [temploy](https://picasso.toptal.net/fx-4146-link-button-disabled/?path=/story/forms-richtexteditor--richtexteditor#links)

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| ![image](https://github.com/toptal/picasso/assets/6830426/1b7b0011-d1a3-4c2c-85a1-f888498ce42a) | ![image](https://github.com/toptal/picasso/assets/6830426/59a698ab-ad34-4f25-8767-901a00bed127) |

### Development checks

- Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- Make sure that additions and changes on design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- Annotate all `props` in component with documentation
- Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- Covered with tests

**Breaking change**

- codemod is created and showcased in the changeset
- test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-4146]: https://toptal-core.atlassian.net/browse/FX-4146?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ