### PR TITLE
feat(RichText): disable white space collapsing on RichText

### DIFF
--- a/packages/picasso-rich-text-editor/src/RichText/RichText.tsx
+++ b/packages/picasso-rich-text-editor/src/RichText/RichText.tsx
@@ -1,9 +1,13 @@
 import React from 'react'
 import type { BaseProps } from '@toptal/picasso-shared'
 import Container from '@toptal/picasso/Container'
+import type { Theme } from '@material-ui/core/styles'
+import { makeStyles } from '@material-ui/core/styles'
+import cx from 'classnames'
 
 import type { ASTType } from './types'
 import useRichText from './hooks/useRichText'
+import styles from './styles'
 
 export interface Props extends BaseProps {
   /**
@@ -11,6 +15,8 @@ export interface Props extends BaseProps {
    */
   value: ASTType
 }
+
+const useStyles = makeStyles<Theme>(styles, { name: 'PicassoRichText' })
 
 export const RichText = ({
   value,
@@ -20,11 +26,13 @@ export const RichText = ({
 }: Props) => {
   const richText = useRichText(value)
 
+  const classes = useStyles()
+
   return (
     <Container
       style={style}
       data-testid={dataTestId}
-      className={className}
+      className={cx(classes.root, className)}
       gap='xsmall'
       flex
       direction='column'

--- a/packages/picasso-rich-text-editor/src/RichText/styles.ts
+++ b/packages/picasso-rich-text-editor/src/RichText/styles.ts
@@ -1,0 +1,8 @@
+import { createStyles } from '@material-ui/core/styles'
+
+export default () =>
+  createStyles({
+    root: {
+      whiteSpace: 'pre-wrap',
+    },
+  })


### PR DESCRIPTION
[FX-4220]

### Description

Add same white space collapsing styles as the editor to the RichText preview.

I think we should consider this as a bugfix, instead of a breaking change. As the editor already shows the text with non collapsed spaces, we are just mirroring it on RichText

### How to test

<!-- The temploy link will be automatically updated when the temploy is deployed -->
- [Temploy](https://picasso.toptal.net/FX-4220-rich-text-editor-contiguous-spaces-collapsing)
- Visit temploy and Happo

### Screenshots

No screenshots

### Development checks

- [ ] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests ([visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md) included)

**Breaking change**

- [x] codemod is created and showcased in the changeset
- [x] test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-4220]: https://toptal-core.atlassian.net/browse/FX-4220?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ