### PR TITLE
fix: initialize editor with empty paragraph if root is empty

### DIFF
--- a/.changeset/sour-bees-tie.md
+++ b/.changeset/sour-bees-tie.md
@@ -1,0 +1,6 @@
+---
+'@toptal/picasso-rich-text-editor': patch
+---
+
+- fix internal Lexical state being initialized without empty paragraph when `{ root: { children: [] } }` is provided as a default value
+- fix editor crash when empty list is being inserted into the editor with no paragraph

--- a/packages/picasso-rich-text-editor/src/LexicalEditor/utils/setEditorValue.ts
+++ b/packages/picasso-rich-text-editor/src/LexicalEditor/utils/setEditorValue.ts
@@ -12,8 +12,9 @@ import { getDomValue } from './getDomValue'
 
 export const setEditorValue = (editor: LexicalEditorType, value?: ASTType) => {
   const root = $getRoot()
+  const isEmptyRoot = root.isEmpty()
 
-  if (value && Object.keys(value).length > 0) {
+  if (value && Object.keys(value).length > 0 && !isEmptyRoot) {
     const domValue = getDomValue(value)
     const lexicalValueNodes = $generateNodesFromDOM(editor, domValue)
 
@@ -26,7 +27,7 @@ export const setEditorValue = (editor: LexicalEditorType, value?: ASTType) => {
       root.append(nodeToAppend)
     })
   } else {
-    if (root.isEmpty()) {
+    if (isEmptyRoot) {
       root.append($createParagraphNode())
     }
   }

--- a/packages/picasso-rich-text-editor/src/LexicalEditor/utils/setEditorValue.ts
+++ b/packages/picasso-rich-text-editor/src/LexicalEditor/utils/setEditorValue.ts
@@ -12,9 +12,9 @@ import { getDomValue } from './getDomValue'
 
 export const setEditorValue = (editor: LexicalEditorType, value?: ASTType) => {
   const root = $getRoot()
-  const isEmptyRoot = root.isEmpty()
+  const isEmptyRootValue = value?.children?.length === 0
 
-  if (value && Object.keys(value).length > 0 && !isEmptyRoot) {
+  if (value && Object.keys(value).length > 0 && !isEmptyRootValue) {
     const domValue = getDomValue(value)
     const lexicalValueNodes = $generateNodesFromDOM(editor, domValue)
 
@@ -27,7 +27,7 @@ export const setEditorValue = (editor: LexicalEditorType, value?: ASTType) => {
       root.append(nodeToAppend)
     })
   } else {
-    if (isEmptyRoot) {
+    if (isEmptyRootValue || root.isEmpty()) {
       root.append($createParagraphNode())
     }
   }


### PR DESCRIPTION
[FX-4190](https://toptal-core.atlassian.net/browse/FX-4190)

### Description

When `{ root: { children: [] } }` is provided as a default value to the RichTextEditor, the internal editor state is initialized without an empty paragraph. According to Lexical docs, this is not a valid state, there should always be at least one paragraph node by default.
This causes the editor to crash when trying to append items to the root node (for example, creating an empty list in editor with an empty default value).

### How to test

<!-- The temploy link will be automatically updated when the temploy is deployed -->
- [Temploy](https://picasso.toptal.net/fx-4190-richtexteditor-throws-error-when-initialized-with-empty-default-value)
- Story for `RichText` can be used for testing
- Change the `HTML` story example code to have the default value of `root: { children: [] } `
- Without doing anything else, click on any list button in the editor


### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests


> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-4190]: https://toptal-core.atlassian.net/browse/FX-4190?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ