### PR TITLE
fix: allow label on FieldWrapper to be ReactNode

### DIFF
--- a/.changeset/swift-bugs-sparkle.md
+++ b/.changeset/swift-bugs-sparkle.md
@@ -1,0 +1,7 @@
+---
+'@toptal/picasso-forms': minor
+---
+
+### FieldWrapper
+
+- change the type of label from string to ReactNode which allows you to have complex labels

--- a/packages/picasso-forms/src/FieldLabel/FieldLabel.tsx
+++ b/packages/picasso-forms/src/FieldLabel/FieldLabel.tsx
@@ -8,7 +8,7 @@ import { useFormConfig } from '../FormConfig'
 
 export type Props = {
   name?: string
-  label?: string
+  label?: React.ReactNode
   required?: boolean
 } & TextLabelProps
 

--- a/packages/picasso-forms/src/FieldWrapper/FieldWrapper.tsx
+++ b/packages/picasso-forms/src/FieldWrapper/FieldWrapper.tsx
@@ -5,10 +5,10 @@ import type { ValueType, IFormComponentProps } from '../FieldBase'
 import FieldLabel from '../FieldLabel'
 import InputField from '../InputField'
 
-export type Props<TWrappedComponentProps, TInputValue> = Omit<
-  FieldProps<TWrappedComponentProps, TInputValue>,
-  'label'
-> & { label?: React.ReactNode }
+export type Props<TWrappedComponentProps, TInputValue> = FieldProps<
+  TWrappedComponentProps,
+  TInputValue
+>
 
 const FieldWrapper = <
   TWrappedComponentProps extends IFormComponentProps,

--- a/packages/picasso-forms/src/FieldWrapper/FieldWrapper.tsx
+++ b/packages/picasso-forms/src/FieldWrapper/FieldWrapper.tsx
@@ -8,7 +8,7 @@ import InputField from '../InputField'
 export type Props<TWrappedComponentProps, TInputValue> = Omit<
   FieldProps<TWrappedComponentProps, TInputValue>,
   'label'
-> & { label?: string }
+> & { label?: React.ReactNode }
 
 const FieldWrapper = <
   TWrappedComponentProps extends IFormComponentProps,


### PR DESCRIPTION
[FX-4318]

### Description

Users want to be able to do complex things with labels, like for example have in label icon and Tooltip. For this we change label type on FieldWrapper from `string` to `ReactNode`

### How to test

<!-- The temploy link will be automatically updated when the temploy is deployed -->
- [Temploy](https://picasso.toptal.net/fx-4318-allow-reactnode-type-for-labels-in-form-elements)
- FIXME: Add the steps describing how to verify your changes

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests ([visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md) included)

**Breaking change**

- [x] codemod is created and showcased in the changeset
- [x] test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-4318]: https://toptal-core.atlassian.net/browse/FX-4318?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ