### PR TITLE
docs: add decision on spacing in picasso

### DIFF
--- a/docs/decisions/18-spacings.md
+++ b/docs/decisions/18-spacings.md
@@ -53,7 +53,7 @@ module.exports = {
 
 ## Proposal
 
-Picasso has to export spacing, compatible with [BASE design](https://toptal-core.atlassian.net/wiki/spaces/Base/pages/3217031216/Spacing). The legacy way of specifying spacing (numbers and string constants) has to be gradually deprecated to encourage usage of BASE spacings. The [How to use spacings](https://picasso.toptal.net/?path=/story/tutorials-how-to-use-spacings--how-to-use-spacings) tutorial is updated to contain guidelines on using a new spacing system for a particular example.
+Picasso has to export spacing, compatible with [BASE design](https://toptal-core.atlassian.net/wiki/spaces/Base/pages/3217031216/Spacing). The legacy way of specifying spacing (numbers and string constants) has to be gradually deprecated to encourage usage of BASE spacings. The [How to use spacings](https://picasso.toptal.net/?path=/story/tutorials-how-to-use-spacings--how-to-use-spacings) tutorial has to be updated to contain up-to-date guidelines on using a new spacing system.
 
 ### Technical implementation
 
@@ -78,7 +78,7 @@ export type SpacingType =
   | PicassoSpacing
 ```
 
-Exported `spacing` object is reused by components with spacing properties (`top`, `right`, `bottom`, `left`, `gap`, and `padded` properties in Container component).
+Exported `spacing` object is reused by components with spacing properties (`top`, `right`, `bottom`, `left`, `gap`, and `padded` properties in Container component and `offset` property in Dropdown component).
 
 ```tsx
 import { spacing } from '@toptal/picasso/utils'

--- a/docs/decisions/18-spacings.md
+++ b/docs/decisions/18-spacings.md
@@ -1,0 +1,116 @@
+# RFC Template
+
+## Problem
+
+BASE design defines [rules](https://toptal-core.atlassian.net/wiki/spaces/Base/pages/3217031216/Spacing) on how to use spacing between page elements in frontend applications. Picasso has to align with design rules and has to provide tools for Picasso consumers to use BASE-compatible spacing in applications.
+
+## Current situation
+
+Picasso provides a specialised `SpacingType` type that can be either a numeric value or one of the pre-defined string constants (`xsmall`, `small`, etc.) that are resolved to a number (in both cases a numeric value corresponds to a number of `rem` units of spacing).
+
+As an example, the `Container` component has a `top` property that has `SpacingType` type. Based on the statistics of `top` property usage (searching for its occurrences in [this](https://github.com/search?q=org%3Atoptal+%22+top%3D%7B%22&type=code&p=1) GitHub search), Picasso consumers frequently use both numeric values and string constants.
+
+All of the `SpacingType` string constants resolve to numeric values that are present in [BASE design spacings](https://toptal-core.atlassian.net/wiki/spaces/Base/pages/3217031216/Spacing#Base-Increment). Some of the BASE design spacings do not have a counterpart between `SpacingType` string constants. There are 5 `SpacingType` string constants and 12 BASE design spacings – for example, there is no string constant for `spacing-12` spacing. 
+
+## Existing approaches
+
+- [Chakra UI](https://chakra-ui.com/docs/styled-system/theme#spacing) exports spacings in a form of key-value pairs, where `key` is the pixel number value and `value` is the `rem` units string value
+
+```ts
+const spacing = {
+  space: {
+    px: '1px',
+    0.5: '0.125rem',
+    1: '0.25rem',
+    ...
+  }
+}
+```
+
+- [Caliber](https://github.com/toptal/caliber/blob/9a0b91110f1c82e07d30f684bb42b49e0e34f918/tailwind.preset.design-tokens.js#L2) defines spacings as key-value pairs and exports spacings in a form of CSS classes generated with TailwindCSS
+
+```js
+// Design tokens preset
+module.exports = {
+  theme: {
+    spacing: {
+      ...
+      4: '16px',
+      ...
+    }
+  }
+}
+```
+
+```css
+...
+/* padding: 16px */
+.p-4
+/* padding-top: 16px */
+.pt-4
+...
+```
+
+## Proposal
+
+### Goal
+
+Picasso has to provide full set of BASE design spacings to allow consumers to use all of them when developing Picasso-based applications. Introduced changes should not break existing usage of spacing in related components mentioned above.
+
+### Technical implementation
+
+Picasso provides a new object `spacing` that includes proposed spacings in a form of key-value pairs (where the key is the index of the increment and the value is a corresponding value in `rem` unit)
+
+```ts
+export const spacing = {
+  0: 0,
+  1: 0.25,
+  ...
+  10: 2.5,
+  12: 3,
+}
+```
+
+Exported `spacing` object with increments is reused by components with spacing properties (`top`, `right`, `bottom` and `left` properties in Container and `offset` property Dropdown)
+
+```tsx
+import { spacing } from '@toptal/picasso/utils'
+...
+<Container top={spacing[6]}/>
+```
+
+The [How to use spacings](https://picasso.toptal.net/?path=/story/tutorials-how-to-use-spacings--how-to-use-spacings) tutorial is updated to contain guidelines on using a new spacing system for a particular example.
+
+## Alternative approaches
+
+- Provide BASE design spacings as separate constants
+
+```ts
+export const spacing0 = 0
+export const spacing1 = 0.25
+...
+export const spacing10 = 2.5
+export const spacing12 = 3
+```
+
+This approach is not consistent with the way `breakpoint` and `color` objects are exposed by Picaso (they are objects with key-value pairs, not as a separate constants)
+
+- Provide BASE design spacings as object with string values in `rem` units
+
+```ts
+export const spacing = {
+  0: `0rem`,
+  1: `0.25rem`,
+  ...
+  10: `2.5rem`,
+  12: `3rem`,
+}
+```
+
+This approach complicates handling of new spacing values in related components (`Container` and `Dropdown`), as they will have to handle new case of `Nrem` string besides the existing `SpacingType` without any significant advantage compared to the proposed approach.
+
+## Steps after approval
+
+- Discuss the update of [How to use spacings](https://picasso.toptal.net/?path=/story/tutorials-how-to-use-spacings--how-to-use-spacings) tutorial with the Design Team, create ticket for the update
+- Discuss the deprecation of existing `SpacingType` string constants with the Design Team, create ticket for deprecation and update of documentation for `Container` and `Dropdown`
+- Create ticket for exposing new `spacing` object from Picasso and announcing the whole change in frontend channels

--- a/docs/decisions/18-spacings.md
+++ b/docs/decisions/18-spacings.md
@@ -62,13 +62,22 @@ Picasso has to provide full set of BASE design spacings to allow consumers to us
 Picasso provides a new object `spacing` that includes proposed spacings in a form of key-value pairs (where the key is the index of the increment and the value is a corresponding value in `rem` unit)
 
 ```ts
-export const spacing = {
+// New internal type
+type PicassoSpacing = 0 | 0.25 | 0.5 | 0.75 | 1 | 1.5 | 2 | 2.5 | 3
+
+export const spacing: Record<number, PicassoSpacing> = {
   0: 0,
   1: 0.25,
   ...
   10: 2.5,
   12: 3,
 }
+...
+// SpacingType is extended with 
+export type SpacingType = PicassoSpacing
+  | number
+  | SizeType<'xsmall' | 'small' | 'medium' | 'large' | 'xlarge'>
+  | PicassoSpacing
 ```
 
 Exported `spacing` object with increments is reused by components with spacing properties (`top`, `right`, `bottom` and `left` properties in Container and `offset` property Dropdown)

--- a/docs/decisions/18-spacings.md
+++ b/docs/decisions/18-spacings.md
@@ -2,15 +2,15 @@
 
 ## Problem
 
-BASE design defines [rules](https://toptal-core.atlassian.net/wiki/spaces/Base/pages/3217031216/Spacing) on how to use spacing between page elements. Picasso does not provide BASE spacings, so consumers can not implement BASE-compatible designs in their applications.
+Picasso spacings are not aligned with [BASE design guidelines](https://toptal-core.atlassian.net/wiki/spaces/Base/pages/3217031216/Spacing). This fact complicates implementation of BASE-compatible applications using Picasso.
 
 ## Current situation
 
-Picasso provides a specialised `SpacingType` type that can be either a numeric value of `rem` units or one of the pre-defined string constants (`xsmall`, `small`, etc.) that are resolved to a number of `rem` units.
+Picasso provides a specialised `SpacingType` type that can be either a numeric value of `rem` units or one of the pre-defined string constants (`xsmall`, `small`, etc.) that are resolved to `rem` units.
 
 As an example, the `Container` component has a `top` property that has `SpacingType` type. Based on the statistics of `top` property usage (searching for its occurrences in [this](https://github.com/search?q=org%3Atoptal+%22+top%3D%7B%22&type=code&p=1) GitHub search), Picasso consumers frequently use both numeric values and string constants.
 
-All of the `SpacingType` string constants resolve to numeric values that are present in [BASE design spacings](https://toptal-core.atlassian.net/wiki/spaces/Base/pages/3217031216/Spacing#Base-Increment). Some of the BASE design spacings do not have a counterpart between `SpacingType` string constants. There are 5 `SpacingType` string constants and 12 BASE design spacings – for example, there is no string constant for `spacing-12` spacing.
+All `SpacingType` string constants resolve to numeric values that are present in [BASE design spacings](https://toptal-core.atlassian.net/wiki/spaces/Base/pages/3217031216/Spacing#Base-Increment). Some of the BASE design spacings do not have a counterpart in `SpacingType` string constants. There are 5 `SpacingType` string constants and 12 BASE design spacings – for example, there is no string constant for `spacing-12` spacing.
 
 ## Existing approaches
 
@@ -53,11 +53,11 @@ module.exports = {
 
 ## Proposal
 
-Picasso has to export spacing, compatible with [BASE design](https://toptal-core.atlassian.net/wiki/spaces/Base/pages/3217031216/Spacing). The legacy way of specifying spacing (numbers and string constants) has to be gradually deprecated to encourage usage of BASE spacings. The [How to use spacings](https://picasso.toptal.net/?path=/story/tutorials-how-to-use-spacings--how-to-use-spacings) tutorial has to be updated to contain up-to-date guidelines on using a new spacing system.
+Picasso has to export spacing, aligned with [BASE design](https://toptal-core.atlassian.net/wiki/spaces/Base/pages/3217031216/Spacing). The legacy way of specifying spacing (numbers and string constants) has to be gradually deprecated to encourage usage of BASE spacings. The [How to use spacings](https://picasso.toptal.net/?path=/story/tutorials-how-to-use-spacings--how-to-use-spacings) tutorial has to be updated to contain up-to-date guidelines on using a new spacing system.
 
 ### Technical implementation
 
-Picasso has to provide a new `spacing` object that includes proposed spacings in a form of key-value pairs (where the key is the index of the increment and the value is a corresponding value in `rem` unit)
+Picasso has to provide a new `spacing` object that includes proposed spacings in a form of key-value pairs (where the key is the index of the increment and the value is a corresponding value in `rem` units)
 
 ```ts
 // New internal type
@@ -88,9 +88,9 @@ import { spacing } from '@toptal/picasso/utils'
 
 ### Deprecation of existing approaches
 
-After BASE spacing is introduced, the number and string constants approaches of specifying spacing have to be deprecated (in 3 weeks). The deprecation plan consists of two steps:
+After BASE spacing is introduced, the number and string constants as spacing value have to be deprecated. The deprecation plan has two steps:
 
-- forbid number spacing, throw TypeScript error. For number values, that map to BASE spacing, codemod should be used for replacement. For custom values that do not map to BASE spacing, manual replacement should be applied by owning Teams.
+1. Forbid number spacing, throw TypeScript error if it is used. For number values, that map to BASE spacing, codemod should be used for replacement. For custom values that do not map to BASE spacing, manual replacement should be applied by owning Teams.
 
 ```jsx
 // Maps to BASE spacing
@@ -104,7 +104,7 @@ After BASE spacing is introduced, the number and string constants approaches of 
 
 Statistics: the `org:toptal "top={"` [GitHub search](https://github.com/search?q=org%3Atoptal+%22top%3D%7B%22&type=code) finds 10 occurences of non-BASE values (for example, `0.1`, `-2`. `0.125`, etc.) used in `Container.top` property 
 
-- forbid string constants and replace them with corresponding BASE spacings. Every string constant maps to BASE spacing, so codemod should be used for replacement.
+2. Forbid string constants and replace them with corresponding BASE spacings. Every string constant maps to BASE spacing, so codemod should be used for replacement.
 
 ```jsx
 type Sizes = 'xxsmall' | 'xsmall' | 'small' | 'medium' | 'large' | 'xlarge'
@@ -126,6 +126,9 @@ export enum SpacingEnum {
 The goal is to remove `number` and `SizeType` from `SpacingType` union type.
 
 ```jsx
+// New internal type
+type PicassoSpacing = 0 | 0.25 | 0.5 | 0.75 | 1 | 1.5 | 2 | 2.5 | 3
+
 export type SpacingType = PicassoSpacing
 ```
 

--- a/docs/decisions/18-spacings.md
+++ b/docs/decisions/18-spacings.md
@@ -53,11 +53,11 @@ module.exports = {
 
 ## Proposal
 
-Picasso has to export spacing, aligned with [BASE design](https://toptal-core.atlassian.net/wiki/spaces/Base/pages/3217031216/Spacing). The legacy way of specifying spacing (numbers and string constants) has to be gradually deprecated to encourage usage of BASE spacings. The [How to use spacings](https://picasso.toptal.net/?path=/story/tutorials-how-to-use-spacings--how-to-use-spacings) tutorial has to be updated to contain up-to-date guidelines on using a new spacing system.
+Picasso exports spacing, aligned with [BASE design](https://toptal-core.atlassian.net/wiki/spaces/Base/pages/3217031216/Spacing). The legacy way of specifying spacing (numbers and string constants) is gradually deprecated to encourage usage of BASE spacings. The [How to use spacings](https://picasso.toptal.net/?path=/story/tutorials-how-to-use-spacings--how-to-use-spacings) tutorial is updated to contain up-to-date guidelines on using a new spacing system.
 
-### Technical implementation
+### Technical details
 
-Picasso has to provide a new `spacing` object that includes proposed spacings in a form of key-value pairs (where the key is the index of the increment and the value is a corresponding value in `rem` units)
+Picasso provides a new `spacing` object that includes proposed spacings in a form of key-value pairs (where the key is the index of the increment and the value is a corresponding value in `rem` units)
 
 ```ts
 // New internal type

--- a/docs/decisions/18-spacings.md
+++ b/docs/decisions/18-spacings.md
@@ -1,16 +1,16 @@
-# RFC Template
+# Spacing
 
 ## Problem
 
-BASE design defines [rules](https://toptal-core.atlassian.net/wiki/spaces/Base/pages/3217031216/Spacing) on how to use spacing between page elements in frontend applications. Picasso has to align with design rules and has to provide tools for Picasso consumers to use BASE-compatible spacing in applications.
+BASE design defines [rules](https://toptal-core.atlassian.net/wiki/spaces/Base/pages/3217031216/Spacing) on how to use spacing between page elements. Picasso does not provide BASE spacings, so consumers can not implement BASE-compatible designs in their applications.
 
 ## Current situation
 
-Picasso provides a specialised `SpacingType` type that can be either a numeric value or one of the pre-defined string constants (`xsmall`, `small`, etc.) that are resolved to a number (in both cases a numeric value corresponds to a number of `rem` units of spacing).
+Picasso provides a specialised `SpacingType` type that can be either a numeric value of `rem` units or one of the pre-defined string constants (`xsmall`, `small`, etc.) that are resolved to a number of `rem` units.
 
 As an example, the `Container` component has a `top` property that has `SpacingType` type. Based on the statistics of `top` property usage (searching for its occurrences in [this](https://github.com/search?q=org%3Atoptal+%22+top%3D%7B%22&type=code&p=1) GitHub search), Picasso consumers frequently use both numeric values and string constants.
 
-All of the `SpacingType` string constants resolve to numeric values that are present in [BASE design spacings](https://toptal-core.atlassian.net/wiki/spaces/Base/pages/3217031216/Spacing#Base-Increment). Some of the BASE design spacings do not have a counterpart between `SpacingType` string constants. There are 5 `SpacingType` string constants and 12 BASE design spacings – for example, there is no string constant for `spacing-12` spacing. 
+All of the `SpacingType` string constants resolve to numeric values that are present in [BASE design spacings](https://toptal-core.atlassian.net/wiki/spaces/Base/pages/3217031216/Spacing#Base-Increment). Some of the BASE design spacings do not have a counterpart between `SpacingType` string constants. There are 5 `SpacingType` string constants and 12 BASE design spacings – for example, there is no string constant for `spacing-12` spacing.
 
 ## Existing approaches
 
@@ -53,14 +53,11 @@ module.exports = {
 
 ## Proposal
 
-### Goal
-
-Picasso has to provide full set of BASE design spacings to allow consumers to use all of them when developing Picasso-based applications. Introduced changes should not break existing usage of spacing in related components mentioned above. The legacy way of specifying spacing (numbers and string constants) has to be gradually deprecated. The upcoming deprecation should be announced and completed in 3 weeks after introduction of BASE spacing.
-
+Picasso has to export spacing, compatible with [BASE design](https://toptal-core.atlassian.net/wiki/spaces/Base/pages/3217031216/Spacing). The legacy way of specifying spacing (numbers and string constants) has to be gradually deprecated to encourage usage of BASE spacings. The [How to use spacings](https://picasso.toptal.net/?path=/story/tutorials-how-to-use-spacings--how-to-use-spacings) tutorial is updated to contain guidelines on using a new spacing system for a particular example.
 
 ### Technical implementation
 
-Picasso provides a new object `spacing` that includes proposed spacings in a form of key-value pairs (where the key is the index of the increment and the value is a corresponding value in `rem` unit)
+Picasso has to provide a new `spacing` object that includes proposed spacings in a form of key-value pairs (where the key is the index of the increment and the value is a corresponding value in `rem` unit)
 
 ```ts
 // New internal type
@@ -81,15 +78,13 @@ export type SpacingType =
   | PicassoSpacing
 ```
 
-Exported `spacing` object with increments is reused by components with spacing properties (`top`, `right`, `bottom` and `left` properties in Container and `offset` property Dropdown)
+Exported `spacing` object is reused by components with spacing properties (`top`, `right`, `bottom`, `left`, `gap`, and `padded` properties in Container component).
 
 ```tsx
 import { spacing } from '@toptal/picasso/utils'
 ...
 <Container top={spacing[6]}/>
 ```
-
-The [How to use spacings](https://picasso.toptal.net/?path=/story/tutorials-how-to-use-spacings--how-to-use-spacings) tutorial is updated to contain guidelines on using a new spacing system for a particular example.
 
 ### Deprecation of existing approaches
 
@@ -150,7 +145,7 @@ export const spacing10 = 2.5
 export const spacing12 = 3
 ```
 
-This approach is not consistent with the way `breakpoint` and `color` objects are exposed by Picaso (they are objects with key-value pairs, not as a separate constants)
+This approach is not consistent with the way `breakpoint` and `color` objects are exposed by Picasso (they are objects with key-value pairs, not as a separate constants)
 
 - Provide BASE design spacings as object with string values in `rem` units
 
@@ -165,10 +160,3 @@ export const spacing = {
 ```
 
 This approach complicates handling of new spacing values in related components (`Container` and `Dropdown`), as they will have to handle new case of `Nrem` string besides the existing `SpacingType` without any significant advantage compared to the proposed approach.
-
-## Steps after approval
-
-- Discuss the update of [How to use spacings](https://picasso.toptal.net/?path=/story/tutorials-how-to-use-spacings--how-to-use-spacings) tutorial with the Design Team, create ticket for the update
-- Discuss the deprecation of existing `SpacingType` string constants with the Design Team, create ticket for deprecation and update of documentation for `Container` and `Dropdown`
-- Create ticket for exposing new `spacing` object from Picasso and announcing the whole change in frontend channels (mention that using numbers of spacing constants will be deprecated in 3 weeks) – minor change
-- Create ticket for removing number and string constants in 3 weeks after introduction of BASE spacing – breaking change 

--- a/docs/decisions/18-spacings.md
+++ b/docs/decisions/18-spacings.md
@@ -4,7 +4,7 @@
 
 Picasso spacings are not aligned with [BASE design guidelines](https://toptal-core.atlassian.net/wiki/spaces/Base/pages/3217031216/Spacing). This fact complicates implementation of BASE-compatible applications using Picasso.
 
-## Current situation
+## Context
 
 Picasso provides a specialised `SpacingType` type that can be either a numeric value of `rem` units or one of the pre-defined string constants (`xsmall`, `small`, etc.) that are resolved to `rem` units.
 

--- a/docs/decisions/18-spacings.md
+++ b/docs/decisions/18-spacings.md
@@ -83,6 +83,11 @@ The [How to use spacings](https://picasso.toptal.net/?path=/story/tutorials-how-
 
 ## Alternative approaches
 
+
+- Intoroduce responsive spacing tokens with different values depending on the screen size
+
+This is one of the approaches used on the market (as an example, [Audi Design System](https://react.ui.audi/?path=/docs/brand-identity-design-tokens--page#layout-system)). However, the responsive spacing tokens idea was abandoned after discussion with the Design Team due to its complexity and unclear benefits.
+
 - Provide BASE design spacings as separate constants
 
 ```ts

--- a/docs/decisions/18-spacings.md
+++ b/docs/decisions/18-spacings.md
@@ -55,7 +55,8 @@ module.exports = {
 
 ### Goal
 
-Picasso has to provide full set of BASE design spacings to allow consumers to use all of them when developing Picasso-based applications. Introduced changes should not break existing usage of spacing in related components mentioned above.
+Picasso has to provide full set of BASE design spacings to allow consumers to use all of them when developing Picasso-based applications. Introduced changes should not break existing usage of spacing in related components mentioned above. The legacy way of specifying spacing (numbers and string constants) has to be gradually deprecated. The upcoming deprecation should be announced and completed in 3 weeks after introduction of BASE spacing.
+
 
 ### Technical implementation
 
@@ -73,8 +74,8 @@ export const spacing: Record<number, PicassoSpacing> = {
   12: 3,
 }
 ...
-// SpacingType is extended with 
-export type SpacingType = PicassoSpacing
+// SpacingType is extended with PicassoSpacing
+export type SpacingType =
   | number
   | SizeType<'xsmall' | 'small' | 'medium' | 'large' | 'xlarge'>
   | PicassoSpacing
@@ -90,8 +91,50 @@ import { spacing } from '@toptal/picasso/utils'
 
 The [How to use spacings](https://picasso.toptal.net/?path=/story/tutorials-how-to-use-spacings--how-to-use-spacings) tutorial is updated to contain guidelines on using a new spacing system for a particular example.
 
-## Alternative approaches
+### Deprecation of existing approaches
 
+After BASE spacing is introduced, the number and string constants approaches of specifying spacing have to be deprecated (in 3 weeks). The deprecation plan consists of two steps:
+
+- forbid number spacing, throw TypeScript error. For number values, that map to BASE spacing, codemod should be used for replacement. For custom values that do not map to BASE spacing, manual replacement should be applied by owning Teams.
+
+```jsx
+// Maps to BASE spacing
+<Container top={1}/>
+// becomes
+<Container top={spacing[4]}/>
+
+// Does not map to BASE spacing, has to be addressed manually, otherwise TypeScript error is thrown
+<Container top={0.1}/>
+```
+
+Statistics: the `org:toptal "top={"` [GitHub search](https://github.com/search?q=org%3Atoptal+%22top%3D%7B%22&type=code) finds 10 occurences of non-BASE values (for example, `0.1`, `-2`. `0.125`, etc.) used in `Container.top` property 
+
+- forbid string constants and replace them with corresponding BASE spacings. Every string constant maps to BASE spacing, so codemod should be used for replacement.
+
+```jsx
+type Sizes = 'xxsmall' | 'xsmall' | 'small' | 'medium' | 'large' | 'xlarge'
+
+export enum SpacingEnum {
+  xsmall = 0.5,  // maps to spacing[2]
+  small = 1,     // maps to spacing[4]
+  medium = 1.5,  // maps to spacing[6]
+  large = 2,     // maps to spacing[8]
+  xlarge = 2.5,  // maps to spacing[10]
+}
+
+// Example of conversion
+<Container top='small'/>
+// becomes
+<Container top={spacing[4]}/>
+```
+
+The goal is to remove `number` and `SizeType` from `SpacingType` union type.
+
+```jsx
+export type SpacingType = PicassoSpacing
+```
+
+## Alternative approaches
 
 - Intoroduce responsive spacing tokens with different values depending on the screen size
 
@@ -127,4 +170,5 @@ This approach complicates handling of new spacing values in related components (
 
 - Discuss the update of [How to use spacings](https://picasso.toptal.net/?path=/story/tutorials-how-to-use-spacings--how-to-use-spacings) tutorial with the Design Team, create ticket for the update
 - Discuss the deprecation of existing `SpacingType` string constants with the Design Team, create ticket for deprecation and update of documentation for `Container` and `Dropdown`
-- Create ticket for exposing new `spacing` object from Picasso and announcing the whole change in frontend channels (mention that using numbers of spacing constants will be deprecated in the future)
+- Create ticket for exposing new `spacing` object from Picasso and announcing the whole change in frontend channels (mention that using numbers of spacing constants will be deprecated in 3 weeks) – minor change
+- Create ticket for removing number and string constants in 3 weeks after introduction of BASE spacing – breaking change 

--- a/docs/decisions/18-spacings.md
+++ b/docs/decisions/18-spacings.md
@@ -118,4 +118,4 @@ This approach complicates handling of new spacing values in related components (
 
 - Discuss the update of [How to use spacings](https://picasso.toptal.net/?path=/story/tutorials-how-to-use-spacings--how-to-use-spacings) tutorial with the Design Team, create ticket for the update
 - Discuss the deprecation of existing `SpacingType` string constants with the Design Team, create ticket for deprecation and update of documentation for `Container` and `Dropdown`
-- Create ticket for exposing new `spacing` object from Picasso and announcing the whole change in frontend channels
+- Create ticket for exposing new `spacing` object from Picasso and announcing the whole change in frontend channels (mention that using numbers of spacing constants will be deprecated in the future)


### PR DESCRIPTION
[FX-4226]

### Description

This pull request adds an RFC for introducing new BASE design spacings described in https://toptal-core.atlassian.net/wiki/spaces/Base/pages/3217031216/Spacing.

The overall plan is presented in https://toptal-core.atlassian.net/wiki/spaces/FE/pages/3389194785/Spacing.

### How to test

- Please review the https://github.com/toptal/picasso/blob/FX-4426-expose-base-spacing/docs/decisions/18-spacings.md

### Development checks

- [x] Self reviewed

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-4226]: https://toptal-core.atlassian.net/browse/FX-4226?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ