### PR TITLE
fix(rich-text-editor): enable alt prop

### DIFF
--- a/.changeset/gold-frogs-itch.md
+++ b/.changeset/gold-frogs-itch.md
@@ -1,0 +1,7 @@
+---
+'@toptal/picasso-rich-text-editor': patch
+---
+
+### RichTextEditor
+
+- enable alt prop

--- a/packages/picasso-rich-text-editor/src/utils/html-to-hast.ts
+++ b/packages/picasso-rich-text-editor/src/utils/html-to-hast.ts
@@ -12,7 +12,7 @@ export const hastSanitizeSchema: Schema = {
   },
   attributes: {
     a: ['href'],
-    img: ['src', 'data*', 'class'],
+    img: ['src', 'alt', 'data*', 'class'],
     '*': [],
   },
   tagNames: [


### PR DESCRIPTION
[SCR-3753]

### Description

This PR fixes a bug where the alt prop was not working on RichTextEditor component

### How to test

<!-- The temploy link will be automatically updated when the temploy is deployed -->
- Go to https://picasso.toptal.net/SCR-3753-rich-text-fix-html-to-hast-util?path=/story/components-richtext--richtext
- Open the Devtools and inspect the image (as I did on the screenshots below)
- You should be able to see the `alt` property

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
|![image](https://github.com/toptal/picasso/assets/99184582/c981e8e8-74ca-45a7-8c12-457b2eaaeebd)|![image](https://github.com/toptal/picasso/assets/99184582/19c604c8-ded9-4139-8ee8-d8913c328568)
|

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests ([visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md) included)

**Breaking change**

- [x] codemod is created and showcased in the changeset
- [x] test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[SCR-3753]: https://toptal-core.atlassian.net/browse/SCR-3753?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ