### PR TITLE
fix: [FX-4181] use proper width for narrow Drawer

### DIFF
--- a/.changeset/tame-coins-breathe.md
+++ b/.changeset/tame-coins-breathe.md
@@ -1,0 +1,7 @@
+---
+'@toptal/picasso': patch
+---
+
+### Icon
+
+- use proper width for narrow Drawer in xs screens

--- a/.changeset/tame-coins-breathe.md
+++ b/.changeset/tame-coins-breathe.md
@@ -2,6 +2,6 @@
 '@toptal/picasso': patch
 ---
 
-### Icon
+### Drawer
 
 - use proper width for narrow Drawer in xs screens

--- a/packages/picasso/src/Drawer/styles.ts
+++ b/packages/picasso/src/Drawer/styles.ts
@@ -26,10 +26,11 @@ export default ({ screens }: Theme) =>
       top: '1rem',
     },
     narrow: {
-      width: '27.5rem',
-      [screens('xs')]: {
-        width: '100vw',
-        maxWidth: '100vw',
+      width: '100vw',
+      maxWidth: '100vw',
+      [screens('sm', 'md', 'lg', 'xl')]: {
+        width: '27.5rem',
+        maxWidth: '100%',
       },
     },
     regular: {

--- a/packages/picasso/src/Drawer/styles.ts
+++ b/packages/picasso/src/Drawer/styles.ts
@@ -1,5 +1,6 @@
 import { createStyles } from '@material-ui/core/styles'
 import { PicassoProvider } from '@toptal/picasso-provider'
+import type { Theme } from '@material-ui/core/styles'
 
 PicassoProvider.override(() => ({
   MuiDrawer: {
@@ -9,7 +10,7 @@ PicassoProvider.override(() => ({
   },
 }))
 
-export default () =>
+export default ({ screens }: Theme) =>
   createStyles({
     container: {
       maxWidth: '100%',
@@ -26,6 +27,10 @@ export default () =>
     },
     narrow: {
       width: '27.5rem',
+      [screens('xs')]: {
+        width: '100vw',
+        maxWidth: '100vw',
+      },
     },
     regular: {
       width: '35rem',


### PR DESCRIPTION
[FX-4181]

### Description

Use full-width size for narrow Drawer in XS screens.
Will be covered with integration tests in a separate task

### How to test

- Use temploy 
- test `Drawer` with prop `width="narrow"`, 
- use screen width between "0-479px"
- Drawer width must be full-sized

### Screenshots

<img width="492" alt="Picasso | Drawer 2023-07-28 15-12-29" src="https://github.com/toptal/picasso/assets/1824723/f12f53a0-b437-4444-bdbf-c0fa7ed4a80b">



### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Ensure that deployed demo has expected results and good examples
- [x] Self reviewed


> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-4181]: https://toptal-core.atlassian.net/browse/FX-4181?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ