### PR TITLE
fix: hamburger menu offset

### DIFF
--- a/.changeset/fast-bulldogs-study.md
+++ b/.changeset/fast-bulldogs-study.md
@@ -4,4 +4,4 @@
 
 ### PageHamburger
 
-- fix hamburger menu positioning
+- fix hamburger button and menu position

--- a/.changeset/fast-bulldogs-study.md
+++ b/.changeset/fast-bulldogs-study.md
@@ -1,0 +1,7 @@
+---
+'@toptal/picasso': patch
+---
+
+### PageHamburger
+
+- fix hamburger menu positioning

--- a/packages/picasso/src/PageHamburger/PageHamburger.tsx
+++ b/packages/picasso/src/PageHamburger/PageHamburger.tsx
@@ -8,6 +8,7 @@ import { useHamburgerContext } from './PageHamburgerContext'
 import Dropdown from '../Dropdown'
 import { Close24, Overview24 } from '../Icon'
 import styles from './styles'
+import { useBreakpoint } from '../utils'
 
 interface Props {
   id: string
@@ -23,6 +24,8 @@ const PageHamburger = ({ id, 'data-testid': dataTestId }: Props) => {
   const [showContent, setShowContent] = useState<boolean>(false)
   const classes = useStyles()
 
+  const nonXlLayout = useBreakpoint(['xs', 'sm', 'md', 'lg'])
+
   const handleShowContent = () => setShowContent(true)
   const handleHideContent = () => setShowContent(false)
 
@@ -33,7 +36,7 @@ const PageHamburger = ({ id, 'data-testid': dataTestId }: Props) => {
         [classes.hidden]: !isHamburgerVisible,
       })}
       classes={{ content: classes.responsiveWrapperContent }}
-      offset={{ top: 0.4 }}
+      offset={{ top: nonXlLayout ? 'small' : 'xsmall' }}
       popperOptions={{
         modifiers: {
           flip: { enabled: false },

--- a/packages/picasso/src/PageHamburger/PageHamburger.tsx
+++ b/packages/picasso/src/PageHamburger/PageHamburger.tsx
@@ -8,7 +8,6 @@ import { useHamburgerContext } from './PageHamburgerContext'
 import Dropdown from '../Dropdown'
 import { Close24, Overview24 } from '../Icon'
 import styles from './styles'
-import { useBreakpoint } from '../utils'
 
 interface Props {
   id: string
@@ -24,8 +23,6 @@ const PageHamburger = ({ id, 'data-testid': dataTestId }: Props) => {
   const [showContent, setShowContent] = useState<boolean>(false)
   const classes = useStyles()
 
-  const nonXlLayout = useBreakpoint(['xs', 'sm', 'md', 'lg'])
-
   const handleShowContent = () => setShowContent(true)
   const handleHideContent = () => setShowContent(false)
 
@@ -35,8 +32,10 @@ const PageHamburger = ({ id, 'data-testid': dataTestId }: Props) => {
       className={cx(classes.root, {
         [classes.hidden]: !isHamburgerVisible,
       })}
-      classes={{ content: classes.responsiveWrapperContent }}
-      offset={{ top: nonXlLayout ? 'small' : 'xsmall' }}
+      classes={{
+        content: classes.responsiveWrapperContent,
+        popper: classes.popper,
+      }}
       popperOptions={{
         modifiers: {
           flip: { enabled: false },

--- a/packages/picasso/src/PageHamburger/styles.ts
+++ b/packages/picasso/src/PageHamburger/styles.ts
@@ -12,6 +12,9 @@ export default ({ palette }: Theme) => {
         display: 'none',
       },
     },
+    popper: {
+      marginTop: '1rem',
+    },
     hamburger: {
       pointerEvents: 'none',
     },

--- a/packages/picasso/src/PageHamburger/styles.ts
+++ b/packages/picasso/src/PageHamburger/styles.ts
@@ -8,7 +8,6 @@ export default ({ palette }: Theme) => {
 
   return createStyles({
     root: {
-      display: 'block',
       [headerBreakingPointXL]: {
         display: 'none',
       },

--- a/packages/picasso/src/PageTopBar/__snapshots__/test.tsx.snap
+++ b/packages/picasso/src/PageTopBar/__snapshots__/test.tsx.snap
@@ -78,7 +78,7 @@ exports[`Page.TopBar render with custom logo 1`] = `
     <div
       class="PicassoPopper-root PicassoDropdown-popper"
       role="navigation"
-      style="position: fixed; top: 0px; left: 0px; display: none; margin-top: 0.4rem;"
+      style="position: fixed; top: 0px; left: 0px; display: none; margin-top: 0.5rem;"
     >
       <div>
         <div
@@ -201,7 +201,7 @@ exports[`Page.TopBar render with link 1`] = `
     <div
       class="PicassoPopper-root PicassoDropdown-popper"
       role="navigation"
-      style="position: fixed; top: 0px; left: 0px; display: none; margin-top: 0.4rem;"
+      style="position: fixed; top: 0px; left: 0px; display: none; margin-top: 0.5rem;"
     >
       <div>
         <div
@@ -319,7 +319,7 @@ exports[`Page.TopBar renders 1`] = `
     <div
       class="PicassoPopper-root PicassoDropdown-popper"
       role="navigation"
-      style="position: fixed; top: 0px; left: 0px; display: none; margin-top: 0.4rem;"
+      style="position: fixed; top: 0px; left: 0px; display: none; margin-top: 0.5rem;"
     >
       <div>
         <div

--- a/packages/picasso/src/PageTopBar/__snapshots__/test.tsx.snap
+++ b/packages/picasso/src/PageTopBar/__snapshots__/test.tsx.snap
@@ -76,9 +76,9 @@ exports[`Page.TopBar render with custom logo 1`] = `
       </header>
     </div>
     <div
-      class="PicassoPopper-root PicassoDropdown-popper"
+      class="PicassoPopper-root PicassoDropdown-popper PageHamburger-popper"
       role="navigation"
-      style="position: fixed; top: 0px; left: 0px; display: none; margin-top: 0.5rem;"
+      style="position: fixed; top: 0px; left: 0px; display: none;"
     >
       <div>
         <div
@@ -199,9 +199,9 @@ exports[`Page.TopBar render with link 1`] = `
       </header>
     </div>
     <div
-      class="PicassoPopper-root PicassoDropdown-popper"
+      class="PicassoPopper-root PicassoDropdown-popper PageHamburger-popper"
       role="navigation"
-      style="position: fixed; top: 0px; left: 0px; display: none; margin-top: 0.5rem;"
+      style="position: fixed; top: 0px; left: 0px; display: none;"
     >
       <div>
         <div
@@ -317,9 +317,9 @@ exports[`Page.TopBar renders 1`] = `
       </header>
     </div>
     <div
-      class="PicassoPopper-root PicassoDropdown-popper"
+      class="PicassoPopper-root PicassoDropdown-popper PageHamburger-popper"
       role="navigation"
-      style="position: fixed; top: 0px; left: 0px; display: none; margin-top: 0.5rem;"
+      style="position: fixed; top: 0px; left: 0px; display: none;"
     >
       <div>
         <div


### PR DESCRIPTION
[FX-4200]

### Description

This pull request fixes the hamburger menu offset and the hamburger button is vertically centered.

Design https://www.figma.com/file/5SCTOPrCDcHuk5We091GBn/Product-Library?type=design&node-id=9938-40726&mode=design&t=brwuhESCM5CsNynL-0

### How to test

<!-- The temploy link will be automatically updated when the temploy is deployed -->
- [Temploy](https://picasso.toptal.net/FX-NULL-fix-compact-dropdown-menu)
- Compare with https://picasso.toptal.net/?path=/story/layout-page--page side-by-side by opening the hamburger menu

### Screenshots

Hamburger button position before

<img width="497" alt="Screenshot 2023-07-26 at 11 53 50" src="https://github.com/toptal/picasso/assets/1390758/048537cf-009f-426e-ad7b-bbd7983695ca">

Hamburger button position after

<img width="446" alt="Screenshot 2023-07-26 at 11 53 57" src="https://github.com/toptal/picasso/assets/1390758/153c3ca1-638b-4a79-a3f5-159a185f8e5b">

Hamburger button position in design

<img width="374" alt="Screenshot 2023-07-26 at 11 54 03" src="https://github.com/toptal/picasso/assets/1390758/a97d41d3-d469-4208-b385-70590b59998f">

---


Please see the side-by-side comparison of hamburger button position and menu (in `master` / in this pull request)

https://github.com/toptal/picasso/assets/1390758/81442492-a25c-4b75-b9c0-85aaddfcd606


### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [N/A] Annotate all `props` in component with documentation
- [N/A] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [N/A] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [N/A] Covered with tests

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-4200]: https://toptal-core.atlassian.net/browse/FX-4200?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ