### PR TITLE
feat: add CodeBlockNode

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,0 +1,2 @@
+global.TextEncoder = require('util').TextEncoder;
+global.TextDecoder = require('util').TextDecoder;

--- a/jest.spec.mjs
+++ b/jest.spec.mjs
@@ -17,7 +17,7 @@ const config = {
       '<rootDir>/packages/picasso-rich-text-editor/src/index.ts',
     '^@toptal/picasso-root/(.*)$': '<rootDir>/$1',
   },
-  setupFiles: ['jest-canvas-mock'],
+  setupFiles: ['jest-canvas-mock', './jest.setup.js'],
   transformIgnorePatterns: [
     'node_modules/(?!@toptal|@topkit|d3|internmap|robust-predicates|delaunator)',
   ],

--- a/packages/picasso-rich-text-editor/src/LexicalEditor/utils/hasChildDOMNodeTag.test.ts
+++ b/packages/picasso-rich-text-editor/src/LexicalEditor/utils/hasChildDOMNodeTag.test.ts
@@ -9,7 +9,7 @@ describe('hasChildDOMNodeTag', () => {
 
   // Test to check if function works with an empty node
   describe('when node has no children', () => {
-    it('should return false', () => {
+    it('returns false', () => {
       const node = document.createElement('div')
 
       expect(hasChildDOMNodeTag(node, 'SPAN')).toBe(false)
@@ -18,7 +18,7 @@ describe('hasChildDOMNodeTag', () => {
 
   // Test to check if function works with a node that does not have a specific child tag
   describe('when node does not have child with specific tag', () => {
-    it('should return false', () => {
+    it('returns false', () => {
       const node = document.createElement('div')
       const child = document.createElement('p')
 
@@ -30,7 +30,7 @@ describe('hasChildDOMNodeTag', () => {
 
   // Test to check if function works with a node that has a specific child tag
   describe('when node has a child with the specific tag', () => {
-    it('should return true', () => {
+    it('returns true', () => {
       const node = document.createElement('div')
       const child = document.createElement('span')
 
@@ -42,7 +42,7 @@ describe('hasChildDOMNodeTag', () => {
 
   // Test to check if function works with a only direct child
   describe('when node has a nested child with the specific tag', () => {
-    it('should return false', () => {
+    it('returns false', () => {
       const node = document.createElement('div')
       const child = document.createElement('p')
       const nestedChild = document.createElement('span')

--- a/packages/picasso-rich-text-editor/src/LexicalEditor/utils/hasChildDOMNodeTag.test.ts
+++ b/packages/picasso-rich-text-editor/src/LexicalEditor/utils/hasChildDOMNodeTag.test.ts
@@ -1,0 +1,56 @@
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { JSDOM } from 'jsdom'
+
+import hasChildDOMNodeTag from './hasChildDOMNodeTag'
+
+describe('hasChildDOMNodeTag', () => {
+  // Set up a JSDOM document and window objects
+  const { document } = new JSDOM('').window
+
+  // Test to check if function works with an empty node
+  describe('when node has no children', () => {
+    it('should return false', () => {
+      const node = document.createElement('div')
+
+      expect(hasChildDOMNodeTag(node, 'SPAN')).toBe(false)
+    })
+  })
+
+  // Test to check if function works with a node that does not have a specific child tag
+  describe('when node does not have child with specific tag', () => {
+    it('should return false', () => {
+      const node = document.createElement('div')
+      const child = document.createElement('p')
+
+      node.appendChild(child)
+
+      expect(hasChildDOMNodeTag(node, 'SPAN')).toBe(false)
+    })
+  })
+
+  // Test to check if function works with a node that has a specific child tag
+  describe('when node has a child with the specific tag', () => {
+    it('should return true', () => {
+      const node = document.createElement('div')
+      const child = document.createElement('span')
+
+      node.appendChild(child)
+
+      expect(hasChildDOMNodeTag(node, 'SPAN')).toBe(true)
+    })
+  })
+
+  // Test to check if function works with a only direct child
+  describe('when node has a nested child with the specific tag', () => {
+    it('should return false', () => {
+      const node = document.createElement('div')
+      const child = document.createElement('p')
+      const nestedChild = document.createElement('span')
+
+      child.appendChild(nestedChild)
+      node.appendChild(child)
+
+      expect(hasChildDOMNodeTag(node, 'SPAN')).toBe(false)
+    })
+  })
+})

--- a/packages/picasso-rich-text-editor/src/LexicalEditor/utils/hasChildDOMNodeTag.test.ts
+++ b/packages/picasso-rich-text-editor/src/LexicalEditor/utils/hasChildDOMNodeTag.test.ts
@@ -4,10 +4,8 @@ import { JSDOM } from 'jsdom'
 import hasChildDOMNodeTag from './hasChildDOMNodeTag'
 
 describe('hasChildDOMNodeTag', () => {
-  // Set up a JSDOM document and window objects
   const { document } = new JSDOM('').window
 
-  // Test to check if function works with an empty node
   describe('when node has no children', () => {
     it('returns false', () => {
       const node = document.createElement('div')
@@ -16,7 +14,6 @@ describe('hasChildDOMNodeTag', () => {
     })
   })
 
-  // Test to check if function works with a node that does not have a specific child tag
   describe('when node does not have child with specific tag', () => {
     it('returns false', () => {
       const node = document.createElement('div')
@@ -28,7 +25,6 @@ describe('hasChildDOMNodeTag', () => {
     })
   })
 
-  // Test to check if function works with a node that has a specific child tag
   describe('when node has a child with the specific tag', () => {
     it('returns true', () => {
       const node = document.createElement('div')
@@ -40,7 +36,6 @@ describe('hasChildDOMNodeTag', () => {
     })
   })
 
-  // Test to check if function works with a only direct child
   describe('when node has a nested child with the specific tag', () => {
     it('returns false', () => {
       const node = document.createElement('div')

--- a/packages/picasso-rich-text-editor/src/LexicalEditor/utils/hasChildDOMNodeTag.ts
+++ b/packages/picasso-rich-text-editor/src/LexicalEditor/utils/hasChildDOMNodeTag.ts
@@ -1,0 +1,15 @@
+import { isHTMLElement } from '@lexical/utils'
+
+const hasChildDOMNodeTag = (node: Node, tagName: string) => {
+  for (const child of Array.from(node.childNodes)) {
+    if (isHTMLElement(child) && child.tagName === tagName) {
+      return true
+    }
+
+    hasChildDOMNodeTag(child, tagName)
+  }
+
+  return false
+}
+
+export default hasChildDOMNodeTag

--- a/packages/picasso-rich-text-editor/src/plugins/CodeBlockPlugin/nodes/CodeBlockNode.tsx
+++ b/packages/picasso-rich-text-editor/src/plugins/CodeBlockPlugin/nodes/CodeBlockNode.tsx
@@ -15,7 +15,6 @@ import {
   $createParagraphNode,
   ElementNode,
 } from 'lexical'
-import { isHTMLElement } from '@lexical/utils'
 
 import type { CodeBlockTextNode } from '../nodes'
 import {
@@ -23,6 +22,7 @@ import {
   $createCodeBlockTextNode,
   $isCodeBlockTextNode,
 } from '../nodes'
+import hasChildDOMNodeTag from '../../../LexicalEditor/utils/hasChildDOMNodeTag'
 
 const getFirstCodeNodeOfLine = (
   anchor: CodeBlockTextNode | LineBreakNode
@@ -36,17 +36,6 @@ const getFirstCodeNodeOfLine = (
   }
 
   return previousNode
-}
-
-const hasChildDOMNodeTag = (node: Node, tagName: string) => {
-  for (const child of Array.from(node.childNodes)) {
-    if (isHTMLElement(child) && child.tagName === tagName) {
-      return true
-    }
-    hasChildDOMNodeTag(child, tagName)
-  }
-
-  return false
 }
 
 const convertPreElement = (): DOMConversionOutput => {

--- a/packages/picasso-rich-text-editor/src/plugins/CodeBlockPlugin/nodes/CodeBlockNode.tsx
+++ b/packages/picasso-rich-text-editor/src/plugins/CodeBlockPlugin/nodes/CodeBlockNode.tsx
@@ -1,0 +1,222 @@
+import type {
+  DOMConversionMap,
+  DOMConversionOutput,
+  DOMExportOutput,
+  EditorConfig,
+  LexicalNode,
+  LineBreakNode,
+  NodeKey,
+  ParagraphNode,
+  RangeSelection,
+  SerializedElementNode,
+} from 'lexical'
+import {
+  $createLineBreakNode,
+  $createParagraphNode,
+  ElementNode,
+} from 'lexical'
+import { isHTMLElement } from '@lexical/utils'
+
+import type { CodeBlockTextNode } from '../nodes'
+import {
+  $createCodeBlockNode,
+  $createCodeBlockTextNode,
+  $isCodeBlockTextNode,
+} from '../nodes'
+
+const getFirstCodeNodeOfLine = (
+  anchor: CodeBlockTextNode | LineBreakNode
+): null | CodeBlockTextNode | LineBreakNode => {
+  let previousNode = anchor
+  let node: null | LexicalNode = anchor
+
+  while ($isCodeBlockTextNode(node)) {
+    previousNode = node
+    node = node.getPreviousSibling()
+  }
+
+  return previousNode
+}
+
+const hasChildDOMNodeTag = (node: Node, tagName: string) => {
+  for (const child of Array.from(node.childNodes)) {
+    if (isHTMLElement(child) && child.tagName === tagName) {
+      return true
+    }
+    hasChildDOMNodeTag(child, tagName)
+  }
+
+  return false
+}
+
+const convertPreElement = (): DOMConversionOutput => {
+  return { node: $createCodeBlockNode() }
+}
+
+const ELEMENT_TYPE = 'code-block'
+
+export class CodeBlockNode extends ElementNode {
+  static getType() {
+    return ELEMENT_TYPE
+  }
+
+  static clone(node: CodeBlockNode) {
+    return new CodeBlockNode(node.__key)
+  }
+
+  constructor(key?: NodeKey) {
+    super(key)
+  }
+
+  createDOM(config: EditorConfig): HTMLElement {
+    const element = document.createElement('code')
+    const theme = config.theme
+    const className = theme.codeBlock
+
+    if (className !== undefined) {
+      element.className = className
+    }
+
+    return element
+  }
+
+  updateDOM() {
+    return false
+  }
+
+  exportDOM(): DOMExportOutput {
+    const element = document.createElement('pre')
+
+    return { element }
+  }
+
+  static importDOM(): DOMConversionMap | null {
+    return {
+      // Typically <pre> is used for code blocks, and <code> for inline code styles
+      // but if it's a multi line <code> we'll create a block. Pass through to
+      // inline format handled by TextNode otherwise.
+      code: (node: Node) => {
+        const isMultiLine =
+          node.textContent != null &&
+          (/\r?\n/.test(node.textContent) || hasChildDOMNodeTag(node, 'BR'))
+
+        return isMultiLine
+          ? {
+              conversion: convertPreElement,
+              priority: 1,
+            }
+          : null
+      },
+      pre: () => ({
+        conversion: convertPreElement,
+        priority: 0,
+      }),
+    }
+  }
+
+  static importJSON(serializedNode: SerializedElementNode): CodeBlockNode {
+    const node = $createCodeBlockNode()
+
+    node.setFormat(serializedNode.format)
+    node.setIndent(serializedNode.indent)
+    node.setDirection(serializedNode.direction)
+
+    return node
+  }
+
+  exportJSON(): SerializedElementNode {
+    return {
+      ...super.exportJSON(),
+      type: ELEMENT_TYPE,
+      version: 1,
+    }
+  }
+
+  canIndent() {
+    return false
+  }
+
+  // eslint-disable-next-line max-statements, complexity
+  insertNewAfter(
+    selection: RangeSelection,
+    restoreSelection = true
+  ): null | ParagraphNode | CodeBlockTextNode {
+    const children = this.getChildren()
+    const childrenLength = children.length
+
+    if (
+      childrenLength >= 2 &&
+      children[childrenLength - 1].getTextContent() === '\n' &&
+      children[childrenLength - 2].getTextContent() === '\n' &&
+      selection.isCollapsed() &&
+      selection.anchor.key === this.__key &&
+      selection.anchor.offset === childrenLength
+    ) {
+      children[childrenLength - 1].remove()
+      children[childrenLength - 2].remove()
+      const newElement = $createParagraphNode()
+
+      this.insertAfter(newElement, restoreSelection)
+
+      return newElement
+    }
+
+    // If the selection is within the codeblock, find all leading tabs and
+    // spaces of the current line. Create a new line that has all those
+    // tabs and spaces, such that leading indentation is preserved.
+    const anchor = selection.anchor
+    const focus = selection.focus
+    const firstPoint = anchor.isBefore(focus) ? anchor : focus
+    const firstSelectionNode = firstPoint.getNode()
+
+    if ($isCodeBlockTextNode(firstSelectionNode)) {
+      let node = getFirstCodeNodeOfLine(firstSelectionNode)
+      const insertNodes = []
+
+      // eslint-disable-next-line no-constant-condition
+      while (true) {
+        if ($isCodeBlockTextNode(node)) {
+          const text = node.getTextContent()
+          const textSize = node.getTextContentSize()
+
+          // eslint-disable-next-line max-depth
+          for (
+            let spaces = 0;
+            spaces < textSize && text[spaces] === ' ';
+            spaces++
+          ) {
+            // eslint-disable-next-line max-depth
+            if (spaces !== 0) {
+              insertNodes.push($createCodeBlockTextNode(' '.repeat(spaces)))
+            }
+            // eslint-disable-next-line max-depth
+            if (spaces !== textSize) {
+              break
+            }
+          }
+          node = node.getNextSibling()
+        } else {
+          break
+        }
+      }
+
+      if (insertNodes.length > 0) {
+        selection.insertNodes([$createLineBreakNode(), ...insertNodes])
+
+        return insertNodes[insertNodes.length - 1]
+      }
+    }
+
+    return null
+  }
+
+  collapseAtStart(): boolean {
+    const paragraph = $createParagraphNode()
+    const children = this.getChildren()
+
+    children.forEach(child => paragraph.append(child))
+    this.replace(paragraph)
+
+    return true
+  }
+}

--- a/packages/picasso-rich-text-editor/src/plugins/CodeBlockPlugin/nodes/index.ts
+++ b/packages/picasso-rich-text-editor/src/plugins/CodeBlockPlugin/nodes/index.ts
@@ -1,0 +1,15 @@
+import type { LexicalNode } from 'lexical'
+import { $applyNodeReplacement } from 'lexical'
+
+import { CodeBlockNode } from './CodeBlockNode'
+
+export const $createCodeBlockNode = (): CodeBlockNode =>
+  $applyNodeReplacement(new CodeBlockNode())
+
+export const $isCodeBlockNode = (
+  node: LexicalNode | null | undefined
+): node is CodeBlockNode => {
+  return node instanceof CodeBlockNode
+}
+
+export { CodeBlockNode }


### PR DESCRIPTION
[FX-4184]

### Description

This PR brings `CodeBlockNode`, which is block level element.

```jsx
<CodeBlockNode>
  // text node will be in different PR
  <CodeBlockTextNode>any text</CodeBlockTextNode><LineBreakNode />
  <CodeBlockTextNode>  any other text and so on</CodeBlockTextNode>
</CodeBlockNode>
```


### How to test

- check the code

### Screenshots


### Development checks

- Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- Covered with tests

**Breaking change**

- codemod is created and showcased in the changeset
- test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-4184]: https://toptal-core.atlassian.net/browse/FX-4184?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ