### PR TITLE
feat: [FX-4139] add appropriate list item types

### DIFF
--- a/.changeset/perfect-spies-clean.md
+++ b/.changeset/perfect-spies-clean.md
@@ -1,0 +1,7 @@
+---
+'@toptal/picasso': minor
+---
+
+### List
+
+- add appropriate list item types for nested lists

--- a/packages/picasso/src/List/List.tsx
+++ b/packages/picasso/src/List/List.tsx
@@ -6,6 +6,7 @@ import { makeStyles } from '@material-ui/core/styles'
 import cx from 'classnames'
 
 import ListItem from '../ListItem'
+import type { Props as ListItemProps } from '../ListItem'
 import styles from './styles'
 import type { ListItemType } from './context'
 import { ListContextProvider, useListContext } from './context'
@@ -27,14 +28,31 @@ const Tags = {
   ordered: 'ol',
 } as const
 
-const getDefaultType = (variant: Props['variant'], level: number) => {
-  if (variant === 'unordered') {
-    const isLevelEven = level % 2 === 0
+const getOrderedStyleType = (level: number): ListItemType => {
+  const levelType = level % 3
 
-    return isLevelEven ? 'disc' : 'circle'
+  switch (levelType) {
+    case 0:
+      return 'numeral'
+    case 1:
+      return 'alpha'
+    case 2:
+      return 'roman'
+    default:
+      throw new Error(`Unknown level type ${levelType}`)
   }
+}
 
-  return undefined
+const getDefaultType = (
+  variant: Props['variant'],
+  level: number
+): ListItemType => {
+  switch (variant) {
+    case 'ordered':
+      return getOrderedStyleType(level)
+    case 'unordered':
+      return level % 2 === 0 ? 'disc' : 'circle'
+  }
 }
 
 export const List = (props: Props) => {
@@ -52,11 +70,11 @@ export const List = (props: Props) => {
   const totalChildElements = React.Children.count(children)
 
   const listItems = React.Children.map(children, (child, index) => {
-    if (!React.isValidElement(child)) {
+    if (!React.isValidElement<ListItemProps>(child)) {
       return child
     }
 
-    return React.cloneElement(child, {
+    return React.cloneElement<ListItemProps>(child, {
       variant,
       isLastElement: totalChildElements === index + 1,
       index: index + start - 1,

--- a/packages/picasso/src/List/__snapshots__/test.tsx.snap
+++ b/packages/picasso/src/List/__snapshots__/test.tsx.snap
@@ -6,7 +6,7 @@ exports[`List renders ordered list 1`] = `
     class="Picasso-root"
   >
     <ol
-      class="PicassoList-root PicassoList-firstLevel"
+      class="PicassoList-root PicassoList-numeral PicassoList-firstLevel"
       data-testid="ordered-list"
     >
       <li

--- a/packages/picasso/src/ListItem/index.ts
+++ b/packages/picasso/src/ListItem/index.ts
@@ -1,1 +1,2 @@
 export { default } from './ListItem'
+export type { Props } from './ListItem'


### PR DESCRIPTION
[FX-4139]

### Description

Add appropriate list item types for ordered list

### How to test

- Use temploy to check `List` and `RichText` stories

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Ensure that deployed demo has expected results and good examples
- [x] Self reviewed


> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-4139]: https://toptal-core.atlassian.net/browse/FX-4139?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ