### PR TITLE
fix: placeholder wrap in RTE

### DIFF
--- a/.changeset/honest-stingrays-lick.md
+++ b/.changeset/honest-stingrays-lick.md
@@ -1,0 +1,7 @@
+---
+'@toptal/picasso-rich-text-editor': patch
+---
+
+### RichTextEditor
+
+- fix placeholder wrap

--- a/cypress/component/RichTextEditor/Default.spec.tsx
+++ b/cypress/component/RichTextEditor/Default.spec.tsx
@@ -455,4 +455,19 @@ describe('RichTextEditor', () => {
       cy.get('body').happoScreenshot({ component, variant: 'focused' })
     })
   })
+
+  describe('when long placeholder string is provided', () => {
+    it('wraps placeholder', () => {
+      cy.mount(
+        renderEditor({
+          ...defaultProps,
+          ...{
+            placeholder: 'abcdabcdab abcabca abab aa 1 '.repeat(32),
+          },
+        })
+      )
+
+      cy.get('body').happoScreenshot({ component, variant: 'long-placeholder' })
+    })
+  })
 })

--- a/packages/picasso-rich-text-editor/src/LexicalEditor/styles.ts
+++ b/packages/picasso-rich-text-editor/src/LexicalEditor/styles.ts
@@ -110,7 +110,7 @@ export default (theme: Theme) => {
       top: '0px',
       left: '0px',
       userSelect: 'none',
-      whiteSpace: 'nowrap',
+      whiteSpace: 'normal',
       display: 'inline-block',
       pointerEvents: 'none',
     },


### PR DESCRIPTION
[FX-4231]

### Description

This pull request fixes the placeholder wrapping in Rich Text Editor.

### How to test

<!-- The temploy link will be automatically updated when the temploy is deployed -->
- [Temploy](https://picasso.toptal.net/fx-4231-rte-word-wrap-is-not-working)
- Check the added visual test

<img width="459" alt="Screenshot 2023-08-14 at 13 53 26" src="https://github.com/toptal/picasso/assets/1390758/9759c7a2-bf60-4f1d-967d-a55b01e9ee8b">



### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| <img width="355" alt="Screenshot 2023-08-14 at 13 44 07" src="https://github.com/toptal/picasso/assets/1390758/e9294cdd-ddf8-4c14-bdfd-77ba8833fe47"> | <img width="394" alt="Screenshot 2023-08-14 at 13 43 28" src="https://github.com/toptal/picasso/assets/1390758/6099fafa-57ad-4337-8eeb-5c7c547f29cc"> |

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [N/A] Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [N/A] Annotate all `props` in component with documentation
- [N/A] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests ([visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md) included)

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-4231]: https://toptal-core.atlassian.net/browse/FX-4231?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ