### PR TITLE
fix(rich-text-editor): apply typography styles to RTE headings

### DIFF
--- a/.changeset/soft-pans-fail.md
+++ b/.changeset/soft-pans-fail.md
@@ -1,0 +1,7 @@
+---
+'@toptal/picasso-rich-text-editor': patch
+---
+
+### RichTextEditor
+
+- apply Picasso Typography styles to RichTextEditor headings

--- a/packages/picasso-rich-text-editor/src/LexicalEditor/LexicalEditor.tsx
+++ b/packages/picasso-rich-text-editor/src/LexicalEditor/LexicalEditor.tsx
@@ -93,6 +93,32 @@ export type Props = BaseProps & {
   hiddenInputId?: string
 }
 
+const useLexicalTheme = (classes: Record<string, string>) => {
+  const bodyTypographyClassName = useTypographyClasses({
+    variant: 'body',
+    size: 'medium',
+  })
+
+  const headingTypographyClassName = useTypographyClasses({
+    variant: 'heading',
+    size: 'medium',
+  })
+
+  const theme = useMemo(
+    () =>
+      createLexicalTheme({
+        typographyClassNames: {
+          root: bodyTypographyClassName,
+          heading: headingTypographyClassName,
+        },
+        classes,
+      }),
+    [bodyTypographyClassName, headingTypographyClassName, classes]
+  )
+
+  return theme
+}
+
 const LexicalEditor = forwardRef<HTMLDivElement, Props>(function LexicalEditor(
   props: Props,
   ref
@@ -117,19 +143,7 @@ const LexicalEditor = forwardRef<HTMLDivElement, Props>(function LexicalEditor(
 
   const toolbarRef = useRef<HTMLDivElement | null>(null)
 
-  const typographyClassNames = useTypographyClasses({
-    variant: 'body',
-    size: 'medium',
-  })
-
-  const theme = useMemo(
-    () =>
-      createLexicalTheme({
-        typographyClassNames,
-        classes,
-      }),
-    [typographyClassNames, classes]
-  )
+  const theme = useLexicalTheme(classes)
 
   const { componentPlugins, lexicalNodes } = useComponentPlugins(
     plugins,

--- a/packages/picasso-rich-text-editor/src/LexicalEditor/utils/create-lexical-theme.ts
+++ b/packages/picasso-rich-text-editor/src/LexicalEditor/utils/create-lexical-theme.ts
@@ -2,7 +2,10 @@ import type { makeStyles } from '@material-ui/core/styles'
 import type { EditorThemeClasses } from 'lexical'
 
 type Props = {
-  typographyClassNames: string
+  typographyClassNames: {
+    root: string
+    heading: string
+  }
   // ClassNameMap is not exported from @material-ui/core
   classes: ReturnType<ReturnType<typeof makeStyles>>
 }
@@ -17,12 +20,15 @@ export const createLexicalTheme = ({
   )
 
   const theme: EditorThemeClasses = {
-    root: typographyClassNames,
+    root: typographyClassNames.root,
     paragraph: classes.paragraph,
     text: {
       italic: classes.italic,
       bold: classes.bold,
       code: classes.code,
+    },
+    heading: {
+      h3: typographyClassNames.heading,
     },
 
     list: {


### PR DESCRIPTION
[FX-4256]

### Description

The heading on RTE assumed the default styling from the browser. We are now providing the styles for it from our own typography package

### How to test

<!-- The temploy link will be automatically updated when the temploy is deployed -->
- [Temploy](https://picasso.toptal.net/fx-4256-set-proper-styles-to-h3-in-richtexteditor)
- Check temploy and Happo

### Screenshots

No Screenshots

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests ([visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md) included)

**Breaking change**

- [x] codemod is created and showcased in the changeset
- [x] test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-4256]: https://toptal-core.atlassian.net/browse/FX-4256?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ