### PR TITLE
feat: add support for standalone links

### DIFF
--- a/.changeset/eleven-badgers-judge.md
+++ b/.changeset/eleven-badgers-judge.md
@@ -1,0 +1,5 @@
+---
+'@toptal/picasso-rich-text-editor': minor
+---
+
+- modify LinkPlugin to be able to insert links as text if nothing is selected in the editor

--- a/cypress/component/RichTextEditor/LinkPlugin.spec.tsx
+++ b/cypress/component/RichTextEditor/LinkPlugin.spec.tsx
@@ -41,7 +41,6 @@ const component = 'RichTextEditor'
 const setAliases = () => {
   cy.get(editorSelector).as('editor')
   cy.getByTestId(linkPluginButton).as('linkPluginButton')
-  cy.getByTestId(linkPluginButton).as('linkPluginButton')
   cy.getByTestId(resultContainerTestId).as('resultContainer')
   cy.contains('placeholder').as('placeholder')
   cy.getByTestId(boldButton).as('boldButton')

--- a/cypress/component/RichTextEditor/LinkPlugin.spec.tsx
+++ b/cypress/component/RichTextEditor/LinkPlugin.spec.tsx
@@ -1,0 +1,158 @@
+import React, { useState } from 'react'
+import type { RichTextEditorProps } from '@toptal/picasso-rich-text-editor'
+import { LinkPlugin, RichTextEditor } from '@toptal/picasso-rich-text-editor'
+import { Container } from '@toptal/picasso'
+
+const editorTestId = 'editor'
+const linkPluginButton = 'link-plugin-button'
+const resultContainerTestId = 'result-container'
+const boldButton = 'boldButton'
+const ulButton = 'ulButton'
+
+const defaultProps = {
+  id: 'foo',
+  onChange: () => {},
+  placeholder: 'placeholder',
+  testIds: {
+    editor: editorTestId,
+    linkPluginButton: linkPluginButton,
+    boldButton,
+    unorderedListButton: ulButton,
+  },
+}
+
+const editorSelector = `#${defaultProps.id}`
+
+const Editor = (props: RichTextEditorProps) => {
+  const [value, setValue] = useState('')
+
+  return (
+    <Container style={{ maxWidth: '600px' }} padded='small'>
+      <RichTextEditor {...props} onChange={value => setValue(value)} />
+      <Container padded='small' data-testid={resultContainerTestId}>
+        {value}
+      </Container>
+    </Container>
+  )
+}
+
+const component = 'RichTextEditor'
+
+const setAliases = () => {
+  cy.get(editorSelector).as('editor')
+  cy.getByTestId(linkPluginButton).as('linkPluginButton')
+  cy.getByTestId(linkPluginButton).as('linkPluginButton')
+  cy.getByTestId(resultContainerTestId).as('resultContainer')
+  cy.contains('placeholder').as('placeholder')
+  cy.getByTestId(boldButton).as('boldButton')
+  cy.getByTestId(ulButton).as('ulButton')
+}
+
+describe('LinkPlugin', () => {
+  describe('when links are inserted into existing text', () => {
+    it('inserts links into rich text editor', () => {
+      // eslint-disable-next-line
+      cy.window().then(win => {
+        cy.stub(win, 'prompt').returns('https://toptal.com/')
+      })
+      cy.mount(
+        <Editor
+          {...{
+            ...defaultProps,
+            plugins: [<LinkPlugin data-testid={linkPluginButton} />],
+          }}
+        />
+      )
+      setAliases()
+
+      // Normal text turns into a link
+      cy.get('@editor').click()
+      cy.get('@editor').type('text')
+      cy.get('@editor').type('{selectall}')
+      cy.get('@linkPluginButton').realClick()
+
+      // Bold text turns into a link
+      cy.get('@editor').click()
+      cy.get('@editor').type('{enter}')
+      cy.get('@boldButton').realClick()
+      cy.get('@editor').type('bold')
+      cy.get('@boldButton').realClick()
+      cy.realPress([
+        'Shift',
+        'ArrowLeft',
+        'ArrowLeft',
+        'ArrowLeft',
+        'ArrowLeft',
+      ])
+      cy.get('@linkPluginButton').realClick()
+
+      // Link is inserted into unordered list
+      cy.get('@editor').click()
+      cy.get('@editor').type('{enter}list')
+      cy.get('@ulButton').click()
+      cy.realPress([
+        'Shift',
+        'ArrowLeft',
+        'ArrowLeft',
+        'ArrowLeft',
+        'ArrowLeft',
+      ])
+      cy.get('@linkPluginButton').realClick()
+
+      cy.get('@resultContainer').contains(
+        `<p><a href="https://toptal.com/" rel="noreferrer"><span>text</span></a></p><p><a href="https://toptal.com/" rel="noreferrer"><strong>bold</strong></a></p><ul><li><a href="https://toptal.com/" rel="noreferrer"><strong>list</strong></a></li></ul>`
+      )
+
+      cy.get('body').happoScreenshot({
+        component,
+        variant: 'link-plugin/links-in-existing-text',
+      })
+    })
+  })
+
+  describe('when links are inserted with no text selected', () => {
+    it('inserts links into rich text editor', () => {
+      // eslint-disable-next-line
+      cy.window().then(win => {
+        cy.stub(win, 'prompt').returns('https://toptal.com/')
+      })
+      cy.mount(
+        <Editor
+          {...{
+            ...defaultProps,
+            plugins: [<LinkPlugin data-testid={linkPluginButton} />],
+          }}
+        />
+      )
+      setAliases()
+
+      // Empty editor creates a Link node
+      cy.get('@editor').click()
+      cy.get('@linkPluginButton').realClick()
+
+      // Text node with bold formatting has Link node inserted
+      cy.get('@editor').click()
+      cy.get('@editor').type('{enter}')
+      cy.get('@boldButton').realClick()
+      cy.get('@editor').type('long bold text')
+      cy.realPress(['ArrowLeft', 'ArrowLeft', 'ArrowLeft', 'ArrowLeft'])
+      cy.get('@linkPluginButton').realClick()
+
+      // Link is inserted into unordered list
+      cy.get('@editor').click()
+      cy.get('@editor').type('{enter}list')
+      cy.get('@ulButton').click()
+      cy.realPress(['Enter'])
+      cy.get('@linkPluginButton').realClick()
+
+      cy.get('@resultContainer').contains(
+        `<p><a href="https://toptal.com/" rel="noreferrer"><span>https://toptal.com/</span></a></p><p><strong>long bold </strong><a href="https://toptal.com/" rel="noreferrer"><span>https://toptal.com/</span></a><strong>text</strong></p><ul><li><strong>list</strong></li><li><a href="https://toptal.com/" rel="noreferrer"><span>https://toptal.com/</span></a></li></ul>`
+      )
+
+      cy.get('body').happoScreenshot({
+        component,
+        variant: 'link-plugin/standalone-links',
+      })
+    })
+  })
+})

--- a/packages/picasso-rich-text-editor/src/plugins/LinkPlugin/LinkPluginButton.tsx
+++ b/packages/picasso-rich-text-editor/src/plugins/LinkPlugin/LinkPluginButton.tsx
@@ -1,7 +1,11 @@
-import { $isLinkNode, TOGGLE_LINK_COMMAND } from '@lexical/link'
+import {
+  $isLinkNode,
+  TOGGLE_LINK_COMMAND,
+  $createLinkNode,
+} from '@lexical/link'
 import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext'
 import { Link16 } from '@toptal/picasso'
-import { $getSelection, $isRangeSelection } from 'lexical'
+import { $createTextNode, $getSelection, $isRangeSelection } from 'lexical'
 import React, { useCallback, useState } from 'react'
 
 import { getSelectedNode } from '../../LexicalEditor/utils/getSelectedNode'
@@ -34,15 +38,41 @@ const LinkPluginButton = ({ 'data-testid': testId }: Props) => {
       return editor.dispatchCommand(TOGGLE_LINK_COMMAND, null)
     }
 
-    const url = window.prompt('URL')
+    editor.update(() => {
+      const selection = $getSelection()
 
-    if (url != null) {
-      if (!validateUrl(url)) {
-        return window.alert('Not valid URL')
+      if ($isRangeSelection(selection)) {
+        const isEmptySelection = selection.anchor.is(selection.focus)
+
+        const url = window.prompt('URL')
+
+        if (url != null) {
+          if (!validateUrl(url)) {
+            return window.alert('Not a valid URL')
+          }
+          const sanitizedUrl = sanitizeUrl(url)
+
+          // When nothing is selected, we create a new Link node without dispatching
+          // any commands to the original Lexical Link plugin
+          if (isEmptySelection) {
+            const linkNode = $createLinkNode(sanitizedUrl, {
+              rel: 'noreferrer',
+            })
+            const textNode = $createTextNode(sanitizedUrl)
+
+            linkNode.append(textNode)
+            const node = getSelectedNode(selection)
+
+            node.append(linkNode)
+            // If we have a selection of any kind, pass the creation of the Link node to the plugin
+          } else {
+            editor.dispatchCommand(TOGGLE_LINK_COMMAND, {
+              url: sanitizedUrl,
+            })
+          }
+        }
       }
-
-      editor.dispatchCommand(TOGGLE_LINK_COMMAND, { url: sanitizeUrl(url) })
-    }
+    })
   }, [editor, active])
 
   return (

--- a/packages/picasso-rich-text-editor/src/plugins/LinkPlugin/LinkPluginButton.tsx
+++ b/packages/picasso-rich-text-editor/src/plugins/LinkPlugin/LinkPluginButton.tsx
@@ -5,7 +5,12 @@ import {
 } from '@lexical/link'
 import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext'
 import { Link16 } from '@toptal/picasso'
-import { $createTextNode, $getSelection, $isRangeSelection } from 'lexical'
+import {
+  $createTextNode,
+  $getSelection,
+  $isElementNode,
+  $isRangeSelection,
+} from 'lexical'
 import React, { useCallback, useState } from 'react'
 
 import { getSelectedNode } from '../../LexicalEditor/utils/getSelectedNode'
@@ -63,7 +68,9 @@ const LinkPluginButton = ({ 'data-testid': testId }: Props) => {
             linkNode.append(textNode)
             const node = getSelectedNode(selection)
 
-            node.append(linkNode)
+            const targetNode = $isElementNode(node) ? node : node.getParent()
+
+            targetNode?.append(linkNode)
             // If we have a selection of any kind, pass the creation of the Link node to the plugin
           } else {
             editor.dispatchCommand(TOGGLE_LINK_COMMAND, {


### PR DESCRIPTION
[FX-4180](https://toptal-core.atlassian.net/browse/FX-4180)

### Description

This PR makes it possible to insert a link while no text is selected. In this case, a link will be inserted as a new `LinkNode` with text content being the link itself.

### How to test

<!-- The temploy link will be automatically updated when the temploy is deployed -->
- [Temploy](https://picasso.toptal.net/fx-4180-rte-linkplugin-wraps-whole-line-when-nothing-selected)
- Check out the `Links` story for `RichTextEditor`
- Try to insert the link with nothing selected
- Try different combinations of inserting (next to other nodes, next to lists, inside/outside other formats)
- Compare to the traditional way of inserting links. There should be no difference in the output


### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-4180]: https://toptal-core.atlassian.net/browse/FX-4180?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ