### PR TITLE
fix: disabled inline formating and empty line in code block

### DIFF
--- a/packages/picasso-rich-text-editor/src/LexicalEditorToolbarPlugin/LexicalEditorToolbarPlugin.tsx
+++ b/packages/picasso-rich-text-editor/src/LexicalEditorToolbarPlugin/LexicalEditorToolbarPlugin.tsx
@@ -26,6 +26,7 @@ import RichTextEditorToolbar, {
 } from '../RichTextEditorToolbar'
 import { useRTEPluginContext, useRTEUpdate } from '../plugins/api'
 import { getSelectedNode } from '../LexicalEditor/utils/getSelectedNode'
+import { $isCodeBlockNode } from '../plugins/CodeBlockPlugin/nodes'
 
 type Props = {
   disabled?: boolean
@@ -74,9 +75,12 @@ const LexicalEditorToolbarPlugin = ({
       const node = getSelectedNode(selection)
       const parent = node.getParent()
 
-      setDisabledFormatting(
-        Boolean($isHeadingNode(node) || $isHeadingNode(parent))
-      )
+      const isCodeBlockSelected =
+        $isCodeBlockNode(parent) || $isCodeBlockNode(node)
+      const isHeadingSelected = $isHeadingNode(node) || $isHeadingNode(parent)
+
+      // prevent formatting inside
+      setDisabledFormatting(isCodeBlockSelected || isHeadingSelected)
     }
   })
 

--- a/packages/picasso-rich-text-editor/src/plugins/CodeBlockPlugin/CodeBlockButton.tsx
+++ b/packages/picasso-rich-text-editor/src/plugins/CodeBlockPlugin/CodeBlockButton.tsx
@@ -116,7 +116,7 @@ const replaceChildrenNodesWithRawText = (selection: RangeSelection) => {
 const CodeBlockButton = ({ 'data-testid': testId }: Props) => {
   const [isButtonActive, setButtonActive] = useState(false)
   const [editor] = useLexicalComposerContext()
-  const { disabled, focused, setDisabledFormatting } = useRTEPluginContext()
+  const { disabled, focused } = useRTEPluginContext()
 
   const handleClick = useCallback(() => {
     editor.update(() => {
@@ -142,8 +142,6 @@ const CodeBlockButton = ({ 'data-testid': testId }: Props) => {
         $isCodeBlockNode(parent) || $isCodeBlockNode(node)
 
       setButtonActive(isCodeBlockSelected)
-      // prevent formatting inside the code block
-      setDisabledFormatting(isCodeBlockSelected)
     }
   })
 

--- a/packages/picasso-rich-text-editor/src/plugins/CodeBlockPlugin/CodeBlockButton.tsx
+++ b/packages/picasso-rich-text-editor/src/plugins/CodeBlockPlugin/CodeBlockButton.tsx
@@ -79,9 +79,11 @@ const appendTextToCodeBlock = (
   codeBlock: CodeBlockNode,
   isLast: boolean
 ) => {
-  const textNode = $createCodeBlockTextNode(node.getTextContent())
+  const text = node.getTextContent()
 
-  codeBlock.append(textNode)
+  if (text) {
+    codeBlock.append($createCodeBlockTextNode(text))
+  }
   if (!isLast) {
     codeBlock.append($createLineBreakNode())
   }


### PR DESCRIPTION
[FX-4184]

### Description

We had two issues:
- when an empty line was converted CodeBlock, it was not looking nice. The problem was that even if there was no text, we were appending the CodeBlock with TextNode. Empty TextNode has no height, so I added a condition to not add the empty TextNode. Instead the BR appears by default.
- Disabling inline formatting was not working correctly as it was triggered from two places that were overlapping, so after moving it into one place it works as expected

### How to test

<!-- The temploy link will be automatically updated when the temploy is deployed -->
- [Temploy](https://picasso.toptal.net/fx-4184-rte-code-block-8)
- FIXME: Add the steps describing how to verify your changes

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| Insert screenshots or screen recordings | Insert screenshots or screen recordings |

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- Annotate all `props` in component with documentation
- Create `examples` for component
- Ensure that deployed demo has expected results and good examples
- Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests ([visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md) included)

**Breaking change**

- codemod is created and showcased in the changeset
- test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-4184]: https://toptal-core.atlassian.net/browse/FX-4184?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ