### PR TITLE
chore: return RTE toolbar id for feature tests

### DIFF
--- a/.changeset/short-cows-shave.md
+++ b/.changeset/short-cows-shave.md
@@ -1,0 +1,7 @@
+---
+'@toptal/picasso-rich-text-editor': patch
+---
+
+### RichTextEditor
+
+- return `id` to the toolbar for backward compatibility

--- a/packages/picasso-rich-text-editor/src/LexicalEditor/LexicalEditor.test.tsx
+++ b/packages/picasso-rich-text-editor/src/LexicalEditor/LexicalEditor.test.tsx
@@ -156,6 +156,7 @@ describe('LexicalEditor', () => {
       expect(mockedToolbarPlugin).toHaveBeenCalledWith(
         {
           disabled: true,
+          id: 'id',
           toolbarRef: {
             current: null,
           },
@@ -172,6 +173,7 @@ describe('LexicalEditor', () => {
       expect(mockedToolbarPlugin).toHaveBeenCalledWith(
         {
           disabled: true,
+          id: 'id',
           toolbarRef: {
             current: null,
           },
@@ -192,6 +194,7 @@ describe('LexicalEditor', () => {
       expect(mockedToolbarPlugin).toHaveBeenCalledWith(
         {
           disabled: true,
+          id: 'id',
           toolbarRef: {
             current: null,
           },

--- a/packages/picasso-rich-text-editor/src/LexicalEditor/LexicalEditor.tsx
+++ b/packages/picasso-rich-text-editor/src/LexicalEditor/LexicalEditor.tsx
@@ -194,6 +194,7 @@ const LexicalEditor = forwardRef<HTMLDivElement, Props>(function LexicalEditor(
             // remount Toolbar when disabled
             key={`${disabled || !focused}`}
             testIds={testIds}
+            id={id}
           />
 
           {defaultValue ? (

--- a/packages/picasso-rich-text-editor/src/LexicalEditorToolbarPlugin/LexicalEditorToolbarPlugin.tsx
+++ b/packages/picasso-rich-text-editor/src/LexicalEditorToolbarPlugin/LexicalEditorToolbarPlugin.tsx
@@ -27,6 +27,7 @@ import RichTextEditorToolbar, {
 
 type Props = {
   disabled?: boolean
+  id: string
   toolbarRef: React.RefObject<HTMLDivElement>
   testIds?: {
     wrapper?: string
@@ -43,6 +44,7 @@ const LexicalEditorToolbarPlugin = ({
   disabled = false,
   toolbarRef,
   testIds,
+  id,
 }: Props) => {
   const [editor] = useLexicalComposerContext()
   const [{ bold, italic, list, header }, dispatch] = useReducer(
@@ -115,6 +117,7 @@ const LexicalEditorToolbarPlugin = ({
       disabled={disabled}
       ref={toolbarRef}
       testIds={testIds}
+      id={id}
     />
   )
 }

--- a/packages/picasso-rich-text-editor/src/RichTextEditorToolbar/RichTextEditorToolbar.tsx
+++ b/packages/picasso-rich-text-editor/src/RichTextEditorToolbar/RichTextEditorToolbar.tsx
@@ -23,6 +23,7 @@ import type {
 
 type Props = {
   disabled: boolean
+  id: string
   format: FormatType
   testIds?: {
     headerSelect?: string
@@ -57,6 +58,7 @@ export const RichTextEditorToolbar = forwardRef<HTMLDivElement, Props>(
       onUnorderedClick,
       onOrderedClick,
       testIds,
+      id,
     } = props
 
     const { setToolbarPortalEl } = useToolbarPortalRegister()
@@ -67,7 +69,11 @@ export const RichTextEditorToolbar = forwardRef<HTMLDivElement, Props>(
     const isHeadingFormat = format.header === ALLOWED_HEADER_TYPE
 
     return (
-      <Container ref={toolbarRef} className={classes.toolbar}>
+      <Container
+        ref={toolbarRef}
+        id={`${id}toolbar`}
+        className={classes.toolbar}
+      >
         <Container
           className={cx(classes.group, {
             groupDisabled: disabled,


### PR DESCRIPTION
[FX-4172]

### Description

For backward compatibility, we need to keep the HTML structure closest as possible to the previous version. In feature tests, they are using the id of the toolbar as a selector.

### How to test

<!-- The temploy link will be automatically updated when the temploy is deployed -->
- [Temploy](https://picasso.toptal.net/fx-4172-return-toolbar-id)
- FIXME: Add the steps describing how to verify your changes

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| Insert screenshots or screen recordings | Insert screenshots or screen recordings |

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- Covered with tests

**Breaking change**

- codemod is created and showcased in the changeset
- test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-4172]: https://toptal-core.atlassian.net/browse/FX-4172?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ