### PR TITLE
feat: [FX-4259] add new spacing values to picasso

### DIFF
--- a/.changeset/lovely-socks-cheat.md
+++ b/.changeset/lovely-socks-cheat.md
@@ -4,4 +4,4 @@
 '@toptal/picasso-shared': minor
 ---
 
-- add new Spacing values to picasso's theme and to `picasso-shared`. See RFC: https://github.com/toptal/picasso/blob/master/docs/decisions/18-spacings.md#technical-details
+- add new spacing values to picasso's theme and to `picasso-shared`. See RFC: https://github.com/toptal/picasso/blob/master/docs/decisions/18-spacings.md

--- a/.changeset/lovely-socks-cheat.md
+++ b/.changeset/lovely-socks-cheat.md
@@ -1,0 +1,7 @@
+---
+'@toptal/picasso-provider': minor
+'@toptal/picasso': minor
+'@toptal/picasso-shared': minor
+---
+
+- add new Spacing values to picasso's theme and to `picasso-shared`. See RFC: https://github.com/toptal/picasso/blob/master/docs/decisions/18-spacings.md#technical-details

--- a/packages/picasso-provider/src/Picasso/PicassoProvider.tsx
+++ b/packages/picasso-provider/src/Picasso/PicassoProvider.tsx
@@ -12,9 +12,10 @@ import {
   typography,
   sizes,
   shadows,
+  spacings,
 } from './config'
 
-const picasso = {
+const picasso: ThemeOptions = {
   palette,
   layout,
   transitions,
@@ -37,6 +38,7 @@ const picasso = {
       notched: false,
     },
   },
+  spacings,
 }
 
 class Provider {

--- a/packages/picasso-provider/src/Picasso/config/index.ts
+++ b/packages/picasso-provider/src/Picasso/config/index.ts
@@ -16,3 +16,10 @@ export {
 } from './breakpoints'
 export { default as layout } from './layout'
 export { default as shadows } from './shadows'
+export { default as spacings, PicassoSpacing, SpacingEnum } from './spacings'
+export type {
+  PicassoSpacingValues,
+  Sizes,
+  SizeType,
+  SpacingType,
+} from './spacings'

--- a/packages/picasso-provider/src/Picasso/config/index.ts
+++ b/packages/picasso-provider/src/Picasso/config/index.ts
@@ -16,10 +16,5 @@ export {
 } from './breakpoints'
 export { default as layout } from './layout'
 export { default as shadows } from './shadows'
-export { default as spacings, PicassoSpacing, SpacingEnum } from './spacings'
-export type {
-  PicassoSpacingValues,
-  Sizes,
-  SizeType,
-  SpacingType,
-} from './spacings'
+export { default as spacings, SpacingEnum } from './spacings'
+export type { Sizes, SizeType, SpacingType, PicassoSpacing } from './spacings'

--- a/packages/picasso-provider/src/Picasso/config/spacings.ts
+++ b/packages/picasso-provider/src/Picasso/config/spacings.ts
@@ -1,45 +1,9 @@
+// ============================
+// TYPES
+// ============================
+
 // BASE-aligned spacing values in "rem" units
 export type PicassoSpacingValues = 0 | 0.25 | 0.5 | 0.75 | 1 | 1.5 | 2 | 2.5 | 3
-
-export class PicassoSpacing {
-  value: number
-
-  constructor(value: PicassoSpacingValues) {
-    this.value = value
-  }
-
-  valueOf() {
-    console.log('this.value: ', this.value)
-
-    return this.value
-  }
-
-  toString() {
-    return this.value.toString()
-  }
-}
-
-const SPACING_0 = new PicassoSpacing(0)
-const SPACING_1 = new PicassoSpacing(0.25)
-const SPACING_2 = new PicassoSpacing(0.5)
-const SPACING_3 = new PicassoSpacing(0.75)
-const SPACING_4 = new PicassoSpacing(1)
-const SPACING_5 = new PicassoSpacing(1.5)
-const SPACING_6 = new PicassoSpacing(2)
-const SPACING_7 = new PicassoSpacing(2.5)
-const SPACING_8 = new PicassoSpacing(3)
-
-const spacings = {
-  SPACING_0,
-  SPACING_1,
-  SPACING_2,
-  SPACING_3,
-  SPACING_4,
-  SPACING_5,
-  SPACING_6,
-  SPACING_7,
-  SPACING_8,
-}
 
 export type Sizes =
   | 'xxsmall'
@@ -49,6 +13,15 @@ export type Sizes =
   | 'large'
   | 'xlarge'
 
+export type SizeType<T extends Sizes> = T
+
+/** @deprecated **/
+export type DeprecatedSpacingType =
+  | number
+  | SizeType<'xsmall' | 'small' | 'medium' | 'large' | 'xlarge'>
+
+export type SpacingType = PicassoSpacing | DeprecatedSpacingType
+
 export enum SpacingEnum {
   xsmall = 0.5,
   small = 1,
@@ -57,11 +30,44 @@ export enum SpacingEnum {
   xlarge = 2.5,
 }
 
-export type SizeType<T extends Sizes> = T
+// ============================
+// CLASS DEFINITION
+// ============================
 
-export type SpacingType =
-  | number
-  | SizeType<'xsmall' | 'small' | 'medium' | 'large' | 'xlarge'>
-  | PicassoSpacing
+export class PicassoSpacing {
+  private value: PicassoSpacingValues
+
+  private constructor(value: PicassoSpacingValues) {
+    this.value = value
+  }
+
+  static create(value: PicassoSpacingValues): PicassoSpacing {
+    return new PicassoSpacing(value)
+  }
+
+  valueOf(): PicassoSpacingValues {
+    return this.value
+  }
+
+  toString(): string {
+    return this.value.toString()
+  }
+}
+
+// ============================
+// SPACING CONSTANTS
+// ============================
+
+const SPACING_VALUES: PicassoSpacingValues[] = [
+  0, 0.25, 0.5, 0.75, 1, 1.5, 2, 2.5, 3,
+]
+
+const spacings = Object.freeze(
+  SPACING_VALUES.reduce((acc, value, index) => {
+    acc[`SPACING_${index}`] = PicassoSpacing.create(value)
+
+    return acc
+  }, {} as Record<string, PicassoSpacing>)
+)
 
 export default spacings

--- a/packages/picasso-provider/src/Picasso/config/spacings.ts
+++ b/packages/picasso-provider/src/Picasso/config/spacings.ts
@@ -1,9 +1,5 @@
-// ============================
-// TYPES
-// ============================
-
 // BASE-aligned spacing values in "rem" units
-export type PicassoSpacingValues = 0 | 0.25 | 0.5 | 0.75 | 1 | 1.5 | 2 | 2.5 | 3
+type PicassoSpacingValues = 0 | 0.25 | 0.5 | 0.75 | 1 | 1.5 | 2 | 2.5 | 3
 
 export type Sizes =
   | 'xxsmall'
@@ -16,7 +12,7 @@ export type Sizes =
 export type SizeType<T extends Sizes> = T
 
 /** @deprecated **/
-export type DeprecatedSpacingType =
+type DeprecatedSpacingType =
   | number
   | SizeType<'xsmall' | 'small' | 'medium' | 'large' | 'xlarge'>
 
@@ -30,15 +26,11 @@ export enum SpacingEnum {
   xlarge = 2.5,
 }
 
-// ============================
-// CLASS DEFINITION
-// ============================
-
-export class PicassoSpacing {
-  private value: PicassoSpacingValues
+class PicassoSpacing {
+  #value: PicassoSpacingValues
 
   private constructor(value: PicassoSpacingValues) {
-    this.value = value
+    this.#value = value
   }
 
   static create(value: PicassoSpacingValues): PicassoSpacing {
@@ -46,28 +38,38 @@ export class PicassoSpacing {
   }
 
   valueOf(): PicassoSpacingValues {
-    return this.value
+    return this.#value
   }
 
   toString(): string {
-    return this.value.toString()
+    return this.#value.toString()
   }
 }
 
-// ============================
-// SPACING CONSTANTS
-// ============================
+export type { PicassoSpacing }
 
-const SPACING_VALUES: PicassoSpacingValues[] = [
-  0, 0.25, 0.5, 0.75, 1, 1.5, 2, 2.5, 3,
-]
+export const isPicassoSpacing = (
+  spacing: SpacingType
+): spacing is PicassoSpacing => spacing instanceof PicassoSpacing
 
-const spacings = Object.freeze(
-  SPACING_VALUES.reduce((acc, value, index) => {
-    acc[`SPACING_${index}`] = PicassoSpacing.create(value)
+export const SPACING_0 = PicassoSpacing.create(0)
+export const SPACING_1 = PicassoSpacing.create(0.25)
+export const SPACING_2 = PicassoSpacing.create(0.5)
+export const SPACING_3 = PicassoSpacing.create(0.75)
+export const SPACING_4 = PicassoSpacing.create(1)
+export const SPACING_6 = PicassoSpacing.create(1.5)
+export const SPACING_8 = PicassoSpacing.create(2)
+export const SPACING_10 = PicassoSpacing.create(2.5)
+export const SPACING_12 = PicassoSpacing.create(3)
 
-    return acc
-  }, {} as Record<string, PicassoSpacing>)
-)
-
-export default spacings
+export default {
+  SPACING_0,
+  SPACING_1,
+  SPACING_2,
+  SPACING_3,
+  SPACING_4,
+  SPACING_6,
+  SPACING_8,
+  SPACING_10,
+  SPACING_12,
+}

--- a/packages/picasso-provider/src/Picasso/config/spacings.ts
+++ b/packages/picasso-provider/src/Picasso/config/spacings.ts
@@ -1,0 +1,67 @@
+// BASE-aligned spacing values in "rem" units
+export type PicassoSpacingValues = 0 | 0.25 | 0.5 | 0.75 | 1 | 1.5 | 2 | 2.5 | 3
+
+export class PicassoSpacing {
+  value: number
+
+  constructor(value: PicassoSpacingValues) {
+    this.value = value
+  }
+
+  valueOf() {
+    console.log('this.value: ', this.value)
+
+    return this.value
+  }
+
+  toString() {
+    return this.value.toString()
+  }
+}
+
+const SPACING_0 = new PicassoSpacing(0)
+const SPACING_1 = new PicassoSpacing(0.25)
+const SPACING_2 = new PicassoSpacing(0.5)
+const SPACING_3 = new PicassoSpacing(0.75)
+const SPACING_4 = new PicassoSpacing(1)
+const SPACING_5 = new PicassoSpacing(1.5)
+const SPACING_6 = new PicassoSpacing(2)
+const SPACING_7 = new PicassoSpacing(2.5)
+const SPACING_8 = new PicassoSpacing(3)
+
+const spacings = {
+  SPACING_0,
+  SPACING_1,
+  SPACING_2,
+  SPACING_3,
+  SPACING_4,
+  SPACING_5,
+  SPACING_6,
+  SPACING_7,
+  SPACING_8,
+}
+
+export type Sizes =
+  | 'xxsmall'
+  | 'xsmall'
+  | 'small'
+  | 'medium'
+  | 'large'
+  | 'xlarge'
+
+export enum SpacingEnum {
+  xsmall = 0.5,
+  small = 1,
+  medium = 1.5,
+  large = 2,
+  xlarge = 2.5,
+}
+
+export type SizeType<T extends Sizes> = T
+
+export type SpacingType =
+  | number
+  | SizeType<'xsmall' | 'small' | 'medium' | 'large' | 'xlarge'>
+  | PicassoSpacing
+
+export default spacings

--- a/packages/picasso-provider/src/Picasso/config/theme.ts
+++ b/packages/picasso-provider/src/Picasso/config/theme.ts
@@ -1,11 +1,21 @@
 import type { BreakpointKeys } from './breakpoints'
 import type { Layout } from './layout'
 import type { Sizes } from './sizes'
+import type spacings from './spacings'
+import type { PicassoSpacing } from './spacings'
 
 declare module '@material-ui/core/styles' {
   interface Theme {
     layout: Layout
     sizes: Sizes
     screens: (...sizes: BreakpointKeys[]) => string
+    spacings: Record<keyof typeof spacings, PicassoSpacing>
+  }
+
+  interface ThemeOptions {
+    layout?: Layout
+    sizes?: Sizes
+    screens?: (...sizes: BreakpointKeys[]) => string
+    spacings?: Record<keyof typeof spacings, PicassoSpacing>
   }
 }

--- a/packages/picasso-provider/src/Picasso/utils/index.ts
+++ b/packages/picasso-provider/src/Picasso/utils/index.ts
@@ -1,2 +1,3 @@
 export * from './generate-random-string'
 export * from './get-serverside-stylesheets'
+export * from './spacings'

--- a/packages/picasso-provider/src/Picasso/utils/spacings.test.ts
+++ b/packages/picasso-provider/src/Picasso/utils/spacings.test.ts
@@ -1,0 +1,74 @@
+import { isNumericSpacing, spacingToRem } from './spacings'
+import {
+  SPACING_0,
+  SPACING_1,
+  SPACING_2,
+  SPACING_3,
+  SPACING_4,
+  SPACING_6,
+  SPACING_8,
+  SPACING_10,
+  SPACING_12,
+} from '../config/spacings'
+
+describe('spacingUtils', () => {
+  describe('isNumericSpacing', () => {
+    describe('when spacing is undefined', () => {
+      it('returns false', () => {
+        expect(isNumericSpacing(undefined)).toBe(false)
+      })
+    })
+
+    describe('when spacing is a number', () => {
+      it('returns true', () => {
+        expect(isNumericSpacing(1)).toBe(true)
+        expect(isNumericSpacing(2.5)).toBe(true)
+      })
+    })
+
+    describe('when spacing is a new Picasso spacing', () => {
+      it('returns true', () => {
+        expect(isNumericSpacing(SPACING_0)).toBe(true)
+      })
+    })
+
+    describe('when spacing is a string Picasso spacing', () => {
+      it('returns false', () => {
+        expect(isNumericSpacing('small')).toBe(false)
+      })
+    })
+  })
+
+  describe('spacingToRem', () => {
+    describe('when spacing is a number', () => {
+      it('converts to rem', () => {
+        expect(spacingToRem(1)).toBe('1rem')
+        expect(spacingToRem(2.5)).toBe('2.5rem')
+      })
+    })
+
+    describe('when spacing is a valid Picasso spacing', () => {
+      it('converts to rem', () => {
+        expect(spacingToRem(SPACING_0)).toBe('0rem')
+        expect(spacingToRem(SPACING_1)).toBe('0.25rem')
+        expect(spacingToRem(SPACING_2)).toBe('0.5rem')
+        expect(spacingToRem(SPACING_3)).toBe('0.75rem')
+        expect(spacingToRem(SPACING_4)).toBe('1rem')
+        expect(spacingToRem(SPACING_6)).toBe('1.5rem')
+        expect(spacingToRem(SPACING_8)).toBe('2rem')
+        expect(spacingToRem(SPACING_10)).toBe('2.5rem')
+        expect(spacingToRem(SPACING_12)).toBe('3rem')
+      })
+    })
+
+    describe('when spacing is a string Picasso spacing', () => {
+      it('converts to rem', () => {
+        expect(spacingToRem('xsmall')).toBe('0.5rem')
+        expect(spacingToRem('small')).toBe('1rem')
+        expect(spacingToRem('medium')).toBe('1.5rem')
+        expect(spacingToRem('large')).toBe('2rem')
+        expect(spacingToRem('xlarge')).toBe('2.5rem')
+      })
+    })
+  })
+})

--- a/packages/picasso-provider/src/Picasso/utils/spacings.ts
+++ b/packages/picasso-provider/src/Picasso/utils/spacings.ts
@@ -1,0 +1,18 @@
+import type { SizeType, SpacingType } from '../config/spacings'
+import { SpacingEnum, PicassoSpacing } from '../config/spacings'
+
+const isNumericSpacing = (spacing?: SpacingType): spacing is number => {
+  if (!spacing) {
+    return false
+  }
+
+  return typeof spacing === 'number' || spacing instanceof PicassoSpacing
+}
+
+const spacingToRem = (spacing: SpacingType): string => {
+  return isNumericSpacing(spacing)
+    ? `${spacing}rem`
+    : `${SpacingEnum[spacing as SizeType<any>]}rem`
+}
+
+export { isNumericSpacing, spacingToRem }

--- a/packages/picasso-provider/src/Picasso/utils/spacings.ts
+++ b/packages/picasso-provider/src/Picasso/utils/spacings.ts
@@ -1,12 +1,13 @@
 import type { SizeType, SpacingType } from '../config/spacings'
-import { SpacingEnum, PicassoSpacing } from '../config/spacings'
+import { SpacingEnum, isPicassoSpacing } from '../config/spacings'
 
-const isNumericSpacing = (spacing?: SpacingType): spacing is number => {
-  if (!spacing) {
-    return false
-  }
+const isNumericSpacing = (
+  spacing: SpacingType | undefined
+): spacing is number | SpacingType => {
+  const isNotNull = spacing != null
+  const isNumber = typeof spacing == 'number'
 
-  return typeof spacing === 'number' || spacing instanceof PicassoSpacing
+  return isNotNull && (isNumber || isPicassoSpacing(spacing))
 }
 
 const spacingToRem = (spacing: SpacingType): string => {

--- a/packages/picasso-provider/src/index.ts
+++ b/packages/picasso-provider/src/index.ts
@@ -25,16 +25,15 @@ export {
   shadows,
   PicassoBreakpoints,
   BreakpointKeys,
-  PicassoSpacing,
   spacings,
   SpacingEnum,
 } from './Picasso/config'
 
 export type {
-  PicassoSpacingValues,
   Sizes,
   SizeType,
   SpacingType,
+  PicassoSpacing,
 } from './Picasso/config'
 
 export { default as PicassoProvider } from './Picasso/PicassoProvider'

--- a/packages/picasso-provider/src/index.ts
+++ b/packages/picasso-provider/src/index.ts
@@ -25,6 +25,16 @@ export {
   shadows,
   PicassoBreakpoints,
   BreakpointKeys,
+  PicassoSpacing,
+  spacings,
+  SpacingEnum,
+} from './Picasso/config'
+
+export type {
+  PicassoSpacingValues,
+  Sizes,
+  SizeType,
+  SpacingType,
 } from './Picasso/config'
 
 export { default as PicassoProvider } from './Picasso/PicassoProvider'
@@ -43,6 +53,8 @@ export {
   generateRandomString,
   generateRandomStringOrGetEmptyInTest,
   getServersideStylesheets,
+  isNumericSpacing,
+  spacingToRem,
 } from './Picasso/utils'
 
 export { default as Favicon } from './Favicon'

--- a/packages/picasso/src/Container/Container.tsx
+++ b/packages/picasso/src/Container/Container.tsx
@@ -7,7 +7,7 @@ import { makeStyles } from '@material-ui/core/styles'
 import type { PropTypes } from '@material-ui/core'
 import cx from 'classnames'
 import type { StandardProps, SpacingType } from '@toptal/picasso-shared'
-import { spacingToRem } from '@toptal/picasso-shared'
+import { spacingToRem, isNumericSpacing } from '@toptal/picasso-shared'
 
 import type { AlignItemsType, JustifyContentType, VariantType } from './styles'
 import styles from './styles'
@@ -101,12 +101,12 @@ export const Container = documentable(
       const classes = useStyles(props)
 
       const margins = {
-        ...(typeof top === 'number' && { marginTop: spacingToRem(top) }),
-        ...(typeof bottom === 'number' && {
+        ...(isNumericSpacing(top) && { marginTop: spacingToRem(top) }),
+        ...(isNumericSpacing(bottom) && {
           marginBottom: spacingToRem(bottom),
         }),
-        ...(typeof left === 'number' && { marginLeft: spacingToRem(left) }),
-        ...(typeof right === 'number' && { marginRight: spacingToRem(right) }),
+        ...(isNumericSpacing(left) && { marginLeft: spacingToRem(left) }),
+        ...(isNumericSpacing(right) && { marginRight: spacingToRem(right) }),
       }
 
       return (
@@ -144,10 +144,10 @@ export const Container = documentable(
           )}
           style={{
             ...margins,
-            ...(typeof padded === 'number' && {
+            ...(isNumericSpacing(padded) && {
               padding: spacingToRem(padded),
             }),
-            ...(typeof gap === 'number' && { gap: spacingToRem(gap) }),
+            ...(isNumericSpacing(gap) && { gap: spacingToRem(gap) }),
             ...style,
           }}
         >

--- a/packages/picasso/src/Container/story/Default.example.tsx
+++ b/packages/picasso/src/Container/story/Default.example.tsx
@@ -1,10 +1,10 @@
 import React from 'react'
 import { Container } from '@toptal/picasso'
-import { SPACING_4, SPACING_6 } from '@toptal/picasso/utils'
+import { SPACING_4, SPACING_8 } from '@toptal/picasso/utils'
 
 const Example = () => (
   <div>
-    <Container bottom={SPACING_6}>Some text</Container>
+    <Container bottom={SPACING_8}>Some text</Container>
     <Container left={SPACING_4}>Some more text with a small margin</Container>
   </div>
 )

--- a/packages/picasso/src/Container/story/Default.example.tsx
+++ b/packages/picasso/src/Container/story/Default.example.tsx
@@ -1,10 +1,11 @@
 import React from 'react'
 import { Container } from '@toptal/picasso'
+import { SPACING_4, SPACING_6 } from '@toptal/picasso/utils'
 
 const Example = () => (
   <div>
-    <Container bottom='large'>Some text</Container>
-    <Container left='small'>Some more text with a small margin</Container>
+    <Container bottom={SPACING_6}>Some text</Container>
+    <Container left={SPACING_4}>Some more text with a small margin</Container>
   </div>
 )
 

--- a/packages/picasso/src/utils/index.ts
+++ b/packages/picasso/src/utils/index.ts
@@ -1,4 +1,4 @@
-import { alpha, lighten, darken } from '@toptal/picasso-shared'
+import { alpha, lighten, darken, spacings } from '@toptal/picasso-shared'
 
 import * as TransitionUtils from './Transitions'
 
@@ -66,3 +66,27 @@ export {
   useDeprecationWarning,
   usePropDeprecationWarning,
 } from './use-deprecation-warnings'
+
+const {
+  SPACING_0,
+  SPACING_1,
+  SPACING_2,
+  SPACING_3,
+  SPACING_4,
+  SPACING_5,
+  SPACING_6,
+  SPACING_7,
+  SPACING_8,
+} = spacings
+
+export {
+  SPACING_0,
+  SPACING_1,
+  SPACING_2,
+  SPACING_3,
+  SPACING_4,
+  SPACING_5,
+  SPACING_6,
+  SPACING_7,
+  SPACING_8,
+}

--- a/packages/picasso/src/utils/index.ts
+++ b/packages/picasso/src/utils/index.ts
@@ -67,26 +67,14 @@ export {
   usePropDeprecationWarning,
 } from './use-deprecation-warnings'
 
-const {
+export const {
   SPACING_0,
   SPACING_1,
   SPACING_2,
   SPACING_3,
   SPACING_4,
-  SPACING_5,
   SPACING_6,
-  SPACING_7,
   SPACING_8,
+  SPACING_10,
+  SPACING_12,
 } = spacings
-
-export {
-  SPACING_0,
-  SPACING_1,
-  SPACING_2,
-  SPACING_3,
-  SPACING_4,
-  SPACING_5,
-  SPACING_6,
-  SPACING_7,
-  SPACING_8,
-}

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -8,6 +8,21 @@ import type {
 
 import type { Classes } from './styles'
 
+export {
+  spacings,
+  PicassoSpacing,
+  SpacingEnum,
+  isNumericSpacing,
+  spacingToRem,
+} from '@toptal/picasso-provider'
+
+export type {
+  PicassoSpacingValues,
+  Sizes,
+  SizeType,
+  SpacingType,
+} from '@toptal/picasso-provider'
+
 export interface BaseProps {
   /** Classnames applied to root element */
   className?: string
@@ -52,8 +67,6 @@ export interface OverridableComponent<P = {}> extends NamedComponent<P> {
   ): JSX.Element | null
 }
 
-type Sizes = 'xxsmall' | 'xsmall' | 'small' | 'medium' | 'large' | 'xlarge'
-
 type BaseEnvironments = 'development' | 'staging' | 'production'
 type Environments = BaseEnvironments | 'temploy' | 'test'
 
@@ -61,23 +74,6 @@ type Environments = BaseEnvironments | 'temploy' | 'test'
 export type EnvironmentType<T extends Environments = BaseEnvironments> =
   | T
   | BaseEnvironments
-
-export type SizeType<T extends Sizes> = T
-
-export type SpacingType =
-  | number
-  | SizeType<'xsmall' | 'small' | 'medium' | 'large' | 'xlarge'>
-
-export enum SpacingEnum {
-  xsmall = 0.5,
-  small = 1,
-  medium = 1.5,
-  large = 2,
-  xlarge = 2.5,
-}
-
-export const spacingToRem = (spacing: SpacingType) =>
-  typeof spacing === 'number' ? `${spacing}rem` : `${SpacingEnum[spacing]}rem`
 
 export type ButtonOrAnchorProps = AnchorHTMLAttributes<HTMLAnchorElement> &
   ButtonHTMLAttributes<HTMLButtonElement>

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -10,17 +10,16 @@ import type { Classes } from './styles'
 
 export {
   spacings,
-  PicassoSpacing,
   SpacingEnum,
   isNumericSpacing,
   spacingToRem,
 } from '@toptal/picasso-provider'
 
 export type {
-  PicassoSpacingValues,
   Sizes,
   SizeType,
   SpacingType,
+  PicassoSpacing,
 } from '@toptal/picasso-provider'
 
 export interface BaseProps {


### PR DESCRIPTION
[FX-4259]

### Description

Add new spacing values to Picasso, described in BASE. 

RFC: https://github.com/toptal/picasso/blob/master/docs/decisions/18-spacings.md#technical-details

- [x] BASE spacings are exported according to RFC
- [x] BASE spacings are exported via theme, so they can be used in custom styles

### How to test

- Use temploy to play with SPACING variables

Example:
```
import { SPACING_4, SPACING_6 } from '@toptal/picasso/utils'

const Example = () => (
  <div>
    <Container bottom={SPACING_6}>Some text</Container>
    <Container left={SPACING_4}>Some more text with a small margin</Container>
  </div>
)
```

Example of new `spacings` variable coming from the theme:

```
export default ({ palette, sizes: { borderRadius }, spacings: { SPACING_6 } }: Theme) => {
  ...

}
```


### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [x] Ensure that deployed demo has expected results and good examples
- [x] Self reviewed

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-4259]: https://toptal-core.atlassian.net/browse/FX-4259?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ