### PR TITLE
ci(Dockerfile): remove setting of alpine mirror

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,12 @@
 FROM node:16-alpine
 
 ENV PATH="${PATH}:/app/node_modules/.bin" \
-  # Defines version of dependencies for apk add
-  APK_BRANCH=3.10 \
   # Installs Chromium (77) package.
   CHROME_BIN=/usr/bin/chromium-browser \
   # We don't pass real value here, workaround to bypass npm check on from .npmrc
   NPM_TOKEN=''
 
-RUN printf "http://nl.alpinelinux.org/alpine/v$APK_BRANCH/%s\n" community main > /etc/apk/repositories && \
-  apk add --no-cache \
+RUN apk add --no-cache \
   harfbuzz \
   nss \
   git \


### PR DESCRIPTION
### Description

Setting the mirror is optional, and recently we are having problems with the mirror [we setup a long time ago](https://github.com/toptal/picasso/commit/446974cf9b434fc9ac5e891a42d4093157f1fcd1), for unknown reasons

### How to test

<!-- The temploy link will be automatically updated when the temploy is deployed -->
- [Temploy](https://picasso.toptal.net/fix/change-alpine-mirror)
- CI should be green

### Screenshots

No screenshots

### Development checks

- [NA] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [NA] Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [NA] Annotate all `props` in component with documentation
- [NA] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [NA] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [NA] Covered with tests ([visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md) included)

**Breaking change**

- [NA] codemod is created and showcased in the changeset
- [NA] test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>
