### PR TITLE
feat: add blue light color to TagRectangular

### DIFF
--- a/.changeset/light-trainers-walk.md
+++ b/.changeset/light-trainers-walk.md
@@ -1,0 +1,7 @@
+---
+'@toptal/picasso': minor
+---
+
+### TagRectangular
+
+- add light blue color

--- a/.changeset/light-trainers-walk.md
+++ b/.changeset/light-trainers-walk.md
@@ -2,7 +2,7 @@
 '@toptal/picasso': minor
 ---
 
-### TagRectangular
+### Tag
 
 - add light blue color
 - align line hight of the text with BASE (can break visual tests, accept new snapshots to resolve)

--- a/.changeset/light-trainers-walk.md
+++ b/.changeset/light-trainers-walk.md
@@ -5,3 +5,4 @@
 ### TagRectangular
 
 - add light blue color
+- align line hight of the text with BASE (can break visual tests, accept new snapshots to resolve)

--- a/packages/picasso/src/TagRectangular/story/Variants.example.tsx
+++ b/packages/picasso/src/TagRectangular/story/Variants.example.tsx
@@ -8,6 +8,7 @@ const Example = () => (
     <Tag.Rectangular variant='green'>Green</Tag.Rectangular>
     <Tag.Rectangular variant='dark-grey'>Dark grey</Tag.Rectangular>
     <Tag.Rectangular variant='light-grey'>Light grey</Tag.Rectangular>
+    <Tag.Rectangular variant='light-blue'>Light blue</Tag.Rectangular>
   </Container>
 )
 

--- a/packages/picasso/src/TagRectangular/styles.ts
+++ b/packages/picasso/src/TagRectangular/styles.ts
@@ -21,6 +21,9 @@ export default ({ palette }: Theme) =>
     'light-grey': {
       backgroundColor: palette.grey.lighter2,
     },
+    'light-blue': {
+      backgroundColor: palette.blue.light,
+    },
     green: {
       backgroundColor: palette.green.dark,
     },
@@ -29,7 +32,7 @@ export default ({ palette }: Theme) =>
     },
     innerLabel: {
       fontSize: '11px',
-      lineHeight: '1em',
+      lineHeight: '12px',
       fontWeight: 600,
       color: palette.common.white,
     },

--- a/packages/picasso/src/TagRectangular/styles.ts
+++ b/packages/picasso/src/TagRectangular/styles.ts
@@ -32,7 +32,7 @@ export default ({ palette }: Theme) =>
     },
     innerLabel: {
       fontSize: '11px',
-      lineHeight: '12px',
+      lineHeight: '0.75rem',
       fontWeight: 600,
       color: palette.common.white,
     },

--- a/packages/picasso/src/TagRectangular/types.ts
+++ b/packages/picasso/src/TagRectangular/types.ts
@@ -12,6 +12,7 @@ export type VariantType =
   | 'dark-grey'
   | 'light-grey'
   | 'green'
+  | 'light-blue'
 
 export interface VariantOnlyProps
   extends BaseProps,


### PR DESCRIPTION
[FX-3949]

### Description

Added blue light color to TagRectangular

### How to test

<!-- The temploy link will be automatically updated when the temploy is deployed -->
- Check Temploy

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| ![image](https://github.com/toptal/picasso/assets/14070311/52a083f4-dc27-4503-a7da-04485c5b02c4) | ![image](https://github.com/toptal/picasso/assets/14070311/ba3ff87b-2d44-4138-8aea-99af00289241)|

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests ([visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md) included)

**Breaking change**

- [x] codemod is created and showcased in the changeset
- [x] test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-3949]: https://toptal-core.atlassian.net/browse/FX-3949?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ