### PR TITLE
fix: disable scroll on click

### DIFF
--- a/cypress/component/RichTextEditor.spec.tsx
+++ b/cypress/component/RichTextEditor.spec.tsx
@@ -70,8 +70,8 @@ const setSelectValue = (
   select: Cypress.Chainable<JQuery<HTMLButtonElement>>,
   value: string
 ) => {
-  select.realClick()
-  cy.get('span').contains(value).realClick()
+  select.realClick({ scrollBehavior: false })
+  cy.get('span').contains(value).realClick({ scrollBehavior: false })
 }
 
 const component = 'RichTextEditor'
@@ -360,9 +360,8 @@ describe('RichTextEditor', () => {
     })
   })
 
-  // TODO: https://toptal-core.atlassian.net/browse/FX-4131
-  describe.skip('when we delete inline formatted word', () => {
-    it('updates the toolbar state correctly', () => {
+  describe('when we delete inline formatted word', () => {
+    it('keeps the formatting enabled', () => {
       cy.mount(renderEditor(defaultProps))
       setAliases()
 
@@ -373,12 +372,12 @@ describe('RichTextEditor', () => {
       cy.get('@editor').type('b')
       buttonShouldBeActive(cy.get('@boldButton'))
       cy.get('@editor').type('{backspace}')
-      buttonShouldNotBeActive(cy.get('@boldButton'))
+      buttonShouldBeActive(cy.get('@boldButton'))
     })
   })
-  // TODO: https://toptal-core.atlassian.net/browse/FX-4131
-  describe.skip('when we delete inline formatted word in the middle of sentense', () => {
-    it('updates the toolbar state correctly', () => {
+
+  describe('when we delete inline formatted word in the middle of sentence', () => {
+    it('keeps the formatting enabled', () => {
       cy.mount(renderEditor(defaultProps))
       setAliases()
 
@@ -390,7 +389,7 @@ describe('RichTextEditor', () => {
       cy.get('@editor').type('b')
       buttonShouldBeActive(cy.get('@boldButton'))
       cy.get('@editor').type('{backspace}')
-      buttonShouldNotBeActive(cy.get('@boldButton'))
+      buttonShouldBeActive(cy.get('@boldButton'))
     })
   })
 
@@ -420,8 +419,7 @@ describe('RichTextEditor', () => {
   })
 
   describe('toolbar', () => {
-    // TODO: https://toptal-core.atlassian.net/browse/FX-4131
-    it.skip('disables bold and italic when header format is active', () => {
+    it('disables bold and italic when header format is active', () => {
       cy.mount(renderEditor(defaultProps))
       setAliases()
 


### PR DESCRIPTION
[FX-4131]

### Description

This pull request restores skipped integration tests.

### How to test

- All integration tests should pass

### Development checks

- [N/A] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [N/A] Make sure that additions and changes on design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [N/A] Annotate all `props` in component with documentation
- [N/A] Create `examples` for component
- [N/A] Ensure that deployed demo has expected results and good examples
- [N/A] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [N/A] Covered with tests

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-4131]: https://toptal-core.atlassian.net/browse/FX-4131?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ