### PR TITLE
feat(barchart): add entry option to customize a bar indicator

### DIFF
--- a/.changeset/blue-pugs-sleep.md
+++ b/.changeset/blue-pugs-sleep.md
@@ -1,0 +1,7 @@
+---
+'@toptal/picasso-charts': minor
+---
+
+### BarChart
+
+- add entry option to getBarLabelColor and renderBarIndicators

--- a/cypress/component/BarChart.spec.tsx
+++ b/cypress/component/BarChart.spec.tsx
@@ -4,7 +4,6 @@ import { Container, Paper, Typography } from '@toptal/picasso'
 import { BarChart } from '@toptal/picasso-charts'
 import { palette } from '@toptal/picasso/utils'
 import BarChartIndicator from '@toptal/picasso-charts/BarChartIndicator'
-import type { BarOptions } from '@toptal/picasso-charts/types'
 
 const INDICATORS: any = {
   Google: { color: palette.blue.light, label: 'A' },
@@ -104,7 +103,7 @@ describe('BarChart', () => {
   it('renders custom chart with customized indicators', () => {
     cy.mount(
       <TestBarChart
-        renderBarIndicators={({ dataKey }: BarOptions) => {
+        renderBarIndicators={({ dataKey }: any) => {
           const indicator = INDICATORS[dataKey]
 
           if (indicator) {

--- a/packages/picasso-charts/src/BarChart/BarChart.tsx
+++ b/packages/picasso-charts/src/BarChart/BarChart.tsx
@@ -16,7 +16,7 @@ import { ticks as getD3Ticks } from 'd3-array'
 
 import BarChartLabel from '../BarChartLabel'
 import { BarChartIndicators } from '../BarChartIndicators'
-import type { BaseChartProps, BarOptions } from '../types'
+import type { BaseChartProps, BarChartDataItem, BarOptions } from '../types'
 import { defineStackId, findTopDomain } from './utils'
 import CHART_CONSTANTS, { chartMargins } from '../utils/constants'
 
@@ -32,13 +32,6 @@ const {
   TICK_HEIGHT,
 } = CHART_CONSTANTS
 const TOOLTIP_WRAPPER_STYLE = { outline: 'none' }
-
-export type BarChartDataItem<K extends string | number | symbol> = {
-  name: string
-  value: {
-    [key in K]: number
-  }
-}
 
 type ShowEverytNthTickValue = 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10
 
@@ -56,13 +49,14 @@ export interface Props<K extends string | number | symbol>
     dataKey: string
     entry?: {
       name: string
-      value: { [key in K]: number }
+      value: { [key in K]: any }
     }
     index?: number
   }) => string
   /** Maps bar's key with a label color */
-  getBarLabelColor?: (barOptions: BarOptions) => string
-  renderBarIndicators?: (barOptions: BarOptions) => ReactNode
+  getBarLabelColor?: (params: BarOptions) => string
+  /** Customizes the bar indicators */
+  renderBarIndicators?: (params: BarOptions) => ReactNode
   testIds?: {
     tooltip?: string
   }

--- a/packages/picasso-charts/src/BarChart/story/StackedWithBarChartIndicators.example.tsx
+++ b/packages/picasso-charts/src/BarChart/story/StackedWithBarChartIndicators.example.tsx
@@ -4,24 +4,18 @@ import { palette } from '@toptal/picasso/utils'
 
 const CHART_DATA = [
   {
-    name: 'Apple',
-    value: { 'engineers hired': 500 },
-  },
-  {
     name: 'Google',
-    value: { 'engineers hired': 700, isEnterprise: true },
-  },
-  {
-    name: 'Facebook',
-    value: { 'engineers hired': 600 },
+    value: {
+      breakAmount: 2000,
+      spendAmount: 1600,
+    },
   },
   {
     name: 'Amazon',
-    value: { 'engineers hired': 400 },
-  },
-  {
-    name: 'Toptal',
-    value: { 'engineers hired': 1000 },
+    value: {
+      breakAmount: 1752,
+      spendAmount: 1423,
+    },
   },
 ]
 
@@ -30,17 +24,23 @@ const INDICATORS: any = {
   Amazon: { color: palette.purple.main, label: 'E' },
 }
 
+const COLORS_MAPPING: Record<string, string> = {
+  breakAmount: palette.blue.main,
+  spendAmount: palette.grey.dark,
+}
+
 const Example = () => (
   <div style={{ width: 720 }}>
     <BarChart
       width='100%'
       data={CHART_DATA as any}
-      getBarColor={() => palette.blue.main}
+      stackedBars={[['breakAmount', 'spendAmount']]}
+      getBarColor={({ dataKey }) => COLORS_MAPPING[dataKey]}
       renderBarIndicators={({ dataKey, dataItem }) => {
         const indicator = INDICATORS[dataKey]
-        const isEnterprise = dataItem?.value?.isEnterprise
+        const valueKey = dataItem?.tooltipPayload?.[0]?.dataKey
 
-        if (indicator && isEnterprise) {
+        if (indicator && valueKey === 'breakAmount') {
           return (
             <BarChartIndicator
               label={indicator.label}

--- a/packages/picasso-charts/src/BarChart/story/index.jsx
+++ b/packages/picasso-charts/src/BarChart/story/index.jsx
@@ -53,6 +53,11 @@ page
       'Bars can be stacked on top of each other by providing `stackedBars`',
     takeScreenshot: false,
   })
+  .addExample('BarChart/story/StackedWithBarChartIndicators.example.tsx', {
+    title: 'Stacked with bar chart indicators',
+    description: 'Bars can have a customized indicator.',
+    takeScreenshot: false,
+  })
   .addExample('BarChart/story/HideBarLabel.example.tsx', {
     title: 'Hide bar label',
     description:

--- a/packages/picasso-charts/src/BarChart/utils/find-top-domain/find-top-domain.ts
+++ b/packages/picasso-charts/src/BarChart/utils/find-top-domain/find-top-domain.ts
@@ -1,4 +1,4 @@
-type DataItem = { [key: string]: number }
+type DataItem = { [key: string]: any }
 
 const getDataItemMaxValue = (dataItem: DataItem) =>
   Math.max(...Object.values(dataItem))

--- a/packages/picasso-charts/src/BarChartIndicators/BarChartIndicators.tsx
+++ b/packages/picasso-charts/src/BarChartIndicators/BarChartIndicators.tsx
@@ -1,12 +1,10 @@
 import React from 'react'
 import type { ReactNode } from 'react'
 
-import type { BarOptions } from '../types'
-
 const INDICATOR_SIZE = 16
 
 export type Props = {
-  renderIndicator: (barOption: BarOptions) => ReactNode
+  renderIndicator: (params: any) => ReactNode
   formattedGraphicalItems?: any
 }
 
@@ -19,8 +17,13 @@ export const BarChartIndicators = ({
 
     return series.map((item: any, index: number) => {
       const dataKey = item.name
+      const dataItem = item
 
-      const barIndicatorComponent = renderIndicator({ dataKey, index })
+      const barIndicatorComponent = renderIndicator({
+        dataKey,
+        index,
+        dataItem,
+      })
 
       if (!barIndicatorComponent) {
         return

--- a/packages/picasso-charts/src/BarChartLabel/BarChartLabel.tsx
+++ b/packages/picasso-charts/src/BarChartLabel/BarChartLabel.tsx
@@ -1,10 +1,12 @@
 import React from 'react'
 import type { LabelProps } from 'recharts'
 
+import type { BarOptions } from '../types'
+
 export type Props = {
   value?: LabelProps['value']
   viewBox?: { width?: number; x?: number; y?: number }
-  getBarLabelColor?: (params: { dataKey: string; index?: number }) => string
+  getBarLabelColor?: (params: BarOptions) => string
   dataKey: string
   index?: number
 }

--- a/packages/picasso-charts/src/types.ts
+++ b/packages/picasso-charts/src/types.ts
@@ -82,7 +82,15 @@ export type BarIndicatorConfig = {
   label: string
 }
 
+export type BarChartDataItem<K extends string | number | symbol> = {
+  name: string
+  value: {
+    [key in K]: string | number | symbol
+  }
+}
+
 export type BarOptions = {
   dataKey: string
+  dataItem?: any
   index?: number
 }


### PR DESCRIPTION
[SDE-1142](https://toptal-core.atlassian.net/browse/SDE-1142)

### Description

This PR adds the `dataItem` option to `renderBarIndicators` and `renderBarIndicators`, allowing us to customize bar indicators as needed.

### How to test

- Run the storybook locally (`yarn start`)
- Navigate to the `BarChart` component (http://localhost:9001/?path=/story/picasso-charts-barchart--barchart#stacked-with-bar-chart-indicators) and find the example provided

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| ![image](https://github.com/toptal/picasso/assets/5639968/40981c23-72be-4d25-97c0-1a9355d7a36e) | ![image](https://github.com/toptal/picasso/assets/5639968/90a7a7af-c0bd-457b-8bf9-3a991a45123a) |

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests

**Breaking change**

- [x] codemod is created and showcased in the changeset
- [x] test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[SDE-1142]: https://toptal-core.atlassian.net/browse/SDE-1142?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ