### PR TITLE
test: modal and date picker

### DIFF
--- a/cypress/component/DatePicker.spec.tsx
+++ b/cypress/component/DatePicker.spec.tsx
@@ -6,9 +6,9 @@ import {
   Typography,
   Button,
 } from '@toptal/picasso'
-import React, { useState } from 'react'
+import { PicassoBreakpoints } from '@toptal/picasso-provider/index'
 import { HAPPO_TARGETS } from '@toptal/picasso/test-utils'
-import { PicassoBreakpoints } from '@toptal/picasso-provider'
+import React, { useState } from 'react'
 
 const TestDatePicker = (props: Partial<DatePickerProps>) => {
   const [value, setValue] = useState<DatePickerProps['value']>(

--- a/cypress/component/DatePicker.spec.tsx
+++ b/cypress/component/DatePicker.spec.tsx
@@ -7,6 +7,8 @@ import {
   Button,
 } from '@toptal/picasso'
 import React, { useState } from 'react'
+import { HAPPO_TARGETS } from '@toptal/picasso/test-utils'
+import { PicassoBreakpoints } from '@toptal/picasso-provider'
 
 const TestDatePicker = (props: Partial<DatePickerProps>) => {
   const [value, setValue] = useState<DatePickerProps['value']>(
@@ -167,5 +169,41 @@ describe('DatePicker', () => {
     cy.getByTestId('reset-button').click()
 
     cy.getByTestId('date-picker-input').should('have.value', '')
+  })
+
+  describe('when number of displayed months is more than one', () => {
+    Cypress._.each(HAPPO_TARGETS, happoTarget => {
+      const { width } = happoTarget
+
+      describe(`when screen has ${width}px width`, () => {
+        const isNarrowScreen = width < PicassoBreakpoints.breakpoints.values.md
+
+        it(
+          isNarrowScreen ? 'displays one month' : 'displays two months',
+          () => {
+            cy.viewport(width, 1000)
+
+            cy.mount(
+              <TestDatePicker
+                numberOfMonths={2}
+                testIds={{
+                  input: 'date-picker-input',
+                  calendar: 'date-picker-calendar',
+                }}
+              />
+            )
+
+            cy.getByTestId('date-picker-input').focus()
+            cy.get('.rdp-month').should('have.length', isNarrowScreen ? 1 : 2)
+
+            cy.get('body').happoScreenshot({
+              component,
+              variant: `date-picker/${width}-default`,
+              targets: [happoTarget],
+            })
+          }
+        )
+      })
+    })
   })
 })

--- a/cypress/component/Dropdown.spec.tsx
+++ b/cypress/component/Dropdown.spec.tsx
@@ -140,6 +140,7 @@ describe('Dropdown', () => {
             targets: [
               {
                 ...happoTarget,
+                name: `chrome-desktop-${width}x${height}`,
                 viewport: `${happoTarget.width}x${height}`,
               },
             ],

--- a/cypress/component/Modal.spec.tsx
+++ b/cypress/component/Modal.spec.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect } from 'react'
 import type { ModalProps } from '@toptal/picasso'
 import { Modal, Form, Input, Select, Checkbox, Button } from '@toptal/picasso'
+import { HAPPO_TARGETS } from '@toptal/picasso/test-utils'
 
 const TestModalForm = (props: Partial<Omit<ModalProps, 'open'>>) => {
   const [isOpen, setOpen] = React.useState(false)
@@ -209,6 +210,28 @@ describe('Modal', () => {
     cy.get('body').happoScreenshot({
       component,
       variant: 'overflown',
+    })
+  })
+
+  Cypress._.each(HAPPO_TARGETS, happoTarget => {
+    const { width } = happoTarget
+
+    describe(`when screen has ${width}px width`, () => {
+      Cypress._.each(['small', 'medium', 'large', 'full-screen'], modalSize => {
+        it(`renders ${modalSize} size modal`, () => {
+          cy.viewport(width, 1000)
+
+          cy.mount(
+            <TestModalOverflown size={modalSize as ModalProps['size']} />
+          )
+
+          cy.get('body').happoScreenshot({
+            component,
+            variant: `modal-${modalSize}-size/${width}-default`,
+            targets: [happoTarget],
+          })
+        })
+      })
     })
   })
 })

--- a/cypress/component/Select.spec.tsx
+++ b/cypress/component/Select.spec.tsx
@@ -420,6 +420,7 @@ describe('Select', () => {
             targets: [
               {
                 ...happoTarget,
+                name: `chrome-desktop-${width}x${height}`,
                 viewport: `${happoTarget.width}x${height}`,
               },
             ],

--- a/packages/picasso/src/test-utils/get-happo-targets/get-checkpoints.test.ts
+++ b/packages/picasso/src/test-utils/get-happo-targets/get-checkpoints.test.ts
@@ -1,0 +1,19 @@
+import { getCheckpoints } from './get-checkpoints'
+
+jest.mock('@toptal/picasso-provider', () => ({
+  PicassoBreakpoints: {
+    breakpoints: {
+      values: {
+        first: 0,
+        second: 100,
+        third: 200,
+      },
+    },
+  },
+}))
+
+describe('getCheckpoints', () => {
+  it('returns correct checkpoints (skips first breakpoint and generates two checkpoints for the last breakpoint)', () => {
+    expect(getCheckpoints()).toEqual([99, 199, 201])
+  })
+})

--- a/packages/picasso/src/test-utils/get-happo-targets/get-happo-targets.test.ts
+++ b/packages/picasso/src/test-utils/get-happo-targets/get-happo-targets.test.ts
@@ -1,0 +1,14 @@
+import { getHappoTargets } from './get-happo-targets'
+
+describe('getHappoTargets', () => {
+  it('returns correct Happo responsive testing targets', () => {
+    expect(getHappoTargets([1000])).toEqual([
+      {
+        browser: 'chrome',
+        name: 'chrome-desktop-width-1000',
+        viewport: '1000x1024',
+        width: 1000,
+      },
+    ])
+  })
+})


### PR DESCRIPTION
[FX-4198]

### 🔗  Fellow pull request https://github.com/toptal/picasso/pull/3756

### Description

This pull request adds visual tests for
- `DatePicker` `numberOfMonths` property (as it is behaviour is influenced by screen width)
- `Modal` behaviour on all screens

### How to test

<!-- The temploy link will be automatically updated when the temploy is deployed -->
- [Temploy](https://picasso.toptal.net/fx-4198-add-all-breakpoints-as-targets-in-cypress-tests)
- All checks should pass, the images should be generated

### Development checks

- [N/A] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [N/A] Annotate all `props` in component with documentation
- [N/A] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [N/A] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests
- [x] Merge https://github.com/toptal/picasso/pull/3756 first

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-4198]: https://toptal-core.atlassian.net/browse/FX-4198?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ