### PR TITLE
docs: summarize defaultValue for filterOptions in a sentence

### DIFF
--- a/packages/picasso/src/Select/story/index.jsx
+++ b/packages/picasso/src/Select/story/index.jsx
@@ -42,9 +42,7 @@ or\n
       },
     },
     filterOptions: {
-      defaultValue: `(options: Option[], searchValue: string) =>
-        options.filter(option => option.text.toLowerCase().includes(searchValue.trim().toLowerCase())))
-      `,
+      defaultValue: 'optionIncludesSearchCaseInsensitive',
     },
   },
 })


### PR DESCRIPTION
[FX-4207]

### Description

Instead of using the function contents as the defaultValue, I tried to summarize its definition on a proper function name.

### How to test

<!-- The temploy link will be automatically updated when the temploy is deployed -->
- [Temploy](https://picasso.toptal.net/fx-4207-select-props-are-displayed-incorrectly)
- Check https://picasso.toptal.net/?path=/story/forms-select--select on temploy, on small screens it should not mess up the width of the props table.

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| ![image](https://github.com/toptal/picasso/assets/5845160/74db4f29-4309-4c1b-8184-97f90e0c64a6) | ![image](https://github.com/toptal/picasso/assets/5845160/9cb6a095-c2f9-4978-8b6c-7c91b38d6f04) |

### Development checks

- [NA] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [NA] Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [NA] Annotate all `props` in component with documentation
- [NA] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [NA] Covered with tests

**Breaking change**

- [NA] codemod is created and showcased in the changeset
- [NA] test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-4207]: https://toptal-core.atlassian.net/browse/FX-4207?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ