### PR TITLE
feat: add support for images in RichText

### DIFF
--- a/.changeset/fresh-suns-hang.md
+++ b/.changeset/fresh-suns-hang.md
@@ -1,0 +1,7 @@
+---
+'@toptal/picasso-rich-text-editor': minor
+---
+
+### RichText
+
+- add support for images

--- a/packages/picasso-rich-text-editor/src/RichText/components/Emoji.tsx
+++ b/packages/picasso-rich-text-editor/src/RichText/components/Emoji.tsx
@@ -1,0 +1,19 @@
+import React from 'react'
+import type { ReactNode } from 'react'
+import { makeStyles } from '@material-ui/core'
+
+const useStyles = makeStyles({
+  default: {
+    maxWidth: 24,
+    height: 24,
+    verticalAlign: 'bottom',
+  },
+})
+
+const Emoji = (props: { children?: ReactNode }) => {
+  const classes = useStyles()
+
+  return <img className={classes.default} {...props} />
+}
+
+export default Emoji

--- a/packages/picasso-rich-text-editor/src/RichText/components/Image.tsx
+++ b/packages/picasso-rich-text-editor/src/RichText/components/Image.tsx
@@ -1,0 +1,17 @@
+import React from 'react'
+import type { ReactNode } from 'react'
+import { makeStyles } from '@material-ui/core'
+
+const useStyles = makeStyles({
+  default: {
+    maxWidth: '100%',
+  },
+})
+
+const Image = (props: { children?: ReactNode }) => {
+  const classes = useStyles()
+
+  return <img className={classes.default} {...props} />
+}
+
+export default Image

--- a/packages/picasso-rich-text-editor/src/RichText/components/index.ts
+++ b/packages/picasso-rich-text-editor/src/RichText/components/index.ts
@@ -1,0 +1,2 @@
+export { default as Emoji } from './Emoji'
+export { default as Image } from './Image'

--- a/packages/picasso-rich-text-editor/src/RichText/hooks/useRichText/useRichText.tsx
+++ b/packages/picasso-rich-text-editor/src/RichText/hooks/useRichText/useRichText.tsx
@@ -1,7 +1,6 @@
 import toH from 'hast-to-hyperscript'
 import type { ReactElement, ReactNode, FC } from 'react'
 import React, { useMemo, createElement, isValidElement } from 'react'
-import { makeStyles } from '@material-ui/core'
 import Typography from '@toptal/picasso/Typography'
 import Container from '@toptal/picasso/Container'
 import List from '@toptal/picasso/List'
@@ -9,6 +8,8 @@ import ListItem from '@toptal/picasso/ListItem'
 import Link from '@toptal/picasso/Link'
 
 import type { ASTType } from '../../types'
+import { Emoji, Image } from '../../components'
+import { isCustomEmojiComponent } from '../../../utils'
 
 type Props = {
   children?: React.ReactNode
@@ -18,14 +19,6 @@ type Props = {
 const Li = ({ children, ...props }: Props) => (
   <ListItem {...props}>{children}</ListItem>
 )
-
-const useStyles = makeStyles({
-  emoji: {
-    width: 24,
-    height: 24,
-    verticalAlign: 'bottom',
-  },
-})
 
 /* eslint-disable id-length */
 const P = ({ children }: Props) => (
@@ -51,11 +44,8 @@ const H3 = ({ children }: Props) => (
 const Ul = ({ children }: Props) => <List variant='unordered'>{children}</List>
 const Ol = ({ children }: Props) => <List variant='ordered'>{children}</List>
 const A = ({ children, ...props }: Props) => <Link {...props}>{children}</Link>
-const Emoji = ({ ...props }: Props) => {
-  const classes = useStyles()
-
-  return <img className={classes.emoji} {...props} />
-}
+const Img = ({ ...props }: Props) =>
+  isCustomEmojiComponent(props) ? <Emoji {...props} /> : <Image {...props} />
 
 const componentMap: Record<string, FC> = {
   p: P,
@@ -66,7 +56,7 @@ const componentMap: Record<string, FC> = {
   ol: Ol,
   ul: Ul,
   a: A,
-  img: Emoji,
+  img: Img,
 } as const
 
 const picassoMapper = (child: ReactNode): ReactNode => {

--- a/packages/picasso-rich-text-editor/src/RichText/story/Default.example.tsx
+++ b/packages/picasso-rich-text-editor/src/RichText/story/Default.example.tsx
@@ -37,6 +37,20 @@ const ast: ASTType = {
       tagName: 'p',
       properties: {},
       children: [
+        {
+          type: 'element',
+          tagName: 'img',
+          properties: {
+            src: './jacqueline/128x88.jpg',
+          },
+        },
+      ],
+    },
+    {
+      type: 'element',
+      tagName: 'p',
+      properties: {},
+      children: [
         { type: 'text', value: 'We’re looking for ' },
         {
           type: 'element',

--- a/packages/picasso-rich-text-editor/src/RichText/types.ts
+++ b/packages/picasso-rich-text-editor/src/RichText/types.ts
@@ -31,7 +31,19 @@ type CustomEmojiType = {
   children: []
 }
 
-export type ASTChildType = ElementType | TextType | CustomEmojiType
+type CustomImageType = {
+  type: 'element'
+  tagName: 'img'
+  properties: {
+    src: string
+  }
+}
+
+export type ASTChildType =
+  | ElementType
+  | TextType
+  | CustomEmojiType
+  | CustomImageType
 
 export type ASTType = {
   type: 'root'

--- a/packages/picasso-rich-text-editor/src/utils/__tests__/is-custom-emoji-component.test.ts
+++ b/packages/picasso-rich-text-editor/src/utils/__tests__/is-custom-emoji-component.test.ts
@@ -1,0 +1,22 @@
+import { isCustomEmojiComponent } from '..'
+
+describe('isCustomEmojiComponent', () => {
+  describe('when component props are specific to Emoji', () => {
+    it('returns true', () => {
+      const props = {
+        'data-src': 'test',
+        'data-emoji-name': 'test',
+      }
+
+      expect(isCustomEmojiComponent(props)).toBeTruthy()
+    })
+  })
+
+  describe('when component props are not specific to Emoji', () => {
+    it('returns false', () => {
+      const props = {}
+
+      expect(isCustomEmojiComponent(props)).toBeFalsy()
+    })
+  })
+})

--- a/packages/picasso-rich-text-editor/src/utils/index.ts
+++ b/packages/picasso-rich-text-editor/src/utils/index.ts
@@ -1,1 +1,2 @@
 export { default as htmlToHast, hastSanitizeSchema } from './html-to-hast'
+export { default as isCustomEmojiComponent } from './is-custom-emoji-component'

--- a/packages/picasso-rich-text-editor/src/utils/is-custom-emoji-component.ts
+++ b/packages/picasso-rich-text-editor/src/utils/is-custom-emoji-component.ts
@@ -1,0 +1,6 @@
+const isCustomEmojiComponent = (componentProps: any) =>
+  componentProps &&
+  'data-src' in componentProps &&
+  'data-emoji-name' in componentProps
+
+export default isCustomEmojiComponent


### PR DESCRIPTION
[FX-4111]

### Description

This pull request adds support for images in the in `RichText`.

### How to test

- Please see the https://picasso.toptal.net/fx-4111-image-show-image-in-richtext/ for demo

### Screenshots

Big picture (takes full width of the container)

<img width="1167" alt="Screenshot 2023-07-05 at 18 18 31" src="https://github.com/toptal/picasso/assets/1390758/2f6efd59-c0f4-4aad-83e1-7a1ce4b5dc35">

Regular picture (takes its full width)

<img width="589" alt="Screenshot 2023-07-05 at 17 21 44" src="https://github.com/toptal/picasso/assets/1390758/06bd721f-2a4e-4cf0-93ee-68b10bad9da5">

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [N/A] Make sure that additions and changes on design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [N/A] Annotate all `props` in component with documentation
- [N/A] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [N/A] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-4111]: https://toptal-core.atlassian.net/browse/FX-4111?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ