### PR TITLE
test: cover getFirstCodeNodeOfLine with unit tests

### DIFF
--- a/packages/picasso-rich-text-editor/src/plugins/CodeBlockPlugin/nodes/CodeBlockNode.tsx
+++ b/packages/picasso-rich-text-editor/src/plugins/CodeBlockPlugin/nodes/CodeBlockNode.tsx
@@ -3,8 +3,6 @@ import type {
   DOMConversionOutput,
   DOMExportOutput,
   EditorConfig,
-  LexicalNode,
-  LineBreakNode,
   NodeKey,
   ParagraphNode,
   RangeSelection,
@@ -23,20 +21,7 @@ import {
   $isCodeBlockTextNode,
 } from '../nodes'
 import hasChildDOMNodeTag from '../../../LexicalEditor/utils/hasChildDOMNodeTag'
-
-const getFirstCodeNodeOfLine = (
-  anchor: CodeBlockTextNode | LineBreakNode
-): null | CodeBlockTextNode | LineBreakNode => {
-  let previousNode = anchor
-  let node: null | LexicalNode = anchor
-
-  while ($isCodeBlockTextNode(node)) {
-    previousNode = node
-    node = node.getPreviousSibling()
-  }
-
-  return previousNode
-}
+import { getFirstCodeNodeOfLine } from '../utils'
 
 const convertPreElement = (): DOMConversionOutput => {
   return { node: $createCodeBlockNode() }

--- a/packages/picasso-rich-text-editor/src/plugins/CodeBlockPlugin/utils/getFirstCodeNodeOfLine.test.ts
+++ b/packages/picasso-rich-text-editor/src/plugins/CodeBlockPlugin/utils/getFirstCodeNodeOfLine.test.ts
@@ -1,0 +1,85 @@
+import type { LineBreakNode } from 'lexical'
+
+import type { CodeBlockTextNode } from '../nodes'
+import { $isCodeBlockTextNode } from '../nodes'
+import getFirstCodeNodeOfLine from './getFirstCodeNodeOfLine' // Your actual function import path
+
+jest.mock('../nodes', () => ({
+  __esModule: true,
+  $isCodeBlockTextNode: jest.fn(),
+}))
+// Mocking the function and methods
+const getPreviousSibling = jest.fn()
+
+const $isCodeBlockTextNodeMock = $isCodeBlockTextNode as jest.MockedFunction<
+  typeof $isCodeBlockTextNode
+>
+
+describe('getFirstCodeNodeOfLine', () => {
+  afterEach(() => {
+    jest.resetAllMocks()
+  })
+
+  describe('when the provided node is a CodeBlockTextNode', () => {
+    it('returns the first CodeBlockTextNode', () => {
+      const codeBlockTextNode = {
+        getPreviousSibling,
+      } as unknown as CodeBlockTextNode
+
+      $isCodeBlockTextNodeMock
+        .mockReturnValueOnce(true)
+        .mockReturnValueOnce(false)
+      getPreviousSibling.mockReturnValueOnce(null)
+
+      const result = getFirstCodeNodeOfLine(codeBlockTextNode)
+
+      expect(result).toBe(codeBlockTextNode)
+      expect($isCodeBlockTextNode).toHaveBeenCalledWith(codeBlockTextNode)
+      expect(getPreviousSibling).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('when the provided node is a LineBreakNode', () => {
+    it('returns the provided node as it is', () => {
+      const lineBreakNode = {
+        getPreviousSibling,
+      } as unknown as LineBreakNode
+
+      $isCodeBlockTextNodeMock.mockReturnValue(false)
+
+      const result = getFirstCodeNodeOfLine(lineBreakNode)
+
+      expect(result).toBe(lineBreakNode)
+      expect($isCodeBlockTextNodeMock).toHaveBeenCalledWith(lineBreakNode)
+      expect(getPreviousSibling).toHaveBeenCalledTimes(0)
+    })
+  })
+
+  describe('when the provided node is a CodeBlockTextNode with a non-CodeBlockTextNode in the sibling chain', () => {
+    it('returns the first CodeBlockTextNode until the non-CodeBlockTextNode', () => {
+      const firstCodeBlockTextNode = {
+        getPreviousSibling,
+      } as unknown as CodeBlockTextNode
+      const secondCodeBlockTextNode = { getPreviousSibling }
+      const nonCodeBlockTextNode = { getPreviousSibling }
+      const thirdCodeBlockTextNode = { getPreviousSibling }
+
+      $isCodeBlockTextNodeMock
+        .mockReturnValueOnce(true)
+        .mockReturnValueOnce(true)
+        .mockReturnValueOnce(false)
+        .mockReturnValueOnce(true)
+      getPreviousSibling
+        .mockReturnValueOnce(secondCodeBlockTextNode)
+        .mockReturnValueOnce(nonCodeBlockTextNode)
+        .mockReturnValueOnce(thirdCodeBlockTextNode)
+        .mockReturnValueOnce(null)
+
+      const result = getFirstCodeNodeOfLine(firstCodeBlockTextNode)
+
+      expect(result).toBe(secondCodeBlockTextNode)
+      expect($isCodeBlockTextNode).toHaveBeenCalledTimes(3)
+      expect(getPreviousSibling).toHaveBeenCalledTimes(2)
+    })
+  })
+})

--- a/packages/picasso-rich-text-editor/src/plugins/CodeBlockPlugin/utils/getFirstCodeNodeOfLine.test.ts
+++ b/packages/picasso-rich-text-editor/src/plugins/CodeBlockPlugin/utils/getFirstCodeNodeOfLine.test.ts
@@ -2,7 +2,7 @@ import type { LineBreakNode } from 'lexical'
 
 import type { CodeBlockTextNode } from '../nodes'
 import { $isCodeBlockTextNode } from '../nodes'
-import getFirstCodeNodeOfLine from './getFirstCodeNodeOfLine' // Your actual function import path
+import getFirstCodeNodeOfLine from './getFirstCodeNodeOfLine'
 
 jest.mock('../nodes', () => ({
   __esModule: true,

--- a/packages/picasso-rich-text-editor/src/plugins/CodeBlockPlugin/utils/getFirstCodeNodeOfLine.ts
+++ b/packages/picasso-rich-text-editor/src/plugins/CodeBlockPlugin/utils/getFirstCodeNodeOfLine.ts
@@ -1,0 +1,20 @@
+import type { LexicalNode, LineBreakNode } from 'lexical'
+
+import type { CodeBlockTextNode } from '../nodes'
+import { $isCodeBlockTextNode } from '../nodes'
+
+const getFirstCodeNodeOfLine = (
+  anchor: CodeBlockTextNode | LineBreakNode
+): null | CodeBlockTextNode | LineBreakNode => {
+  let previousNode = anchor
+  let node: null | LexicalNode = anchor
+
+  while ($isCodeBlockTextNode(node)) {
+    previousNode = node
+    node = node.getPreviousSibling()
+  }
+
+  return previousNode
+}
+
+export default getFirstCodeNodeOfLine

--- a/packages/picasso-rich-text-editor/src/plugins/CodeBlockPlugin/utils/index.ts
+++ b/packages/picasso-rich-text-editor/src/plugins/CodeBlockPlugin/utils/index.ts
@@ -1,0 +1,1 @@
+export { default as getFirstCodeNodeOfLine } from './getFirstCodeNodeOfLine'


### PR DESCRIPTION
[FX-4184]

### Description

move `getFirstCodeNodeOfLine` to separate function and cover it with tests

### How to test

<!-- The temploy link will be automatically updated when the temploy is deployed -->
- Temploy
- FIXME: Add the steps describing how to verify your changes

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| Insert screenshots or screen recordings | Insert screenshots or screen recordings |

### Development checks

- Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- Annotate all `props` in component with documentation
- Create `examples` for component
- Ensure that deployed demo has expected results and good examples
- Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests ([visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md) included)

**Breaking change**

- codemod is created and showcased in the changeset
- test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-4184]: https://toptal-core.atlassian.net/browse/FX-4184?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ