### PR TITLE
feat: add CodeBlockTextNode

### DIFF
--- a/packages/picasso-rich-text-editor/src/plugins/CodeBlockPlugin/nodes/CodeBlockTextNode.tsx
+++ b/packages/picasso-rich-text-editor/src/plugins/CodeBlockPlugin/nodes/CodeBlockTextNode.tsx
@@ -1,0 +1,55 @@
+import type { SerializedTextNode, EditorConfig, NodeKey } from 'lexical'
+import { TextNode } from 'lexical'
+
+import { $createCodeBlockNode } from '../nodes'
+import type { CodeBlockNode } from '../nodes'
+
+const ELEMENT_TYPE = 'code-block-text'
+
+export class CodeBlockTextNode extends TextNode {
+  constructor(text: string, key?: NodeKey) {
+    super(text, key)
+  }
+
+  static getType() {
+    return ELEMENT_TYPE
+  }
+
+  static clone(node: CodeBlockTextNode): CodeBlockTextNode {
+    return new CodeBlockTextNode(node.__text, node.__key)
+  }
+
+  createDOM(config: EditorConfig): HTMLElement {
+    const element = super.createDOM(config)
+
+    const theme = config.theme
+    const className = theme.codeBlockText
+
+    if (className !== undefined) {
+      element.className = className
+    }
+
+    return element
+  }
+
+  exportJSON(): SerializedTextNode {
+    return {
+      ...super.exportJSON(),
+      type: ELEMENT_TYPE,
+      version: 1,
+    }
+  }
+
+  // prevent formatting
+  setFormat(): this {
+    return this
+  }
+
+  isParentRequired() {
+    return true
+  }
+
+  createParentElementNode(): CodeBlockNode {
+    return $createCodeBlockNode()
+  }
+}

--- a/packages/picasso-rich-text-editor/src/plugins/CodeBlockPlugin/nodes/index.ts
+++ b/packages/picasso-rich-text-editor/src/plugins/CodeBlockPlugin/nodes/index.ts
@@ -2,6 +2,7 @@ import type { LexicalNode } from 'lexical'
 import { $applyNodeReplacement } from 'lexical'
 
 import { CodeBlockNode } from './CodeBlockNode'
+import { CodeBlockTextNode } from './CodeBlockTextNode'
 
 export const $createCodeBlockNode = (): CodeBlockNode =>
   $applyNodeReplacement(new CodeBlockNode())
@@ -12,4 +13,14 @@ export const $isCodeBlockNode = (
   return node instanceof CodeBlockNode
 }
 
-export { CodeBlockNode }
+export const $isCodeBlockTextNode = (
+  node: LexicalNode | CodeBlockTextNode | null | undefined
+): node is CodeBlockTextNode => {
+  return node instanceof CodeBlockTextNode
+}
+
+export const $createCodeBlockTextNode = (text: string): CodeBlockTextNode => {
+  return $applyNodeReplacement(new CodeBlockTextNode(text))
+}
+
+export { CodeBlockNode, CodeBlockTextNode }


### PR DESCRIPTION
[FX-4184]

### Description

In this pull request, we
- add `CodeBlockTextNode` which is inline level element (text).
- register new node transform, where we check TextNode and if its parent is CodeBlockNode, we transform it to CodeBlockTextNode. It is similar to how Lexical is doing it internally.

```jsx
<CodeBlockNode>
  <CodeBlockTextNode>any text</CodeBlockTextNode><LineBreakNode />
  <CodeBlockTextNode>  any other text and so on</CodeBlockTextNode>
</CodeBlockNode>
```

You might ask why we need `CodeBlockTextNode`. 
Because inside `CodeBlock` we don't allow any inline formatting (bold, italic, ...)

### How to test


- check the code
 

### Screenshots


### Development checks

- Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- Covered with tests

**Breaking change**

- codemod is created and showcased in the changeset
- test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-4184]: https://toptal-core.atlassian.net/browse/FX-4184?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ