### PR TITLE
feat(tooltip): change tooltip zindex to the same as modal

### DIFF
--- a/.changeset/chatty-rice-design.md
+++ b/.changeset/chatty-rice-design.md
@@ -1,0 +1,7 @@
+---
+'@toptal/picasso': major
+---
+
+### Dependencies
+
+- update picasso-provider

--- a/.changeset/eleven-games-occur.md
+++ b/.changeset/eleven-games-occur.md
@@ -1,0 +1,7 @@
+---
+'@toptal/picasso-provider': minor
+---
+
+### Theme
+
+- set Tooltip's zIndex to be the same as Modal

--- a/packages/picasso-provider/src/Picasso/PicassoProvider.tsx
+++ b/packages/picasso-provider/src/Picasso/PicassoProvider.tsx
@@ -14,7 +14,7 @@ import {
   shadows,
 } from './config'
 
-const picasso = {
+const picasso: ThemeOptions = {
   palette,
   layout,
   transitions,
@@ -23,6 +23,9 @@ const picasso = {
   screens,
   shadows,
   typography,
+  zIndex: {
+    tooltip: 1300,
+  },
   props: {
     MuiButtonBase: {
       disableRipple: true,

--- a/packages/picasso-provider/src/Picasso/config/theme.ts
+++ b/packages/picasso-provider/src/Picasso/config/theme.ts
@@ -8,4 +8,6 @@ declare module '@material-ui/core/styles' {
     sizes: Sizes
     screens: (...sizes: BreakpointKeys[]) => string
   }
+
+  interface ThemeOptions extends Partial<Theme> {}
 }

--- a/packages/picasso-provider/src/Picasso/config/theme.ts
+++ b/packages/picasso-provider/src/Picasso/config/theme.ts
@@ -9,5 +9,9 @@ declare module '@material-ui/core/styles' {
     screens: (...sizes: BreakpointKeys[]) => string
   }
 
-  interface ThemeOptions extends Partial<Theme> {}
+  interface ThemeOptions {
+    layout?: Layout
+    sizes?: Sizes
+    screens?: (...sizes: BreakpointKeys[]) => string
+  }
 }

--- a/packages/picasso/src/Modal/story/Tooltips.example.tsx
+++ b/packages/picasso/src/Modal/story/Tooltips.example.tsx
@@ -31,6 +31,12 @@ const ModalDialog = ({
               setDate(newDate as Date)
             }}
           />
+          <Tooltip open content='Inner Tooltip' placement='bottom'>
+            <span>
+              Lorem facere corrupti accusantium asperiores magnam Atque
+              doloribus asperiores corrupti!
+            </span>
+          </Tooltip>
         </Form.Field>
       </Modal.Content>
     </Modal>


### PR DESCRIPTION
[FX-4241]

### Description

Tooltip and Modal now have the same z-index CSS prop, which means the one to be
written last on HTML will be the one on top. This allows Modal to overlay
tooltips behind, and allow Tooltips to work inside Modals.

To be noted, that this is a very special case, most Tooltips will close
automatically when a Modal is open, if, for whatever reason, they still need to
be open, they will be overlaid by Modal.

### How to test

<!-- The temploy link will be automatically updated when the temploy is deployed -->
- [Temploy](https://picasso.toptal.net/fx-4241-tooltips-are-rendered-over-the-modal-and-backdrop)
- Check on temploy


### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| ![image](https://github.com/toptal/picasso/assets/5845160/82ad3c15-f0b0-46f2-ad2a-17a6ca95a316) | ![image](https://github.com/toptal/picasso/assets/5845160/44f5e170-396e-4284-a602-16d863d8ec62) |

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests ([visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md) included)

**Breaking change**

- [x] codemod is created and showcased in the changeset
- [x] test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-4241]: https://toptal-core.atlassian.net/browse/FX-4241?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ