### PR TITLE
fix(DatePicker): react to external updates accordingly

### DIFF
--- a/.changeset/tiny-dodos-lie.md
+++ b/.changeset/tiny-dodos-lie.md
@@ -1,0 +1,7 @@
+---
+'@toptal/picasso': patch
+---
+
+### DatePicker
+
+- fix DatePicker visible input value not reacting to async external changes appropriately

--- a/cypress/component/DatePicker.spec.tsx
+++ b/cypress/component/DatePicker.spec.tsx
@@ -1,5 +1,11 @@
-import type { DatePickerProps } from '@toptal/picasso'
-import { Container, DatePicker, Link, Typography } from '@toptal/picasso'
+import type { DatePickerProps, DatePickerValue } from '@toptal/picasso'
+import {
+  Container,
+  DatePicker,
+  Link,
+  Typography,
+  Button,
+} from '@toptal/picasso'
 import React, { useState } from 'react'
 
 const TestDatePicker = (props: Partial<DatePickerProps>) => {
@@ -108,5 +114,55 @@ describe('DatePicker', () => {
       component,
       variant: 'customized-footer',
     })
+  })
+
+  const TestAsyncExternalUpdateDatePicker = () => {
+    const [datepickerValue, setDatepickerValue] = useState<DatePickerValue>()
+    const [disabled, setDisabled] = useState(false)
+
+    const handleChange = (value: any) => {
+      setDisabled(true)
+      setTimeout(() => {
+        setDatepickerValue(value)
+        setDisabled(false)
+      }, 100)
+    }
+
+    return (
+      <Container padded='medium' flex>
+        <Button
+          data-testid='reset-button'
+          onClick={() => {
+            setDisabled(true)
+            setTimeout(() => {
+              setDatepickerValue(undefined)
+              setDisabled(false)
+            }, 100)
+          }}
+        >
+          Reset
+        </Button>
+        <DatePicker
+          testIds={{
+            input: 'date-picker-input',
+          }}
+          value={datepickerValue}
+          enableReset
+          disabled={disabled}
+          onResetClick={() => setDatepickerValue(null)}
+          onChange={handleChange}
+        />
+      </Container>
+    )
+  }
+
+  it('reacts to external value updates correctly', () => {
+    cy.mount(<TestAsyncExternalUpdateDatePicker />)
+
+    cy.getByTestId('date-picker-input').focus()
+    cy.getByTestId('day-button-15').click()
+    cy.getByTestId('reset-button').click()
+
+    cy.getByTestId('date-picker-input').should('have.value', '')
   })
 })

--- a/cypress/component/DatePicker.spec.tsx
+++ b/cypress/component/DatePicker.spec.tsx
@@ -117,7 +117,9 @@ describe('DatePicker', () => {
   })
 
   const TestAsyncExternalUpdateDatePicker = () => {
-    const [datepickerValue, setDatepickerValue] = useState<DatePickerValue>()
+    const [datepickerValue, setDatepickerValue] = useState<DatePickerValue>(
+      new Date(2020, 7, 21)
+    )
     const [disabled, setDisabled] = useState(false)
 
     const handleChange = (value: any) => {
@@ -135,7 +137,7 @@ describe('DatePicker', () => {
           onClick={() => {
             setDisabled(true)
             setTimeout(() => {
-              setDatepickerValue(undefined)
+              setDatepickerValue(null)
               setDisabled(false)
             }, 100)
           }}
@@ -161,6 +163,7 @@ describe('DatePicker', () => {
 
     cy.getByTestId('date-picker-input').focus()
     cy.getByTestId('day-button-15').click()
+    cy.getByTestId('date-picker-input').should('have.value', 'Aug 15, 2020')
     cy.getByTestId('reset-button').click()
 
     cy.getByTestId('date-picker-input').should('have.value', '')

--- a/packages/picasso/src/DatePicker/DatePicker.tsx
+++ b/packages/picasso/src/DatePicker/DatePicker.tsx
@@ -221,13 +221,13 @@ export const DatePicker = (props: Props) => {
   // Should not update when input is focused to prevent overriding it's value
   useEffect(() => {
     updateInputValue({ preventUpdateOnFocus: true })
-  }, [value, timezone])
+  }, [value, timezone, updateInputValue])
 
   // Keep the input format in sync with its 'focus' state
   // Updating on input focus state change
   useEffect(() => {
     updateInputValue({ preventUpdateOnFocus: false })
-  }, [isInputFocused])
+  }, [isInputFocused, updateInputValue])
 
   // Keep the calendar in sync with the input value
   useEffect(() => {

--- a/packages/picasso/src/DatePicker/DatePicker.tsx
+++ b/packages/picasso/src/DatePicker/DatePicker.tsx
@@ -221,13 +221,19 @@ export const DatePicker = (props: Props) => {
   // Should not update when input is focused to prevent overriding it's value
   useEffect(() => {
     updateInputValue({ preventUpdateOnFocus: true })
-  }, [value, timezone, updateInputValue])
+  }, [value, timezone])
 
   // Keep the input format in sync with its 'focus' state
   // Updating on input focus state change
   useEffect(() => {
     updateInputValue({ preventUpdateOnFocus: false })
-  }, [isInputFocused, updateInputValue])
+  }, [isInputFocused])
+
+  useEffect(() => {
+    if (disabled) {
+      setIsInputFocused(false)
+    }
+  }, [disabled])
 
   // Keep the calendar in sync with the input value
   useEffect(() => {


### PR DESCRIPTION
[FX-4183](https://toptal-core.atlassian.net/browse/FX-4183)

### Description

When an external async value update is issued to DatePicker value while it is disabled (as demonstrated in this [example](https://codesandbox.io/s/thirsty-swartz-d83chh?file=/src/Page.tsx)), a `isFocused` state is not set back to `false` when input becomes disabled. This causes the logic that relied on the flag to not function properly.

### How to test

<!-- The temploy link will be automatically updated when the temploy is deployed -->
- [Temploy](https://picasso.toptal.net/fx-4183-datepicker-does-not-reset-value-if-it-s-in-disabled-state)
- All tests should pass
- The new test added for the case should pass

### Screenshots

#### Before

https://github.com/toptal/picasso/assets/18409292/28afb89f-81e3-4e09-aa59-b7c467bdfd1a


#### After
https://github.com/toptal/picasso/assets/18409292/408c64fe-eab9-4aef-8bcc-b4cd69fa8ac2


### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests


> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-4183]: https://toptal-core.atlassian.net/browse/FX-4183?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ