### PR TITLE
fix: properly set context value in PicassoGlobalStylesProvider

### DIFF
--- a/.changeset/strange-kids-play.md
+++ b/.changeset/strange-kids-play.md
@@ -1,0 +1,7 @@
+---
+'@toptal/picasso-provider': patch
+---
+
+### PicassoGlobalStylesProvider
+
+- fixed issue with `PicassoGlobalStylesProvider` setting context value incorrectly, thus causing style mismatch when both sidebar + drawer are used

--- a/packages/picasso-provider/src/Picasso/PicassoGlobalStylesProvider.tsx
+++ b/packages/picasso-provider/src/Picasso/PicassoGlobalStylesProvider.tsx
@@ -46,26 +46,26 @@ const PicassoGlobalStylesProvider = (
     currentBreakpointRange,
     hasTopBar: false,
     setHasTopBar: (hasTopBar: boolean) => {
-      setContextValue({
-        ...contextValue,
+      setContextValue(context => ({
+        ...context,
         hasTopBar,
-      })
+      }))
     },
     environment,
     titleCase,
     hasDrawer: false,
     setHasDrawer: (hasDrawer: boolean) => {
-      setContextValue({
-        ...contextValue,
+      setContextValue(context => ({
+        ...context,
         hasDrawer,
-      })
+      }))
     },
     hasSidebar: false,
     setHasSidebar: (hasSidebar: boolean) => {
-      setContextValue({
-        ...contextValue,
+      setContextValue(context => ({
+        ...context,
         hasSidebar,
-      })
+      }))
     },
     disableTransitions,
   })


### PR DESCRIPTION
[FX-4218](https://toptal-core.atlassian.net/browse/FX-4218)

### Description

Previously the context setters for `PicassoGlobalStylesProvider` were not taking the previous context value into account properly. This caused the property values of `hasDrawer`, `hasSidebar` and `hasTopbar` to be overridden when one of them changes.

### How to test

<!-- The temploy link will be automatically updated when the temploy is deployed -->
- [Temploy](https://picasso.toptal.net/fx-4218-sidebar-changes-color-after-drawer-is-opened)
- Change any `Page` story code to the following:
<details>
<summary>reproduction code</summary>
<br />

```ts
import React, { useState } from 'react'
// In actual application you can simply do
// import Picasso from '@toptal/picasso-provider'
import { default as Picasso } from '@toptal/picasso-provider'
import {
  Grid,
  Page,
  Container,
  Drawer,
  Menu,
  Typography,
} from '@toptal/picasso'

const Example = () => {
  const [open, setOpen] = useState(false)

  return (
    <div style={{ height: '30rem' }}>
      <Page>
        <Page.TopBar rightContent={<RightContent />} title='Default example' />
        <Page.Content>
          <SidebarMenu />
          <Page.Article>
            <button onClick={() => setOpen(true)}>Toggle</button>
            <Drawer
              open={open}
              onClose={() => setOpen(false)}
              transparentBackdrop
            >
              Test
            </Drawer>
            <Content />
          </Page.Article>
        </Page.Content>
        <Page.Footer />
      </Page>
    </div>
  )
}

const handleClick = () => window.alert('Item clicked')

const SidebarMenu = () => (
  <Page.Sidebar>
    <Page.Sidebar.Menu>
      <Page.Sidebar.Item>Home</Page.Sidebar.Item>
      <Page.Sidebar.Item>Contacts</Page.Sidebar.Item>
      <Page.Sidebar.Item>Team</Page.Sidebar.Item>
    </Page.Sidebar.Menu>
  </Page.Sidebar>
)

const RightContent = () => (
  <Page.TopBarMenu
    name='Jacqueline Roque'
    avatar='./jacqueline-with-flowers-1954-square.jpg'
  >
    <Menu>
      <Menu.Item onClick={handleClick}>My Account</Menu.Item>
      <Menu.Item onClick={handleClick}>Log Out</Menu.Item>
    </Menu>
  </Page.TopBarMenu>
)

const Content = () => (
  <Container top='small' bottom='small' left='small' right='small'>
    <Typography align='center' variant='heading' size='large'>
      Default example
    </Typography>
    <Grid>
      <Grid.Item sm={6}>
        <p>
          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
          eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad
          minim veniam, quis nostrud exercitation ullamco laboris nisi ut
          aliquip ex ea commodo consequat. Duis aute irure dolor in
          reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
          pariatur. Excepteur sint occaecat cupidatat non proident, sunt in
          culpa qui officia deserunt mollit anim id est laborum.
        </p>
      </Grid.Item>
      <Grid.Item sm={6}>
        <p>
          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
          eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad
          minim veniam, quis nostrud exercitation ullamco laboris nisi ut
          aliquip ex ea commodo consequat. Duis aute irure dolor in
          reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla
          pariatur. Excepteur sint occaecat cupidatat non proident, sunt in
          culpa qui officia deserunt mollit anim id est laborum.
        </p>
      </Grid.Item>
    </Grid>
  </Container>
)

const Index = () => (
  <div id='root'>
    <Picasso responsive={false} loadFavicon={false} fixViewport={false}>
      <Example />
    </Picasso>
  </div>
)

export default Index
```

</details>


### Screenshots

**Before**


https://github.com/toptal/picasso/assets/18409292/2615e67a-87ad-487f-895c-2880fc229088

**After**



https://github.com/toptal/picasso/assets/18409292/aa8dfe64-7a25-4415-84e2-7357ed846ad2


### Development checks




- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests ([visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md) included)


> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-4218]: https://toptal-core.atlassian.net/browse/FX-4218?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ