### PR TITLE
feat(rich-text-editor): move toolbar plugin groups to portal

### DIFF
--- a/.changeset/good-actors-glow.md
+++ b/.changeset/good-actors-glow.md
@@ -1,0 +1,7 @@
+---
+'@toptal/picasso': minor
+---
+
+### utils
+
+- add utility for forwarding a ref to multiple holders

--- a/.changeset/tender-kangaroos-shout.md
+++ b/.changeset/tender-kangaroos-shout.md
@@ -1,0 +1,7 @@
+---
+'@toptal/picasso-rich-text-editor': patch
+---
+
+### RichTextEditorToolbar
+
+- add groups for component plugins using the Toolbar portal automatically

--- a/packages/picasso-rich-text-editor/src/RichTextEditorToolbar/RichTextEditorToolbar.tsx
+++ b/packages/picasso-rich-text-editor/src/RichTextEditorToolbar/RichTextEditorToolbar.tsx
@@ -1,26 +1,27 @@
-import React, { forwardRef } from 'react'
 import type { Theme } from '@material-ui/core'
 import { makeStyles } from '@material-ui/core'
-import cx from 'classnames'
 import {
   Bold16,
+  Container,
   Italic16,
   ListOrdered16,
   ListUnordered16,
-  Container,
   Select,
 } from '@toptal/picasso'
+import { useMultipleForwardRefs } from '@toptal/picasso/utils'
+import cx from 'classnames'
+import React, { forwardRef } from 'react'
 
-import styles from './styles'
+import type { CustomEmojiGroup, EditorPlugin, Emoji } from '../LexicalEditor'
+import { useToolbarPortalRegister } from '../plugins/api'
 import TextEditorButton from '../RichTextEditorButton'
+import { RichTextEditorEmojiPicker } from '../RichTextEditorEmojiPicker/RichTextEditorEmojiPicker'
+import styles from './styles'
 import type {
   ButtonHandlerType,
-  SelectOnChangeHandler,
   FormatType,
+  SelectOnChangeHandler,
 } from './types'
-import type { CustomEmojiGroup, EditorPlugin, Emoji } from '../LexicalEditor'
-import { RichTextEditorEmojiPicker } from '../RichTextEditorEmojiPicker/RichTextEditorEmojiPicker'
-import { useToolbarPortalRegister } from '../plugins/api'
 
 type Props = {
   disabled: boolean
@@ -71,13 +72,19 @@ export const RichTextEditorToolbar = forwardRef<HTMLDivElement, Props>(
 
     const { setToolbarPortalEl } = useToolbarPortalRegister()
 
+    const toolbarRef = useMultipleForwardRefs([ref, setToolbarPortalEl])
+
     const classes = useStyles(props)
     const isHeadingFormat = format.header === ALLOWED_HEADER_TYPE
 
     const allowEmojis = plugins?.includes('emoji')
 
     return (
-      <Container id={`${id}toolbar`} ref={ref} className={classes.toolbar}>
+      <Container
+        id={`${id}toolbar`}
+        ref={toolbarRef}
+        className={classes.toolbar}
+      >
         <Container
           className={cx(classes.group, {
             groupDisabled: disabled,
@@ -129,7 +136,6 @@ export const RichTextEditorToolbar = forwardRef<HTMLDivElement, Props>(
             data-testid={testIds?.orderedListButton}
           />
         </Container>
-        <Container ref={setToolbarPortalEl} className={classes.group} />
         {allowEmojis && (
           <RichTextEditorEmojiPicker
             richEditorId={id}

--- a/packages/picasso-rich-text-editor/src/plugins/Toolbar/Toolbar.tsx
+++ b/packages/picasso-rich-text-editor/src/plugins/Toolbar/Toolbar.tsx
@@ -45,19 +45,17 @@ const useStyles = makeStyles<Theme, Props>(styles, {
 
 export const Toolbar = (props: Props) => {
   const { children, keyName } = props
-
-  const { portalEl: element } = useContext(Context)
+  const { portalEl } = useContext(Context)
 
   const classes = useStyles(props)
 
-  return (
-    <>
-      {element &&
-        createPortal(
-          <Container className={classes.group}>{children}</Container>,
-          element,
-          keyName
-        )}
-    </>
+  if (!portalEl) {
+    return null
+  }
+
+  return createPortal(
+    <Container className={classes.group}>{children}</Container>,
+    portalEl,
+    keyName
   )
 }

--- a/packages/picasso-rich-text-editor/src/plugins/Toolbar/Toolbar.tsx
+++ b/packages/picasso-rich-text-editor/src/plugins/Toolbar/Toolbar.tsx
@@ -1,0 +1,63 @@
+import type { Theme } from '@material-ui/core'
+import { makeStyles } from '@material-ui/core'
+import { Container } from '@toptal/picasso'
+import type { ReactNode } from 'react'
+import React, { createContext, useContext, useState } from 'react'
+import { createPortal } from 'react-dom'
+
+import styles from './styles'
+
+type ContextValue = {
+  portalEl?: HTMLElement
+  setPortalEl: (element: HTMLElement | null) => void
+}
+
+const Context = createContext<ContextValue>({
+  setPortalEl: () => {},
+})
+
+export const ToolbarProvider = ({ children }: { children: ReactNode }) => {
+  const [portalEl, setPortalEl] = useState<HTMLElement | null>(null)
+
+  return (
+    <Context.Provider value={{ portalEl: portalEl ?? undefined, setPortalEl }}>
+      {children}
+    </Context.Provider>
+  )
+}
+
+export const useToolbarPortalRegister = () => {
+  const { setPortalEl } = useContext(Context)
+
+  return {
+    setToolbarPortalEl: setPortalEl,
+  }
+}
+
+export type Props = {
+  children: ReactNode
+  keyName: string
+}
+
+const useStyles = makeStyles<Theme, Props>(styles, {
+  name: 'RichTextEditorToolbar',
+})
+
+export const Toolbar = (props: Props) => {
+  const { children, keyName } = props
+
+  const { portalEl: element } = useContext(Context)
+
+  const classes = useStyles(props)
+
+  return (
+    <>
+      {element &&
+        createPortal(
+          <Container className={classes.group}>{children}</Container>,
+          element,
+          keyName
+        )}
+    </>
+  )
+}

--- a/packages/picasso-rich-text-editor/src/plugins/Toolbar/index.ts
+++ b/packages/picasso-rich-text-editor/src/plugins/Toolbar/index.ts
@@ -1,0 +1,1 @@
+export * from './Toolbar'

--- a/packages/picasso-rich-text-editor/src/plugins/Toolbar/styles.ts
+++ b/packages/picasso-rich-text-editor/src/plugins/Toolbar/styles.ts
@@ -1,0 +1,22 @@
+import type { Theme } from '@material-ui/core/styles'
+import { createStyles } from '@material-ui/core/styles'
+
+export default ({ palette }: Theme) =>
+  createStyles({
+    group: {
+      display: 'flex',
+      alignItems: 'center',
+      position: 'relative',
+      pointerEvents: 'unset',
+
+      '&:not(:last-child):not(:empty)::after': {
+        content: '""',
+        height: '1em',
+        width: '1px',
+        position: 'relative',
+        marginLeft: '0.5em',
+        marginRight: '0.5em',
+        backgroundColor: palette.grey.lighter2,
+      },
+    },
+  })

--- a/packages/picasso-rich-text-editor/src/plugins/api.tsx
+++ b/packages/picasso-rich-text-editor/src/plugins/api.tsx
@@ -1,10 +1,10 @@
-import React, { createContext, useState, useContext, useEffect } from 'react'
-import type { ReactElement, ReactNode } from 'react'
-import { createPortal } from 'react-dom'
-import type { LexicalNode, Klass } from 'lexical'
 import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext'
+import type { Klass, LexicalNode } from 'lexical'
+import type { ReactElement, ReactNode } from 'react'
+import React, { createContext, useContext, useEffect } from 'react'
 
 import { registerLexicalEvents } from '../LexicalEditor/utils'
+import { ToolbarProvider } from './Toolbar/Toolbar'
 
 export const RTEPluginMeta = Symbol('PicassoRTEPluginMeta')
 
@@ -35,8 +35,6 @@ export const isRTEPluginElement = (plugin: {}): plugin is ReactElement<
 type RTEPluginContextValue = {
   disabled: boolean
   focused: boolean
-  toolbarPortalEl?: HTMLElement
-  setToolbarPortalEl: (element: HTMLElement | null) => void
 }
 
 export const useRTEUpdate = (callback: () => void) => {
@@ -55,7 +53,6 @@ export const useRTEUpdate = (callback: () => void) => {
 const RTEPluginContext = createContext<RTEPluginContextValue>({
   disabled: false,
   focused: false,
-  setToolbarPortalEl: () => {},
 })
 
 export type ToolbarPortalProviderProps = {
@@ -69,28 +66,18 @@ export const RTEPluginContextProvider = ({
   disabled,
   focused,
 }: ToolbarPortalProviderProps) => {
-  const [element, setElement] = useState<HTMLElement | null>(null)
-
   const value: RTEPluginContextValue = {
     disabled,
     focused,
-    toolbarPortalEl: element ?? undefined,
-    setToolbarPortalEl: setElement,
   }
 
   return (
-    <RTEPluginContext.Provider value={value}>
-      {children}
-    </RTEPluginContext.Provider>
+    <ToolbarProvider>
+      <RTEPluginContext.Provider value={value}>
+        {children}
+      </RTEPluginContext.Provider>
+    </ToolbarProvider>
   )
-}
-
-export const useToolbarPortalRegister = () => {
-  const { setToolbarPortalEl } = useContext(RTEPluginContext)
-
-  return {
-    setToolbarPortalEl,
-  }
 }
 
 export const useRTEPluginContext = () => {
@@ -102,13 +89,8 @@ export const useRTEPluginContext = () => {
   }
 }
 
-export type ToolbarProps = {
-  children: ReactNode
-  keyName: string
-}
-
-export const Toolbar = ({ children, keyName }: ToolbarProps) => {
-  const { toolbarPortalEl: element } = useContext(RTEPluginContext)
-
-  return <>{element && createPortal(children, element, keyName)}</>
-}
+export {
+  Props as ToolbarProps,
+  Toolbar,
+  useToolbarPortalRegister,
+} from './Toolbar/Toolbar'

--- a/packages/picasso/src/utils/index.ts
+++ b/packages/picasso/src/utils/index.ts
@@ -49,6 +49,7 @@ export { default as unsafeErrorLog } from './unsafe-error-log'
 export { default as useBoolean } from './useBoolean/use-boolean'
 export { default as sum } from './sum'
 export type { ReferenceObject } from './use-width-of'
+export { default as useMultipleForwardRefs } from './use-multiple-forward-refs'
 
 export const Transitions = TransitionUtils
 

--- a/packages/picasso/src/utils/use-multiple-forward-refs.ts
+++ b/packages/picasso/src/utils/use-multiple-forward-refs.ts
@@ -1,0 +1,37 @@
+import type { ForwardedRef } from 'react'
+import { useCallback } from 'react'
+
+const forwardRef = <T>(ref: ForwardedRef<T>, value: T) => {
+  if (typeof ref === 'function') {
+    ref(value)
+  } else if (ref) {
+    ref.current = value
+  }
+}
+
+/**
+ * This hook allows to forward ref to multiple holders.
+ *
+ * @example
+ *
+ *   const ref1 = useRef(null)
+ *   const ref2 = useRef(null)
+ *
+ *   const ref = useMultipleForwardRefs([ref1, ref2])
+ *
+ *   <div ref={ref} />
+ *
+ *   console.log(ref1.current) // <div />
+ *   console.log(ref2.current) // <div />
+ */
+const useMultipleForwardRefs = <T>(refs: ForwardedRef<T>[]) =>
+  useCallback(
+    (refValue: T) => {
+      for (const ref of refs) {
+        forwardRef(ref, refValue)
+      }
+    },
+    [...refs]
+  )
+
+export default useMultipleForwardRefs


### PR DESCRIPTION
[FX-4137]

### Description

On this PR, we are wrapping all toolbar plugins on groups. For now, every Toolbar has its group, in the future, we can think of a mechanism for controlling groups more precisely

### How to test

<!-- [Temploy](https://picasso.toptal.net/fx-4137-make-emoji-plugin-optional--groups) link will be updated automatically -->
- Temploy
- Check happo and temploy, last toolbar vertical bar

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| ![image](https://github.com/toptal/picasso/assets/5845160/9cb61cb5-1f40-4ae9-93d6-65261b0c185a) | ![image](https://github.com/toptal/picasso/assets/5845160/72b39226-4d0b-447f-add8-653ac34efdc4) |

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [ ] Covered with tests

**Breaking change**

- [NA] codemod is created and showcased in the changeset
- [NA] test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-4137]: https://toptal-core.atlassian.net/browse/FX-4137?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ