### PR TITLE
fix: lock body scroll for `Drawer`

### DIFF
--- a/.changeset/neat-impalas-notice.md
+++ b/.changeset/neat-impalas-notice.md
@@ -1,0 +1,8 @@
+---
+'@toptal/picasso': major
+---
+
+### Drawer
+
+- modified Drawer component to lock the body scroll when opened (previously it was locking the scroll on Picasso root)
+- prop `maintainBodyScrollLock` is now true by default

--- a/cypress/component/Drawer.spec.tsx
+++ b/cypress/component/Drawer.spec.tsx
@@ -88,6 +88,9 @@ const TestDrawerBehindModal = (props: Partial<DrawerProps>) => {
 const component = 'Drawer'
 
 describe('Drawer', () => {
+  beforeEach(() => {
+    cy.viewport(1280, 660)
+  })
   it('renders with narrow width and custom title', () => {
     cy.mount(
       <TestDrawer
@@ -162,7 +165,7 @@ describe('Drawer', () => {
     describe(`when screen has ${width}px width`, () => {
       Cypress._.each(testedDrawerVariants, variant => {
         it(`renders ${variant} drawer`, () => {
-          cy.viewport(width, 1000)
+          cy.viewport(width, 660)
           cy.mount(
             <TestDrawer title={`${variant} drawer title`}>
               <Container>

--- a/cypress/component/Page.spec.tsx
+++ b/cypress/component/Page.spec.tsx
@@ -1,6 +1,13 @@
 import React from 'react'
 import type { PageSidebarProps } from '@toptal/picasso'
-import { Container, Menu, Page, Typography } from '@toptal/picasso'
+import {
+  Button,
+  Container,
+  Drawer,
+  Menu,
+  Page,
+  Typography,
+} from '@toptal/picasso'
 import { HAPPO_TARGETS, getHappoTargets } from '@toptal/picasso/test-utils'
 
 const component = 'Page'
@@ -10,6 +17,8 @@ enum TestIds {
   WRAPPER = 'wrapper',
   SIDEBAR_SCROLLABLE_CONTAINER = 'sidebar-scrollable-container',
   MENU_CONTAINER = 'menu-container',
+  DRAWER_BUTTON = 'drawer-button',
+  MENU_ITEM = 'menu_item',
 }
 
 const Paragraph = () => (
@@ -90,8 +99,50 @@ const Content = () => (
     <Paragraph />
     <Paragraph />
     <Paragraph />
+    <Paragraph />
+    <Paragraph />
+    <Paragraph />
   </Container>
 )
+
+const DrawerContent = () => {
+  const [open, setOpen] = React.useState(false)
+
+  return (
+    <Page data-testid={TestIds.WRAPPER}>
+      <Page.TopBar />
+      <Page.Content data-testid={TestIds.MENU_CONTAINER}>
+        <Page.Sidebar
+          wrapperMaxHeight={`calc(800px - 3.5rem)`}
+          style={{ height: 'unset' }}
+        >
+          <Page.Sidebar.Menu>
+            <Page.Sidebar.Item selected testIds={{ header: TestIds.MENU_ITEM }}>
+              Overview
+            </Page.Sidebar.Item>
+            <Page.Sidebar.Item>Jobs</Page.Sidebar.Item>
+          </Page.Sidebar.Menu>
+
+          <Page.Sidebar.Menu bottom>
+            <Page.Sidebar.Item>Help</Page.Sidebar.Item>
+          </Page.Sidebar.Menu>
+        </Page.Sidebar>
+        <Page.Article>
+          <Content />
+          <Drawer onClose={() => setOpen(false)} open={open}>
+            Drawer Content
+          </Drawer>
+          <Button
+            data-testid={TestIds.DRAWER_BUTTON}
+            onClick={() => setOpen(!open)}
+          >
+            Open drawer
+          </Button>
+        </Page.Article>
+      </Page.Content>
+    </Page>
+  )
+}
 
 type ExampleProps = {
   sidebarProps?: PageSidebarProps
@@ -149,6 +200,21 @@ describe('Page', () => {
       cy.get('body').happoScreenshot({
         component,
         variant: 'default/sticky-sidebar-scroll-bottom',
+      })
+    })
+    it('retains sticky position when Drawer is open', () => {
+      cy.viewport(1280, 800)
+      cy.mount(<DrawerContent />)
+
+      cy.getByTestId(TestIds.MENU_CONTAINER)
+        .getByTestId(TestIds.MENU_ITEM)
+        .should('be.visible')
+      cy.scrollTo('bottom')
+      cy.getByTestId(TestIds.DRAWER_BUTTON).click()
+
+      cy.get('body').happoScreenshot({
+        component,
+        variant: 'default/sticky-sidebar-scroll-bottom-with-drawer',
       })
     })
   })

--- a/packages/picasso/src/Drawer/Drawer.tsx
+++ b/packages/picasso/src/Drawer/Drawer.tsx
@@ -53,7 +53,7 @@ export const Drawer = (props: Props) => {
     title,
     width = 'regular',
     transitionProps,
-    maintainBodyScrollLock,
+    maintainBodyScrollLock = true,
     transparentBackdrop,
     ...rest
   } = props
@@ -88,6 +88,7 @@ export const Drawer = (props: Props) => {
       BackdropProps={{ invisible: transparentBackdrop }}
       disablePortal={disablePortal}
       container={container}
+      disableScrollLock
       ModalProps={{ style: { zIndex: theme.zIndex.drawer } }}
       SlideProps={transitionProps}
     >


### PR DESCRIPTION
[FX-4247](https://toptal-core.atlassian.net/browse/FX-4247)

### Description

Due to the original Picasso implementation, `PicassoRoot` is the default container for all popup dialogs. This causes most popup items to lock scroll on `PicassoRoot` instead of `body`. While it works in most scenarios, when `Drawer` is open on a page with a sticky sidebar and long content that is scrolled down, scroll should be locked on `body`, otherwise it prevents the proper sticky positioning of the sidebar.

### How to test

<!-- The temploy link will be automatically updated when the temploy is deployed -->
- [Temploy](https://picasso.toptal.net/fx-4247-wrong-sidebar-appearance-when-drawer-opens)
- Verify the new Happo screenshot has the proper sidebar state
- All the other tests should pass
- Check the client-portal PR https://github.com/toptal/client-portal/pull/7246 (test examples are in the description)

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
|![image](https://github.com/toptal/picasso/assets/18409292/69a554fd-cd80-4873-9f9d-d41ddaabea85) | ![image](https://github.com/toptal/picasso/assets/18409292/6ecf9d8b-97a9-498c-a6bd-ca1237265ca9) |

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests ([visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md) included)

**Breaking change**

- [n/a] codemod is created and showcased in the changeset
- [x] test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-4247]: https://toptal-core.atlassian.net/browse/FX-4247?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ