### PR TITLE
fix: sometimes crashing mutator

### DIFF
--- a/.changeset/silly-snails-tickle.md
+++ b/.changeset/silly-snails-tickle.md
@@ -1,0 +1,7 @@
+---
+'@toptal/picasso-forms': patch
+---
+
+### Form
+
+- applied defensive coding to one of the form mutators to try to prevent seldom crashes in production

--- a/packages/picasso-forms/src/Form/mutators/set-active-field-touched.ts
+++ b/packages/picasso-forms/src/Form/mutators/set-active-field-touched.ts
@@ -8,10 +8,9 @@ export const setActiveFieldTouched = <
   state: MutableState<FormValues, InitialFormValues>
 ) => {
   const activeFieldName = state.formState.active
+  const field = activeFieldName && state.fields[activeFieldName]
 
-  if (activeFieldName) {
-    const field = state.fields[activeFieldName]
-
+  if (field) {
     field.touched = true
   }
 }


### PR DESCRIPTION
### Description

We have the final form mutator crashing sometimes https://toptal-core.slack.com/archives/CERF5NHT3/p1692093998693089?thread_ts=1691993118.653259&cid=CERF5NHT3

This PR attempts to fix the problem by applying defencive coding without understanding the root cause because user could not reproduce. 

### How to test

<!-- The temploy link will be automatically updated when the temploy is deployed -->
- [Temploy](https://picasso.toptal.net/fx-fix-crashing-form-mutator)
- FIXME: Add the steps describing how to verify your changes

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| Insert screenshots or screen recordings | Insert screenshots or screen recordings |

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests ([visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md) included)

**Breaking change**

- [x] codemod is created and showcased in the changeset
- [x] test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>
