### PR TITLE
fix: page background color

### DIFF
--- a/.changeset/poor-buckets-provide.md
+++ b/.changeset/poor-buckets-provide.md
@@ -1,0 +1,5 @@
+---
+'@toptal/picasso': patch
+---
+
+- align page background color with BASE design

--- a/packages/picasso/src/PageContent/styles.ts
+++ b/packages/picasso/src/PageContent/styles.ts
@@ -13,11 +13,11 @@ export default ({ layout, palette }: Theme) =>
       height: '100%',
       flexGrow: 1,
       maxWidth: layout.contentWidth,
-      backgroundColor: palette.common.white,
+      backgroundColor: palette.grey.lightest,
       backgroundClip: 'content-box',
     },
     hasSidebar: {
-      background: `linear-gradient(90deg, ${palette.grey.lighter} 50%, ${palette.common.white} 50%)`,
+      background: `linear-gradient(90deg, ${palette.grey.lighter} 50%, ${palette.grey.lightest} 50%)`,
     },
     wide: {
       maxWidth: layout.contentWidthWide,


### PR DESCRIPTION
[FX-4213]

### Description

Page content should have a different background color according to the BASE design.

### How to test

<!-- The temploy link will be automatically updated when the temploy is deployed -->
- [Temploy](https://picasso.toptal.net/fx-4213-align-page-background-with-base)
- Check visual changes
- https://picasso.toptal.net/?path=/story/picasso-introduction--introduction and https://picasso.toptal.net/fx-4213-align-page-background-with-base/?path=/story/picasso-introduction--introduction

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [N/A] Annotate all `props` in component with documentation
- [N/A] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [N/A] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [N/A] Covered with tests ([visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md) included)

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-4213]: https://toptal-core.atlassian.net/browse/FX-4213?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ