### PR TITLE
fix: field typing and lockfile

### DIFF
--- a/.changeset/shaggy-paws-hide.md
+++ b/.changeset/shaggy-paws-hide.md
@@ -1,0 +1,7 @@
+---
+'@toptal/picasso-forms': patch
+---
+
+### Field
+
+- fix typing for form field component

--- a/.changeset/shaggy-paws-hide.md
+++ b/.changeset/shaggy-paws-hide.md
@@ -2,6 +2,6 @@
 '@toptal/picasso-forms': patch
 ---
 
-### Field
+### FieldWrapper
 
-- fix typing for form field component
+- fix typing for form field wrapper component

--- a/packages/picasso-forms/src/Field/Field.tsx
+++ b/packages/picasso-forms/src/Field/Field.tsx
@@ -26,19 +26,18 @@ export type FieldProps<TInputValue> = FinalFieldProps<
 export type Props<
   TWrappedComponentProps extends IFormComponentProps,
   TInputValue
-> = TWrappedComponentProps &
-  FieldProps<TInputValue> & {
-    name: string
-    type?: string
-    label?: React.ReactNode
-    status?: OutlinedInputStatus
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    children: (props: any) => React.ReactNode
-    renderFieldRequirements?: (props: {
-      value?: TInputValue
-      error?: boolean
-    }) => React.ReactNode
-  }
+> = Omit<TWrappedComponentProps & FieldProps<TInputValue>, 'children'> & {
+  name: string
+  type?: string
+  label?: React.ReactNode
+  status?: OutlinedInputStatus
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  children: (props: any) => React.ReactNode
+  renderFieldRequirements?: (props: {
+    value?: TInputValue
+    error?: boolean
+  }) => React.ReactNode
+}
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const getValidators = (required: boolean, validate?: any) => {

--- a/packages/picasso-forms/src/Field/Field.tsx
+++ b/packages/picasso-forms/src/Field/Field.tsx
@@ -26,18 +26,19 @@ export type FieldProps<TInputValue> = FinalFieldProps<
 export type Props<
   TWrappedComponentProps extends IFormComponentProps,
   TInputValue
-> = Omit<TWrappedComponentProps & FieldProps<TInputValue>, 'children'> & {
-  name: string
-  type?: string
-  label?: React.ReactNode
-  status?: OutlinedInputStatus
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  children: (props: any) => React.ReactNode
-  renderFieldRequirements?: (props: {
-    value?: TInputValue
-    error?: boolean
-  }) => React.ReactNode
-}
+> = TWrappedComponentProps &
+  FieldProps<TInputValue> & {
+    name: string
+    type?: string
+    label?: React.ReactNode
+    status?: OutlinedInputStatus
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    children: (props: any) => React.ReactNode
+    renderFieldRequirements?: (props: {
+      value?: TInputValue
+      error?: boolean
+    }) => React.ReactNode
+  }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const getValidators = (required: boolean, validate?: any) => {

--- a/packages/picasso-forms/src/FieldWrapper/FieldWrapper.tsx
+++ b/packages/picasso-forms/src/FieldWrapper/FieldWrapper.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from 'react'
 import React from 'react'
 
 import type { Props as FieldProps } from '../Field'
@@ -5,10 +6,12 @@ import type { ValueType, IFormComponentProps } from '../FieldBase'
 import FieldLabel from '../FieldLabel'
 import InputField from '../InputField'
 
-export type Props<TWrappedComponentProps, TInputValue> = FieldProps<
-  TWrappedComponentProps,
-  TInputValue
->
+export type Props<TWrappedComponentProps, TInputValue> = Omit<
+  FieldProps<TWrappedComponentProps, TInputValue>,
+  'label'
+> & {
+  label?: ReactNode
+}
 
 const FieldWrapper = <
   TWrappedComponentProps extends IFormComponentProps,

--- a/yarn.lock
+++ b/yarn.lock
@@ -15301,14 +15301,14 @@ json-stringify-safe@^5.0.1, json-stringify-safe@~5.0.1:
   resolved "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
   integrity sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==
 
-json5@1, json5@^1.0.1, json5@^2.1.1:
+json5@1, json5@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/json5/-/json5-1.0.2.tgz#63d98d60f21b313b77c4d6da18bfa69d80e1d593"
   integrity sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==
   dependencies:
     minimist "^1.2.0"
 
-json5@2.2.3, json5@^2.1.0, json5@^2.1.2, json5@^2.1.3, json5@^2.2.0, json5@^2.2.2, json5@^2.2.3, json5@^2.x:
+json5@2.2.3, json5@^2.1.0, json5@^2.1.1, json5@^2.1.2, json5@^2.1.3, json5@^2.2.0, json5@^2.2.2, json5@^2.2.3, json5@^2.x:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.3.tgz#78cd6f1a19bdc12b73db5ad0c61efd66c1e29283"
   integrity sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==
@@ -24572,15 +24572,10 @@ ws@^7.3.1, ws@^7.4.6:
   resolved "https://registry.yarnpkg.com/ws/-/ws-7.5.9.tgz#54fa7db29f4c7cec68b1ddd3a89de099942bb591"
   integrity sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==
 
-ws@^8.13.0:
+ws@^8.13.0, ws@^8.2.3:
   version "8.14.1"
   resolved "https://registry.yarnpkg.com/ws/-/ws-8.14.1.tgz#4b9586b4f70f9e6534c7bb1d3dc0baa8b8cf01e0"
   integrity sha512-4OOseMUq8AzRBI/7SLMUwO+FEDnguetSk7KMb1sHwvF2w2Wv5Hoj0nlifx8vtGsftE/jWHojPy8sMMzYLJ2G/A==
-
-ws@^8.2.3:
-  version "8.12.1"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-8.12.1.tgz#c51e583d79140b5e42e39be48c934131942d4a8f"
-  integrity sha512-1qo+M9Ba+xNhPB+YTWUlK6M17brTut5EXbcBaMRN5pH5dFrXz7lzz1ChFSUq3bOUl8yEvSenhHmYUNJxFzdJew==
 
 x-default-browser@^0.4.0:
   version "0.4.0"


### PR DESCRIPTION
[FX-4344]

### Description

This pull request restores the typing after https://github.com/toptal/picasso/pull/3856/files#diff-08a8fe1a5f1850b294d0ab3c9d60773422eb33ec29d310a6c98fdd48e0b0eefcL8 change. Additionally, it fixes the lockfile in main branch.

### Research

The reason why type check fails in consumer projects is not clear.

It was discovered that if the following type definition 

```ts
// packages/picasso-forms/src/FieldWrapper/FieldWrapper.tsx
export type Props<TWrappedComponentProps, TInputValue> = FieldProps<TWrappedComponentProps, TInputValue>
```

is replaced with

```ts
// packages/picasso-forms/src/FieldWrapper/FieldWrapper.tsx
export type Props<TWrappedComponentProps, TInputValue> = Omit<FieldProps<TWrappedComponentProps, TInputValue>, 'randomText'>
```

type checks starts working in Staff Portal. Adding `Omit` with random field somehow **modifies the resulting type definition**.

In order to restore the previous state of `picasso`, the change in this pull request is pushed further without proper investigation (the follow-up spike will be discussed on Daily).

### How to test

<!-- The temploy link will be automatically updated when the temploy is deployed -->
- [Temploy](https://picasso.toptal.net/FX-NULL-fix-field-wrapper-typing)
- Alpha package in Staff Portal should pass lint check in https://github.com/toptal/staff-portal/actions/runs/6162548037 (https://github.com/toptal/staff-portal/pull/10993)

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [N/A] Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [N/A] Annotate all `props` in component with documentation
- [N/A] Create `examples` for component
- [N/A] Ensure that deployed demo has expected results and good examples
- [N/A] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [N/A] Covered with tests ([visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md) included)

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-4344]: https://toptal-core.atlassian.net/browse/FX-4344?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ