### PR TITLE
feat: add disableFormatting functionality

### DIFF
--- a/packages/picasso-rich-text-editor/src/LexicalEditor/styles.ts
+++ b/packages/picasso-rich-text-editor/src/LexicalEditor/styles.ts
@@ -6,7 +6,7 @@ import { rem } from '@toptal/picasso-shared'
 import { codeBlockStyles, codeStyles } from '../RichText/components/styles'
 
 const margins = {
-  '& p': {
+  '& p, & code[dir]': {
     margin: '0.5rem 0',
   },
   '& h3': {

--- a/packages/picasso-rich-text-editor/src/RichText/components/styles.ts
+++ b/packages/picasso-rich-text-editor/src/RichText/components/styles.ts
@@ -1,8 +1,9 @@
 import type { Theme } from '@material-ui/core/styles'
 import { createStyles } from '@material-ui/core/styles'
+import type { CSSProperties } from '@material-ui/core/styles/withStyles'
 import { rem } from '@toptal/picasso-shared'
 
-export const codeStyles = ({ palette, typography }: Theme) => ({
+export const codeStyles = ({ palette, typography }: Theme): CSSProperties => ({
   color: palette.red.main,
   backgroundColor: palette.grey.lighter,
   border: `1px solid ${palette.grey.light}`,
@@ -10,9 +11,15 @@ export const codeStyles = ({ palette, typography }: Theme) => ({
   padding: '1px 0.25rem',
   fontSize: typography.fontSizes.xsmall,
   fontFamily: 'monospace',
+  textWrap: 'wrap',
+  wordBreak: 'break-word',
 })
 
-export const codeBlockStyles = ({ palette, sizes, typography }: Theme) => ({
+export const codeBlockStyles = ({
+  palette,
+  sizes,
+  typography,
+}: Theme): CSSProperties => ({
   backgroundColor: palette.grey.lighter,
   borderRadius: sizes.borderRadius.small,
   padding: '0.25rem 0.5rem',
@@ -21,6 +28,9 @@ export const codeBlockStyles = ({ palette, sizes, typography }: Theme) => ({
   fontSize: typography.fontSizes.xxsmall,
   lineHeight: rem('18px'),
   color: palette.common.black,
+  textWrap: 'wrap',
+  wordBreak: 'break-word',
+  margin: 0,
 })
 
 export default (theme: Theme) =>

--- a/packages/picasso-rich-text-editor/src/RichTextEditor/story/Code.example.tsx
+++ b/packages/picasso-rich-text-editor/src/RichTextEditor/story/Code.example.tsx
@@ -5,8 +5,14 @@ import {
   CodePlugin,
   RichTextEditor,
 } from '@toptal/picasso-rich-text-editor'
+import { htmlToHast } from '@toptal/picasso-rich-text-editor/utils'
 
 import type { RichTextEditorChangeHandler } from '../types'
+
+// we expect defaultValue to be HAST from BE
+const defaultValue = htmlToHast(
+  '<p>foo <code>bar</code> baz</p><p>qux <code>quux</code> quuz</p>'
+)
 
 const Example = () => {
   const [value, setValue] = useState<string | undefined>()
@@ -21,6 +27,7 @@ const Example = () => {
         onChange={handleChange}
         placeholder='Write some cool rich text'
         plugins={[<CodePlugin />, <CodeBlockPlugin />]}
+        defaultValue={defaultValue}
       />
       <Container
         padded='small'

--- a/packages/picasso-rich-text-editor/src/RichTextEditor/story/Default.example.tsx
+++ b/packages/picasso-rich-text-editor/src/RichTextEditor/story/Default.example.tsx
@@ -1,9 +1,6 @@
 import React, { useState } from 'react'
 import { Container } from '@toptal/picasso'
-import {
-  CodeBlockPlugin,
-  RichTextEditor,
-} from '@toptal/picasso-rich-text-editor'
+import { RichTextEditor } from '@toptal/picasso-rich-text-editor'
 
 import type { RichTextEditorChangeHandler } from '../types'
 
@@ -19,7 +16,6 @@ const Example = () => {
         id='editor'
         onChange={handleChange}
         placeholder='Write some cool rich text'
-        plugins={[<CodeBlockPlugin />]}
       />
       <Container
         padded='small'

--- a/packages/picasso-rich-text-editor/src/RichTextEditorToolbar/RichTextEditorToolbar.tsx
+++ b/packages/picasso-rich-text-editor/src/RichTextEditorToolbar/RichTextEditorToolbar.tsx
@@ -12,7 +12,7 @@ import { useMultipleForwardRefs } from '@toptal/picasso/utils'
 import cx from 'classnames'
 import React, { forwardRef } from 'react'
 
-import { useToolbarPortalRegister } from '../plugins/api'
+import { useRTEPluginContext, useToolbarPortalRegister } from '../plugins/api'
 import TextEditorButton from '../RichTextEditorButton'
 import styles from './styles'
 import type {
@@ -62,11 +62,13 @@ export const RichTextEditorToolbar = forwardRef<HTMLDivElement, Props>(
     } = props
 
     const { setToolbarPortalEl } = useToolbarPortalRegister()
+    const { disabledFormatting } = useRTEPluginContext()
 
     const toolbarRef = useMultipleForwardRefs([ref, setToolbarPortalEl])
 
     const classes = useStyles(props)
-    const isHeadingFormat = format.header === ALLOWED_HEADER_TYPE
+
+    const isInlineFormattingDisabled = disabled || disabledFormatting
 
     return (
       <Container
@@ -97,15 +99,15 @@ export const RichTextEditorToolbar = forwardRef<HTMLDivElement, Props>(
           <TextEditorButton
             icon={<Bold16 />}
             onClick={onBoldClick}
-            active={isHeadingFormat ? false : format.bold}
-            disabled={isHeadingFormat || disabled}
+            active={isInlineFormattingDisabled ? false : format.bold}
+            disabled={isInlineFormattingDisabled}
             data-testid={testIds?.boldButton}
           />
           <TextEditorButton
             icon={<Italic16 />}
             onClick={onItalicClick}
-            active={isHeadingFormat ? false : format.italic}
-            disabled={isHeadingFormat || disabled}
+            active={isInlineFormattingDisabled ? false : format.italic}
+            disabled={isInlineFormattingDisabled}
             data-testid={testIds?.italicButton}
           />
         </Container>

--- a/packages/picasso-rich-text-editor/src/plugins/CodePlugin/CodeButton.tsx
+++ b/packages/picasso-rich-text-editor/src/plugins/CodePlugin/CodeButton.tsx
@@ -13,7 +13,7 @@ export type Props = {
 const CodeButton = ({ 'data-testid': testId }: Props) => {
   const [active, setActive] = useState(false)
   const [editor] = useLexicalComposerContext()
-  const { disabled, focused } = useRTEPluginContext()
+  const { disabled, focused, disabledFormatting } = useRTEPluginContext()
 
   useRTEUpdate(() => {
     const selection = $getSelection()
@@ -27,12 +27,14 @@ const CodeButton = ({ 'data-testid': testId }: Props) => {
     editor.dispatchCommand(FORMAT_TEXT_COMMAND, 'code')
   }
 
+  const isDisabled = disabled || !focused || disabledFormatting
+
   return (
     <RichTextEditorButton
       icon={<Code16 />}
       onClick={handleCodeClick}
-      active={active}
-      disabled={disabled || !focused}
+      active={isDisabled ? false : active}
+      disabled={isDisabled}
       data-testid={testId}
     />
   )

--- a/packages/picasso-rich-text-editor/src/plugins/ImagePlugin/components/ImagePluginButton/ImagePluginButton.tsx
+++ b/packages/picasso-rich-text-editor/src/plugins/ImagePlugin/components/ImagePluginButton/ImagePluginButton.tsx
@@ -10,13 +10,13 @@ export type Props = {
 }
 
 const ImagePluginButton = ({ 'data-testid': testId, onClick }: Props) => {
-  const { disabled, focused } = useRTEPluginContext()
+  const { disabled, focused, disabledFormatting } = useRTEPluginContext()
 
   return (
     <RichTextEditorButton
       icon={<Image16 />}
       onClick={onClick}
-      disabled={disabled || !focused}
+      disabled={disabled || !focused || disabledFormatting}
       data-testid={testId}
     />
   )

--- a/packages/picasso-rich-text-editor/src/plugins/LinkPlugin/LinkPluginButton.tsx
+++ b/packages/picasso-rich-text-editor/src/plugins/LinkPlugin/LinkPluginButton.tsx
@@ -16,7 +16,7 @@ export type Props = {
 const LinkPluginButton = ({ 'data-testid': testId }: Props) => {
   const [active, setActive] = useState(false)
   const [editor] = useLexicalComposerContext()
-  const { disabled, focused } = useRTEPluginContext()
+  const { disabled, focused, disabledFormatting } = useRTEPluginContext()
 
   useRTEUpdate(() => {
     const selection = $getSelection()
@@ -45,12 +45,14 @@ const LinkPluginButton = ({ 'data-testid': testId }: Props) => {
     }
   }, [editor, active])
 
+  const isDisabled = disabled || !focused || disabledFormatting
+
   return (
     <RichTextEditorButton
       icon={<Link16 />}
       onClick={onLinkClick}
-      active={active}
-      disabled={disabled || !focused}
+      active={isDisabled ? false : active}
+      disabled={isDisabled}
       data-testid={testId}
     />
   )

--- a/packages/picasso-rich-text-editor/src/plugins/api.tsx
+++ b/packages/picasso-rich-text-editor/src/plugins/api.tsx
@@ -1,7 +1,7 @@
 import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext'
 import type { Klass, LexicalNode } from 'lexical'
 import type { ReactElement, ReactNode } from 'react'
-import React, { createContext, useContext, useEffect } from 'react'
+import React, { createContext, useContext, useEffect, useState } from 'react'
 
 import { registerLexicalEvents } from '../LexicalEditor/utils/registerLexicalEvents'
 import { ToolbarProvider } from './Toolbar/Toolbar'
@@ -34,7 +34,9 @@ export const isRTEPluginElement = (plugin: {}): plugin is ReactElement<
 
 type RTEPluginContextValue = {
   disabled: boolean
+  disabledFormatting: boolean
   focused: boolean
+  setDisabledFormatting: (value: boolean) => void
 }
 
 export const useRTEUpdate = (callback: () => void) => {
@@ -52,7 +54,9 @@ export const useRTEUpdate = (callback: () => void) => {
 
 const RTEPluginContext = createContext<RTEPluginContextValue>({
   disabled: false,
+  disabledFormatting: false,
   focused: false,
+  setDisabledFormatting: () => {},
 })
 
 export type ToolbarPortalProviderProps = {
@@ -66,8 +70,12 @@ export const RTEPluginContextProvider = ({
   disabled,
   focused,
 }: ToolbarPortalProviderProps) => {
+  const [disabledFormatting, setDisabledFormatting] = useState(false)
+
   const value: RTEPluginContextValue = {
     disabled,
+    disabledFormatting,
+    setDisabledFormatting,
     focused,
   }
 
@@ -81,11 +89,14 @@ export const RTEPluginContextProvider = ({
 }
 
 export const useRTEPluginContext = () => {
-  const { disabled, focused } = useContext(RTEPluginContext)
+  const { disabled, focused, disabledFormatting, setDisabledFormatting } =
+    useContext(RTEPluginContext)
 
   return {
     disabled,
+    disabledFormatting,
     focused,
+    setDisabledFormatting,
   }
 }
 

--- a/packages/picasso-rich-text-editor/src/utils/html-to-hast.ts
+++ b/packages/picasso-rich-text-editor/src/utils/html-to-hast.ts
@@ -13,7 +13,6 @@ export const hastSanitizeSchema: Schema = {
   attributes: {
     a: ['href'],
     img: ['src', 'data*', 'class'],
-    pre: ['data*'],
     '*': [],
   },
   tagNames: [


### PR DESCRIPTION
[FX-4184]

### Description

When we are using codeBlock or heading, we don't allow to format inner text nodes. We used to have this condition locally only for heading, but now we need to share this information across custom plugins

### How to test

<!-- The temploy link will be automatically updated when the temploy is deployed -->
- [Temploy](https://picasso.toptal.net/fx-4184-rte-code-block-4)
- check the code and you can test that when you use heading, all inline formats are disabled. You can do it only locally, till all other PRs are merged to feature/branch.

### Screenshots

![image](https://github.com/toptal/picasso/assets/6830426/53eb2dd5-7d0a-43a0-a0b4-0896173cfc74)


### Development checks

- Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- Covered with tests ([visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md) included)

**Breaking change**

- codemod is created and showcased in the changeset
- test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-4184]: https://toptal-core.atlassian.net/browse/FX-4184?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ