### PR TITLE
feat: create base for CodeBlockPlugin

### DIFF
--- a/.changeset/serious-poets-argue.md
+++ b/.changeset/serious-poets-argue.md
@@ -1,0 +1,6 @@
+---
+'@toptal/picasso-rich-text-editor': major
+---
+
+- add support for the code block
+- the only breaking change is the need of updating Picasso to ^37.3.0

--- a/.changeset/silent-carpets-move.md
+++ b/.changeset/silent-carpets-move.md
@@ -1,0 +1,5 @@
+---
+'@toptal/picasso-forms': patch
+---
+
+- update boundary of rich text editor peer dependency

--- a/packages/picasso-forms/package.json
+++ b/packages/picasso-forms/package.json
@@ -25,7 +25,7 @@
   "peerDependencies": {
     "@toptal/picasso": "^37.0.0",
     "@toptal/picasso-shared": "^12.0.0",
-    "@toptal/picasso-rich-text-editor": "^4.0.0",
+    "@toptal/picasso-rich-text-editor": "4 | 5",
     "react": ">=16.12.0 < 19.0.0",
     "react-dom": ">=16.12.0 < 19.0.0",
     "typescript": "~4.7.0"

--- a/packages/picasso-rich-text-editor/package.json
+++ b/packages/picasso-rich-text-editor/package.json
@@ -23,7 +23,7 @@
     "url": "https://github.com/toptal/picasso/issues"
   },
   "peerDependencies": {
-    "@toptal/picasso": "^37.1.0",
+    "@toptal/picasso": "^37.3.0",
     "@toptal/picasso-shared": "^12.0.0",
     "@material-ui/core": "4.12.4",
     "@lexical/utils": "0.11.2",

--- a/packages/picasso-rich-text-editor/src/LexicalEditor/styles.ts
+++ b/packages/picasso-rich-text-editor/src/LexicalEditor/styles.ts
@@ -3,7 +3,7 @@ import type { Theme } from '@material-ui/core/styles'
 import type { CSSProperties } from '@material-ui/core/styles/withStyles'
 import { rem } from '@toptal/picasso-shared'
 
-import { codeStyles } from '../RichText/components/styles'
+import { codeBlockStyles, codeStyles } from '../RichText/components/styles'
 
 const margins = {
   '& p': {
@@ -165,5 +165,12 @@ export default (theme: Theme) => {
       },
     },
     code: codeStyles(theme),
+    codeBlock: codeBlockStyles(theme),
+    codeBlockText: {
+      fontFamily: 'inherit',
+      fontSize: 'inherit',
+      lineHeight: 'inherit',
+      color: 'inherit',
+    },
   })
 }

--- a/packages/picasso-rich-text-editor/src/LexicalEditor/utils/createLexicalTheme.ts
+++ b/packages/picasso-rich-text-editor/src/LexicalEditor/utils/createLexicalTheme.ts
@@ -36,6 +36,8 @@ export const createLexicalTheme = ({
       ol: classes.ol,
     },
     customEmoji: classes.customEmoji,
+    codeBlock: classes.codeBlock,
+    codeBlockText: classes.codeBlockText,
   }
 
   return theme

--- a/packages/picasso-rich-text-editor/src/RichText/components/CodeBlock.tsx
+++ b/packages/picasso-rich-text-editor/src/RichText/components/CodeBlock.tsx
@@ -1,0 +1,20 @@
+import type { ReactNode } from 'react'
+import type { Theme } from '@material-ui/core/styles'
+import React from 'react'
+import { makeStyles } from '@material-ui/core/styles'
+
+import styles from './styles'
+
+type Props = {
+  children?: ReactNode
+}
+
+const useStyles = makeStyles<Theme>(styles, { name: 'PicassoCode' })
+
+const CodeBlockComponent = ({ children }: Props) => {
+  const classes = useStyles()
+
+  return <pre className={classes.codeBlock}>{children}</pre>
+}
+
+export default CodeBlockComponent

--- a/packages/picasso-rich-text-editor/src/RichText/components/index.ts
+++ b/packages/picasso-rich-text-editor/src/RichText/components/index.ts
@@ -1,2 +1,4 @@
 export { default as Emoji } from './Emoji'
 export { default as Image } from './Image'
+export { default as CodeBlock } from './CodeBlock'
+export { default as Code } from './Code'

--- a/packages/picasso-rich-text-editor/src/RichText/components/styles.ts
+++ b/packages/picasso-rich-text-editor/src/RichText/components/styles.ts
@@ -1,5 +1,6 @@
 import type { Theme } from '@material-ui/core/styles'
 import { createStyles } from '@material-ui/core/styles'
+import { rem } from '@toptal/picasso-shared/styles'
 
 export const codeStyles = ({ palette, typography }: Theme) => ({
   color: palette.red.main,
@@ -11,7 +12,19 @@ export const codeStyles = ({ palette, typography }: Theme) => ({
   fontFamily: 'monospace',
 })
 
+export const codeBlockStyles = ({ palette, sizes, typography }: Theme) => ({
+  backgroundColor: palette.grey.lighter,
+  borderRadius: sizes.borderRadius.small,
+  padding: '0.25rem 0.5rem',
+  display: 'block',
+  fontFamily: 'monospace',
+  fontSize: typography.fontSizes.xxsmall,
+  lineHeight: rem('18px'),
+  color: palette.common.black,
+})
+
 export default (theme: Theme) =>
   createStyles({
     code: codeStyles(theme),
+    codeBlock: codeBlockStyles(theme),
   })

--- a/packages/picasso-rich-text-editor/src/RichText/components/styles.ts
+++ b/packages/picasso-rich-text-editor/src/RichText/components/styles.ts
@@ -1,6 +1,6 @@
 import type { Theme } from '@material-ui/core/styles'
 import { createStyles } from '@material-ui/core/styles'
-import { rem } from '@toptal/picasso-shared/styles'
+import { rem } from '@toptal/picasso-shared'
 
 export const codeStyles = ({ palette, typography }: Theme) => ({
   color: palette.red.main,

--- a/packages/picasso-rich-text-editor/src/RichText/hooks/useRichText/useRichText.tsx
+++ b/packages/picasso-rich-text-editor/src/RichText/hooks/useRichText/useRichText.tsx
@@ -8,9 +8,8 @@ import ListItem from '@toptal/picasso/ListItem'
 import Link from '@toptal/picasso/Link'
 
 import type { ASTType } from '../../types'
-import { Emoji, Image } from '../../components'
+import { Emoji, Image, Code, CodeBlock } from '../../components'
 import { isCustomEmoji } from '../../../utils'
-import Code from '../../components/Code'
 
 type Props = {
   children?: React.ReactNode
@@ -59,6 +58,7 @@ const componentMap: Record<string, FC> = {
   a: A,
   img: Img,
   code: Code,
+  pre: CodeBlock,
 } as const
 
 const picassoMapper = (child: ReactNode): ReactNode => {

--- a/packages/picasso-rich-text-editor/src/RichText/story/Default.example.tsx
+++ b/packages/picasso-rich-text-editor/src/RichText/story/Default.example.tsx
@@ -42,6 +42,7 @@ const ast: ASTType = {
           tagName: 'img',
           properties: {
             src: './jacqueline/128x88.jpg',
+            alt: 'Jacqueline',
           },
           children: [],
         },
@@ -115,6 +116,18 @@ const ast: ASTType = {
           properties: {},
           children: [{ type: 'text', value: 'code()' }],
         },
+      ],
+    },
+    {
+      type: 'element',
+      tagName: 'pre',
+      properties: {},
+      children: [
+        { type: 'text', value: '<CodeBlock' },
+        { type: 'element', tagName: 'br', properties: {}, children: [] },
+        { type: 'text', value: '  {...props}' },
+        { type: 'element', tagName: 'br', properties: {}, children: [] },
+        { type: 'text', value: '/>' },
       ],
     },
     {

--- a/packages/picasso-rich-text-editor/src/RichText/story/HTML.example.tsx
+++ b/packages/picasso-rich-text-editor/src/RichText/story/HTML.example.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import React, { useState } from 'react'
 import { Grid, Container } from '@toptal/picasso'
 import {
   ImagePlugin,
@@ -16,10 +16,6 @@ import type { ASTType } from '../types'
 
 const Example = () => {
   const [html, setHtml] = useState('')
-
-  useEffect(() => {
-    console.log(htmlToHast(html))
-  }, [html])
 
   return (
     <Container style={{ minHeight: '800px' }}>

--- a/packages/picasso-rich-text-editor/src/RichText/story/HTML.example.tsx
+++ b/packages/picasso-rich-text-editor/src/RichText/story/HTML.example.tsx
@@ -1,7 +1,8 @@
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import { Grid, Container } from '@toptal/picasso'
 import {
   ImagePlugin,
+  CodeBlockPlugin,
   RichText,
   RichTextEditor,
   LinkPlugin,
@@ -16,6 +17,10 @@ import type { ASTType } from '../types'
 const Example = () => {
   const [html, setHtml] = useState('')
 
+  useEffect(() => {
+    console.log(htmlToHast(html))
+  }, [html])
+
   return (
     <Container style={{ minHeight: '800px' }}>
       <Grid>
@@ -27,12 +32,13 @@ const Example = () => {
             plugins={[
               <LinkPlugin />,
               <EmojiPlugin customEmojis={customEmojis} />,
-              <CodePlugin />,
               <ImagePlugin
                 onUpload={() =>
                   new Promise(resolve => setTimeout(resolve, 2000))
                 }
               />,
+              <CodePlugin />,
+              <CodeBlockPlugin />,
             ]}
           />
         </Grid.Item>
@@ -156,6 +162,18 @@ const defaultValue: ASTType = {
           properties: {},
           children: [{ type: 'text', value: 'code()' }],
         },
+      ],
+    },
+    {
+      type: 'element',
+      tagName: 'pre',
+      properties: {},
+      children: [
+        { type: 'text', value: '<CodeBlock' },
+        { type: 'element', tagName: 'br', properties: {}, children: [] },
+        { type: 'text', value: '  {...props}' },
+        { type: 'element', tagName: 'br', properties: {}, children: [] },
+        { type: 'text', value: '/>' },
       ],
     },
     {

--- a/packages/picasso-rich-text-editor/src/RichText/types.ts
+++ b/packages/picasso-rich-text-editor/src/RichText/types.ts
@@ -17,6 +17,7 @@ export type ElementType = {
     | 'a'
     | 'img'
     | 'code'
+    | 'pre'
   properties: {}
   children: ASTChildType[]
 }

--- a/packages/picasso-rich-text-editor/src/RichTextEditor/story/Code.example.tsx
+++ b/packages/picasso-rich-text-editor/src/RichTextEditor/story/Code.example.tsx
@@ -1,6 +1,10 @@
 import React, { useState } from 'react'
 import { Container } from '@toptal/picasso'
-import { CodePlugin, RichTextEditor } from '@toptal/picasso-rich-text-editor'
+import {
+  CodeBlockPlugin,
+  CodePlugin,
+  RichTextEditor,
+} from '@toptal/picasso-rich-text-editor'
 
 import type { RichTextEditorChangeHandler } from '../types'
 
@@ -16,7 +20,7 @@ const Example = () => {
         id='editor'
         onChange={handleChange}
         placeholder='Write some cool rich text'
-        plugins={[<CodePlugin />]}
+        plugins={[<CodePlugin />, <CodeBlockPlugin />]}
       />
       <Container
         padded='small'

--- a/packages/picasso-rich-text-editor/src/RichTextEditor/story/Default.example.tsx
+++ b/packages/picasso-rich-text-editor/src/RichTextEditor/story/Default.example.tsx
@@ -1,6 +1,9 @@
 import React, { useState } from 'react'
 import { Container } from '@toptal/picasso'
-import { RichTextEditor } from '@toptal/picasso-rich-text-editor'
+import {
+  CodeBlockPlugin,
+  RichTextEditor,
+} from '@toptal/picasso-rich-text-editor'
 
 import type { RichTextEditorChangeHandler } from '../types'
 
@@ -16,6 +19,7 @@ const Example = () => {
         id='editor'
         onChange={handleChange}
         placeholder='Write some cool rich text'
+        plugins={[<CodeBlockPlugin />]}
       />
       <Container
         padded='small'

--- a/packages/picasso-rich-text-editor/src/RichTextEditor/story/index.jsx
+++ b/packages/picasso-rich-text-editor/src/RichTextEditor/story/index.jsx
@@ -38,4 +38,4 @@ page
     takeScreenshot: false,
   })
   .addExample('RichTextEditor/story/ImageUpload.example.tsx', 'Image upload')
-  .addExample('RichTextEditor/story/Code.example.tsx', 'Inline code')
+  .addExample('RichTextEditor/story/Code.example.tsx', 'Code')

--- a/packages/picasso-rich-text-editor/src/index.ts
+++ b/packages/picasso-rich-text-editor/src/index.ts
@@ -5,5 +5,11 @@ export type {
 } from './RichTextEditor'
 export { default as RichText } from './RichText'
 export type { RichTextProps, ASTType } from './RichText'
-export { ImagePlugin, EmojiPlugin, LinkPlugin, CodePlugin } from './plugins'
+export {
+  ImagePlugin,
+  EmojiPlugin,
+  LinkPlugin,
+  CodePlugin,
+  CodeBlockPlugin,
+} from './plugins'
 export type { UploadedImage, CustomEmoji, CustomEmojiGroup } from './plugins'

--- a/packages/picasso-rich-text-editor/src/plugins/CodeBlockPlugin/CodeBlockButton.tsx
+++ b/packages/picasso-rich-text-editor/src/plugins/CodeBlockPlugin/CodeBlockButton.tsx
@@ -1,0 +1,27 @@
+import { CodeBlock16 } from '@toptal/picasso'
+import React from 'react'
+
+import { useRTEPluginContext } from '../api'
+import RichTextEditorButton from '../../RichTextEditorButton'
+
+export type Props = {
+  'data-testid'?: string
+}
+
+const CodeBlockButton = ({ 'data-testid': testId }: Props) => {
+  const { disabled, focused } = useRTEPluginContext()
+
+  const handleClick = () => {}
+
+  return (
+    <RichTextEditorButton
+      icon={<CodeBlock16 />}
+      onClick={handleClick}
+      active={false}
+      disabled={disabled || !focused}
+      data-testid={testId}
+    />
+  )
+}
+
+export default CodeBlockButton

--- a/packages/picasso-rich-text-editor/src/plugins/CodeBlockPlugin/CodeBlockPlugin.tsx
+++ b/packages/picasso-rich-text-editor/src/plugins/CodeBlockPlugin/CodeBlockPlugin.tsx
@@ -1,0 +1,32 @@
+import React from 'react'
+
+import type { RTEPlugin } from '../api'
+import { RTEPluginMeta, Toolbar } from '../api'
+import CodeBlockButton from './CodeBlockButton'
+
+const PLUGIN_NAME = 'code-block'
+
+export type Props = {
+  testIds?: {
+    button?: string
+  }
+}
+
+const CodeBlockPlugin: RTEPlugin<Props> = ({ testIds = {} }: Props) => {
+  return (
+    <>
+      <Toolbar keyName={PLUGIN_NAME}>
+        <CodeBlockButton data-testid={testIds.button} />
+      </Toolbar>
+    </>
+  )
+}
+
+CodeBlockPlugin[RTEPluginMeta] = {
+  name: PLUGIN_NAME,
+  lexical: {
+    nodes: [],
+  },
+}
+
+export default CodeBlockPlugin

--- a/packages/picasso-rich-text-editor/src/plugins/CodeBlockPlugin/index.ts
+++ b/packages/picasso-rich-text-editor/src/plugins/CodeBlockPlugin/index.ts
@@ -1,0 +1,1 @@
+export { default, Props } from './CodeBlockPlugin'

--- a/packages/picasso-rich-text-editor/src/plugins/index.ts
+++ b/packages/picasso-rich-text-editor/src/plugins/index.ts
@@ -9,4 +9,5 @@ export { default as TriggerInitialOnChangePlugin } from './TriggerInitialOnChang
 export { default as FocusOnLabelClickPlugin } from './FocusOnLabelClickPlugin'
 export { default as CodePlugin } from './CodePlugin'
 export { default as ImagePlugin } from './ImagePlugin'
+export { default as CodeBlockPlugin } from './CodeBlockPlugin'
 export type { UploadedImage } from './ImagePlugin'

--- a/packages/picasso-rich-text-editor/src/utils/html-to-hast.ts
+++ b/packages/picasso-rich-text-editor/src/utils/html-to-hast.ts
@@ -13,7 +13,7 @@ export const hastSanitizeSchema: Schema = {
   attributes: {
     a: ['href'],
     img: ['src', 'data*', 'class'],
-    pre: ['data*', 'spellcheck'],
+    pre: ['data*'],
     '*': [],
   },
   tagNames: [

--- a/packages/picasso-rich-text-editor/src/utils/html-to-hast.ts
+++ b/packages/picasso-rich-text-editor/src/utils/html-to-hast.ts
@@ -13,6 +13,7 @@ export const hastSanitizeSchema: Schema = {
   attributes: {
     a: ['href'],
     img: ['src', 'data*', 'class'],
+    pre: ['data*', 'spellcheck'],
     '*': [],
   },
   tagNames: [
@@ -27,6 +28,7 @@ export const hastSanitizeSchema: Schema = {
     'a',
     'img',
     'code',
+    'pre',
   ],
   strip: ['script'],
 }


### PR DESCRIPTION
[FX-4184]

### Description

This PR brings the default structure for the `CodeBlockPlugin`
- stories
- toolbar button
- RichText component
- styles
- types

The logic will be in different PR

### How to test

<!-- The temploy link will be automatically updated when the temploy is deployed -->
- [Temploy](https://picasso.toptal.net/fx-4184-rte-code-block)
- check the code and [the story](https://picasso.toptal.net/fx-4184-rte-code-block/?path=/story/forms-richtexteditor--richtexteditor#code)

### Screenshots

![image](https://github.com/toptal/picasso/assets/6830426/16f2839a-8646-43fb-a4c5-d050220ead37)

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests

**Breaking change**

- codemod is created and showcased in the changeset
- test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-4184]: https://toptal-core.atlassian.net/browse/FX-4184?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ