### PR TITLE
fix: spacing in picasso stories

### DIFF
--- a/.storybook/stories/tutorials/form-components/story/Components.3.example.tsx
+++ b/.storybook/stories/tutorials/form-components/story/Components.3.example.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { Container } from '@toptal/picasso'
+import { SPACING_4 } from '@toptal/picasso/utils'
 import { Form } from '@toptal/picasso-forms'
 
 const Example = () => (
@@ -17,7 +18,7 @@ const Example = () => (
       placeholder='e.g. 25'
     />
 
-    <Container top='small'>
+    <Container top={SPACING_4}>
       <Form.SubmitButton>Submit</Form.SubmitButton>
     </Container>
   </Form>

--- a/.storybook/stories/tutorials/layout/story/Layout.2.example.tsx
+++ b/.storybook/stories/tutorials/layout/story/Layout.2.example.tsx
@@ -1,13 +1,15 @@
 import React from 'react'
 import { Page, Container } from '@toptal/picasso'
 
+import { SPACING_4 } from '@toptal/picasso/utils'
+
 const Example = () => (
   <div style={{ height: '40rem' }}>
     <Page>
       <Page.TopBar title='How to layout a page' />
       <Page.Content>
-        <Container padded='small'>Sidebar</Container>
-        <Container padded='small'>Main Content</Container>
+        <Container padded={SPACING_4}>Sidebar</Container>
+        <Container padded={SPACING_4}>Main Content</Container>
       </Page.Content>
       <Page.Footer />
     </Page>

--- a/.storybook/stories/tutorials/layout/story/Layout.3.example.tsx
+++ b/.storybook/stories/tutorials/layout/story/Layout.3.example.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { Page, Container } from '@toptal/picasso'
+import { SPACING_6 } from '@toptal/picasso/utils'
 import { Globe16, Profile16, PortfolioDesigner16 } from '@toptal/picasso/Icon'
 
 const SidebarMenu = () => (
@@ -19,7 +20,7 @@ const Example = () => (
       <Page.Content>
         <SidebarMenu />
         <Page.Article>
-          <Container top='medium' bottom='medium'>
+          <Container top={SPACING_6} bottom={SPACING_6}>
             Main Content
           </Container>
         </Page.Article>

--- a/.storybook/stories/tutorials/layout/story/Layout.final.example.tsx
+++ b/.storybook/stories/tutorials/layout/story/Layout.final.example.tsx
@@ -5,8 +5,9 @@ import {
   Typography,
   Table,
   Helpbox,
-  PageHead
+  PageHead,
 } from '@toptal/picasso'
+import { SPACING_4 } from '@toptal/picasso/utils'
 import { Section } from '@toptal/picasso'
 import { Globe16, Profile16, PortfolioDesigner16 } from '@toptal/picasso/Icon'
 
@@ -28,7 +29,7 @@ const MainContent = () => (
       </PageHead.Main>
     </PageHead>
     <Section title='Details'>
-      <Container bottom='small'>
+      <Container bottom={SPACING_4}>
         <Typography variant='heading' size='small'>
           UI/UX Designer
         </Typography>

--- a/.storybook/stories/tutorials/spacings/story/Spacings.1.example.tsx
+++ b/.storybook/stories/tutorials/spacings/story/Spacings.1.example.tsx
@@ -1,10 +1,12 @@
 import React from 'react'
 import { Container, Paper } from '@toptal/picasso'
 
+import { SPACING_6 } from '@toptal/picasso/utils'
+
 const Example = () => (
   <div style={{ width: '35rem' }}>
     <Paper>
-      <Container padded='medium'>Card content</Container>
+      <Container padded={SPACING_6}>Card content</Container>
     </Paper>
   </div>
 )

--- a/.storybook/stories/tutorials/spacings/story/Spacings.2.example.tsx
+++ b/.storybook/stories/tutorials/spacings/story/Spacings.2.example.tsx
@@ -1,10 +1,12 @@
 import React from 'react'
 import { Container, Typography, Paper, Stepper } from '@toptal/picasso'
 
+import { SPACING_6 } from '@toptal/picasso/utils'
+
 const Example = () => (
   <div style={{ width: '35rem' }}>
     <Paper>
-      <Container padded='medium'>
+      <Container padded={SPACING_6}>
         <Container flex justifyContent='space-between' alignItems='flex-start'>
           <Container>
             <Typography variant='heading' size='small'>

--- a/.storybook/stories/tutorials/spacings/story/Spacings.final.example.tsx
+++ b/.storybook/stories/tutorials/spacings/story/Spacings.final.example.tsx
@@ -1,8 +1,10 @@
 import React from 'react'
 import { Container, Typography, Paper, Stepper, Avatar } from '@toptal/picasso'
 
+import { SPACING_2, SPACING_6, SPACING_4 } from '@toptal/picasso/utils'
+
 const JobCandidate = () => (
-  <Container right='xsmall'>
+  <Container right={SPACING_2}>
     <Avatar
       alt='Jacqueline Roque. Pablo Picasso, 1954'
       src='./jacqueline-with-flowers-1954-square.jpg'
@@ -13,12 +15,12 @@ const JobCandidate = () => (
 const Example = () => (
   <div style={{ width: '35rem' }}>
     <Paper>
-      <Container padded='medium'>
+      <Container padded={SPACING_6}>
         <Container
           flex
           justifyContent='space-between'
           alignItems='flex-start'
-          bottom='small'
+          bottom={SPACING_4}
         >
           <Container>
             <Typography variant='heading' size='small'>
@@ -33,7 +35,7 @@ const Example = () => (
           />
         </Container>
         <Typography size='small'>Candidates</Typography>
-        <Container top='small' flex>
+        <Container top={SPACING_4} flex>
           <JobCandidate />
           <JobCandidate />
           <JobCandidate />

--- a/packages/picasso-charts/src/BarChart/story/AutoSize.example.tsx
+++ b/packages/picasso-charts/src/BarChart/story/AutoSize.example.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Container } from '@toptal/picasso'
+import { SPACING_6, palette } from '@toptal/picasso/utils'
 import { BarChart } from '@toptal/picasso-charts'
-import { palette } from '@toptal/picasso/utils'
 
 const CHART_DATA = [
   {
@@ -28,7 +28,7 @@ const CHART_DATA = [
 
 const Example = () => (
   <div style={{ width: 720 }}>
-    <Container bottom='medium'>
+    <Container bottom={SPACING_6}>
       <BarChart
         data={CHART_DATA}
         getBarColor={() => palette.blue.main}

--- a/packages/picasso-charts/src/BarChart/story/Customized.example.tsx
+++ b/packages/picasso-charts/src/BarChart/story/Customized.example.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Paper, Container, Typography } from '@toptal/picasso'
+import { SPACING_2, palette } from '@toptal/picasso/utils'
 import { BarChart } from '@toptal/picasso-charts'
-import { palette } from '@toptal/picasso/utils'
 
 const CHART_DATA = [
   {
@@ -28,7 +28,7 @@ const CustomTooltip = ({ active, payload }: any) => {
 
     return (
       <Paper data-testid='tooltip'>
-        <Container padded='xsmall'>
+        <Container padded={SPACING_2}>
           <Typography size='medium' color='red'>
             Infected: {infected}
           </Typography>

--- a/packages/picasso-charts/src/LineChart/story/Multiple.example.tsx
+++ b/packages/picasso-charts/src/LineChart/story/Multiple.example.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { palette } from '@toptal/picasso/utils'
+import { palette, SPACING_2, SPACING_4 } from '@toptal/picasso/utils'
 import { LineChart } from '@toptal/picasso-charts'
 import { Page, Paper, Container, Typography, Indicator } from '@toptal/picasso'
 
@@ -10,10 +10,10 @@ const CustomTooltip = ({ active, payload }: any) => {
 
     return (
       <Paper>
-        <Container padded='xsmall'>
+        <Container padded={SPACING_2}>
           <Typography size='medium'>Date: {x}</Typography>
           <Container>
-            <Container inline right='small'>
+            <Container inline right={SPACING_4}>
               <Indicator color='yellow' />
             </Container>
             <Typography inline size='medium'>
@@ -22,7 +22,7 @@ const CustomTooltip = ({ active, payload }: any) => {
           </Container>
 
           <Container>
-            <Container inline right='small'>
+            <Container inline right={SPACING_4}>
               <Indicator color='red' />
             </Container>
             <Typography inline size='medium'>
@@ -31,7 +31,7 @@ const CustomTooltip = ({ active, payload }: any) => {
           </Container>
 
           <Container>
-            <Container inline right='small'>
+            <Container inline right={SPACING_4}>
               <Indicator color='green' />
             </Container>
             <Typography inline size='medium'>

--- a/packages/picasso-forms/src/Form/story/AutoSave.example.tsx
+++ b/packages/picasso-forms/src/Form/story/AutoSave.example.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useState } from 'react'
 import { Container, FormAutoSaveIndicator, Typography } from '@toptal/picasso'
+import { SPACING_6, SPACING_4 } from '@toptal/picasso/utils'
 import type { ChangedFields } from '@toptal/picasso-forms'
 import {
   FormNonCompound as Form,
@@ -52,7 +53,7 @@ const Example = () => {
       onSubmit={values => window.alert(JSON.stringify(values, undefined, 2))}
       decorators={[autoSaveDecorator]}
     >
-      <Container flex direction='row' gap='medium'>
+      <Container flex direction='row' gap={SPACING_6}>
         <Container>
           <Input
             required
@@ -95,7 +96,7 @@ const Example = () => {
             }
           />
         </Container>
-        <Container variant='grey' padded='medium'>
+        <Container variant='grey' padded={SPACING_6}>
           <Typography size='small'>
             Values should be updated only after subscribed fields changes.
           </Typography>
@@ -109,7 +110,7 @@ const Example = () => {
         </Container>
       </Container>
 
-      <Container top='small'>
+      <Container top={SPACING_4}>
         <SubmitButton>Submit</SubmitButton>
       </Container>
     </Form>

--- a/packages/picasso-forms/src/Form/story/AvatarUpload.example.tsx
+++ b/packages/picasso-forms/src/Form/story/AvatarUpload.example.tsx
@@ -3,6 +3,7 @@ import type {
   AvatarUploadFileUpload,
   AvatarUploadFileRejection,
 } from '@toptal/picasso'
+import { SPACING_4 } from '@toptal/picasso/utils'
 import { Container } from '@toptal/picasso'
 import {
   FormNonCompound as Form,
@@ -58,7 +59,7 @@ const FormRenderer = () => {
         uploading={uploading}
       />
 
-      <Container top='small'>
+      <Container top={SPACING_4}>
         <SubmitButton>Submit</SubmitButton>
       </Container>
     </>

--- a/packages/picasso-forms/src/Form/story/BackendCommunication.example.tsx
+++ b/packages/picasso-forms/src/Form/story/BackendCommunication.example.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback } from 'react'
 import { Container } from '@toptal/picasso'
+import { SPACING_4 } from '@toptal/picasso/utils'
 import { FormNonCompound, Input, SubmitButton } from '@toptal/picasso-forms'
 
 const BackendCommunicationExample = () => {
@@ -43,7 +44,7 @@ const BackendCommunicationExample = () => {
           width='full'
         />
 
-        <Container top='small'>
+        <Container top={SPACING_4}>
           <SubmitButton variant='positive' data-testid='success-submit-button'>
             Login Success
           </SubmitButton>
@@ -69,7 +70,7 @@ const BackendCommunicationExample = () => {
           width='full'
         />
 
-        <Container top='small'>
+        <Container top={SPACING_4}>
           <SubmitButton
             variant='negative'
             data-testid='submit-with-inline-error-button'
@@ -95,7 +96,7 @@ const BackendCommunicationExample = () => {
           width='full'
         />
 
-        <Container top='small'>
+        <Container top={SPACING_4}>
           <SubmitButton
             variant='negative'
             data-testid='submit-with-custom-notification-button'

--- a/packages/picasso-forms/src/Form/story/CustomFormLevelConfiguration.example.tsx
+++ b/packages/picasso-forms/src/Form/story/CustomFormLevelConfiguration.example.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { Container } from '@toptal/picasso'
+import { SPACING_4 } from '@toptal/picasso/utils'
 import type { FormConfigProps } from '@toptal/picasso-forms'
 import {
   FormNonCompound,
@@ -24,7 +25,7 @@ const Example = () => (
         placeholder='e.g. Bruce'
       />
 
-      <Container top='small'>
+      <Container top={SPACING_4}>
         <SubmitButton>Submit</SubmitButton>
       </Container>
     </FormNonCompound>

--- a/packages/picasso-forms/src/Form/story/CustomValidator.example.tsx
+++ b/packages/picasso-forms/src/Form/story/CustomValidator.example.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { Container } from '@toptal/picasso'
+import { SPACING_4 } from '@toptal/picasso/utils'
 import {
   FormNonCompound,
   Input,
@@ -43,7 +44,7 @@ const CustomValidatorExample = () => (
       placeholder='e.g. 25'
     />
 
-    <Container top='small'>
+    <Container top={SPACING_4}>
       <SubmitButton>Submit</SubmitButton>
     </Container>
   </FormNonCompound>

--- a/packages/picasso-forms/src/Form/story/Default.example.tsx
+++ b/packages/picasso-forms/src/Form/story/Default.example.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react'
 import { Container } from '@toptal/picasso'
+import { SPACING_4, isSubstring } from '@toptal/picasso/utils'
 import type { Item } from '@toptal/picasso/Autocomplete'
-import { isSubstring } from '@toptal/picasso/utils'
 import {
   FormNonCompound as Form,
   NumberInput,
@@ -208,7 +208,7 @@ const Example = () => {
         width='auto'
       />
 
-      <Container top='small'>
+      <Container top={SPACING_4}>
         <SubmitButton>Submit</SubmitButton>
       </Container>
     </Form>

--- a/packages/picasso-forms/src/Form/story/Dropzone.example.tsx
+++ b/packages/picasso-forms/src/Form/story/Dropzone.example.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { Container } from '@toptal/picasso'
+import { SPACING_4 } from '@toptal/picasso/utils'
 import { FormNonCompound, Dropzone, SubmitButton } from '@toptal/picasso-forms'
 import type { FileUpload } from '@toptal/picasso/FileInput'
 
@@ -31,7 +32,7 @@ const Example = () => {
         dropzoneHint={`Max file size: ${MAX_SIZE}MB.`}
         hint='These documents will be used to analyze and identify your potential.'
       />
-      <Container top='small'>
+      <Container top={SPACING_4}>
         <SubmitButton>Submit</SubmitButton>
       </Container>
     </FormNonCompound>

--- a/packages/picasso-forms/src/Form/story/FieldRequirements.example.tsx
+++ b/packages/picasso-forms/src/Form/story/FieldRequirements.example.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { Container } from '@toptal/picasso'
+import { SPACING_4 } from '@toptal/picasso/utils'
 import {
   FormNonCompound,
   PasswordInput,
@@ -47,7 +48,7 @@ const Example = () => {
           }
         }}
       />
-      <Container top='small'>
+      <Container top={SPACING_4}>
         <SubmitButton>Submit</SubmitButton>
       </Container>
     </FormNonCompound>

--- a/packages/picasso-forms/src/Form/story/FileInput.example.tsx
+++ b/packages/picasso-forms/src/Form/story/FileInput.example.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { Container } from '@toptal/picasso'
+import { SPACING_4 } from '@toptal/picasso/utils'
 import { FormNonCompound, FileInput, SubmitButton } from '@toptal/picasso-forms'
 import type { FileUpload } from '@toptal/picasso/FileInput'
 
@@ -32,7 +33,7 @@ const Example = () => {
         name='fileInput-attachments'
         hint={`Max file size: ${MAX_SIZE}MB.`}
       />
-      <Container top='small'>
+      <Container top={SPACING_4}>
         <SubmitButton>Submit</SubmitButton>
       </Container>
     </FormNonCompound>

--- a/packages/picasso-forms/src/Form/story/HighlightAutofill.example.tsx
+++ b/packages/picasso-forms/src/Form/story/HighlightAutofill.example.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { Container } from '@toptal/picasso'
+import { SPACING_4 } from '@toptal/picasso/utils'
 import type { FormConfigProps } from '@toptal/picasso-forms'
 import {
   FormNonCompound,
@@ -83,7 +84,7 @@ const Example = () => (
       />
       <TimePicker label='timepicker' name='highlight-timepicker' />
 
-      <Container top='small'>
+      <Container top={SPACING_4}>
         <SubmitButton>Submit</SubmitButton>
       </Container>
     </FormNonCompound>

--- a/packages/picasso-forms/src/Form/story/Horizontal.example.tsx
+++ b/packages/picasso-forms/src/Form/story/Horizontal.example.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react'
 import { Container } from '@toptal/picasso'
+import { SPACING_4, isSubstring } from '@toptal/picasso/utils'
 import type { Item } from '@toptal/picasso/Autocomplete'
-import { isSubstring } from '@toptal/picasso/utils'
 import {
   FormNonCompound as Form,
   NumberInput,
@@ -209,7 +209,7 @@ const Example = () => {
         width='auto'
       />
 
-      <Container top='small'>
+      <Container top={SPACING_4}>
         <SubmitButton>Submit</SubmitButton>
       </Container>
     </Form>

--- a/packages/picasso-forms/src/Form/story/NoScrolling.example.tsx
+++ b/packages/picasso-forms/src/Form/story/NoScrolling.example.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { Container } from '@toptal/picasso'
+import { SPACING_4 } from '@toptal/picasso/utils'
 import { FormNonCompound, Input, SubmitButton } from '@toptal/picasso-forms'
 
 const failWithAnError = () => ({
@@ -8,7 +9,7 @@ const failWithAnError = () => ({
 
 const NoScrollingExample = () => (
   <Container>
-    <Container top='small'>
+    <Container top={SPACING_4}>
       <FormNonCompound onSubmit={failWithAnError}>
         <Input
           required
@@ -16,13 +17,13 @@ const NoScrollingExample = () => (
           label='With scrolling'
           placeholder='Some field'
         />
-        <Container top='small'>
+        <Container top={SPACING_4}>
           <SubmitButton>Submit</SubmitButton>
         </Container>
       </FormNonCompound>
     </Container>
 
-    <Container top='small'>
+    <Container top={SPACING_4}>
       <FormNonCompound disableScrollOnError onSubmit={failWithAnError}>
         <Input
           required
@@ -30,7 +31,7 @@ const NoScrollingExample = () => (
           label='No scrolling'
           placeholder='Some field'
         />
-        <Container top='small'>
+        <Container top={SPACING_4}>
           <SubmitButton>Submit</SubmitButton>
         </Container>
       </FormNonCompound>

--- a/packages/picasso-forms/src/Form/story/ParseInput.example.tsx
+++ b/packages/picasso-forms/src/Form/story/ParseInput.example.tsx
@@ -1,12 +1,13 @@
 import React from 'react'
 import { Container, Typography } from '@toptal/picasso'
+import { SPACING_4 } from '@toptal/picasso/utils'
 import { FormNonCompound, Input, SubmitButton } from '@toptal/picasso-forms'
 
 const ParseInputExample = () => (
   <FormNonCompound
     onSubmit={values => window.alert(JSON.stringify(values, undefined, 2))}
   >
-    <Container bottom='small'>
+    <Container bottom={SPACING_4}>
       <Typography size='medium'>
         I want to trim my first name from the empty spaces:
       </Typography>
@@ -20,7 +21,7 @@ const ParseInputExample = () => (
         limit={24}
       />
 
-      <Container left='small'>
+      <Container left={SPACING_4}>
         <SubmitButton>Submit</SubmitButton>
       </Container>
     </Container>

--- a/packages/picasso-forms/src/Form/story/RichTextEditor.example.tsx
+++ b/packages/picasso-forms/src/Form/story/RichTextEditor.example.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import type { ASTType } from '@toptal/picasso-rich-text-editor'
 import { Container } from '@toptal/picasso'
+import { SPACING_4 } from '@toptal/picasso/utils'
 import {
   FormNonCompound,
   RichTextEditor,
@@ -14,7 +15,7 @@ const DEFAULT_EXAMPLE: ASTType = {
 
 const RichTextEditorExample = () => (
   <FormNonCompound onSubmit={data => window.alert(JSON.stringify(data))}>
-    <Container bottom='small'>
+    <Container bottom={SPACING_4}>
       <RichTextEditor
         required
         defaultValue={DEFAULT_EXAMPLE}

--- a/packages/picasso-forms/src/Form/story/Status.example.tsx
+++ b/packages/picasso-forms/src/Form/story/Status.example.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { Container } from '@toptal/picasso'
+import { SPACING_4 } from '@toptal/picasso/utils'
 import type { FormConfigProps } from '@toptal/picasso-forms'
 import {
   FormNonCompound,
@@ -24,7 +25,7 @@ const Example = () => (
         placeholder='e.g. Bruce'
       />
 
-      <Container top='small'>
+      <Container top={SPACING_4}>
         <SubmitButton>Submit</SubmitButton>
       </Container>
     </FormNonCompound>

--- a/packages/picasso-forms/src/Form/story/TitleCase.example.tsx
+++ b/packages/picasso-forms/src/Form/story/TitleCase.example.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react'
 import { Container } from '@toptal/picasso'
+import { SPACING_4, isSubstring } from '@toptal/picasso/utils'
 import type { Item } from '@toptal/picasso/Autocomplete'
-import { isSubstring } from '@toptal/picasso/utils'
 import {
   FormNonCompound,
   Input,
@@ -184,7 +184,7 @@ const Example = () => {
         width='auto'
       />
 
-      <Container top='small'>
+      <Container top={SPACING_4}>
         <SubmitButton>Submit</SubmitButton>
       </Container>
     </FormNonCompound>

--- a/packages/picasso-forms/src/Form/story/ValidateOnSubmit.example.tsx
+++ b/packages/picasso-forms/src/Form/story/ValidateOnSubmit.example.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback } from 'react'
 import { useField } from 'react-final-form'
 import { Container } from '@toptal/picasso'
+import { SPACING_4 } from '@toptal/picasso/utils'
 import {
   FormNonCompound,
   Checkbox,
@@ -66,7 +67,7 @@ const Example = () => {
       >
         <FormContent />
 
-        <Container top='small'>
+        <Container top={SPACING_4}>
           <SubmitButton>Submit</SubmitButton>
         </Container>
       </FormNonCompound>

--- a/packages/picasso-forms/src/SubmitButton/story/ButtonTypes.example.tsx
+++ b/packages/picasso-forms/src/SubmitButton/story/ButtonTypes.example.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { Check16, Container, Typography } from '@toptal/picasso'
+import { SPACING_4, SPACING_8 } from '@toptal/picasso/utils'
 import { FormNonCompound, SubmitButton } from '@toptal/picasso-forms'
 
 const onSubmit = () => new Promise(resolve => setTimeout(resolve, 1000))
@@ -9,9 +10,9 @@ const Example = () => (
     <Typography variant='heading' size='small'>
       Rectangular (Default)
     </Typography>
-    <Container top='small' bottom='large'>
+    <Container top={SPACING_4} bottom={SPACING_8}>
       <FormNonCompound onSubmit={onSubmit}>
-        <Container top='small'>
+        <Container top={SPACING_4}>
           <SubmitButton buttonType='rectangular'>Rectangular</SubmitButton>
         </Container>
       </FormNonCompound>
@@ -20,9 +21,9 @@ const Example = () => (
     <Typography variant='heading' size='small'>
       Circular
     </Typography>
-    <Container top='small' bottom='large'>
+    <Container top={SPACING_4} bottom={SPACING_8}>
       <FormNonCompound onSubmit={onSubmit}>
-        <Container top='small'>
+        <Container top={SPACING_4}>
           <SubmitButton buttonType='circular' icon={<Check16 />} />
         </Container>
       </FormNonCompound>
@@ -31,9 +32,9 @@ const Example = () => (
     <Typography variant='heading' size='small'>
       Action
     </Typography>
-    <Container top='small' bottom='large'>
+    <Container top={SPACING_4} bottom={SPACING_8}>
       <FormNonCompound onSubmit={onSubmit}>
-        <Container top='small'>
+        <Container top={SPACING_4}>
           <SubmitButton buttonType='action'>Action</SubmitButton>
         </Container>
       </FormNonCompound>

--- a/packages/picasso-forms/src/SubmitButton/story/Default.example.tsx
+++ b/packages/picasso-forms/src/SubmitButton/story/Default.example.tsx
@@ -1,12 +1,13 @@
 import React from 'react'
 import { Container } from '@toptal/picasso'
+import { SPACING_4 } from '@toptal/picasso/utils'
 import { FormNonCompound, SubmitButton } from '@toptal/picasso-forms'
 
 const onSubmit = () => new Promise(resolve => setTimeout(resolve, 1000))
 
 const Example = () => (
   <FormNonCompound onSubmit={onSubmit}>
-    <Container top='small'>
+    <Container top={SPACING_4}>
       <SubmitButton>Submit form</SubmitButton>
     </Container>
   </FormNonCompound>

--- a/packages/picasso-forms/src/story/Deserialization.example.tsx
+++ b/packages/picasso-forms/src/story/Deserialization.example.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { Container } from '@toptal/picasso'
+import { SPACING_4 } from '@toptal/picasso/utils'
 import {
   FormNonCompound,
   RadioGroup,
@@ -30,7 +31,7 @@ const Example = () => (
       <Radio label='yes' value='true' />
       <Radio label='no' value='false' />
     </RadioGroup>
-    <Container top='small'>
+    <Container top={SPACING_4}>
       <SubmitButton>Submit</SubmitButton>
     </Container>
   </FormNonCompound>

--- a/packages/picasso-forms/src/story/FormSpy.example.tsx
+++ b/packages/picasso-forms/src/story/FormSpy.example.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { Container } from '@toptal/picasso'
+import { SPACING_4 } from '@toptal/picasso/utils'
 import {
   FormSpy,
   FormNonCompound,
@@ -30,7 +31,7 @@ const Example = () => (
       )}
     </FormSpy>
 
-    <Container top='small'>
+    <Container top={SPACING_4}>
       <FormSpy>
         {({ pristine, values }) => {
           const isDisabled = pristine || !values?.lastName

--- a/packages/picasso-pictograms/src/Pictogram/story/Default.example.tsx
+++ b/packages/picasso-pictograms/src/Pictogram/story/Default.example.tsx
@@ -4,16 +4,17 @@ import {
   WaterfallBlue64,
 } from '@toptal/picasso-pictograms/Pictogram'
 import { Container } from '@toptal/picasso'
+import { SPACING_6 } from '@toptal/picasso/utils'
 
 const Example = () => (
   <Container flex>
-    <Container right='medium'>
-      <Container padded='medium' variant='grey'>
+    <Container right={SPACING_6}>
+      <Container padded={SPACING_6} variant='grey'>
         <WaterfallWhite64 />
       </Container>
     </Container>
     <Container>
-      <Container padded='medium' variant='grey'>
+      <Container padded={SPACING_6} variant='grey'>
         <WaterfallBlue64 />
       </Container>
     </Container>

--- a/packages/picasso-pictograms/src/Pictogram/story/List.example.tsx
+++ b/packages/picasso-pictograms/src/Pictogram/story/List.example.tsx
@@ -7,6 +7,7 @@ import {
   Input,
   Search16,
 } from '@toptal/picasso'
+import { SPACING_4, SPACING_6 } from '@toptal/picasso/utils'
 import * as pictograms from '@toptal/picasso-pictograms/Pictogram'
 
 const Example = () => {
@@ -46,7 +47,7 @@ const Example = () => {
                   flex
                   alignItems='center'
                   justifyContent='center'
-                  padded='small'
+                  padded={SPACING_4}
                   style={{
                     paddingBottom: '0.5rem',
                     minWidth: '9rem',
@@ -54,7 +55,7 @@ const Example = () => {
                 >
                   <Grid alignItems='center' direction='column' spacing={8}>
                     <Grid.Item>
-                      <Container padded='medium' variant='grey'>
+                      <Container padded={SPACING_6} variant='grey'>
                         <Pictogram />
                       </Container>
                     </Grid.Item>

--- a/packages/picasso-pictograms/src/Pictogram/story/Scale.example.tsx
+++ b/packages/picasso-pictograms/src/Pictogram/story/Scale.example.tsx
@@ -1,13 +1,14 @@
 import { Container } from '@toptal/picasso'
+import { SPACING_6 } from '@toptal/picasso/utils'
 import React from 'react'
 import { WaterfallBlue64 } from '@toptal/picasso-pictograms/Pictogram'
 
 const Example = () => (
   <Container flex>
-    <Container padded='medium' right='medium'>
+    <Container padded={SPACING_6} right={SPACING_6}>
       <WaterfallBlue64 scale={1} />
     </Container>
-    <Container padded='medium'>
+    <Container padded={SPACING_6}>
       <WaterfallBlue64 scale={2} />
     </Container>
   </Container>

--- a/packages/picasso-provider/src/Picasso/story/BarePicassoLight.example.tsx
+++ b/packages/picasso-provider/src/Picasso/story/BarePicassoLight.example.tsx
@@ -9,7 +9,11 @@ const App = ({ children }: { children: ReactNode }) => (
       <Page.TopBar title='Picasso without any dependencies' />
       <Page.Content>
         <Page.Article>
-          <Container top={7} bottom={7} flex justifyContent='center'>
+          <Container
+            flex
+            justifyContent='center'
+            style={{ paddingTop: '7rem', paddingBottom: '7rem' }}
+          >
             {children}
           </Container>
         </Page.Article>

--- a/packages/picasso-provider/src/Picasso/story/BarePicassoLight.example.tsx
+++ b/packages/picasso-provider/src/Picasso/story/BarePicassoLight.example.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from 'react'
 import React from 'react'
 import { PicassoLight } from '@toptal/picasso-provider'
 import { Page, Container } from '@toptal/picasso'
+import { SPACING_12 } from '@toptal/picasso/utils'
 
 const App = ({ children }: { children: ReactNode }) => (
   <PicassoLight>
@@ -12,7 +13,8 @@ const App = ({ children }: { children: ReactNode }) => (
           <Container
             flex
             justifyContent='center'
-            style={{ paddingTop: '7rem', paddingBottom: '7rem' }}
+            top={SPACING_12}
+            style={{ height: '14rem' }}
           >
             {children}
           </Container>

--- a/packages/picasso-provider/src/Picasso/story/Default.example.tsx
+++ b/packages/picasso-provider/src/Picasso/story/Default.example.tsx
@@ -10,7 +10,11 @@ const App = () => (
       <Page.TopBar title='App Page' />
       <Page.Content>
         <Page.Article>
-          <Container top={7} bottom={7} flex justifyContent='center'>
+          <Container
+            flex
+            justifyContent='center'
+            style={{ paddingTop: '7rem', paddingBottom: '7rem' }}
+          >
             Your application goes here
           </Container>
         </Page.Article>

--- a/packages/picasso-provider/src/Picasso/story/Default.example.tsx
+++ b/packages/picasso-provider/src/Picasso/story/Default.example.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 // import Picasso from '@toptal/picasso-provider'
 import { default as Picasso } from '@toptal/picasso-provider'
 import { Page, Container } from '@toptal/picasso'
+import { SPACING_12 } from '@toptal/picasso/utils'
 
 const App = () => (
   <Picasso loadFavicon={false} fixViewport={false}>
@@ -13,7 +14,8 @@ const App = () => (
           <Container
             flex
             justifyContent='center'
-            style={{ paddingTop: '7rem', paddingBottom: '7rem' }}
+            top={SPACING_12}
+            style={{ height: '14rem' }}
           >
             Your application goes here
           </Container>

--- a/packages/picasso-provider/src/Picasso/story/DisableClassNamePrefix.example.tsx
+++ b/packages/picasso-provider/src/Picasso/story/DisableClassNamePrefix.example.tsx
@@ -5,6 +5,7 @@ import React from 'react'
 import { default as Picasso } from '@toptal/picasso-provider'
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { Page, Container } from '@toptal/picasso'
+import { SPACING_12 } from '@toptal/picasso/utils'
 
 const App = () => (
   <Picasso disableClassNamePrefix>
@@ -15,7 +16,8 @@ const App = () => (
           <Container
             flex
             justifyContent='center'
-            style={{ paddingTop: '7rem', paddingBottom: '7rem' }}
+            top={SPACING_12}
+            style={{ height: '14rem' }}
           >
             Your application goes here
           </Container>

--- a/packages/picasso-provider/src/Picasso/story/DisableClassNamePrefix.example.tsx
+++ b/packages/picasso-provider/src/Picasso/story/DisableClassNamePrefix.example.tsx
@@ -12,7 +12,11 @@ const App = () => (
       <Page.TopBar title='App Page' />
       <Page.Content>
         <Page.Article>
-          <Container top={7} bottom={7} flex justifyContent='center'>
+          <Container
+            flex
+            justifyContent='center'
+            style={{ paddingTop: '7rem', paddingBottom: '7rem' }}
+          >
             Your application goes here
           </Container>
         </Page.Article>

--- a/packages/picasso-provider/src/Picasso/story/DisableResponsiveUI.example.tsx
+++ b/packages/picasso-provider/src/Picasso/story/DisableResponsiveUI.example.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 // import Picasso from '@toptal/picasso-provider'
 import { default as Picasso } from '@toptal/picasso-provider'
 import { Grid, Page, Container, Menu, Typography } from '@toptal/picasso'
+import { SPACING_4 } from '@toptal/picasso/utils'
 
 const Example = () => (
   <div style={{ height: '30rem' }}>
@@ -44,7 +45,12 @@ const RightContent = () => (
 )
 
 const Content = () => (
-  <Container top='small' bottom='small' left='small' right='small'>
+  <Container
+    top={SPACING_4}
+    bottom={SPACING_4}
+    left={SPACING_4}
+    right={SPACING_4}
+  >
     <Typography align='center' variant='heading' size='large'>
       Default example
     </Typography>

--- a/packages/picasso-provider/src/Picasso/story/LightWithFixViewportAndFontsLoader.example.tsx
+++ b/packages/picasso-provider/src/Picasso/story/LightWithFixViewportAndFontsLoader.example.tsx
@@ -6,6 +6,7 @@ import {
   FontsLoader,
 } from '@toptal/picasso-provider'
 import { Page, Container } from '@toptal/picasso'
+import { SPACING_12 } from '@toptal/picasso/utils'
 
 const App = ({ children }: { children: ReactNode }) => (
   <PicassoLight>
@@ -18,7 +19,8 @@ const App = ({ children }: { children: ReactNode }) => (
           <Container
             flex
             justifyContent='center'
-            style={{ paddingTop: '7rem', paddingBottom: '7rem' }}
+            top={SPACING_12}
+            style={{ height: '14rem' }}
           >
             {children}
           </Container>

--- a/packages/picasso-provider/src/Picasso/story/LightWithFixViewportAndFontsLoader.example.tsx
+++ b/packages/picasso-provider/src/Picasso/story/LightWithFixViewportAndFontsLoader.example.tsx
@@ -15,7 +15,11 @@ const App = ({ children }: { children: ReactNode }) => (
       <Page.TopBar title='Picasso with viewport fixing utility and fonts loaded' />
       <Page.Content>
         <Page.Article>
-          <Container top={7} bottom={7} flex justifyContent='center'>
+          <Container
+            flex
+            justifyContent='center'
+            style={{ paddingTop: '7rem', paddingBottom: '7rem' }}
+          >
             {children}
           </Container>
         </Page.Article>

--- a/packages/picasso-provider/src/Picasso/story/LightWithNotificationsAndFavicon.example.tsx
+++ b/packages/picasso-provider/src/Picasso/story/LightWithNotificationsAndFavicon.example.tsx
@@ -6,7 +6,7 @@ import {
   NotificationsProvider,
 } from '@toptal/picasso-provider'
 import { Page, Container, Button } from '@toptal/picasso'
-import { useNotifications } from '@toptal/picasso/utils'
+import { SPACING_12, useNotifications } from '@toptal/picasso/utils'
 
 const App = ({ children }: { children?: ReactNode }) => {
   const { showInfo } = useNotifications()
@@ -22,7 +22,8 @@ const App = ({ children }: { children?: ReactNode }) => {
               <Container
                 flex
                 justifyContent='center'
-                style={{ paddingTop: '7rem', paddingBottom: '7rem' }}
+                top={SPACING_12}
+                style={{ height: '14rem' }}
               >
                 <Button
                   data-testid='trigger'

--- a/packages/picasso-provider/src/Picasso/story/LightWithNotificationsAndFavicon.example.tsx
+++ b/packages/picasso-provider/src/Picasso/story/LightWithNotificationsAndFavicon.example.tsx
@@ -19,7 +19,11 @@ const App = ({ children }: { children?: ReactNode }) => {
           <Page.TopBar title='Picasso with notifications provider and favicon' />
           <Page.Content>
             <Page.Article>
-              <Container top={7} bottom={7} flex justifyContent='center'>
+              <Container
+                flex
+                justifyContent='center'
+                style={{ paddingTop: '7rem', paddingBottom: '7rem' }}
+              >
                 <Button
                   data-testid='trigger'
                   variant='secondary'

--- a/packages/picasso-rich-text-editor/src/RichTextEditor/story/Code.example.tsx
+++ b/packages/picasso-rich-text-editor/src/RichTextEditor/story/Code.example.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react'
 import { Container } from '@toptal/picasso'
+import { SPACING_4, SPACING_8 } from '@toptal/picasso/utils'
 import {
   CodeBlockPlugin,
   CodePlugin,
@@ -31,8 +32,8 @@ const Example = () => {
         defaultValue={defaultValue}
       />
       <Container
-        padded='small'
-        top='large'
+        padded={SPACING_4}
+        top={SPACING_8}
         style={{
           fontFamily: "Consolas, 'Courier New', monospace",
           background: 'lightyellow',

--- a/packages/picasso-rich-text-editor/src/RichTextEditor/story/Default.example.tsx
+++ b/packages/picasso-rich-text-editor/src/RichTextEditor/story/Default.example.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react'
 import { Container } from '@toptal/picasso'
+import { SPACING_4, SPACING_8 } from '@toptal/picasso/utils'
 import { RichTextEditor } from '@toptal/picasso-rich-text-editor'
 
 import type { RichTextEditorChangeHandler } from '../types'
@@ -18,8 +19,8 @@ const Example = () => {
         placeholder='Write some cool rich text'
       />
       <Container
-        padded='small'
-        top='large'
+        padded={SPACING_4}
+        top={SPACING_8}
         style={{
           fontFamily: "Consolas, 'Courier New', monospace",
           background: 'lightyellow',

--- a/packages/picasso-rich-text-editor/src/RichTextEditor/story/DefaultValue.example.tsx
+++ b/packages/picasso-rich-text-editor/src/RichTextEditor/story/DefaultValue.example.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react'
 import { Container } from '@toptal/picasso'
+import { SPACING_4, SPACING_8 } from '@toptal/picasso/utils'
 import type {
   RichTextEditorChangeHandler,
   ASTType,
@@ -136,8 +137,8 @@ const Example = () => {
         defaultValue={ast}
       />
       <Container
-        padded='small'
-        top='large'
+        padded={SPACING_4}
+        top={SPACING_8}
         style={{
           fontFamily: "Consolas, 'Courier New', monospace",
           background: 'lightyellow',

--- a/packages/picasso-rich-text-editor/src/RichTextEditor/story/Emoji.example.tsx
+++ b/packages/picasso-rich-text-editor/src/RichTextEditor/story/Emoji.example.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react'
 import { Container } from '@toptal/picasso'
+import { SPACING_4, SPACING_8 } from '@toptal/picasso/utils'
 import { EmojiPlugin, RichTextEditor } from '@toptal/picasso-rich-text-editor'
 
 import type { RichTextEditorChangeHandler } from '../types'
@@ -39,8 +40,8 @@ const Example = () => {
         plugins={[<EmojiPlugin customEmojis={customEmojis} />]}
       />
       <Container
-        padded='small'
-        top='large'
+        padded={SPACING_4}
+        top={SPACING_8}
         style={{
           fontFamily: "Consolas, 'Courier New', monospace",
           background: 'lightyellow',

--- a/packages/picasso-rich-text-editor/src/RichTextEditor/story/ImageUpload.example.tsx
+++ b/packages/picasso-rich-text-editor/src/RichTextEditor/story/ImageUpload.example.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react'
 import { Container, Radio } from '@toptal/picasso'
+import { SPACING_6, SPACING_4, SPACING_8 } from '@toptal/picasso/utils'
 import type { UploadedImage } from '@toptal/picasso-rich-text-editor'
 import { ImagePlugin, RichTextEditor } from '@toptal/picasso-rich-text-editor'
 
@@ -34,7 +35,7 @@ const Example = () => {
 
   return (
     <>
-      <Container bottom='medium'>
+      <Container bottom={SPACING_6}>
         <Radio.Group
           name='onUploadCase'
           onChange={(event: React.ChangeEvent<{ value: string }>) => {
@@ -61,8 +62,8 @@ const Example = () => {
         ]}
       />
       <Container
-        padded='small'
-        top='large'
+        padded={SPACING_4}
+        top={SPACING_8}
         style={{
           fontFamily: "Consolas, 'Courier New', monospace",
           background: 'lightyellow',

--- a/packages/picasso-rich-text-editor/src/RichTextEditor/story/Limit.example.tsx
+++ b/packages/picasso-rich-text-editor/src/RichTextEditor/story/Limit.example.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react'
 import { Container } from '@toptal/picasso'
+import { SPACING_4, SPACING_8 } from '@toptal/picasso/utils'
 import { RichTextEditor } from '@toptal/picasso-rich-text-editor'
 
 import type { RichTextEditorChangeHandler } from '../types'
@@ -20,8 +21,8 @@ const Example = () => {
         maxLength={25}
       />
       <Container
-        padded='small'
-        top='large'
+        padded={SPACING_4}
+        top={SPACING_8}
         style={{
           fontFamily: "Consolas, 'Courier New', monospace",
           background: 'lightyellow',

--- a/packages/picasso-rich-text-editor/src/RichTextEditor/story/Links.example.tsx
+++ b/packages/picasso-rich-text-editor/src/RichTextEditor/story/Links.example.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react'
 import { Container } from '@toptal/picasso'
+import { SPACING_4, SPACING_8 } from '@toptal/picasso/utils'
 import { LinkPlugin, RichTextEditor } from '@toptal/picasso-rich-text-editor'
 
 import type { RichTextEditorChangeHandler } from '../types'
@@ -19,8 +20,8 @@ const Example = () => {
         plugins={[<LinkPlugin />]}
       />
       <Container
-        padded='small'
-        top='large'
+        padded={SPACING_4}
+        top={SPACING_8}
         style={{
           fontFamily: "Consolas, 'Courier New', monospace",
           background: 'lightyellow',

--- a/packages/picasso/src/Accordion/story/BorderedGroups.example.tsx
+++ b/packages/picasso/src/Accordion/story/BorderedGroups.example.tsx
@@ -1,11 +1,12 @@
 import React from 'react'
 import { Accordion, Container, Grid, Typography } from '@toptal/picasso'
+import { SPACING_6 } from '@toptal/picasso/utils'
 
 const Example = () => {
   return (
     <Grid>
       <Grid.Item sm={4}>
-        <Container bottom='medium'>
+        <Container bottom={SPACING_6}>
           <Typography variant='heading'>All Borders</Typography>
         </Container>
 
@@ -25,7 +26,7 @@ const Example = () => {
       </Grid.Item>
 
       <Grid.Item sm={4}>
-        <Container bottom='medium'>
+        <Container bottom={SPACING_6}>
           <Typography variant='heading'>Middle Borders</Typography>
         </Container>
 
@@ -44,7 +45,7 @@ const Example = () => {
         </Accordion>
       </Grid.Item>
       <Grid.Item sm={4}>
-        <Container bottom='medium'>
+        <Container bottom={SPACING_6}>
           <Typography variant='heading'>No Borders</Typography>
         </Container>
 

--- a/packages/picasso/src/Accordion/story/Controlled.example.tsx
+++ b/packages/picasso/src/Accordion/story/Controlled.example.tsx
@@ -6,17 +6,18 @@ import {
   Typography,
   Plus16,
 } from '@toptal/picasso'
+import { SPACING_4, SPACING_8, SPACING_2 } from '@toptal/picasso/utils'
 
 const Example = () => {
   const [expanded, setExpanded] = React.useState(true)
 
   return (
     <Container style={{ width: '500px' }}>
-      <Container bottom={1}>
+      <Container bottom={SPACING_4}>
         <Button onClick={() => setExpanded(!expanded)}>Toggle state</Button>
       </Container>
       <Container flex>
-        <Container right='large'>
+        <Container right={SPACING_8}>
           <Accordion
             content={<DetailsDogDefinitionPanel />}
             expanded={expanded}
@@ -43,7 +44,7 @@ const DetailsDogDefinitionPanel = () => (
 
 const DetailsDogKindPanel = () => (
   <Accordion.Details>
-    <Container top='xsmall' bottom='xsmall'>
+    <Container top={SPACING_2} bottom={SPACING_2}>
       <Typography size='medium' weight='semibold' color='black'>
         Breeds of dogs
       </Typography>

--- a/packages/picasso/src/Accordion/story/CustomSummary.example.tsx
+++ b/packages/picasso/src/Accordion/story/CustomSummary.example.tsx
@@ -1,13 +1,19 @@
 import React, { useState } from 'react'
 import { Accordion, Typography, Button, Container, Link } from '@toptal/picasso'
 import {
+  SPACING_4,
+  SPACING_6,
+  SPACING_2,
+  palette,
+  Transitions,
+} from '@toptal/picasso/utils'
+import {
   ArrowDownMinor16,
   Drag16,
   Bell16,
   Time16,
   VideoOn16,
 } from '@toptal/picasso/Icon'
-import { palette, Transitions } from '@toptal/picasso/utils'
 
 const Summary = ({
   onClick,
@@ -20,8 +26,8 @@ const Summary = ({
     flex
     alignItems='center'
     justifyContent='space-between'
-    bottom='small'
-    top='small'
+    bottom={SPACING_4}
+    top={SPACING_4}
   >
     <Typography variant='heading' size='medium'>
       Upcoming interviews (1)
@@ -53,7 +59,7 @@ const InterviewCard = () => (
     <Container
       flex
       direction='column'
-      padded='medium'
+      padded={SPACING_6}
       alignItems='center'
       justifyContent='center'
     >
@@ -76,13 +82,13 @@ const InterviewCard = () => (
       }}
     />
 
-    <Container padded='medium' style={{ flex: 1 }}>
-      <Container flex justifyContent='space-between' bottom='xsmall'>
+    <Container padded={SPACING_6} style={{ flex: 1 }}>
+      <Container flex justifyContent='space-between' bottom={SPACING_2}>
         <Container>
           <Typography size='medium' as='span'>
             <Link href='#'>React Front End Developer</Link>
           </Typography>
-          <Container left='xsmall' inline>
+          <Container left={SPACING_2} inline>
             <Typography size='medium' as='span'>
               with Walsh Group
             </Typography>
@@ -91,7 +97,7 @@ const InterviewCard = () => (
 
         <Container>
           <Bell16 />
-          <Container left='xsmall' right='small' inline>
+          <Container left={SPACING_2} right={SPACING_4} inline>
             <Typography size='xsmall' as='span'>
               <Link href='#'>Add to calendar</Link>
             </Typography>
@@ -108,9 +114,9 @@ const InterviewCard = () => (
 
       <Container flex justifyContent='space-between' alignItems='center'>
         <Container>
-          <Container bottom='xsmall'>
+          <Container bottom={SPACING_2}>
             <Time16 />
-            <Container left='small' inline>
+            <Container left={SPACING_4} inline>
               <Typography size='medium' as='span'>
                 07:00 PM – 07:30 PM (UTC+02:00) Europe – Belgrade
               </Typography>
@@ -119,7 +125,7 @@ const InterviewCard = () => (
 
           <Container>
             <VideoOn16 />
-            <Container left='small' right='xsmall' inline>
+            <Container left={SPACING_4} right={SPACING_2} inline>
               <Typography size='medium' as='span'>
                 Bluejeans Conference
               </Typography>

--- a/packages/picasso/src/AccountSelect/story/Page.example.tsx
+++ b/packages/picasso/src/AccountSelect/story/Page.example.tsx
@@ -7,6 +7,7 @@ import {
   Typography,
   Logo,
 } from '@toptal/picasso'
+import { SPACING_8 } from '@toptal/picasso/utils'
 
 const accounts = [
   {
@@ -40,7 +41,7 @@ const Example = () => (
               Select an Account
             </Typography>
           </Container>
-          <Container top={2}>
+          <Container top={SPACING_8}>
             <AccountSelect
               accounts={accounts}
               onSelect={account => console.log(account)}

--- a/packages/picasso/src/Alert/story/Default.example.tsx
+++ b/packages/picasso/src/Alert/story/Default.example.tsx
@@ -1,10 +1,11 @@
 import React from 'react'
 import { Container, Typography, Alert } from '@toptal/picasso'
+import { SPACING_4 } from '@toptal/picasso/utils'
 
 const Example = () => (
   <div>
-    <Container bottom={1}>
-      <Container bottom={1}>
+    <Container bottom={SPACING_4}>
+      <Container bottom={SPACING_4}>
         <Typography variant='heading' size='small'>
           Yellow
         </Typography>
@@ -12,8 +13,8 @@ const Example = () => (
       <Alert>This is a warning alert.</Alert>
     </Container>
 
-    <Container bottom={1}>
-      <Container bottom={1}>
+    <Container bottom={SPACING_4}>
+      <Container bottom={SPACING_4}>
         <Typography variant='heading' size='small'>
           Red
         </Typography>
@@ -21,8 +22,8 @@ const Example = () => (
       <Alert variant='red'>This is a critical warning alert.</Alert>
     </Container>
 
-    <Container bottom={1}>
-      <Container bottom={1}>
+    <Container bottom={SPACING_4}>
+      <Container bottom={SPACING_4}>
         <Typography variant='heading' size='small'>
           Blue
         </Typography>
@@ -30,8 +31,8 @@ const Example = () => (
       <Alert variant='blue'>This is a info alert.</Alert>
     </Container>
 
-    <Container bottom={1}>
-      <Container bottom={1}>
+    <Container bottom={SPACING_4}>
+      <Container bottom={SPACING_4}>
         <Typography variant='heading' size='small'>
           Green
         </Typography>

--- a/packages/picasso/src/AlertInline/story/Default.example.tsx
+++ b/packages/picasso/src/AlertInline/story/Default.example.tsx
@@ -1,10 +1,11 @@
 import React from 'react'
 import { Container, Typography, Alert } from '@toptal/picasso'
+import { SPACING_4 } from '@toptal/picasso/utils'
 
 const Example = () => (
   <div>
-    <Container bottom={1}>
-      <Container bottom={1}>
+    <Container bottom={SPACING_4}>
+      <Container bottom={SPACING_4}>
         <Typography variant='heading' size='small'>
           Yellow
         </Typography>
@@ -12,8 +13,8 @@ const Example = () => (
       <Alert.Inline>This is a warning inline alert.</Alert.Inline>
     </Container>
 
-    <Container bottom={1}>
-      <Container bottom={1}>
+    <Container bottom={SPACING_4}>
+      <Container bottom={SPACING_4}>
         <Typography variant='heading' size='small'>
           Red
         </Typography>
@@ -23,8 +24,8 @@ const Example = () => (
       </Alert.Inline>
     </Container>
 
-    <Container bottom={1}>
-      <Container bottom={1}>
+    <Container bottom={SPACING_4}>
+      <Container bottom={SPACING_4}>
         <Typography variant='heading' size='small'>
           Blue
         </Typography>
@@ -32,8 +33,8 @@ const Example = () => (
       <Alert.Inline variant='blue'>This is a info inline alert.</Alert.Inline>
     </Container>
 
-    <Container bottom={1}>
-      <Container bottom={1}>
+    <Container bottom={SPACING_4}>
+      <Container bottom={SPACING_4}>
         <Typography variant='heading' size='small'>
           Green
         </Typography>

--- a/packages/picasso/src/Amount/story/Currency.example.tsx
+++ b/packages/picasso/src/Amount/story/Currency.example.tsx
@@ -1,15 +1,16 @@
 import { Amount, Container } from '@toptal/picasso'
+import { SPACING_4 } from '@toptal/picasso/utils'
 import React from 'react'
 
 const Example = () => (
   <div>
-    <Container bottom={1}>
+    <Container bottom={SPACING_4}>
       <Amount amount={1500} currency='EUR' />
     </Container>
-    <Container bottom={1}>
+    <Container bottom={SPACING_4}>
       <Amount amount={150} currency='USD' />
     </Container>
-    <Container bottom={1}>
+    <Container bottom={SPACING_4}>
       <Amount amount={15} currency='HUF' />
     </Container>
   </div>

--- a/packages/picasso/src/Amount/story/Decimals.example.tsx
+++ b/packages/picasso/src/Amount/story/Decimals.example.tsx
@@ -1,15 +1,16 @@
 import { Amount, Container, Typography } from '@toptal/picasso'
+import { SPACING_4 } from '@toptal/picasso/utils'
 import React from 'react'
 
 const Example = () => (
   <div>
-    <Container bottom={1}>
+    <Container bottom={SPACING_4}>
       <Typography variant='heading' size='medium'>
         minimumFractionDigits: 5
       </Typography>
       <Amount amount={1234.67} minimumFractionDigits={5} />
     </Container>
-    <Container bottom={1}>
+    <Container bottom={SPACING_4}>
       <Typography variant='heading' size='medium'>
         maximumFractionDigits: 1
       </Typography>

--- a/packages/picasso/src/Amount/story/Default.example.tsx
+++ b/packages/picasso/src/Amount/story/Default.example.tsx
@@ -1,15 +1,16 @@
 import { Amount, Container } from '@toptal/picasso'
+import { SPACING_4 } from '@toptal/picasso/utils'
 import React from 'react'
 
 const Example = () => (
   <div>
-    <Container bottom={1}>
+    <Container bottom={SPACING_4}>
       <Amount amount={1500} color='green' weight='semibold' size='medium' />
     </Container>
-    <Container bottom={1}>
+    <Container bottom={SPACING_4}>
       <Amount amount={150} color='grey' size='xsmall' />
     </Container>
-    <Container bottom={1}>
+    <Container bottom={SPACING_4}>
       <Amount amount={15} inline={false} />
     </Container>
   </div>

--- a/packages/picasso/src/Amount/story/Locale.example.tsx
+++ b/packages/picasso/src/Amount/story/Locale.example.tsx
@@ -1,27 +1,28 @@
 import { Amount, Container, Typography } from '@toptal/picasso'
+import { SPACING_4 } from '@toptal/picasso/utils'
 import React from 'react'
 
 const Example = () => (
   <div>
-    <Container bottom={1}>
+    <Container bottom={SPACING_4}>
       <Typography variant='heading' size='medium'>
         Using default (en-US) locale
       </Typography>
       <Amount amount={15} />
     </Container>
-    <Container bottom={1}>
+    <Container bottom={SPACING_4}>
       <Typography variant='heading' size='medium'>
         Using French locale
       </Typography>
       <Amount amount={1500} locale='fr-FR' />
     </Container>
-    <Container bottom={1}>
+    <Container bottom={SPACING_4}>
       <Typography variant='heading' size='medium'>
         Using Hungarian locale
       </Typography>
       <Amount amount={150} locale='hu-HU' />
     </Container>
-    <Container bottom={1}>
+    <Container bottom={SPACING_4}>
       <Typography variant='heading' size='medium'>
         Using Austrian locale
       </Typography>

--- a/packages/picasso/src/Amount/story/Variants.example.tsx
+++ b/packages/picasso/src/Amount/story/Variants.example.tsx
@@ -1,18 +1,19 @@
 import { Amount, Container } from '@toptal/picasso'
+import { SPACING_4 } from '@toptal/picasso/utils'
 import React from 'react'
 
 const Example = () => (
   <div>
-    <Container bottom={1}>
+    <Container bottom={SPACING_4}>
       <Amount amount={1500} color='red' />
     </Container>
-    <Container bottom={1}>
+    <Container bottom={SPACING_4}>
       <Amount amount={1500} color='green' />
     </Container>
-    <Container bottom={1}>
+    <Container bottom={SPACING_4}>
       <Amount amount={150} weight='semibold' />
     </Container>
-    <Container bottom={1}>
+    <Container bottom={SPACING_4}>
       <Amount amount={15} size='large' />
     </Container>
   </div>

--- a/packages/picasso/src/Autocomplete/story/Controlled.example.tsx
+++ b/packages/picasso/src/Autocomplete/story/Controlled.example.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react'
 import { Button, Container, Grid, Autocomplete } from '@toptal/picasso'
+import { SPACING_8 } from '@toptal/picasso/utils'
 
 const options = [
   { text: 'Belarus', value: 'BY' },
@@ -28,7 +29,7 @@ const Example = () => {
           setValue(newValue)
         }}
       />
-      <Container top={2}>
+      <Container top={SPACING_8}>
         <Grid>
           <Grid.Item>
             <Button

--- a/packages/picasso/src/Avatar/story/Editable.example.tsx
+++ b/packages/picasso/src/Avatar/story/Editable.example.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { Avatar, Container } from '@toptal/picasso'
+import { SPACING_6 } from '@toptal/picasso/utils'
 
 const Example = () => {
   const handleEdit = () => {
@@ -7,7 +8,7 @@ const Example = () => {
   }
 
   return (
-    <Container gap='medium' flex>
+    <Container gap={SPACING_6} flex>
       <Avatar name='Jacqueline Roque' onEdit={handleEdit} />
       <Avatar
         alt='Jacqueline Roque. Pablo Picasso, 1954'

--- a/packages/picasso/src/Avatar/story/LongName.example.tsx
+++ b/packages/picasso/src/Avatar/story/LongName.example.tsx
@@ -1,21 +1,22 @@
 import React from 'react'
 import { Avatar, Container } from '@toptal/picasso'
+import { SPACING_4 } from '@toptal/picasso/utils'
 
 const Example = () => (
-  <Container top='small'>
+  <Container top={SPACING_4}>
     <Container inline>
       <Avatar size='xxsmall' name='William Wallace Wo Wade' />
     </Container>
-    <Container inline left='small'>
+    <Container inline left={SPACING_4}>
       <Avatar size='xsmall' name='William Wallace Wo Wade' />
     </Container>
-    <Container inline left='small'>
+    <Container inline left={SPACING_4}>
       <Avatar size='small' name='William Wallace Wo Wade' />
     </Container>
-    <Container inline left='small'>
+    <Container inline left={SPACING_4}>
       <Avatar size='medium' name='William Wallace Wo Wade' />
     </Container>
-    <Container inline left='small'>
+    <Container inline left={SPACING_4}>
       <Avatar size='large' name='William Wallace Wo Wade' />
     </Container>
   </Container>

--- a/packages/picasso/src/Avatar/story/Sizes.example.tsx
+++ b/packages/picasso/src/Avatar/story/Sizes.example.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { Avatar, Container } from '@toptal/picasso'
+import { SPACING_4 } from '@toptal/picasso/utils'
 
 const Example = () => (
   <div>
@@ -12,7 +13,7 @@ const Example = () => (
           src='./jacqueline-with-flowers-1954-square.jpg'
         />
       </Container>
-      <Container inline left='small'>
+      <Container inline left={SPACING_4}>
         <Avatar
           size='xsmall'
           alt='Jacqueline Roque. Pablo Picasso, 1954. Small'
@@ -20,7 +21,7 @@ const Example = () => (
           src='./jacqueline-with-flowers-1954-square.jpg'
         />
       </Container>
-      <Container inline left='small'>
+      <Container inline left={SPACING_4}>
         <Avatar
           size='small'
           alt='Jacqueline Roque. Pablo Picasso, 1954. Small'
@@ -28,7 +29,7 @@ const Example = () => (
           src='./jacqueline-with-flowers-1954-square.jpg'
         />
       </Container>
-      <Container inline left='small'>
+      <Container inline left={SPACING_4}>
         <Avatar
           size='medium'
           alt='Jacqueline Roque. Pablo Picasso, 1954. Medium'
@@ -36,7 +37,7 @@ const Example = () => (
           src='./jacqueline-with-flowers-1954-square.jpg'
         />
       </Container>
-      <Container inline left='small'>
+      <Container inline left={SPACING_4}>
         <Avatar
           size='large'
           alt='Jacqueline Roque. Pablo Picasso, 1954. Large'
@@ -46,38 +47,38 @@ const Example = () => (
       </Container>
     </Container>
 
-    <Container top='small'>
+    <Container top={SPACING_4}>
       <Container inline>
         <Avatar size='xxsmall' name='Jacqueline Roque' />
       </Container>
-      <Container inline left='small'>
+      <Container inline left={SPACING_4}>
         <Avatar size='xsmall' name='Jacqueline Roque' />
       </Container>
-      <Container inline left='small'>
+      <Container inline left={SPACING_4}>
         <Avatar size='small' name='Jacqueline Roque' />
       </Container>
-      <Container inline left='small'>
+      <Container inline left={SPACING_4}>
         <Avatar size='medium' name='Jacqueline Roque' />
       </Container>
-      <Container inline left='small'>
+      <Container inline left={SPACING_4}>
         <Avatar size='large' name='Jacqueline Roque' />
       </Container>
     </Container>
 
-    <Container top='small'>
+    <Container top={SPACING_4}>
       <Container inline>
         <Avatar size='xxsmall' />
       </Container>
-      <Container inline left='small'>
+      <Container inline left={SPACING_4}>
         <Avatar size='xsmall' />
       </Container>
-      <Container inline left='small'>
+      <Container inline left={SPACING_4}>
         <Avatar size='small' />
       </Container>
-      <Container inline left='small'>
+      <Container inline left={SPACING_4}>
         <Avatar size='medium' />
       </Container>
-      <Container inline left='small'>
+      <Container inline left={SPACING_4}>
         <Avatar size='large' />
       </Container>
     </Container>

--- a/packages/picasso/src/Avatar/story/Variants.example.tsx
+++ b/packages/picasso/src/Avatar/story/Variants.example.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { Avatar, Container } from '@toptal/picasso'
+import { SPACING_4 } from '@toptal/picasso/utils'
 
 const Example = () => (
   <div>
@@ -11,13 +12,13 @@ const Example = () => (
         src='./jacqueline-with-flowers-1954-square.jpg'
       />
     </Container>
-    <Container inline left='small'>
+    <Container inline left={SPACING_4}>
       <Avatar size='medium' name='Jacqueline Roque' />
     </Container>
-    <Container inline left='small'>
+    <Container inline left={SPACING_4}>
       <Avatar size='medium' />
     </Container>
-    <Container inline left='small'>
+    <Container inline left={SPACING_4}>
       <Avatar
         variant='portrait'
         size='medium'
@@ -26,7 +27,7 @@ const Example = () => (
         src='./jacqueline-with-flowers-1954-square.jpg'
       />
     </Container>
-    <Container inline left='small'>
+    <Container inline left={SPACING_4}>
       <Avatar
         variant='landscape'
         size='medium'

--- a/packages/picasso/src/AvatarGroup/story/Limit.example.tsx
+++ b/packages/picasso/src/AvatarGroup/story/Limit.example.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { Avatar, Container } from '@toptal/picasso'
+import { SPACING_8 } from '@toptal/picasso/utils'
 
 const person = {
   alt: 'Jacqueline Roque. Pablo Picasso, 1954',
@@ -15,7 +16,7 @@ const people6 = generatePeople(6)
 const people3 = generatePeople(3)
 
 const Example = () => (
-  <Container flex direction='column' gap='large'>
+  <Container flex direction='column' gap={SPACING_8}>
     <div>
       Over the Limit
       <Avatar.Group items={people6} />

--- a/packages/picasso/src/AvatarGroup/story/Sizes.example.tsx
+++ b/packages/picasso/src/AvatarGroup/story/Sizes.example.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { Avatar, Container } from '@toptal/picasso'
+import { SPACING_8 } from '@toptal/picasso/utils'
 
 const person = {
   alt: 'Jacqueline Roque. Pablo Picasso, 1954',
@@ -27,7 +28,7 @@ const people = [
 ]
 
 const Example = () => (
-  <Container flex direction='column' gap='large'>
+  <Container flex direction='column' gap={SPACING_8}>
     <div>
       xxsmall
       <Avatar.Group items={people} size='xxsmall' />

--- a/packages/picasso/src/AvatarUpload/story/Default.example.tsx
+++ b/packages/picasso/src/AvatarUpload/story/Default.example.tsx
@@ -1,9 +1,10 @@
 import React from 'react'
 import { AvatarUpload, Container } from '@toptal/picasso'
+import { SPACING_6 } from '@toptal/picasso/utils'
 
 const Example = () => {
   return (
-    <Container padded='medium'>
+    <Container padded={SPACING_6}>
       <AvatarUpload />
     </Container>
   )

--- a/packages/picasso/src/AvatarUpload/story/Sizes.example.tsx
+++ b/packages/picasso/src/AvatarUpload/story/Sizes.example.tsx
@@ -1,9 +1,10 @@
 import React from 'react'
 import { AvatarUpload, Container } from '@toptal/picasso'
+import { SPACING_6 } from '@toptal/picasso/utils'
 
 const Example = () => {
   return (
-    <Container flex gap='medium' padded='medium' alignItems='flex-end'>
+    <Container flex gap={SPACING_6} padded={SPACING_6} alignItems='flex-end'>
       <AvatarUpload size='xxsmall' />
       <AvatarUpload size='xsmall' />
       <AvatarUpload size='small' />

--- a/packages/picasso/src/AvatarUpload/story/States.example.tsx
+++ b/packages/picasso/src/AvatarUpload/story/States.example.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { AvatarUpload, Container, Typography } from '@toptal/picasso'
+import { SPACING_6 } from '@toptal/picasso/utils'
 
 const HoveredExample = () => (
   <Container flex direction='column' alignItems='center'>
@@ -56,7 +57,7 @@ const ActiveExample = () => (
 )
 
 const Example = () => (
-  <Container flex padded='medium' gap='medium'>
+  <Container flex padded={SPACING_6} gap={SPACING_6}>
     <HoveredExample />
     <FocusedExample />
     <ErrorExample />

--- a/packages/picasso/src/AvatarUpload/story/UsingRef.example.tsx
+++ b/packages/picasso/src/AvatarUpload/story/UsingRef.example.tsx
@@ -1,5 +1,6 @@
 import React, { useRef, useState } from 'react'
 import { AvatarUpload, Container } from '@toptal/picasso'
+import { SPACING_6 } from '@toptal/picasso/utils'
 
 const Example = () => {
   const [src, setSrc] = useState('./jacqueline-with-flowers-1954-square.jpg')
@@ -25,7 +26,7 @@ const Example = () => {
   }
 
   return (
-    <Container padded='medium'>
+    <Container padded={SPACING_6}>
       <AvatarUpload
         ref={avatarUploadRef}
         onEdit={handleEdit}

--- a/packages/picasso/src/AvatarUpload/story/WithUpload.example.tsx
+++ b/packages/picasso/src/AvatarUpload/story/WithUpload.example.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react'
 import { AvatarUpload, Container } from '@toptal/picasso'
+import { SPACING_6 } from '@toptal/picasso/utils'
 import type { FileRejection } from '@toptal/picasso/AvatarUpload'
 
 const Example = () => {
@@ -37,7 +38,7 @@ const Example = () => {
   }
 
   return (
-    <Container padded='medium'>
+    <Container padded={SPACING_6}>
       <AvatarUpload
         alt='Jacqueline Roque. Pablo Picasso, 1954'
         onDrop={handleDrop}

--- a/packages/picasso/src/Badge/story/Overlay.example.tsx
+++ b/packages/picasso/src/Badge/story/Overlay.example.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { Avatar, Container, Typography, Badge } from '@toptal/picasso'
+import { SPACING_4, SPACING_6 } from '@toptal/picasso/utils'
 
 const Example = () => (
   <>
@@ -9,7 +10,7 @@ const Example = () => (
       </Typography>
     </Container>
 
-    <Container top='small' flex bottom='medium' gap='small'>
+    <Container top={SPACING_4} flex bottom={SPACING_6} gap={SPACING_4}>
       <Badge content={1} variant='white' size='small'>
         <Avatar name='Jacqueline Roque' />
       </Badge>
@@ -27,7 +28,7 @@ const Example = () => (
       </Typography>
     </Container>
 
-    <Container top='small' flex gap='small'>
+    <Container top={SPACING_4} flex gap={SPACING_4}>
       <Badge content={100} variant='red' size='small'>
         <Avatar name='Adam Jones' />
       </Badge>

--- a/packages/picasso/src/Badge/story/Sizes.example.tsx
+++ b/packages/picasso/src/Badge/story/Sizes.example.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { Container, Typography, Badge, Grid } from '@toptal/picasso'
+import { SPACING_4, SPACING_6 } from '@toptal/picasso/utils'
 
 const Example = () => (
   <>
@@ -10,14 +11,14 @@ const Example = () => (
     </Container>
     <Grid>
       <Grid.Item sm={6}>
-        <Container top='small' bottom='medium' flex gap='small'>
+        <Container top={SPACING_4} bottom={SPACING_6} flex gap={SPACING_4}>
           <Badge content={1} variant='white' size='small' />
           <Badge content={7} variant='white' size='small' />
           <Badge content={25} variant='white' size='small' />
         </Container>
       </Grid.Item>
       <Grid.Item sm={6}>
-        <Container top='small' bottom='medium' flex gap='small'>
+        <Container top={SPACING_4} bottom={SPACING_6} flex gap={SPACING_4}>
           <Badge content={1} variant='red' size='small' />
           <Badge content={7} variant='red' size='small' />
           <Badge content={25} variant='red' size='small' />
@@ -32,7 +33,7 @@ const Example = () => (
     </Container>
     <Grid>
       <Grid.Item sm={6}>
-        <Container top='small' bottom='medium' flex gap='small'>
+        <Container top={SPACING_4} bottom={SPACING_6} flex gap={SPACING_4}>
           <Badge content={1} variant='white' size='medium' />
           <Badge content={7} variant='white' size='medium' />
           <Badge content={25} variant='white' size='medium' />
@@ -41,7 +42,7 @@ const Example = () => (
         </Container>
       </Grid.Item>
       <Grid.Item sm={6}>
-        <Container top='small' bottom='medium' flex gap='small'>
+        <Container top={SPACING_4} bottom={SPACING_6} flex gap={SPACING_4}>
           <Badge content={1} variant='red' size='medium' />
           <Badge content={7} variant='red' size='medium' />
           <Badge content={25} variant='red' size='medium' />
@@ -58,7 +59,7 @@ const Example = () => (
     </Container>
     <Grid>
       <Grid.Item sm={6}>
-        <Container top='small' bottom='medium' flex gap='small'>
+        <Container top={SPACING_4} bottom={SPACING_6} flex gap={SPACING_4}>
           <Badge content={1} variant='white' size='large' />
           <Badge content={7} variant='white' size='large' />
           <Badge content={25} variant='white' size='large' />
@@ -67,7 +68,7 @@ const Example = () => (
         </Container>
       </Grid.Item>
       <Grid.Item sm={6}>
-        <Container top='small' bottom='medium' flex gap='small'>
+        <Container top={SPACING_4} bottom={SPACING_6} flex gap={SPACING_4}>
           <Badge content={1} variant='red' size='large' />
           <Badge content={7} variant='red' size='large' />
           <Badge content={25} variant='red' size='large' />
@@ -83,14 +84,14 @@ const Example = () => (
     </Container>
     <Grid>
       <Grid.Item sm={6}>
-        <Container top='small' flex alignItems='center' gap='small'>
+        <Container top={SPACING_4} flex alignItems='center' gap={SPACING_4}>
           <Badge content={9999} variant='white' size='small' max={999} />
           <Badge content={9999} variant='white' size='medium' max={999} />
           <Badge content={9999} variant='white' size='large' max={999} />
         </Container>
       </Grid.Item>
       <Grid.Item sm={6}>
-        <Container top='small' flex alignItems='center' gap='small'>
+        <Container top={SPACING_4} flex alignItems='center' gap={SPACING_4}>
           <Badge content={9999} variant='red' size='small' max={999} />
           <Badge content={9999} variant='red' size='medium' max={999} />
           <Badge content={9999} variant='red' size='large' max={999} />

--- a/packages/picasso/src/Badge/story/Variants.example.tsx
+++ b/packages/picasso/src/Badge/story/Variants.example.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { Container, Typography, Badge } from '@toptal/picasso'
+import { SPACING_4, SPACING_6 } from '@toptal/picasso/utils'
 
 const Example = () => (
   <>
@@ -8,17 +9,17 @@ const Example = () => (
         White:
       </Typography>
     </Container>
-    <Container top='small' flex gap='small'>
+    <Container top={SPACING_4} flex gap={SPACING_4}>
       <Badge content={1} variant='white' />
       <Badge content={0} variant='white' />
     </Container>
 
-    <Container top='medium'>
+    <Container top={SPACING_6}>
       <Typography variant='heading' size='small'>
         Red:
       </Typography>
     </Container>
-    <Container top='small' flex gap='small'>
+    <Container top={SPACING_4} flex gap={SPACING_4}>
       <Badge content={100} variant='red' />
       <Badge content={1} variant='red' />
     </Container>

--- a/packages/picasso/src/Breadcrumbs/story/Default.example.tsx
+++ b/packages/picasso/src/Breadcrumbs/story/Default.example.tsx
@@ -8,11 +8,12 @@ import {
   useLocation,
 } from 'react-router-dom'
 import { Container, Logo, Link, Breadcrumbs } from '@toptal/picasso'
+import { SPACING_4 } from '@toptal/picasso/utils'
 
 const Usa = () => <h2>USA</h2>
 const Software = () => <h2>Software</h2>
 const Toptal = () => (
-  <Container top='small'>
+  <Container top={SPACING_4}>
     <Logo />
   </Container>
 )

--- a/packages/picasso/src/Button/story/States.example.tsx
+++ b/packages/picasso/src/Button/story/States.example.tsx
@@ -1,13 +1,13 @@
 import React from 'react'
 import { Button, Container, Typography } from '@toptal/picasso'
-import { palette } from '@toptal/picasso/utils'
+import { SPACING_4, SPACING_8, SPACING_2, palette } from '@toptal/picasso/utils'
 
 const Example = () => (
   <div>
     <Typography variant='heading' size='small'>
       Primary (Default)
     </Typography>
-    <Container top='small' bottom='large'>
+    <Container top={SPACING_4} bottom={SPACING_8}>
       <Button>Normal</Button>
       <Button hovered>Hovered</Button>
       <Button focused>Focused</Button>
@@ -19,7 +19,7 @@ const Example = () => (
     <Typography variant='heading' size='small'>
       Negative
     </Typography>
-    <Container top='small' bottom='large'>
+    <Container top={SPACING_4} bottom={SPACING_8}>
       <Button variant='negative'>Normal</Button>
       <Button hovered variant='negative'>
         Hovered
@@ -41,7 +41,7 @@ const Example = () => (
     <Typography variant='heading' size='small'>
       Positive
     </Typography>
-    <Container top='small' bottom='large'>
+    <Container top={SPACING_4} bottom={SPACING_8}>
       <Button variant='positive'>Normal</Button>
       <Button hovered variant='positive'>
         Hovered
@@ -63,7 +63,7 @@ const Example = () => (
     <Typography variant='heading' size='small'>
       Secondary
     </Typography>
-    <Container top='small' bottom='large'>
+    <Container top={SPACING_4} bottom={SPACING_8}>
       <Button variant='secondary'>Normal</Button>
       <Button hovered variant='secondary'>
         Hovered
@@ -86,10 +86,10 @@ const Example = () => (
       Transparent
     </Typography>
     <Container
-      top='small'
+      top={SPACING_4}
       inline
       style={{ backgroundColor: palette.blue.main }}
-      padded={0.5}
+      padded={SPACING_2}
     >
       <Button variant='transparent'>Normal</Button>
       <Button hovered variant='transparent'>

--- a/packages/picasso/src/Button/story/Variants.example.tsx
+++ b/packages/picasso/src/Button/story/Variants.example.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { Button, Container } from '@toptal/picasso'
-import { palette } from '@toptal/picasso/utils'
+import { SPACING_4, SPACING_2, palette } from '@toptal/picasso/utils'
 
 const Example = () => (
   <div>
@@ -13,9 +13,9 @@ const Example = () => (
     <Button variant='secondary'>Secondary</Button>
 
     <Container
-      top='small'
-      left='small'
-      padded={0.5}
+      top={SPACING_4}
+      left={SPACING_4}
+      padded={SPACING_2}
       inline
       style={{ backgroundColor: palette.blue.main }}
     >

--- a/packages/picasso/src/ButtonAction/story/CustomBackground.example.tsx
+++ b/packages/picasso/src/ButtonAction/story/CustomBackground.example.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { Button, Container, Typography } from '@toptal/picasso'
+import { SPACING_4, SPACING_8 } from '@toptal/picasso/utils'
 import { Link16 } from '@toptal/picasso/Icon'
 
 const Example = () => (
@@ -7,7 +8,11 @@ const Example = () => (
     <Typography variant='heading' size='small'>
       No icon
     </Typography>
-    <Container top='small' bottom='large' style={{ background: 'lightyellow' }}>
+    <Container
+      top={SPACING_4}
+      bottom={SPACING_8}
+      style={{ background: 'lightyellow' }}
+    >
       <Button.Action>Default</Button.Action>
       <Button.Action hovered>Hovered</Button.Action>
       <Button.Action focused>Focused</Button.Action>

--- a/packages/picasso/src/ButtonAction/story/States.example.tsx
+++ b/packages/picasso/src/ButtonAction/story/States.example.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { Button, Container, Typography } from '@toptal/picasso'
+import { SPACING_4, SPACING_8 } from '@toptal/picasso/utils'
 import { Link16 } from '@toptal/picasso/Icon'
 
 const Example = () => (
@@ -7,7 +8,7 @@ const Example = () => (
     <Typography variant='heading' size='small'>
       No icon
     </Typography>
-    <Container top='small' bottom='large'>
+    <Container top={SPACING_4} bottom={SPACING_8}>
       <Button.Action>Default</Button.Action>
       <Button.Action hovered>Hovered</Button.Action>
       <Button.Action focused>Focused</Button.Action>
@@ -18,7 +19,7 @@ const Example = () => (
     <Typography variant='heading' size='small'>
       Icon on the left
     </Typography>
-    <Container top='small' bottom='large'>
+    <Container top={SPACING_4} bottom={SPACING_8}>
       <Button.Action icon={<Link16 />}>Default</Button.Action>
       <Button.Action hovered icon={<Link16 />}>
         Hovered
@@ -39,7 +40,7 @@ const Example = () => (
     <Typography variant='heading' size='small'>
       Icon on the right
     </Typography>
-    <Container top='small' bottom='large'>
+    <Container top={SPACING_4} bottom={SPACING_8}>
       <Button.Action icon={<Link16 />} iconPosition='right'>
         Default
       </Button.Action>

--- a/packages/picasso/src/ButtonCircular/story/States.example.tsx
+++ b/packages/picasso/src/ButtonCircular/story/States.example.tsx
@@ -1,14 +1,14 @@
 import React from 'react'
 import { Button, Container, Typography } from '@toptal/picasso'
+import { SPACING_4, SPACING_8, SPACING_2, palette } from '@toptal/picasso/utils'
 import { Settings16 } from '@toptal/picasso/Icon'
-import { palette } from '@toptal/picasso/utils'
 
 const Example = () => (
   <div>
     <Typography variant='heading' size='small'>
       Primary (Default)
     </Typography>
-    <Container top='small' bottom='large'>
+    <Container top={SPACING_4} bottom={SPACING_8}>
       <Button.Circular icon={<Settings16 />} />
       <Button.Circular hovered icon={<Settings16 />} />
       <Button.Circular focused icon={<Settings16 />} />
@@ -20,7 +20,7 @@ const Example = () => (
     <Typography variant='heading' size='small'>
       Flat
     </Typography>
-    <Container top='small' bottom='large'>
+    <Container top={SPACING_4} bottom={SPACING_8}>
       <Button.Circular variant='flat' icon={<Settings16 />} />
       <Button.Circular variant='flat' hovered icon={<Settings16 />} />
       <Button.Circular variant='flat' focused icon={<Settings16 />} />
@@ -34,10 +34,10 @@ const Example = () => (
     </Typography>
     <Container
       inline
-      top='small'
-      bottom='large'
+      top={SPACING_4}
+      bottom={SPACING_8}
       style={{ backgroundColor: palette.blue.main }}
-      padded={0.5}
+      padded={SPACING_2}
     >
       <Button.Circular variant='transparent' icon={<Settings16 />} />
       <Button.Circular variant='transparent' hovered icon={<Settings16 />} />

--- a/packages/picasso/src/ButtonCircular/story/Variants.example.tsx
+++ b/packages/picasso/src/ButtonCircular/story/Variants.example.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Button, Container, Typography } from '@toptal/picasso'
+import { SPACING_4, SPACING_6, palette } from '@toptal/picasso/utils'
 import { Settings16 } from '@toptal/picasso/Icon'
-import { palette } from '@toptal/picasso/utils'
 
 const Example = () => (
   <div>
@@ -9,28 +9,28 @@ const Example = () => (
       <Typography variant='heading' size='small' align='center'>
         Primary (Default)
       </Typography>
-      <Container padded='small'>
+      <Container padded={SPACING_4}>
         <Button.Circular icon={<Settings16 />} />
       </Container>
     </Container>
 
-    <Container inline left='medium'>
+    <Container inline left={SPACING_6}>
       <Typography variant='heading' size='small' align='center'>
         Flat
       </Typography>
-      <Container padded='small'>
+      <Container padded={SPACING_4}>
         <Button.Circular variant='flat' icon={<Settings16 />} />
       </Container>
     </Container>
 
-    <Container inline left='medium'>
+    <Container inline left={SPACING_6}>
       <Typography variant='heading' size='small' align='center'>
         Transparent
       </Typography>
       <Container
         style={{ backgroundColor: palette.blue.main }}
         inline
-        padded='small'
+        padded={SPACING_4}
       >
         <Button.Circular variant='transparent' icon={<Settings16 />} />
       </Container>

--- a/packages/picasso/src/ButtonLoader/story/Default.example.tsx
+++ b/packages/picasso/src/ButtonLoader/story/Default.example.tsx
@@ -1,17 +1,18 @@
 import React from 'react'
 import { SkeletonLoader, Container, Typography } from '@toptal/picasso'
+import { SPACING_6, SPACING_2, SPACING_4 } from '@toptal/picasso/utils'
 
 const Example = () => (
   <>
-    <Container bottom='medium'>
-      <Container bottom='xsmall'>
+    <Container bottom={SPACING_6}>
+      <Container bottom={SPACING_2}>
         <Typography>Default</Typography>
       </Container>
       <SkeletonLoader.Button />
     </Container>
 
-    <Container bottom='medium'>
-      <Container bottom='xsmall'>
+    <Container bottom={SPACING_6}>
+      <Container bottom={SPACING_2}>
         <Typography>Align center</Typography>
       </Container>
 
@@ -20,8 +21,8 @@ const Example = () => (
       </Container>
     </Container>
 
-    <Container bottom='medium'>
-      <Container bottom='xsmall'>
+    <Container bottom={SPACING_6}>
+      <Container bottom={SPACING_2}>
         <Typography>Align right</Typography>
       </Container>
 
@@ -30,32 +31,32 @@ const Example = () => (
       </Container>
     </Container>
 
-    <Container bottom='medium'>
-      <Container bottom='xsmall'>
+    <Container bottom={SPACING_6}>
+      <Container bottom={SPACING_2}>
         <Typography variant='heading'>Sizes</Typography>
       </Container>
       <Container inline>
         <SkeletonLoader.Button size='small' />
       </Container>
-      <Container inline left='small'>
+      <Container inline left={SPACING_4}>
         <SkeletonLoader.Button size='medium' />
       </Container>
-      <Container inline left='small'>
+      <Container inline left={SPACING_4}>
         <SkeletonLoader.Button size='large' />
       </Container>
     </Container>
 
-    <Container bottom='medium'>
-      <Container bottom='xsmall'>
+    <Container bottom={SPACING_6}>
+      <Container bottom={SPACING_2}>
         <Typography variant='heading'>Circular</Typography>
       </Container>
       <Container inline>
         <SkeletonLoader.Button circular size='small' />
       </Container>
-      <Container inline left='small'>
+      <Container inline left={SPACING_4}>
         <SkeletonLoader.Button circular size='medium' />
       </Container>
-      <Container inline left='small'>
+      <Container inline left={SPACING_4}>
         <SkeletonLoader.Button circular size='large' />
       </Container>
     </Container>

--- a/packages/picasso/src/ButtonSplit/story/Sizes.example.tsx
+++ b/packages/picasso/src/ButtonSplit/story/Sizes.example.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { Button, Menu, Container } from '@toptal/picasso'
+import { SPACING_4 } from '@toptal/picasso/utils'
 
 const Example = () => {
   const handleClick = () => console.info('Item is clicked')
@@ -13,7 +14,7 @@ const Example = () => {
   )
 
   return (
-    <Container flex gap='small'>
+    <Container flex gap={SPACING_4}>
       <Button.Split size='small' menu={menu}>
         Button
       </Button.Split>

--- a/packages/picasso/src/ButtonSplit/story/States.example.tsx
+++ b/packages/picasso/src/ButtonSplit/story/States.example.tsx
@@ -1,6 +1,7 @@
 import type { ComponentProps } from 'react'
 import React from 'react'
 import { Button, Menu, Container, Typography } from '@toptal/picasso'
+import { SPACING_4 } from '@toptal/picasso/utils'
 
 type ButtonSplitProps = ComponentProps<typeof Button.Split>
 
@@ -92,13 +93,13 @@ const Example = () => {
         Primary (Default)
       </Typography>
 
-      <Container flex top='small' bottom='small'>
+      <Container flex top={SPACING_4} bottom={SPACING_4}>
         {renderStates()}
       </Container>
       <Typography variant='heading' size='small'>
         Secondary
       </Typography>
-      <Container flex top='small'>
+      <Container flex top={SPACING_4}>
         {renderStates({ variant: 'secondary' })}
       </Container>
     </>

--- a/packages/picasso/src/ButtonSplit/story/Variants.example.tsx
+++ b/packages/picasso/src/ButtonSplit/story/Variants.example.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { Button, Menu, Container } from '@toptal/picasso'
+import { SPACING_4 } from '@toptal/picasso/utils'
 
 const Example = () => {
   const handleClick = () => console.info('Item is clicked')
@@ -13,7 +14,7 @@ const Example = () => {
   )
 
   return (
-    <Container flex gap='small'>
+    <Container flex gap={SPACING_4}>
       <Button.Split menu={menu} variant='primary'>
         Primary
       </Button.Split>

--- a/packages/picasso/src/Carousel/story/Autoplay.example.tsx
+++ b/packages/picasso/src/Carousel/story/Autoplay.example.tsx
@@ -1,9 +1,10 @@
 import React from 'react'
 import { Carousel, Container, Typography, Settings16 } from '@toptal/picasso'
+import { SPACING_6, SPACING_2 } from '@toptal/picasso/utils'
 
 const CarouselDefaultExample = () => {
   return (
-    <Container flex direction='column' gap='medium'>
+    <Container flex direction='column' gap={SPACING_6}>
       <Container style={{ maxWidth: 370 }}>
         <Carousel hasDots hasArrows autoplay>
           <SlideExample>Delivery Manager</SlideExample>
@@ -31,7 +32,7 @@ const SlideExample = ({ children }: { children: React.ReactNode }) => {
   return (
     <Container
       flex
-      gap='xsmall'
+      gap={SPACING_2}
       direction='column'
       alignItems='center'
       style={{ maxWidth: '100%' }}

--- a/packages/picasso/src/Carousel/story/Default.example.tsx
+++ b/packages/picasso/src/Carousel/story/Default.example.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { Carousel, Container, Typography, Settings16 } from '@toptal/picasso'
+import { SPACING_2 } from '@toptal/picasso/utils'
 
 const CarouselDefaultExample = () => {
   return (
@@ -19,7 +20,7 @@ const SlideExample = ({ children }: { children: React.ReactNode }) => {
   return (
     <Container
       flex
-      gap='xsmall'
+      gap={SPACING_2}
       direction='column'
       alignItems='center'
       style={{ maxWidth: '100%' }}

--- a/packages/picasso/src/Carousel/story/Events.example.tsx
+++ b/packages/picasso/src/Carousel/story/Events.example.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react'
 import { Carousel, Container, Typography, Settings16 } from '@toptal/picasso'
+import { SPACING_2 } from '@toptal/picasso/utils'
 
 const CarouselDefaultExample = () => {
   const [currentSlide, setCurrentSlide] = useState(0)
@@ -24,7 +25,7 @@ const SlideExample = ({ children }: { children: React.ReactNode }) => {
   return (
     <Container
       flex
-      gap='xsmall'
+      gap={SPACING_2}
       direction='column'
       alignItems='center'
       style={{ maxWidth: '100%' }}

--- a/packages/picasso/src/Carousel/story/Navigation.example.tsx
+++ b/packages/picasso/src/Carousel/story/Navigation.example.tsx
@@ -1,8 +1,9 @@
 import React from 'react'
 import { Carousel, Container, Typography, Settings16 } from '@toptal/picasso'
+import { SPACING_6, SPACING_2 } from '@toptal/picasso/utils'
 
 const CarouselDefaultExample = () => (
-  <Container flex direction='column' gap='medium'>
+  <Container flex direction='column' gap={SPACING_6}>
     <Container style={{ maxWidth: 370 }}>
       <Carousel hasArrows>
         <SlideExample>Delivery Manager</SlideExample>
@@ -28,7 +29,7 @@ const SlideExample = ({ children }: { children: React.ReactNode }) => {
   return (
     <Container
       flex
-      gap='xsmall'
+      gap={SPACING_2}
       direction='column'
       alignItems='center'
       style={{ maxWidth: '100%' }}

--- a/packages/picasso/src/Carousel/story/Rewind.example.tsx
+++ b/packages/picasso/src/Carousel/story/Rewind.example.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { Carousel, Container, Typography, Settings16 } from '@toptal/picasso'
+import { SPACING_2 } from '@toptal/picasso/utils'
 
 const CarouselDefaultExample = () => {
   return (
@@ -19,7 +20,7 @@ const SlideExample = ({ children }: { children: React.ReactNode }) => {
   return (
     <Container
       flex
-      gap='xsmall'
+      gap={SPACING_2}
       direction='column'
       alignItems='center'
       style={{ maxWidth: '100%' }}

--- a/packages/picasso/src/Carousel/story/SlidesToShow.example.tsx
+++ b/packages/picasso/src/Carousel/story/SlidesToShow.example.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { Carousel, Container, Typography, Settings16 } from '@toptal/picasso'
+import { SPACING_2 } from '@toptal/picasso/utils'
 
 const CarouselDefaultExample = () => (
   <Container style={{ maxWidth: 370 }}>
@@ -17,7 +18,7 @@ const SlideExample = ({ children }: { children: React.ReactNode }) => {
   return (
     <Container
       flex
-      gap='xsmall'
+      gap={SPACING_2}
       direction='column'
       alignItems='center'
       style={{ maxWidth: '100%' }}

--- a/packages/picasso/src/Checkbox/story/CustomLabel.example.tsx
+++ b/packages/picasso/src/Checkbox/story/CustomLabel.example.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { Checkbox, Container, Typography } from '@toptal/picasso'
+import { SPACING_2 } from '@toptal/picasso/utils'
 import styled from 'styled-components'
 
 const Label = styled.label`
@@ -9,7 +10,7 @@ const Label = styled.label`
 
 const CustomLabelExample = () => (
   <Container flex alignItems='center'>
-    <Container right='xsmall' flex alignItems='center'>
+    <Container right={SPACING_2} flex alignItems='center'>
       <Checkbox id='id-1' />
     </Container>
     <Label htmlFor='id-1'>

--- a/packages/picasso/src/Container/story/Bordered.example.tsx
+++ b/packages/picasso/src/Container/story/Bordered.example.tsx
@@ -1,9 +1,10 @@
 import React from 'react'
 import { Container } from '@toptal/picasso'
+import { SPACING_6 } from '@toptal/picasso/utils'
 
 const Example = () => (
   <div>
-    <Container bordered rounded padded='medium'>
+    <Container bordered rounded padded={SPACING_6}>
       With default border
     </Container>
   </div>

--- a/packages/picasso/src/Container/story/Inline.example.tsx
+++ b/packages/picasso/src/Container/story/Inline.example.tsx
@@ -1,9 +1,10 @@
 import React from 'react'
 import { Container } from '@toptal/picasso'
+import { SPACING_8 } from '@toptal/picasso/utils'
 
 const Example = () => (
   <div>
-    <Container inline right='large'>
+    <Container inline right={SPACING_8}>
       <span>Some inline text</span>
     </Container>
     <span>Another inline text</span>

--- a/packages/picasso/src/Container/story/Spacing.example.tsx
+++ b/packages/picasso/src/Container/story/Spacing.example.tsx
@@ -1,33 +1,59 @@
 import React from 'react'
 import { Container, Paper, Grid } from '@toptal/picasso'
+import {
+  SPACING_4,
+  SPACING_2,
+  SPACING_6,
+  SPACING_8,
+} from '@toptal/picasso/utils'
 
 const Example = () => (
   <div>
-    <Container bottom='small'>Outer spacing</Container>
+    <Container bottom={SPACING_4}>Outer spacing</Container>
     <Grid>
       <Grid.Item>
-        <Container top='xsmall' bottom='xsmall' left='xsmall' right='xsmall'>
+        <Container
+          top={SPACING_2}
+          bottom={SPACING_2}
+          left={SPACING_2}
+          right={SPACING_2}
+        >
           <Paper>
             <span>xsmall</span>
           </Paper>
         </Container>
       </Grid.Item>
       <Grid.Item>
-        <Container top='small' bottom='small' left='small' right='small'>
+        <Container
+          top={SPACING_4}
+          bottom={SPACING_4}
+          left={SPACING_4}
+          right={SPACING_4}
+        >
           <Paper>
             <span>small</span>
           </Paper>
         </Container>
       </Grid.Item>
       <Grid.Item>
-        <Container top='medium' bottom='medium' left='medium' right='medium'>
+        <Container
+          top={SPACING_6}
+          bottom={SPACING_6}
+          left={SPACING_6}
+          right={SPACING_6}
+        >
           <Paper>
             <span>medium</span>
           </Paper>
         </Container>
       </Grid.Item>
       <Grid.Item>
-        <Container top='large' bottom='large' left='large' right='large'>
+        <Container
+          top={SPACING_8}
+          bottom={SPACING_8}
+          left={SPACING_8}
+          right={SPACING_8}
+        >
           <Paper>
             <span>large</span>
           </Paper>
@@ -42,32 +68,32 @@ const Example = () => (
       </Grid.Item>
     </Grid>
 
-    <Container bottom='small'>Inner spacing</Container>
+    <Container bottom={SPACING_4}>Inner spacing</Container>
     <Grid>
       <Grid.Item>
         <Paper>
-          <Container padded='xsmall'>
+          <Container padded={SPACING_2}>
             <span>xsmall</span>
           </Container>
         </Paper>
       </Grid.Item>
       <Grid.Item>
         <Paper>
-          <Container padded='small'>
+          <Container padded={SPACING_4}>
             <span>small</span>
           </Container>
         </Paper>
       </Grid.Item>
       <Grid.Item>
         <Paper>
-          <Container padded='medium'>
+          <Container padded={SPACING_6}>
             <span>medium</span>
           </Container>
         </Paper>
       </Grid.Item>
       <Grid.Item>
         <Paper>
-          <Container padded='large'>
+          <Container padded={SPACING_8}>
             <span>large</span>
           </Container>
         </Paper>

--- a/packages/picasso/src/Container/story/Spacing.example.tsx
+++ b/packages/picasso/src/Container/story/Spacing.example.tsx
@@ -59,13 +59,6 @@ const Example = () => (
           </Paper>
         </Container>
       </Grid.Item>
-      <Grid.Item>
-        <Container top={5} bottom={5} left={5} right={5}>
-          <Paper>
-            <span>custom</span>
-          </Paper>
-        </Container>
-      </Grid.Item>
     </Grid>
 
     <Container bottom={SPACING_4}>Inner spacing</Container>
@@ -95,13 +88,6 @@ const Example = () => (
         <Paper>
           <Container padded={SPACING_8}>
             <span>large</span>
-          </Container>
-        </Paper>
-      </Grid.Item>
-      <Grid.Item>
-        <Paper>
-          <Container padded={5}>
-            <span>custom</span>
           </Container>
         </Paper>
       </Grid.Item>

--- a/packages/picasso/src/Container/story/Variant.example.tsx
+++ b/packages/picasso/src/Container/story/Variant.example.tsx
@@ -1,14 +1,21 @@
 import React from 'react'
 import { Container, Typography } from '@toptal/picasso'
+import { SPACING_6, SPACING_4 } from '@toptal/picasso/utils'
 
 const Example = () => (
   <Container flex direction='column'>
-    <Container bottom='medium'>
+    <Container bottom={SPACING_6}>
       <Typography variant='heading' size='medium'>
         Bordered
       </Typography>
 
-      <Container bordered rounded padded='medium' bottom='small' top='small'>
+      <Container
+        bordered
+        rounded
+        padded={SPACING_6}
+        bottom={SPACING_4}
+        top={SPACING_4}
+      >
         White
       </Container>
     </Container>
@@ -18,22 +25,22 @@ const Example = () => (
         Non-bordered
       </Typography>
 
-      <Container rounded padded='medium' bottom='small' top='small'>
+      <Container rounded padded={SPACING_6} bottom={SPACING_4} top={SPACING_4}>
         White
       </Container>
-      <Container rounded variant='red' padded='medium' bottom='small'>
+      <Container rounded variant='red' padded={SPACING_6} bottom={SPACING_4}>
         Red
       </Container>
-      <Container rounded variant='yellow' padded='medium' bottom='small'>
+      <Container rounded variant='yellow' padded={SPACING_6} bottom={SPACING_4}>
         Yellow
       </Container>
-      <Container rounded variant='green' padded='medium' bottom='small'>
+      <Container rounded variant='green' padded={SPACING_6} bottom={SPACING_4}>
         Green
       </Container>
-      <Container rounded variant='blue' padded='medium' bottom='small'>
+      <Container rounded variant='blue' padded={SPACING_6} bottom={SPACING_4}>
         Blue
       </Container>
-      <Container rounded variant='grey' padded='medium'>
+      <Container rounded variant='grey' padded={SPACING_6}>
         Grey
       </Container>
     </Container>

--- a/packages/picasso/src/Container/story/index.jsx
+++ b/packages/picasso/src/Container/story/index.jsx
@@ -20,19 +20,17 @@ page
     title: 'Spacing',
     description: 'Creating inner and outer space for component',
     extra: `
-Spacing is based on BASE design enums that gets transformed into **rem** unit in following manner:
+Spacing is aligned with BASE design and gets transformed into **rem** units in following manner:
 
-| Spacing name  | Value   |
-| ------------- | ------- |
-| "SPACING_0"   | 0rem    |
-| "SPACING_1"   | 0.25rem |
-| "SPACING_2"   | 0.5rem  |
-| "SPACING_3"   | 0.75rem |
-| "SPACING_4"   | 1rem    |
-| "SPACING_6"   | 1.5rem  |
-| "SPACING_8"   | 2rem    |
-| "SPACING_10"  | 2.5rem  |
-| "SPACING_12"  | 3rem    |
+- SPACING_0 = 0rem,
+- SPACING_1 = 0.25rem,
+- SPACING_2 = 0.5rem,
+- SPACING_3 = 0.75rem,
+- SPACING_4 = 1rem,
+- SPACING_6 = 1.5rem,
+- SPACING_8 = 2rem,
+- SPACING_10 = 2.5rem,
+- SPACING_12 = 3rem
 
 `,
   })

--- a/packages/picasso/src/DatePicker/story/Autocomplete.example.tsx
+++ b/packages/picasso/src/DatePicker/story/Autocomplete.example.tsx
@@ -1,6 +1,7 @@
 import type { FormEvent } from 'react'
 import React, { useState } from 'react'
 import { DatePicker, Form, Button, Container } from '@toptal/picasso'
+import { SPACING_4 } from '@toptal/picasso/utils'
 
 const AutocompleteExample = () => {
   const [datepickerValue, setDatepickerValue] = useState<Date>()
@@ -34,7 +35,7 @@ const AutocompleteExample = () => {
           />
         </Form.Field>
 
-        <Container top='small'>
+        <Container top={SPACING_4}>
           <Button type='submit'>
             Submit to include value to the browser autocomplete
           </Button>

--- a/packages/picasso/src/DatePicker/story/WithFooterBackgroundColor.example.tsx
+++ b/packages/picasso/src/DatePicker/story/WithFooterBackgroundColor.example.tsx
@@ -6,7 +6,7 @@ import {
   Link,
   Typography,
 } from '@toptal/picasso'
-import { palette } from '@toptal/picasso/utils'
+import { SPACING_2, palette } from '@toptal/picasso/utils'
 
 const WithFooterBackgroundColorRendering = () => {
   const [datepickerValue, setDatepickerValue] = useState<Date>()
@@ -20,7 +20,7 @@ const WithFooterBackgroundColorRendering = () => {
         }}
         footer={
           <Container flex>
-            <Container right='xsmall'>
+            <Container right={SPACING_2}>
               {' '}
               <Chat16 />{' '}
             </Container>

--- a/packages/picasso/src/Drawer/story/CustomTitle.example.tsx
+++ b/packages/picasso/src/Drawer/story/CustomTitle.example.tsx
@@ -1,8 +1,9 @@
 import { Button, Typography, Container, List, Drawer } from '@toptal/picasso'
+import { SPACING_4 } from '@toptal/picasso/utils'
 import React, { useState } from 'react'
 
 const Title = () => (
-  <Container flex alignItems='center' padded='small'>
+  <Container flex alignItems='center' padded={SPACING_4}>
     <Typography>This Drawer has a custom title</Typography>
     <Button size='small'>OK!</Button>
   </Container>
@@ -17,7 +18,7 @@ const Example = () => {
         Show drawer
       </Button>
       <Drawer title={<Title />} open={open} onClose={() => setOpen(false)}>
-        <Container data-testid='content' padded='small'>
+        <Container data-testid='content' padded={SPACING_4}>
           <List variant='ordered'>
             <List.Item>Add at least 10 skills</List.Item>
             <List.Item>Set your age</List.Item>

--- a/packages/picasso/src/Drawer/story/Default.example.tsx
+++ b/packages/picasso/src/Drawer/story/Default.example.tsx
@@ -1,4 +1,5 @@
 import { Button, Container, List, Drawer } from '@toptal/picasso'
+import { SPACING_6 } from '@toptal/picasso/utils'
 import React, { useState } from 'react'
 
 const Example = () => {
@@ -14,7 +15,7 @@ const Example = () => {
         open={open}
         onClose={() => setOpen(false)}
       >
-        <Container data-testid='content' padded='medium'>
+        <Container data-testid='content' padded={SPACING_6}>
           <List variant='ordered'>
             <List.Item>Add at least 10 skills</List.Item>
             <List.Item>Set your age</List.Item>

--- a/packages/picasso/src/Drawer/story/DrawerAndNotification.example.tsx
+++ b/packages/picasso/src/Drawer/story/DrawerAndNotification.example.tsx
@@ -1,5 +1,5 @@
 import { Button, Container, List, Drawer } from '@toptal/picasso'
-import { useNotifications } from '@toptal/picasso/utils'
+import { SPACING_6, useNotifications } from '@toptal/picasso/utils'
 import React, { useState } from 'react'
 
 const Example = () => {
@@ -19,7 +19,7 @@ const Example = () => {
         open={open}
         onClose={() => setOpen(false)}
       >
-        <Container padded='medium'>
+        <Container padded={SPACING_6}>
           <List variant='ordered'>
             <List.Item>Add at least 10 skills</List.Item>
             <List.Item>Set your age</List.Item>

--- a/packages/picasso/src/Drawer/story/Widths.example.tsx
+++ b/packages/picasso/src/Drawer/story/Widths.example.tsx
@@ -1,4 +1,5 @@
 import { Container, List, Button, Drawer } from '@toptal/picasso'
+import { SPACING_6 } from '@toptal/picasso/utils'
 import React, { useState } from 'react'
 
 type WidthType = 'narrow' | 'regular' | 'medium' | 'wide' | 'ultra-wide'
@@ -31,7 +32,7 @@ const Example = () => {
         onClose={() => setOpen(false)}
         width={width}
       >
-        <Container data-testid='content' padded='medium'>
+        <Container data-testid='content' padded={SPACING_6}>
           <List variant='ordered'>
             <List.Item>Add at least 10 skills</List.Item>
             <List.Item>Set your age</List.Item>

--- a/packages/picasso/src/Drawer/story/WithBodyScrollLock.example.tsx
+++ b/packages/picasso/src/Drawer/story/WithBodyScrollLock.example.tsx
@@ -1,4 +1,5 @@
 import { Button, Container, List, Drawer, Checkbox } from '@toptal/picasso'
+import { SPACING_4, SPACING_6 } from '@toptal/picasso/utils'
 import React, { useState } from 'react'
 
 const Example = () => {
@@ -14,7 +15,7 @@ const Example = () => {
         }}
         label='Maintain body scroll lock'
       />
-      <Container top='small'>
+      <Container top={SPACING_4}>
         <Button data-testid='trigger' onClick={() => setOpen(!open)}>
           Show drawer
         </Button>
@@ -25,7 +26,7 @@ const Example = () => {
         onClose={() => setOpen(false)}
         maintainBodyScrollLock={maintainBodyScrollLock}
       >
-        <Container data-testid='content' padded='medium'>
+        <Container data-testid='content' padded={SPACING_6}>
           <List variant='ordered'>
             {Array(100)
               .fill(undefined)

--- a/packages/picasso/src/Drawer/story/WithTransparentBackdrop.example.tsx
+++ b/packages/picasso/src/Drawer/story/WithTransparentBackdrop.example.tsx
@@ -1,4 +1,5 @@
 import { Button, Typography, Container, Drawer } from '@toptal/picasso'
+import { SPACING_4 } from '@toptal/picasso/utils'
 import React, { useState } from 'react'
 
 const Example = () => {
@@ -10,7 +11,7 @@ const Example = () => {
         Show drawer
       </Button>
       <Drawer open={open} transparentBackdrop onClose={() => setOpen(false)}>
-        <Container data-testid='content' padded='small'>
+        <Container data-testid='content' padded={SPACING_4}>
           <Typography>
             This is the content. The backdrop doesn't have dark overlay, it is
             transparent.

--- a/packages/picasso/src/Drawer/story/WithoutTitle.example.tsx
+++ b/packages/picasso/src/Drawer/story/WithoutTitle.example.tsx
@@ -1,4 +1,5 @@
 import { Button, Typography, Container, Drawer } from '@toptal/picasso'
+import { SPACING_4 } from '@toptal/picasso/utils'
 import React, { useState } from 'react'
 
 const Example = () => {
@@ -10,7 +11,7 @@ const Example = () => {
         Show drawer
       </Button>
       <Drawer open={open} onClose={() => setOpen(false)}>
-        <Container data-testid='content' padded='small'>
+        <Container data-testid='content' padded={SPACING_4}>
           <Typography>This is the content. The title is omitted.</Typography>
         </Container>
       </Drawer>

--- a/packages/picasso/src/Dropdown/story/CustomContent.example.tsx
+++ b/packages/picasso/src/Dropdown/story/CustomContent.example.tsx
@@ -8,6 +8,7 @@ import {
   Button,
   Typography,
 } from '@toptal/picasso'
+import { SPACING_6, SPACING_4 } from '@toptal/picasso/utils'
 
 // Autofocus will force scrolling to the bottom of the portal, so we disable portal
 const Example = () => (
@@ -23,8 +24,8 @@ const ComplexContent = () => {
   const { close } = Dropdown.useContext()
 
   return (
-    <Container padded='medium'>
-      <Container bottom='small'>
+    <Container padded={SPACING_6}>
+      <Container bottom={SPACING_4}>
         <Typography variant='heading' size='medium'>
           Talent
         </Typography>
@@ -37,7 +38,7 @@ const ComplexContent = () => {
           <Select placeholder='Select talent' options={OPTIONS} />
         </Form.Field>
       </Form>
-      <Container flex top='small' justifyContent='flex-end'>
+      <Container flex top={SPACING_4} justifyContent='flex-end'>
         <Button onClick={close}>Close</Button>
       </Container>
     </Container>

--- a/packages/picasso/src/Dropdown/story/CustomTrigger.example.tsx
+++ b/packages/picasso/src/Dropdown/story/CustomTrigger.example.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { Dropdown, Menu, UserBadge } from '@toptal/picasso'
+import { SPACING_2 } from '@toptal/picasso/utils'
 
 const handleClick = () => window.alert('Item clicked')
 
@@ -13,7 +14,7 @@ const Example = () => (
           <Menu.Item onClick={handleClick}>Third item</Menu.Item>
         </Menu>
       }
-      offset={{ top: 'xsmall' }}
+      offset={{ top: SPACING_2 }}
     >
       <UserBadge
         name='Jacqueline Roque'

--- a/packages/picasso/src/Dropdown/story/PositionsAndOffsets.example.tsx
+++ b/packages/picasso/src/Dropdown/story/PositionsAndOffsets.example.tsx
@@ -1,13 +1,14 @@
 import React from 'react'
 import { Dropdown, Menu, Container, Typography } from '@toptal/picasso'
+import { SPACING_2, SPACING_6, SPACING_8 } from '@toptal/picasso/utils'
 
 const Example = () => (
   <div>
-    <Container bottom='xsmall'>
+    <Container bottom={SPACING_2}>
       <Typography>Popper placement</Typography>
     </Container>
-    <Container flex inline bottom='medium'>
-      <Container right='large'>
+    <Container flex inline bottom={SPACING_6}>
+      <Container right={SPACING_8}>
         <Dropdown
           content={
             <Menu>
@@ -22,7 +23,7 @@ const Example = () => (
         </Dropdown>
       </Container>
 
-      <Container right='large'>
+      <Container right={SPACING_8}>
         <Dropdown
           content={
             <Menu>
@@ -38,7 +39,7 @@ const Example = () => (
         </Dropdown>
       </Container>
 
-      <Container right='large'>
+      <Container right={SPACING_8}>
         <Dropdown
           content={
             <Menu>
@@ -55,11 +56,11 @@ const Example = () => (
       </Container>
     </Container>
 
-    <Container bottom='xsmall'>
+    <Container bottom={SPACING_2}>
       <Typography>Offsets</Typography>
     </Container>
-    <Container flex inline bottom='medium'>
-      <Container right='large'>
+    <Container flex inline bottom={SPACING_6}>
+      <Container right={SPACING_8}>
         <Dropdown
           content={
             <Menu>
@@ -74,7 +75,7 @@ const Example = () => (
         </Dropdown>
       </Container>
 
-      <Container right='large'>
+      <Container right={SPACING_8}>
         <Dropdown
           content={
             <Menu>
@@ -83,14 +84,14 @@ const Example = () => (
               <Menu.Item>Third item</Menu.Item>
             </Menu>
           }
-          offset={{ top: 'large' }}
+          offset={{ top: SPACING_8 }}
         >
           Large offset - top
           <Dropdown.Arrow />
         </Dropdown>
       </Container>
 
-      <Container right='large'>
+      <Container right={SPACING_8}>
         <Dropdown
           content={
             <Menu>
@@ -99,7 +100,7 @@ const Example = () => (
               <Menu.Item>Third item</Menu.Item>
             </Menu>
           }
-          offset={{ right: 'medium' }}
+          offset={{ right: SPACING_6 }}
         >
           Medium offset - right
           <Dropdown.Arrow />

--- a/packages/picasso/src/FileInput/story/AllowedExtensions.example.tsx
+++ b/packages/picasso/src/FileInput/story/AllowedExtensions.example.tsx
@@ -1,21 +1,22 @@
 import React from 'react'
 import { Container, FileInput } from '@toptal/picasso'
+import { SPACING_2 } from '@toptal/picasso/utils'
 
 const Example = () => (
   <div>
-    <Container bottom='xsmall'>
+    <Container bottom={SPACING_2}>
       <FileInput accept='image/png' hint='Accept png image files' />
     </Container>
 
-    <Container bottom='xsmall'>
+    <Container bottom={SPACING_2}>
       <FileInput accept='image/*' hint='Accept all image files' />
     </Container>
 
-    <Container bottom='xsmall'>
+    <Container bottom={SPACING_2}>
       <FileInput accept='.js' hint='Accept *.js files' />
     </Container>
 
-    <Container bottom='xsmall'>
+    <Container bottom={SPACING_2}>
       <FileInput accept='application/pdf' hint='Accept pdf files' />
     </Container>
   </div>

--- a/packages/picasso/src/FileInput/story/Uploading.example.tsx
+++ b/packages/picasso/src/FileInput/story/Uploading.example.tsx
@@ -1,10 +1,11 @@
 import React from 'react'
 import { FileInput, Container, Typography } from '@toptal/picasso'
+import { SPACING_6, SPACING_4 } from '@toptal/picasso/utils'
 
 const Example = () => (
   <div>
-    <Container bottom='medium'>
-      <Container bottom='small'>
+    <Container bottom={SPACING_6}>
+      <Container bottom={SPACING_4}>
         <Typography variant='heading' size='medium'>
           Progress:
         </Typography>
@@ -22,8 +23,8 @@ const Example = () => (
       />
     </Container>
 
-    <Container bottom='medium'>
-      <Container bottom='small'>
+    <Container bottom={SPACING_6}>
+      <Container bottom={SPACING_4}>
         <Typography variant='heading' size='medium'>
           Undetermined:
         </Typography>

--- a/packages/picasso/src/FormField/story/Required.example.tsx
+++ b/packages/picasso/src/FormField/story/Required.example.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { Form, Input, Container, Typography } from '@toptal/picasso'
+import { SPACING_12 } from '@toptal/picasso/utils'
 
 const Example = () => (
   <Container
@@ -10,7 +11,7 @@ const Example = () => (
     }}
   >
     <Form style={{ maxWidth: '350px' }}>
-      <Container bottom={3}>
+      <Container bottom={SPACING_12}>
         <Typography weight='semibold'>Recommended:</Typography>
       </Container>
       <Form.Field>
@@ -27,7 +28,7 @@ const Example = () => (
     </Form>
 
     <Form style={{ maxWidth: '350px' }}>
-      <Container bottom={3}>
+      <Container bottom={SPACING_12}>
         <Typography weight='semibold'>Deprecated:</Typography>
       </Container>
       <Form.Field>

--- a/packages/picasso/src/Grid/story/Direction.example.tsx
+++ b/packages/picasso/src/Grid/story/Direction.example.tsx
@@ -1,10 +1,11 @@
 import React from 'react'
 import { Grid, Button, Container, Typography } from '@toptal/picasso'
+import { SPACING_8, SPACING_4 } from '@toptal/picasso/utils'
 
 const Example = () => (
   <div>
-    <Container bottom='large'>
-      <Container bottom='small'>
+    <Container bottom={SPACING_8}>
+      <Container bottom={SPACING_4}>
         <Typography>Row direction</Typography>
       </Container>
 
@@ -18,7 +19,7 @@ const Example = () => (
       </Grid>
     </Container>
 
-    <Container bottom='small'>
+    <Container bottom={SPACING_4}>
       <Typography>Column direction</Typography>
     </Container>
 

--- a/packages/picasso/src/Grid/story/ResponsiveSpacing.example.tsx
+++ b/packages/picasso/src/Grid/story/ResponsiveSpacing.example.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react'
 import { Grid, Container, Button } from '@toptal/picasso'
+import { SPACING_4 } from '@toptal/picasso/utils'
 import { useScreens } from '@toptal/picasso-provider'
 
 const BorderedContainer = () => {
@@ -13,7 +14,7 @@ const BorderedContainer = () => {
   }) as string
 
   return (
-    <Container padded='small' bordered rounded>
+    <Container padded={SPACING_4} bordered rounded>
       {currentSpacing}
     </Container>
   )
@@ -33,7 +34,7 @@ const Example = () => {
       <Container>
         <Grid>{gridItems}</Grid>
       </Container>
-      <Container top='small'>
+      <Container top={SPACING_4}>
         <Button onClick={() => setGridItems([...gridItems, gridItem])}>
           Add another grid item
         </Button>

--- a/packages/picasso/src/Grid/story/Wrapping.example.tsx
+++ b/packages/picasso/src/Grid/story/Wrapping.example.tsx
@@ -1,10 +1,11 @@
 import React from 'react'
 import { Grid, Button, Container, Typography } from '@toptal/picasso'
+import { SPACING_8, SPACING_4 } from '@toptal/picasso/utils'
 
 const Example = () => (
   <div>
-    <Container bottom='large'>
-      <Container bottom='small'>
+    <Container bottom={SPACING_8}>
+      <Container bottom={SPACING_4}>
         <Typography>Wrap</Typography>
       </Container>
       <Grid wrap='wrap' style={{ maxWidth: '200px' }}>
@@ -23,8 +24,8 @@ const Example = () => (
       </Grid>
     </Container>
 
-    <Container bottom='large'>
-      <Container bottom='small'>
+    <Container bottom={SPACING_8}>
+      <Container bottom={SPACING_4}>
         <Typography>Nowrap</Typography>
       </Container>
       <Grid wrap='nowrap' style={{ maxWidth: '200px' }}>
@@ -43,8 +44,8 @@ const Example = () => (
       </Grid>
     </Container>
 
-    <Container bottom='large'>
-      <Container bottom='small'>
+    <Container bottom={SPACING_8}>
+      <Container bottom={SPACING_4}>
         <Typography>Wrap-reverse</Typography>
       </Container>
       <Grid wrap='wrap-reverse' style={{ maxWidth: '200px' }}>

--- a/packages/picasso/src/GridItem/story/Default.example.tsx
+++ b/packages/picasso/src/GridItem/story/Default.example.tsx
@@ -1,11 +1,14 @@
 import React from 'react'
 import { Grid, Container, Typography } from '@toptal/picasso'
-import { palette } from '@toptal/picasso/utils'
+import { SPACING_4, palette } from '@toptal/picasso/utils'
 
 type Props = { children: React.ReactNode }
 
 const ContentContainer = ({ children }: Props) => (
-  <Container padded='small' style={{ backgroundColor: palette.blue.lighter }}>
+  <Container
+    padded={SPACING_4}
+    style={{ backgroundColor: palette.blue.lighter }}
+  >
     <Typography variant='heading' size='small' align='center'>
       {children}
     </Typography>

--- a/packages/picasso/src/GridItem/story/Responsive.example.tsx
+++ b/packages/picasso/src/GridItem/story/Responsive.example.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { Grid, Container, Typography } from '@toptal/picasso'
-import { palette, useBreakpoint } from '@toptal/picasso/utils'
+import { SPACING_4, palette, useBreakpoint } from '@toptal/picasso/utils'
 
 const ScreenSize = () => {
   const isExtraLarge = useBreakpoint('xl')
@@ -23,7 +23,10 @@ const ScreenSize = () => {
 type Props = { children: React.ReactNode }
 
 const ContentContainer = ({ children }: Props) => (
-  <Container padded='small' style={{ backgroundColor: palette.blue.lighter }}>
+  <Container
+    padded={SPACING_4}
+    style={{ backgroundColor: palette.blue.lighter }}
+  >
     <Typography variant='heading' size='small' align='center'>
       {children}
     </Typography>

--- a/packages/picasso/src/HeaderLoader/story/Default.example.tsx
+++ b/packages/picasso/src/HeaderLoader/story/Default.example.tsx
@@ -1,17 +1,18 @@
 import React from 'react'
 import { SkeletonLoader, Container, Typography } from '@toptal/picasso'
+import { SPACING_6, SPACING_2 } from '@toptal/picasso/utils'
 
 const Example = () => (
   <>
-    <Container bottom='medium'>
-      <Container bottom='xsmall'>
+    <Container bottom={SPACING_6}>
+      <Container bottom={SPACING_2}>
         <Typography>Default alignment</Typography>
       </Container>
       <SkeletonLoader.Header />
     </Container>
 
-    <Container bottom='medium'>
-      <Container bottom='xsmall'>
+    <Container bottom={SPACING_6}>
+      <Container bottom={SPACING_2}>
         <Typography>Centered</Typography>
       </Container>
       <Container flex justifyContent='center'>

--- a/packages/picasso/src/Helpbox/story/Default.example.tsx
+++ b/packages/picasso/src/Helpbox/story/Default.example.tsx
@@ -1,9 +1,10 @@
 import React from 'react'
 import { Helpbox, Container } from '@toptal/picasso'
+import { SPACING_4 } from '@toptal/picasso/utils'
 
 const Example = () => (
   <Container>
-    <Container bottom='small'>
+    <Container bottom={SPACING_4}>
       <Helpbox>
         <Helpbox.Title>Heading Small</Helpbox.Title>
         <Helpbox.Content>
@@ -17,7 +18,7 @@ const Example = () => (
         </Helpbox.Content>
       </Helpbox>
     </Container>
-    <Container bottom='small'>
+    <Container bottom={SPACING_4}>
       <Helpbox variant='red'>
         <Helpbox.Title>Heading Small</Helpbox.Title>
         <Helpbox.Content>
@@ -31,7 +32,7 @@ const Example = () => (
         </Helpbox.Content>
       </Helpbox>
     </Container>
-    <Container bottom='small'>
+    <Container bottom={SPACING_4}>
       <Helpbox variant='yellow'>
         <Helpbox.Title>Heading Small</Helpbox.Title>
         <Helpbox.Content>
@@ -45,7 +46,7 @@ const Example = () => (
         </Helpbox.Content>
       </Helpbox>
     </Container>
-    <Container bottom='small'>
+    <Container bottom={SPACING_4}>
       <Helpbox variant='green'>
         <Helpbox.Title>Heading Small</Helpbox.Title>
         <Helpbox.Content>
@@ -59,7 +60,7 @@ const Example = () => (
         </Helpbox.Content>
       </Helpbox>
     </Container>
-    <Container bottom='small'>
+    <Container bottom={SPACING_4}>
       <Helpbox variant='blue'>
         <Helpbox.Title>Heading Small</Helpbox.Title>
         <Helpbox.Content>

--- a/packages/picasso/src/Helpbox/story/Width.example.tsx
+++ b/packages/picasso/src/Helpbox/story/Width.example.tsx
@@ -1,9 +1,10 @@
 import React from 'react'
 import { Helpbox, Container } from '@toptal/picasso'
+import { SPACING_4 } from '@toptal/picasso/utils'
 
 const Example = () => (
   <Container>
-    <Container bottom='small'>
+    <Container bottom={SPACING_4}>
       <Helpbox variant='green'>
         <Helpbox.Title>Full width</Helpbox.Title>
         <Helpbox.Content width='full'>
@@ -17,7 +18,7 @@ const Example = () => (
         </Helpbox.Content>
       </Helpbox>
     </Container>
-    <Container bottom='small'>
+    <Container bottom={SPACING_4}>
       <Helpbox variant='green'>
         <Helpbox.Title>Shrink width</Helpbox.Title>
         <Helpbox.Content width='shrink'>

--- a/packages/picasso/src/Icon/story/Color.example.tsx
+++ b/packages/picasso/src/Icon/story/Color.example.tsx
@@ -1,20 +1,21 @@
 import React from 'react'
 import { Container } from '@toptal/picasso'
+import { SPACING_4, SPACING_2 } from '@toptal/picasso/utils'
 import { Settings16 } from '@toptal/picasso/Icon'
 
 const Example = () => (
   <div>
-    <Container inline right='small'>
+    <Container inline right={SPACING_4}>
       <Settings16 color='red' />
     </Container>
-    <Container inline right='small'>
+    <Container inline right={SPACING_4}>
       <Settings16 color='green' />
     </Container>
     <Container
       inline
-      right='small'
+      right={SPACING_4}
       style={{ backgroundColor: 'black' }}
-      padded='xsmall'
+      padded={SPACING_2}
     >
       <Settings16 color='white' />
     </Container>

--- a/packages/picasso/src/Icon/story/List.example.tsx
+++ b/packages/picasso/src/Icon/story/List.example.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { Grid, Paper, Typography, Container, Input } from '@toptal/picasso'
+import { SPACING_4 } from '@toptal/picasso/utils'
 import * as icons from '@toptal/picasso/Icon'
 
 /** We don't want to render internal icons */
@@ -47,7 +48,7 @@ const Example = () => {
                   flex
                   alignItems='center'
                   justifyContent='center'
-                  padded='small'
+                  padded={SPACING_4}
                   style={{
                     paddingBottom: '0.5rem',
                     minWidth: '9rem',

--- a/packages/picasso/src/Icon/story/Scale.example.tsx
+++ b/packages/picasso/src/Icon/story/Scale.example.tsx
@@ -1,19 +1,20 @@
 import React from 'react'
 import { Container } from '@toptal/picasso'
+import { SPACING_4 } from '@toptal/picasso/utils'
 import { Settings16, Settings24 } from '@toptal/picasso/Icon'
 
 const Example = () => (
   <div>
-    <Container inline right='small'>
+    <Container inline right={SPACING_4}>
       <Settings16 scale={2} />
     </Container>
-    <Container inline right='small'>
+    <Container inline right={SPACING_4}>
       <Settings24 scale={2} />
     </Container>
-    <Container inline right='small'>
+    <Container inline right={SPACING_4}>
       <Settings16 scale={3} />
     </Container>
-    <Container inline right='small'>
+    <Container inline right={SPACING_4}>
       <Settings24 scale={3} />
     </Container>
   </div>

--- a/packages/picasso/src/Icon/story/WithText.example.tsx
+++ b/packages/picasso/src/Icon/story/WithText.example.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { Container } from '@toptal/picasso'
+import { SPACING_4 } from '@toptal/picasso/utils'
 import { Settings16, Settings24 } from '@toptal/picasso/Icon'
 
 const Example = () => (
@@ -9,7 +10,7 @@ const Example = () => (
       Vertical alignment of the icon with the same height as text
     </div>
 
-    <Container flex alignItems='center' top='small'>
+    <Container flex alignItems='center' top={SPACING_4}>
       <Settings24 style={{ marginRight: '0.5rem' }} />
       Vertical alignment of the icon with bigger height than text
     </Container>

--- a/packages/picasso/src/Image/story/Variants.example.tsx
+++ b/packages/picasso/src/Image/story/Variants.example.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { Image, Container } from '@toptal/picasso'
+import { SPACING_4 } from '@toptal/picasso/utils'
 
 const Example = () => (
   <div>
@@ -10,7 +11,7 @@ const Example = () => (
         style={{ width: '250px', height: '250px' }}
       />
     </Container>
-    <Container left='small' inline>
+    <Container left={SPACING_4} inline>
       <Image
         variant='circular'
         alt='Circular image'

--- a/packages/picasso/src/Indicator/story/Default.example.tsx
+++ b/packages/picasso/src/Indicator/story/Default.example.tsx
@@ -1,10 +1,11 @@
 import React from 'react'
 import { Indicator, Typography, Container } from '@toptal/picasso'
+import { SPACING_6, SPACING_4 } from '@toptal/picasso/utils'
 
 const Example = () => (
   <>
-    <Container bottom='medium'>
-      <Container inline right='small'>
+    <Container bottom={SPACING_6}>
+      <Container inline right={SPACING_4}>
         <Indicator color='light-blue' />
       </Container>
       <Typography inline size='medium'>
@@ -12,9 +13,9 @@ const Example = () => (
       </Typography>
     </Container>
 
-    <Container bottom='medium'>
-      <Container bottom='medium'>
-        <Container inline right='small'>
+    <Container bottom={SPACING_6}>
+      <Container bottom={SPACING_6}>
+        <Container inline right={SPACING_4}>
           <Indicator color='light-grey' />
         </Container>
         <Typography inline size='medium'>
@@ -22,7 +23,7 @@ const Example = () => (
         </Typography>
       </Container>
 
-      <Container inline right='small'>
+      <Container inline right={SPACING_4}>
         <Indicator color='green' />
       </Container>
       <Typography inline size='medium'>
@@ -30,8 +31,8 @@ const Example = () => (
       </Typography>
     </Container>
 
-    <Container bottom='medium'>
-      <Container inline right='small'>
+    <Container bottom={SPACING_6}>
+      <Container inline right={SPACING_4}>
         <Indicator color='red' />
       </Container>
       <Typography inline size='medium'>
@@ -39,8 +40,8 @@ const Example = () => (
       </Typography>
     </Container>
 
-    <Container bottom='medium'>
-      <Container inline right='small'>
+    <Container bottom={SPACING_6}>
+      <Container inline right={SPACING_4}>
         <Indicator color='yellow' />
       </Container>
       <Typography inline size='medium'>
@@ -48,7 +49,7 @@ const Example = () => (
       </Typography>
     </Container>
 
-    <Container inline right='small'>
+    <Container inline right={SPACING_4}>
       <Indicator color='blue' />
     </Container>
     <Typography inline size='medium'>

--- a/packages/picasso/src/Input/story/Disabled.example.tsx
+++ b/packages/picasso/src/Input/story/Disabled.example.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react'
 import { Input, Container } from '@toptal/picasso'
+import { SPACING_4 } from '@toptal/picasso/utils'
 
 const Example = () => {
   const [value, setValue] = useState('Text')
@@ -10,7 +11,7 @@ const Example = () => {
 
   return (
     <Container flex inline>
-      <Container right='small'>
+      <Container right={SPACING_4}>
         <Input disabled value={value} onChange={handleChange} />
       </Container>
       <Input disabled placeholder='Placeholder' />

--- a/packages/picasso/src/Input/story/Multiline.example.tsx
+++ b/packages/picasso/src/Input/story/Multiline.example.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react'
 import { Input, Container } from '@toptal/picasso'
+import { SPACING_4 } from '@toptal/picasso/utils'
 
 const Example = () => {
   const [value, setValue] = useState('Multiline text')
@@ -10,10 +11,10 @@ const Example = () => {
 
   return (
     <Container flex inline>
-      <Container right='small'>
+      <Container right={SPACING_4}>
         <Input multiline rows={4} value={value} onChange={handleChange} />
       </Container>
-      <Container right='small'>
+      <Container right={SPACING_4}>
         <Input multiline rows={4} placeholder='Placeholder' />
       </Container>
     </Container>

--- a/packages/picasso/src/Input/story/MultilineExpand.example.tsx
+++ b/packages/picasso/src/Input/story/MultilineExpand.example.tsx
@@ -1,14 +1,15 @@
 import React from 'react'
 import { Input, Container, Typography } from '@toptal/picasso'
+import { SPACING_4 } from '@toptal/picasso/utils'
 
 const Example = () => {
   return (
     <Container flex direction='column'>
-      <Container padded='small'>
+      <Container padded={SPACING_4}>
         <Typography variant='heading' size='small'>
           With auto-expand (up to 5 rows)
         </Typography>
-        <Container right='small'>
+        <Container right={SPACING_4}>
           <Input
             multiline
             rows={2}
@@ -17,11 +18,11 @@ const Example = () => {
           />
         </Container>
       </Container>
-      <Container padded='small'>
+      <Container padded={SPACING_4}>
         <Typography variant='heading' size='small'>
           With auto-expand (up to 5 rows) and manual resize
         </Typography>
-        <Container right='small'>
+        <Container right={SPACING_4}>
           <Input
             multiline
             multilineResizable

--- a/packages/picasso/src/Input/story/Refs.example.tsx
+++ b/packages/picasso/src/Input/story/Refs.example.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { Input, Container, Tooltip } from '@toptal/picasso'
+import { SPACING_4 } from '@toptal/picasso/utils'
 
 import type { Props } from '../Input'
 
@@ -10,12 +11,12 @@ const InputWrapper = React.forwardRef<HTMLInputElement, Props>((props, ref) => (
 const RefsExample = () => {
   return (
     <Container flex direction='column'>
-      <Container padded='small'>
+      <Container padded={SPACING_4}>
         <Tooltip content='Tooltip has Input as a children' placement='right'>
           <Input placeholder='ref demo' />
         </Tooltip>
       </Container>
-      <Container padded='small'>
+      <Container padded={SPACING_4}>
         <Tooltip
           content='Tooltip has InputWrapper as a children. The InputWrapper passes ref to outlineRef of the Input.'
           placement='right'

--- a/packages/picasso/src/Input/story/Sizes.example.tsx
+++ b/packages/picasso/src/Input/story/Sizes.example.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react'
 import { Input, Container, Typography } from '@toptal/picasso'
+import { SPACING_4 } from '@toptal/picasso/utils'
 
 const Example = () => {
   const [value, setValue] = useState<string>('')
@@ -10,11 +11,11 @@ const Example = () => {
 
   return (
     <Container flex direction='column'>
-      <Container padded='small'>
+      <Container padded={SPACING_4}>
         <Typography variant='heading' size='small'>
           Small
         </Typography>
-        <Container top='small' bottom='small'>
+        <Container top={SPACING_4} bottom={SPACING_4}>
           <Input
             size='small'
             value={value}
@@ -23,11 +24,11 @@ const Example = () => {
           />
         </Container>
       </Container>
-      <Container padded='small'>
+      <Container padded={SPACING_4}>
         <Typography variant='heading' size='small'>
           Medium (default)
         </Typography>
-        <Container top='small' bottom='small'>
+        <Container top={SPACING_4} bottom={SPACING_4}>
           <Input
             size='medium'
             value={value}
@@ -36,11 +37,11 @@ const Example = () => {
           />
         </Container>
       </Container>
-      <Container padded='small'>
+      <Container padded={SPACING_4}>
         <Typography variant='heading' size='small'>
           Large
         </Typography>
-        <Container top='small' bottom='small'>
+        <Container top={SPACING_4} bottom={SPACING_4}>
           <Input
             size='large'
             value={value}

--- a/packages/picasso/src/Input/story/WithIcon.example.tsx
+++ b/packages/picasso/src/Input/story/WithIcon.example.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react'
 import { Input, Container } from '@toptal/picasso'
+import { SPACING_4 } from '@toptal/picasso/utils'
 import { Search16 } from '@toptal/picasso/Icon'
 
 const Example = () => {
@@ -11,10 +12,10 @@ const Example = () => {
 
   return (
     <Container flex direction='column'>
-      <Container bottom='small'>
+      <Container bottom={SPACING_4}>
         <Input icon={<Search16 />} value={value} onChange={handleChange} />
       </Container>
-      <Container bottom='small'>
+      <Container bottom={SPACING_4}>
         <Input
           disabled
           icon={<Search16 />}
@@ -22,7 +23,7 @@ const Example = () => {
           onChange={handleChange}
         />
       </Container>
-      <Container bottom='small'>
+      <Container bottom={SPACING_4}>
         <Input
           iconPosition='end'
           icon={<Search16 />}
@@ -30,7 +31,7 @@ const Example = () => {
           onChange={handleChange}
         />
       </Container>
-      <Container bottom='small'>
+      <Container bottom={SPACING_4}>
         <Input
           iconPosition='end'
           icon={<Search16 />}

--- a/packages/picasso/src/Input/story/WithLimit.example.tsx
+++ b/packages/picasso/src/Input/story/WithLimit.example.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react'
 import { Input, Container, Typography } from '@toptal/picasso'
+import { SPACING_4 } from '@toptal/picasso/utils'
 
 type ChangeHandler = (event: React.ChangeEvent<{ value: string }>) => void
 
@@ -27,11 +28,11 @@ const InputWithLimitExample = () => {
 
   return (
     <Container flex direction='column'>
-      <Container padded='small'>
+      <Container padded={SPACING_4}>
         <Typography variant='heading' size='small'>
           Remaining chars counter:
         </Typography>
-        <Container top='small' bottom='small'>
+        <Container top={SPACING_4} bottom={SPACING_4}>
           <Input
             limit={10}
             value={inputRemainingValue}
@@ -50,11 +51,11 @@ const InputWithLimitExample = () => {
         </Container>
       </Container>
 
-      <Container padded='small'>
+      <Container padded={SPACING_4}>
         <Typography variant='heading' size='small'>
           Entered chars counter:
         </Typography>
-        <Container top='small' bottom='small'>
+        <Container top={SPACING_4} bottom={SPACING_4}>
           <Input
             counter='entered'
             value={inputEnteredValue}

--- a/packages/picasso/src/Link/story/Color.example.tsx
+++ b/packages/picasso/src/Link/story/Color.example.tsx
@@ -1,10 +1,10 @@
 import React from 'react'
 import { Container, Link, Typography } from '@toptal/picasso'
-import { palette } from '@toptal/picasso/utils'
+import { SPACING_8, SPACING_6, palette } from '@toptal/picasso/utils'
 
 const ColorLinkExample = () => (
   <div>
-    <Container inline right='large'>
+    <Container inline right={SPACING_8}>
       <Typography size='medium'>
         <Link href={window.parent.location.href + '#'}>Blue Link</Link>
       </Typography>
@@ -12,7 +12,7 @@ const ColorLinkExample = () => (
     <Container
       inline
       style={{ backgroundColor: palette.grey.darker }}
-      padded='medium'
+      padded={SPACING_6}
     >
       <Typography size='medium'>
         <Link color='white' href={window.parent.location.href + '#'}>

--- a/packages/picasso/src/Link/story/FontSize.example.tsx
+++ b/packages/picasso/src/Link/story/FontSize.example.tsx
@@ -1,6 +1,7 @@
 import type { MouseEvent } from 'react'
 import React from 'react'
 import { Link, Container, Typography } from '@toptal/picasso'
+import { SPACING_8 } from '@toptal/picasso/utils'
 
 const FontSizeExample = () => {
   const handleClick = (e: MouseEvent) => {
@@ -10,7 +11,7 @@ const FontSizeExample = () => {
 
   return (
     <div>
-      <Container inline right='large'>
+      <Container inline right={SPACING_8}>
         <Typography>
           Please{' '}
           <Link onClick={handleClick} href='https://toptal.com'>
@@ -19,7 +20,7 @@ const FontSizeExample = () => {
           your email
         </Typography>
       </Container>
-      <Container inline right='large'>
+      <Container inline right={SPACING_8}>
         <Typography variant='heading' size='large'>
           Please{' '}
           <Link onClick={handleClick} href='https://toptal.com'>

--- a/packages/picasso/src/List/story/Nested.example.tsx
+++ b/packages/picasso/src/List/story/Nested.example.tsx
@@ -1,8 +1,9 @@
 import React from 'react'
 import { List, Container } from '@toptal/picasso'
+import { SPACING_6 } from '@toptal/picasso/utils'
 
 const NestedExample = () => (
-  <Container bottom='medium'>
+  <Container bottom={SPACING_6}>
     <Container>
       <h3>Ordered</h3>
       <Container>

--- a/packages/picasso/src/List/story/Ordered.example.tsx
+++ b/packages/picasso/src/List/story/Ordered.example.tsx
@@ -1,8 +1,9 @@
 import React from 'react'
 import { List, Container } from '@toptal/picasso'
+import { SPACING_6 } from '@toptal/picasso/utils'
 
 const DefaultExample = () => (
-  <Container bottom='medium'>
+  <Container bottom={SPACING_6}>
     <List variant='ordered'>
       <List.Item>Add at least 10 skills</List.Item>
       <List.Item>Set your age</List.Item>

--- a/packages/picasso/src/List/story/OrderedWithStart.example.tsx
+++ b/packages/picasso/src/List/story/OrderedWithStart.example.tsx
@@ -1,8 +1,9 @@
 import React from 'react'
 import { List, Container } from '@toptal/picasso'
+import { SPACING_6 } from '@toptal/picasso/utils'
 
 const DefaultExample = () => (
-  <Container bottom='medium'>
+  <Container bottom={SPACING_6}>
     <List variant='ordered' start={5}>
       <List.Item>Add at least 10 skills</List.Item>
       <List.Item>Set your age</List.Item>

--- a/packages/picasso/src/List/story/Styles.example.tsx
+++ b/packages/picasso/src/List/story/Styles.example.tsx
@@ -1,9 +1,10 @@
 import React from 'react'
 import { Container, List, Typography } from '@toptal/picasso'
+import { SPACING_8 } from '@toptal/picasso/utils'
 import type { ListItemType } from '@toptal/picasso/List'
 
 const ListStyleExample = ({ type }: { type: ListItemType }) => (
-  <Container bottom='large'>
+  <Container bottom={SPACING_8}>
     <Typography variant='heading' size='medium'>
       Style Type: {type}
     </Typography>

--- a/packages/picasso/src/List/story/Unordered.example.tsx
+++ b/packages/picasso/src/List/story/Unordered.example.tsx
@@ -1,8 +1,9 @@
 import React from 'react'
 import { List, Container } from '@toptal/picasso'
+import { SPACING_6 } from '@toptal/picasso/utils'
 
 const DefaultExample = () => (
-  <Container bottom='medium'>
+  <Container bottom={SPACING_6}>
     <List variant='unordered'>
       <List.Item>Add at least 10 skills</List.Item>
       <List.Item>Set your age</List.Item>

--- a/packages/picasso/src/Loader/story/Sizes.example.tsx
+++ b/packages/picasso/src/Loader/story/Sizes.example.tsx
@@ -1,12 +1,13 @@
 import React from 'react'
 import { Loader, Container } from '@toptal/picasso'
+import { SPACING_8 } from '@toptal/picasso/utils'
 
 const Example = () => (
   <div>
-    <Container bottom='large'>
+    <Container bottom={SPACING_8}>
       <Loader size='small'>small</Loader>
     </Container>
-    <Container bottom='large'>
+    <Container bottom={SPACING_8}>
       <Loader size='medium'>medium</Loader>
     </Container>
     <Loader size='large'>large</Loader>

--- a/packages/picasso/src/Logo/story/Variants.example.tsx
+++ b/packages/picasso/src/Logo/story/Variants.example.tsx
@@ -1,17 +1,17 @@
 import React from 'react'
 import type { ContainerProps } from '@toptal/picasso'
-import { SPACING_8 } from '@toptal/picasso/utils'
+import { SPACING_4, SPACING_8 } from '@toptal/picasso/utils'
 import { Logo, Container } from '@toptal/picasso'
 import type { PicassoSpacing } from '@toptal/picasso-provider/Picasso/config/spacings'
 
 const Example = () => (
   <div>
     <div>
-      <LogoContainer bgcolor='#ffffff' inline right='small'>
+      <LogoContainer bgcolor='#ffffff' inline right={SPACING_4}>
         <Logo />
       </LogoContainer>
 
-      <LogoContainer bgcolor='#204ecf' inline right='small'>
+      <LogoContainer bgcolor='#204ecf' inline right={SPACING_4}>
         <Logo variant='white' />
       </LogoContainer>
 
@@ -25,11 +25,11 @@ const Example = () => (
     </div>
 
     <Container top={SPACING_8}>
-      <LogoContainer bgcolor='#ffffff' inline right='small'>
+      <LogoContainer bgcolor='#ffffff' inline right={SPACING_4}>
         <Logo emblem />
       </LogoContainer>
 
-      <LogoContainer bgcolor='#204ecf' inline right='small'>
+      <LogoContainer bgcolor='#204ecf' inline right={SPACING_4}>
         <Logo emblem variant='white' />
       </LogoContainer>
 

--- a/packages/picasso/src/Logo/story/Variants.example.tsx
+++ b/packages/picasso/src/Logo/story/Variants.example.tsx
@@ -1,8 +1,8 @@
 import React from 'react'
 import type { ContainerProps } from '@toptal/picasso'
+import { SPACING_8 } from '@toptal/picasso/utils'
 import { Logo, Container } from '@toptal/picasso'
 import type { PicassoSpacing } from '@toptal/picasso-provider/Picasso/config/spacings'
-import { SPACING_8 } from '@toptal/picasso/utils'
 
 const Example = () => (
   <div>
@@ -24,7 +24,7 @@ const Example = () => (
       </LogoContainer>
     </div>
 
-    <Container top='large'>
+    <Container top={SPACING_8}>
       <LogoContainer bgcolor='#ffffff' inline right='small'>
         <Logo emblem />
       </LogoContainer>

--- a/packages/picasso/src/MediaSkeletonLoader/story/Default.example.tsx
+++ b/packages/picasso/src/MediaSkeletonLoader/story/Default.example.tsx
@@ -1,88 +1,89 @@
 import React from 'react'
 import { SkeletonLoader, Container, Typography } from '@toptal/picasso'
+import { SPACING_6, SPACING_4, SPACING_2 } from '@toptal/picasso/utils'
 
 const Example = () => (
   <>
-    <Container bottom='medium'>
-      <Container bottom='small'>
+    <Container bottom={SPACING_6}>
+      <Container bottom={SPACING_4}>
         <Typography variant='heading'>Variant: Avatar</Typography>
       </Container>
 
-      <Container bottom='medium'>
-        <Container bottom='xsmall'>
+      <Container bottom={SPACING_6}>
+        <Container bottom={SPACING_2}>
           <Typography>Sizes</Typography>
         </Container>
         <Container>
           <Container inline>
             <SkeletonLoader.Media size='xxsmall' />
           </Container>
-          <Container inline left='small'>
+          <Container inline left={SPACING_4}>
             <SkeletonLoader.Media variant='avatar' size='xsmall' />
           </Container>
-          <Container inline left='small'>
+          <Container inline left={SPACING_4}>
             <SkeletonLoader.Media variant='avatar' size='small' />
           </Container>
-          <Container inline left='small'>
+          <Container inline left={SPACING_4}>
             <SkeletonLoader.Media variant='avatar' size='medium' />
           </Container>
-          <Container inline left='small'>
+          <Container inline left={SPACING_4}>
             <SkeletonLoader.Media variant='avatar' size='large' />
           </Container>
         </Container>
       </Container>
 
-      <Container bottom='small'>
+      <Container bottom={SPACING_4}>
         <Typography variant='heading'>Variant: Icon</Typography>
       </Container>
 
-      <Container bottom='medium'>
-        <Container bottom='xsmall'>
+      <Container bottom={SPACING_6}>
+        <Container bottom={SPACING_2}>
           <Typography>Sizes</Typography>
         </Container>
         <Container>
           <Container inline>
             <SkeletonLoader.Media variant='icon' size='medium' />
           </Container>
-          <Container inline left='small'>
+          <Container inline left={SPACING_4}>
             <SkeletonLoader.Media variant='icon' size='large' />
           </Container>
         </Container>
       </Container>
 
-      <Container bottom='medium'>
-        <Container bottom='xsmall'>
+      <Container bottom={SPACING_6}>
+        <Container bottom={SPACING_2}>
           <Typography>Shapes</Typography>
         </Container>
         <Container>
           <Container inline>
             <SkeletonLoader.Media variant='icon' size='large' circle />
           </Container>
-          <Container inline left='small'>
+          <Container inline left={SPACING_4}>
             <SkeletonLoader.Media variant='icon' size='large' />
           </Container>
         </Container>
       </Container>
 
-      <Container bottom='small'>
+      <Container bottom={SPACING_4}>
         <Typography variant='heading'>Variant: Image</Typography>
       </Container>
 
-      <Container bottom='medium'>
-        <Container bottom='xsmall'>
+      <Container bottom={SPACING_6}>
+        <Container bottom={SPACING_2}>
           <Typography>Sizes</Typography>
         </Container>
         <Container>
           <Container inline>
             <SkeletonLoader.Media variant='image' width='2rem' height='2rem' />
           </Container>
-          <Container inline left='small'>
+          <Container inline left={SPACING_4}>
             <SkeletonLoader.Media variant='image' width='4rem' height='4rem' />
           </Container>
         </Container>
       </Container>
 
-      <Container bottom='medium'>
-        <Container bottom='xsmall'>
+      <Container bottom={SPACING_6}>
+        <Container bottom={SPACING_2}>
           <Typography>Shapes</Typography>
         </Container>
         <Container>
@@ -94,7 +95,7 @@ const Example = () => (
               circle
             />
           </Container>
-          <Container inline left='small'>
+          <Container inline left={SPACING_4}>
             <SkeletonLoader.Media variant='image' width='2rem' height='2rem' />
           </Container>
         </Container>

--- a/packages/picasso/src/Menu/story/Default.example.tsx
+++ b/packages/picasso/src/Menu/story/Default.example.tsx
@@ -8,12 +8,13 @@ import {
   Component16,
   Avatar,
 } from '@toptal/picasso'
+import { SPACING_6, SPACING_4 } from '@toptal/picasso/utils'
 
 const handleClick = () => window.alert('Item clicked')
 
 const Example = () => (
-  <Container flex gap='medium'>
-    <Container flex gap='small' direction='column'>
+  <Container flex gap={SPACING_6}>
+    <Container flex gap={SPACING_4} direction='column'>
       <Typography variant='heading' size='small'>
         Regular
       </Typography>
@@ -26,7 +27,7 @@ const Example = () => (
       </Menu>
     </Container>
 
-    <Container flex gap='small' direction='column'>
+    <Container flex gap={SPACING_4} direction='column'>
       <Typography variant='heading' size='small'>
         With Description
       </Typography>
@@ -43,7 +44,7 @@ const Example = () => (
       </Menu>
     </Container>
 
-    <Container flex gap='small' direction='column'>
+    <Container flex gap={SPACING_4} direction='column'>
       <Typography variant='heading' size='small'>
         With Icon
       </Typography>
@@ -60,7 +61,7 @@ const Example = () => (
       </Menu>
     </Container>
 
-    <Container flex gap='small' direction='column'>
+    <Container flex gap={SPACING_4} direction='column'>
       <Typography variant='heading' size='small'>
         With Description and Icon
       </Typography>
@@ -90,7 +91,7 @@ const Example = () => (
       </Menu>
     </Container>
 
-    <Container flex gap='small' direction='column'>
+    <Container flex gap={SPACING_4} direction='column'>
       <Typography variant='heading' size='small'>
         With avatar
       </Typography>

--- a/packages/picasso/src/Menu/story/Dropdown.example.tsx
+++ b/packages/picasso/src/Menu/story/Dropdown.example.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { Container, Dropdown, Form, Menu } from '@toptal/picasso'
+import { SPACING_4 } from '@toptal/picasso/utils'
 
 const Example = () => {
   const menuForItemB1 = (
@@ -39,7 +40,7 @@ const Example = () => {
 
   return (
     <Container flex>
-      <Container right='small'>
+      <Container right={SPACING_4}>
         <Form.Label>Default</Form.Label>
         <Dropdown content={sliderMenu}>
           Open Dropdown

--- a/packages/picasso/src/Menu/story/Multilevel.example.tsx
+++ b/packages/picasso/src/Menu/story/Multilevel.example.tsx
@@ -7,6 +7,7 @@ import {
   Menu,
   Typography,
 } from '@toptal/picasso'
+import { SPACING_6, SPACING_4 } from '@toptal/picasso/utils'
 
 const SlideMenu = () => (
   <Menu>
@@ -117,7 +118,7 @@ const DrilldownMenuWithDescIcon = () => (
 
 const Example = () => {
   return (
-    <Container flex gap='medium'>
+    <Container flex gap={SPACING_6}>
       <ExampleContainer title='Slide (default)'>
         <SlideMenu />
       </ExampleContainer>
@@ -145,7 +146,7 @@ const ExampleContainer = ({
   children: React.ReactNode
 }) => {
   return (
-    <Container flex gap='small' direction='column'>
+    <Container flex gap={SPACING_4} direction='column'>
       <Typography variant='heading' size='small'>
         {title}
       </Typography>

--- a/packages/picasso/src/NumberInput/story/Sizes.example.tsx
+++ b/packages/picasso/src/NumberInput/story/Sizes.example.tsx
@@ -1,6 +1,7 @@
 import type { ChangeEventHandler } from 'react'
 import React, { useState } from 'react'
 import { NumberInput, Container, FormLabel } from '@toptal/picasso'
+import { SPACING_4 } from '@toptal/picasso/utils'
 
 const SizesExample = () => {
   const [value, setValue] = useState('1')
@@ -11,7 +12,7 @@ const SizesExample = () => {
 
   return (
     <Container>
-      <Container padded='small'>
+      <Container padded={SPACING_4}>
         <FormLabel htmlFor='small-number-input'>Small</FormLabel>
         <NumberInput
           id='small-number-input'
@@ -24,7 +25,7 @@ const SizesExample = () => {
         />
       </Container>
 
-      <Container padded='small'>
+      <Container padded={SPACING_4}>
         <FormLabel htmlFor='medium-number-input'>Medium (default)</FormLabel>
         <NumberInput
           id='medium-number-input'
@@ -37,7 +38,7 @@ const SizesExample = () => {
         />
       </Container>
 
-      <Container padded='small'>
+      <Container padded={SPACING_4}>
         <FormLabel htmlFor='large-number-input'>Large</FormLabel>
         <NumberInput
           id='large-number-input'

--- a/packages/picasso/src/OverviewBlockGroup/story/BlockWidth.example.tsx
+++ b/packages/picasso/src/OverviewBlockGroup/story/BlockWidth.example.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { OverviewBlock, Container } from '@toptal/picasso'
+import { SPACING_4 } from '@toptal/picasso/utils'
 
 const BlockWidthExample = () => {
   return (
@@ -14,7 +15,7 @@ const BlockWidthExample = () => {
         </OverviewBlock.Group>
       </Container>
 
-      <Container top='small'>
+      <Container top={SPACING_4}>
         <OverviewBlock.Group blockWidth='regular'>
           <OverviewBlock value='Regular' label='Width' />
           <OverviewBlock value='Regular' label='Width' />
@@ -23,7 +24,7 @@ const BlockWidthExample = () => {
         </OverviewBlock.Group>
       </Container>
 
-      <Container top='small'>
+      <Container top={SPACING_4}>
         <OverviewBlock.Group blockWidth='wide'>
           <OverviewBlock value='Wide' label='Width' />
           <OverviewBlock value='Wide' label='Width' />

--- a/packages/picasso/src/Page/story/Default.example.tsx
+++ b/packages/picasso/src/Page/story/Default.example.tsx
@@ -11,6 +11,7 @@ import {
   Home16,
   HeartbeatResponsive,
 } from '@toptal/picasso'
+import { SPACING_4 } from '@toptal/picasso/utils'
 
 const Example = () => (
   <div style={{ height: '30rem' }}>
@@ -79,8 +80,8 @@ const ActionItems = () => (
 )
 
 const Content = () => (
-  <Container top='small' bottom='small'>
-    <Container bottom='small'>
+  <Container top={SPACING_4} bottom={SPACING_4}>
+    <Container bottom={SPACING_4}>
       <Typography align='center' variant='heading' size='large'>
         Default example
       </Typography>

--- a/packages/picasso/src/Page/story/FullWidth.example.tsx
+++ b/packages/picasso/src/Page/story/FullWidth.example.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { Page, Container, Menu, Typography } from '@toptal/picasso'
+import { SPACING_4 } from '@toptal/picasso/utils'
 
 const Example = () => (
   <div style={{ height: '30rem' }}>
@@ -30,8 +31,8 @@ const RightContent = () => (
 )
 
 const Content = () => (
-  <Container top='small' bottom='small'>
-    <Container bottom='small'>
+  <Container top={SPACING_4} bottom={SPACING_4}>
+    <Container bottom={SPACING_4}>
       <Typography align='center' variant='heading' size='large'>
         Full width example
       </Typography>

--- a/packages/picasso/src/Page/story/Scroll.example.tsx
+++ b/packages/picasso/src/Page/story/Scroll.example.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { Page, Container, Typography } from '@toptal/picasso'
+import { SPACING_4 } from '@toptal/picasso/utils'
 
 const Example = () => (
   <div style={{ maxHeight: '30rem', overflowY: 'scroll' }}>
@@ -16,8 +17,8 @@ const Example = () => (
 )
 
 const Content = () => (
-  <Container top='small' bottom='small'>
-    <Container bottom='small'>
+  <Container top={SPACING_4} bottom={SPACING_4}>
+    <Container bottom={SPACING_4}>
       <Typography align='center' variant='heading' size='large'>
         Scrollable example
       </Typography>

--- a/packages/picasso/src/Page/story/WideWidth.example.tsx
+++ b/packages/picasso/src/Page/story/WideWidth.example.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { Page, Container, Menu, Typography } from '@toptal/picasso'
+import { SPACING_4 } from '@toptal/picasso/utils'
 
 const Example = () => (
   <div style={{ height: '30rem' }}>
@@ -30,8 +31,8 @@ const RightContent = () => (
 )
 
 const Content = () => (
-  <Container top='small' bottom='small'>
-    <Container bottom='small'>
+  <Container top={SPACING_4} bottom={SPACING_4}>
+    <Container bottom={SPACING_4}>
       <Typography align='center' variant='heading' size='large'>
         Wide width example
       </Typography>

--- a/packages/picasso/src/Page/story/WithBanner.example.tsx
+++ b/packages/picasso/src/Page/story/WithBanner.example.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { Page, Container, Menu, Typography } from '@toptal/picasso'
+import { SPACING_4 } from '@toptal/picasso/utils'
 
 const Example = () => (
   <div style={{ maxHeight: '30rem' }}>
@@ -34,8 +35,8 @@ const RightContent = () => (
 )
 
 const Content = () => (
-  <Container top='small' bottom='small'>
-    <Container bottom='small'>
+  <Container top={SPACING_4} bottom={SPACING_4}>
+    <Container bottom={SPACING_4}>
       <Typography align='center' variant='heading' size='large'>
         Banner example
       </Typography>

--- a/packages/picasso/src/Page/story/WithBannerAndSidebar.example.tsx
+++ b/packages/picasso/src/Page/story/WithBannerAndSidebar.example.tsx
@@ -17,6 +17,7 @@ import {
   Help16,
   Logo,
 } from '@toptal/picasso'
+import { SPACING_4 } from '@toptal/picasso/utils'
 
 const containerHeight = '30rem'
 
@@ -54,8 +55,8 @@ const RightContent = () => (
 )
 
 const Content = () => (
-  <Container top='small' bottom='small'>
-    <Container bottom='small'>
+  <Container top={SPACING_4} bottom={SPACING_4}>
+    <Container bottom={SPACING_4}>
       <Typography align='center' variant='heading' size='large'>
         Banner example
       </Typography>

--- a/packages/picasso/src/Page/story/WithCompoundBanner.example.tsx
+++ b/packages/picasso/src/Page/story/WithCompoundBanner.example.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { Page, Container, Menu, Typography, Link } from '@toptal/picasso'
+import { SPACING_4 } from '@toptal/picasso/utils'
 const { Banner } = Page
 
 const Example = () => (
@@ -44,8 +45,8 @@ const RightContent = () => (
 )
 
 const Content = () => (
-  <Container top='small' bottom='small'>
-    <Container bottom='small'>
+  <Container top={SPACING_4} bottom={SPACING_4}>
+    <Container bottom={SPACING_4}>
       <Typography align='center' variant='heading' size='large'>
         Compound banner example
       </Typography>

--- a/packages/picasso/src/PageArticle/story/Default.example.tsx
+++ b/packages/picasso/src/PageArticle/story/Default.example.tsx
@@ -1,8 +1,8 @@
 import React from 'react'
 import styled from 'styled-components'
 import { Page, Container, Typography } from '@toptal/picasso'
+import { SPACING_4, palette } from '@toptal/picasso/utils'
 import { Globe16, Profile16, PortfolioDesigner16 } from '@toptal/picasso/Icon'
-import { palette } from '@toptal/picasso/utils'
 
 const RightSidebar = styled(Container)`
   border-left: 1px solid ${palette.grey.lighter};
@@ -36,11 +36,16 @@ const SidebarMenu = () => (
 
 const SidebarTips = () => (
   <RightSidebar>
-    <Container top='small' bottom='small' left='small' right='small'>
+    <Container
+      top={SPACING_4}
+      bottom={SPACING_4}
+      left={SPACING_4}
+      right={SPACING_4}
+    >
       <Typography variant='heading' size='small'>
         Some Tips
       </Typography>
-      <Container top='small'>
+      <Container top={SPACING_4}>
         <p>
           Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
           eiusmod tempor incididunt ut labore et dolore magna aliqua.
@@ -51,7 +56,7 @@ const SidebarTips = () => (
 )
 
 const Content = () => (
-  <Container top='small' bottom='small'>
+  <Container top={SPACING_4} bottom={SPACING_4}>
     <Typography align='center' variant='heading' size='large'>
       Default example
     </Typography>

--- a/packages/picasso/src/PageBanner/story/Default.example.tsx
+++ b/packages/picasso/src/PageBanner/story/Default.example.tsx
@@ -1,8 +1,9 @@
 import React from 'react'
 import { Page, Container } from '@toptal/picasso'
+import { SPACING_4 } from '@toptal/picasso/utils'
 
 const Example = () => (
-  <Container bottom='small'>
+  <Container bottom={SPACING_4}>
     <Page.Banner>
       We are now in the process of reviewing your profile. After your profile
       has been checked, we will reach to you via email about next steps.

--- a/packages/picasso/src/PageContent/story/Default.example.tsx
+++ b/packages/picasso/src/PageContent/story/Default.example.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { Page, Container, Typography } from '@toptal/picasso'
+import { SPACING_4 } from '@toptal/picasso/utils'
 
 const Example = () => (
   <div style={{ height: '30rem' }}>
@@ -10,7 +11,12 @@ const Example = () => (
 )
 
 const Content = () => (
-  <Container top='small' bottom='small' left='small' right='small'>
+  <Container
+    top={SPACING_4}
+    bottom={SPACING_4}
+    left={SPACING_4}
+    right={SPACING_4}
+  >
     <Typography align='center' variant='heading' size='large'>
       Default example
     </Typography>

--- a/packages/picasso/src/PageHead/story/NoBorder.example.tsx
+++ b/packages/picasso/src/PageHead/story/NoBorder.example.tsx
@@ -7,6 +7,7 @@ import {
   Container,
   Button,
 } from '@toptal/picasso'
+import { SPACING_4, SPACING_8 } from '@toptal/picasso/utils'
 
 const BlankExample = () => (
   <div>
@@ -22,12 +23,12 @@ const BlankExample = () => (
           </Page.Article>
           <Page.Article style={{ marginTop: '1rem' }}>
             <Section variant='bordered'>
-              <Container bottom='small'>
+              <Container bottom={SPACING_4}>
                 <Typography variant='heading' size='large'>
                   Next step: Speak with ToptTal representative
                 </Typography>
               </Container>
-              <Container bottom='large'>
+              <Container bottom={SPACING_8}>
                 <Typography>
                   On this call, we will discuss the scope of the project and go
                   over how Toptal works to se if we can be a good fir to for

--- a/packages/picasso/src/PageSidebar/story/Size.example.tsx
+++ b/packages/picasso/src/PageSidebar/story/Size.example.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { Page, Logo, Typography, Container } from '@toptal/picasso'
+import { SPACING_8 } from '@toptal/picasso/utils'
 import {
   Jobs16,
   Home16,
@@ -26,7 +27,7 @@ const Menu = ({ size }: { size: 'small' | 'medium' | 'large' }) => (
 )
 
 const Example = () => (
-  <Container flex gap='large'>
+  <Container flex gap={SPACING_8}>
     <Container>
       <Typography variant='heading' size='xsmall'>
         Small (212px)

--- a/packages/picasso/src/PageSidebar/story/Variants.example.tsx
+++ b/packages/picasso/src/PageSidebar/story/Variants.example.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { Page, Logo, Container, Typography, Grid } from '@toptal/picasso'
+import { SPACING_4 } from '@toptal/picasso/utils'
 import {
   Jobs16,
   Home16,
@@ -68,7 +69,7 @@ const ExampleSidebar = ({ variant }: { variant: 'light' | 'dark' }) => (
 const Example = () => (
   <Grid spacing={32}>
     <Grid.Item style={{ height: '58rem' }}>
-      <Container bottom='small'>
+      <Container bottom={SPACING_4}>
         <Typography variant='heading' size='small'>
           Light (default):
         </Typography>
@@ -77,7 +78,7 @@ const Example = () => (
     </Grid.Item>
 
     <Grid.Item style={{ height: '58rem' }}>
-      <Container bottom='small'>
+      <Container bottom={SPACING_4}>
         <Typography variant='heading' size='small'>
           Dark:
         </Typography>

--- a/packages/picasso/src/PageTopBar/story/CenterContent.example.tsx
+++ b/packages/picasso/src/PageTopBar/story/CenterContent.example.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { Container, Button, Bell16, Page, Menu } from '@toptal/picasso'
+import { SPACING_6 } from '@toptal/picasso/utils'
 
 const Example = () => (
   <div style={{ height: '4.5rem' }}>
@@ -15,7 +16,7 @@ const Example = () => (
           </Page.TopBar.Menu>
         }
         actionItems={
-          <Container right='medium'>
+          <Container right={SPACING_6}>
             <Button.Circular variant='transparent' icon={<Bell16 />} />
           </Container>
         }

--- a/packages/picasso/src/PageTopBar/story/ExtraMenuContent.example.tsx
+++ b/packages/picasso/src/PageTopBar/story/ExtraMenuContent.example.tsx
@@ -1,12 +1,13 @@
 import React from 'react'
 import { Page, Menu, Container, Button, Tag } from '@toptal/picasso'
+import { SPACING_6 } from '@toptal/picasso/utils'
 
 const Example = () => (
   <div style={{ height: '4.5rem' }}>
     <Page.TopBar
       rightContent={<RightContent />}
       actionItems={
-        <Container right='medium'>
+        <Container right={SPACING_6}>
           <Button variant='transparent'>Create job</Button>
         </Container>
       }

--- a/packages/picasso/src/PageTopBar/story/LeftContent.example.tsx
+++ b/packages/picasso/src/PageTopBar/story/LeftContent.example.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import type { AutocompleteItem } from '@toptal/picasso'
+import { SPACING_6 } from '@toptal/picasso/utils'
 import { Page, Container, Button, UserBadge, Typography } from '@toptal/picasso'
 
 const options = [
@@ -23,7 +24,7 @@ const Example = () => (
     <Page.TopBar
       title='Onboarding'
       actionItems={
-        <Container right='medium'>
+        <Container right={SPACING_6}>
           <Button variant='transparent'>Create job</Button>
         </Container>
       }

--- a/packages/picasso/src/PageTopBar/story/RightContent.example.tsx
+++ b/packages/picasso/src/PageTopBar/story/RightContent.example.tsx
@@ -1,11 +1,12 @@
 import React from 'react'
 import { Page, Menu, Container, Button } from '@toptal/picasso'
+import { SPACING_6 } from '@toptal/picasso/utils'
 
 const Example = () => (
   <div style={{ height: '4.5rem' }}>
     <Page.TopBar
       actionItems={
-        <Container right='medium'>
+        <Container right={SPACING_6}>
           <Button variant='transparent'>Create job</Button>
         </Container>
       }

--- a/packages/picasso/src/PageTopBar/story/Variants.example.tsx
+++ b/packages/picasso/src/PageTopBar/story/Variants.example.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { Page, Container, Stepper, Button, Menu, Bell16 } from '@toptal/picasso'
+import { SPACING_6 } from '@toptal/picasso/utils'
 
 const Example = () => (
   <div>
@@ -22,7 +23,7 @@ const Example = () => (
         variant='dark'
         title='Dark'
         actionItems={
-          <Container right='medium'>
+          <Container right={SPACING_6}>
             <Button variant='transparent'>Create job</Button>
           </Container>
         }
@@ -34,7 +35,7 @@ const Example = () => (
         variant='grey'
         title='Grey'
         actionItems={
-          <Container right='medium'>
+          <Container right={SPACING_6}>
             <Button.Circular variant='transparent' icon={<Bell16 />} />
           </Container>
         }

--- a/packages/picasso/src/Pagination/story/Ellipsis.example.tsx
+++ b/packages/picasso/src/Pagination/story/Ellipsis.example.tsx
@@ -1,15 +1,16 @@
 import React from 'react'
 import { Pagination, Container, Typography } from '@toptal/picasso'
+import { SPACING_2, SPACING_4 } from '@toptal/picasso/utils'
 
 const Example = () => (
   <Container flex direction='column' justifyContent='space-between'>
-    <Container bottom='xsmall'>
+    <Container bottom={SPACING_2}>
       <Typography variant='heading' size='small'>
         0 or 1 pages
       </Typography>
       <Typography size='xsmall'>~ NULL ~</Typography>
     </Container>
-    <Container bottom='small'>
+    <Container bottom={SPACING_4}>
       <Pagination
         activePage={1}
         onPageChange={handlePageChange}
@@ -17,12 +18,12 @@ const Example = () => (
       />
     </Container>
 
-    <Container bottom='xsmall'>
+    <Container bottom={SPACING_2}>
       <Typography variant='heading' size='small'>
         No ellipsises
       </Typography>
     </Container>
-    <Container bottom='small'>
+    <Container bottom={SPACING_4}>
       <Pagination
         activePage={3}
         onPageChange={handlePageChange}
@@ -30,12 +31,12 @@ const Example = () => (
       />
     </Container>
 
-    <Container bottom='xsmall'>
+    <Container bottom={SPACING_2}>
       <Typography variant='heading' size='small'>
         End ellipsis
       </Typography>
     </Container>
-    <Container bottom='small'>
+    <Container bottom={SPACING_4}>
       <Pagination
         activePage={1}
         onPageChange={handlePageChange}
@@ -43,12 +44,12 @@ const Example = () => (
       />
     </Container>
 
-    <Container bottom='xsmall'>
+    <Container bottom={SPACING_2}>
       <Typography variant='heading' size='small'>
         Start ellipsis
       </Typography>
     </Container>
-    <Container bottom='small'>
+    <Container bottom={SPACING_4}>
       <Pagination
         activePage={5}
         onPageChange={handlePageChange}
@@ -56,12 +57,12 @@ const Example = () => (
       />
     </Container>
 
-    <Container bottom='xsmall'>
+    <Container bottom={SPACING_2}>
       <Typography variant='heading' size='small'>
         Two ellipsises
       </Typography>
     </Container>
-    <Container bottom='small'>
+    <Container bottom={SPACING_4}>
       <Pagination
         activePage={1234}
         onPageChange={handlePageChange}
@@ -69,12 +70,12 @@ const Example = () => (
       />
     </Container>
 
-    <Container bottom='xsmall'>
+    <Container bottom={SPACING_2}>
       <Typography variant='heading' size='small'>
         Custom siblings count
       </Typography>
     </Container>
-    <Container bottom='small'>
+    <Container bottom={SPACING_4}>
       <Pagination
         activePage={1234}
         onPageChange={handlePageChange}

--- a/packages/picasso/src/Pagination/story/Variants.example.tsx
+++ b/packages/picasso/src/Pagination/story/Variants.example.tsx
@@ -1,14 +1,15 @@
 import React from 'react'
 import { Pagination, Container, Typography } from '@toptal/picasso'
+import { SPACING_2, SPACING_4 } from '@toptal/picasso/utils'
 
 const Example = () => (
   <Container flex direction='column' justifyContent='space-between'>
-    <Container bottom='xsmall'>
+    <Container bottom={SPACING_2}>
       <Typography variant='heading' size='small'>
         Default
       </Typography>
     </Container>
-    <Container bottom='small'>
+    <Container bottom={SPACING_4}>
       <Pagination
         activePage={3}
         onPageChange={handlePageChange}
@@ -16,7 +17,7 @@ const Example = () => (
       />
     </Container>
 
-    <Container bottom='xsmall'>
+    <Container bottom={SPACING_2}>
       <Typography variant='heading' size='small'>
         Compact
       </Typography>

--- a/packages/picasso/src/Paper/story/Default.example.tsx
+++ b/packages/picasso/src/Paper/story/Default.example.tsx
@@ -1,11 +1,12 @@
 import React from 'react'
 import { Paper, Typography, Container } from '@toptal/picasso'
+import { SPACING_4 } from '@toptal/picasso/utils'
 
 const Example = () => (
   <div style={{ width: '25rem' }}>
     <Paper>
-      <Container padded='small'>
-        <Container bottom='small'>
+      <Container padded={SPACING_4}>
+        <Container bottom={SPACING_4}>
           <Typography variant='heading' size='medium'>
             This is paper
           </Typography>

--- a/packages/picasso/src/ProgressBar/story/AnimatingProgressChange.example.tsx
+++ b/packages/picasso/src/ProgressBar/story/AnimatingProgressChange.example.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react'
 import { Container, Button, ProgressBar } from '@toptal/picasso'
+import { SPACING_8, SPACING_4 } from '@toptal/picasso/utils'
 
 const AnimatingProgressChange = () => {
   const [percentage, setPercentage] = useState(10)
@@ -8,11 +9,11 @@ const AnimatingProgressChange = () => {
     <Container
       flex
       direction='column'
-      bottom='large'
+      bottom={SPACING_8}
       style={{ width: '200px' }}
     >
       <ProgressBar value={percentage} showPercentage />
-      <Container flex direction='row' top='small'>
+      <Container flex direction='row' top={SPACING_4}>
         <Button
           variant='primary'
           disabled={percentage <= 0}

--- a/packages/picasso/src/ProgressBar/story/Default.example.tsx
+++ b/packages/picasso/src/ProgressBar/story/Default.example.tsx
@@ -1,40 +1,41 @@
 import React from 'react'
 import { Container, ProgressBar } from '@toptal/picasso'
+import { SPACING_4 } from '@toptal/picasso/utils'
 
 const Example = () => {
   return (
     <Container flex direction='column' style={{ maxWidth: '200px' }}>
-      <Container top='small'>
+      <Container top={SPACING_4}>
         <ProgressBar value={0} />
       </Container>
-      <Container top='small'>
+      <Container top={SPACING_4}>
         <ProgressBar value={10} />
       </Container>
-      <Container top='small'>
+      <Container top={SPACING_4}>
         <ProgressBar value={20} />
       </Container>
-      <Container top='small'>
+      <Container top={SPACING_4}>
         <ProgressBar value={30} />
       </Container>
-      <Container top='small'>
+      <Container top={SPACING_4}>
         <ProgressBar value={40} />
       </Container>
-      <Container top='small'>
+      <Container top={SPACING_4}>
         <ProgressBar value={50} />
       </Container>
-      <Container top='small'>
+      <Container top={SPACING_4}>
         <ProgressBar value={60} />
       </Container>
-      <Container top='small'>
+      <Container top={SPACING_4}>
         <ProgressBar value={70} />
       </Container>
-      <Container top='small'>
+      <Container top={SPACING_4}>
         <ProgressBar value={80} />
       </Container>
-      <Container top='small'>
+      <Container top={SPACING_4}>
         <ProgressBar value={90} />
       </Container>
-      <Container top='small'>
+      <Container top={SPACING_4}>
         <ProgressBar value={100} />
       </Container>
     </Container>

--- a/packages/picasso/src/ProgressBar/story/WithPercentage.example.tsx
+++ b/packages/picasso/src/ProgressBar/story/WithPercentage.example.tsx
@@ -1,39 +1,40 @@
 import React from 'react'
 import { Container, ProgressBar } from '@toptal/picasso'
+import { SPACING_4 } from '@toptal/picasso/utils'
 
 const Example = () => (
   <Container flex direction='column' style={{ maxWidth: '200px' }}>
-    <Container top='small'>
+    <Container top={SPACING_4}>
       <ProgressBar value={0} showPercentage />
     </Container>
-    <Container top='small'>
+    <Container top={SPACING_4}>
       <ProgressBar value={10} showPercentage />
     </Container>
-    <Container top='small'>
+    <Container top={SPACING_4}>
       <ProgressBar value={20} showPercentage />
     </Container>
-    <Container top='small'>
+    <Container top={SPACING_4}>
       <ProgressBar value={30} showPercentage />
     </Container>
-    <Container top='small'>
+    <Container top={SPACING_4}>
       <ProgressBar value={40} showPercentage />
     </Container>
-    <Container top='small'>
+    <Container top={SPACING_4}>
       <ProgressBar value={50} showPercentage />
     </Container>
-    <Container top='small'>
+    <Container top={SPACING_4}>
       <ProgressBar value={60} showPercentage />
     </Container>
-    <Container top='small'>
+    <Container top={SPACING_4}>
       <ProgressBar value={70} showPercentage />
     </Container>
-    <Container top='small'>
+    <Container top={SPACING_4}>
       <ProgressBar value={80} showPercentage />
     </Container>
-    <Container top='small'>
+    <Container top={SPACING_4}>
       <ProgressBar value={90} showPercentage />
     </Container>
-    <Container top='small'>
+    <Container top={SPACING_4}>
       <ProgressBar value={100} showPercentage />
     </Container>
   </Container>

--- a/packages/picasso/src/Radio/story/CustomLabel.example.tsx
+++ b/packages/picasso/src/Radio/story/CustomLabel.example.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { Radio, Container, Typography } from '@toptal/picasso'
+import { SPACING_2, SPACING_6 } from '@toptal/picasso/utils'
 import styled from 'styled-components'
 
 const Label = styled.label`
@@ -16,7 +17,7 @@ const List = styled.ul`
 const CustomRadio = () => {
   return (
     <Container flex alignItems='center'>
-      <Container right='xsmall' flex alignItems='center'>
+      <Container right={SPACING_2} flex alignItems='center'>
         <Radio id='id-1' />
       </Container>
       <Label htmlFor='id-1'>
@@ -61,7 +62,7 @@ const PayoneerPicker = () => {
       flex
       alignItems='center'
       justifyContent='space-between'
-      bottom='xsmall'
+      bottom={SPACING_2}
     >
       <CustomRadio />
       <PayoneerLogo />
@@ -71,7 +72,12 @@ const PayoneerPicker = () => {
 
 const Example = () => (
   <div>
-    <Container rounded padded='medium' variant='blue' style={{ maxWidth: 400 }}>
+    <Container
+      rounded
+      padded={SPACING_6}
+      variant='blue'
+      style={{ maxWidth: 400 }}
+    >
       <PayoneerPicker />
       <Benefits />
     </Container>

--- a/packages/picasso/src/RatingStars/story/Default.example.tsx
+++ b/packages/picasso/src/RatingStars/story/Default.example.tsx
@@ -1,6 +1,7 @@
 import type { ChangeEvent } from 'react'
 import React, { useState } from 'react'
 import { Container, Rating, Typography } from '@toptal/picasso'
+import { SPACING_4, SPACING_6, SPACING_10 } from '@toptal/picasso/utils'
 
 const Example = () => {
   const [starsValue, setStarsValue] = useState(1)
@@ -11,8 +12,8 @@ const Example = () => {
   }
 
   return (
-    <Container padded='small'>
-      <Container bottom='medium'>
+    <Container padded={SPACING_4}>
+      <Container bottom={SPACING_6}>
         <Typography size='medium' variant='heading'>
           Stars
         </Typography>
@@ -28,7 +29,7 @@ const Example = () => {
           Thumbs
         </Typography>
         <Container flex>
-          <Container right='xlarge'>
+          <Container right={SPACING_10}>
             <Rating.Thumbs
               onChange={setThumbsValue}
               name='rating-thumbs'

--- a/packages/picasso/src/RatingStars/story/NonInteractive.example.tsx
+++ b/packages/picasso/src/RatingStars/story/NonInteractive.example.tsx
@@ -1,12 +1,13 @@
 import React from 'react'
 import { Container, Rating, Typography } from '@toptal/picasso'
+import { SPACING_4, SPACING_6 } from '@toptal/picasso/utils'
 
 const Example = () => {
   const value = 3
 
   return (
-    <Container padded='small'>
-      <Container bottom='medium'>
+    <Container padded={SPACING_4}>
+      <Container bottom={SPACING_6}>
         <Typography size='medium' variant='heading'>
           Stars
         </Typography>

--- a/packages/picasso/src/RatingStars/story/Sizes.example.tsx
+++ b/packages/picasso/src/RatingStars/story/Sizes.example.tsx
@@ -1,6 +1,7 @@
 import type { ChangeEvent } from 'react'
 import React, { useState } from 'react'
 import { Container, Rating, Typography } from '@toptal/picasso'
+import { SPACING_6, SPACING_4 } from '@toptal/picasso/utils'
 
 const Example = () => {
   const [smallValue, setSmallValue] = useState(1)
@@ -18,17 +19,17 @@ const Example = () => {
 
   return (
     <Container>
-      <Container bottom='medium'>
+      <Container bottom={SPACING_6}>
         <Typography variant='heading' size='medium'>
           Stars
         </Typography>
 
         <Container flex direction='row'>
-          <Container padded='small'>
+          <Container padded={SPACING_4}>
             <Typography variant='heading' size='small'>
               Small (default)
             </Typography>
-            <Container top='small' bottom='small'>
+            <Container top={SPACING_4} bottom={SPACING_4}>
               <Rating.Stars
                 size='small'
                 onChange={onChangeSmall}
@@ -38,11 +39,11 @@ const Example = () => {
             </Container>
           </Container>
 
-          <Container padded='small'>
+          <Container padded={SPACING_4}>
             <Typography variant='heading' size='small'>
               Large
             </Typography>
-            <Container top='small' bottom='small'>
+            <Container top={SPACING_4} bottom={SPACING_4}>
               <Rating.Stars
                 size='large'
                 onChange={onChangeLarge}
@@ -59,11 +60,11 @@ const Example = () => {
           Thumbs
         </Typography>
         <Container flex direction='row'>
-          <Container padded='small'>
+          <Container padded={SPACING_4}>
             <Typography variant='heading' size='small'>
               Small (default)
             </Typography>
-            <Container top='small' bottom='small'>
+            <Container top={SPACING_4} bottom={SPACING_4}>
               <Rating.Thumbs
                 size='small'
                 onChange={setThumbsSmallValue}
@@ -73,11 +74,11 @@ const Example = () => {
             </Container>
           </Container>
 
-          <Container padded='small'>
+          <Container padded={SPACING_4}>
             <Typography variant='heading' size='small'>
               Large
             </Typography>
-            <Container top='small' bottom='small'>
+            <Container top={SPACING_4} bottom={SPACING_4}>
               <Rating.Thumbs
                 size='large'
                 onChange={setThumbsLargeValue}

--- a/packages/picasso/src/Section/story/Collapsible.example.tsx
+++ b/packages/picasso/src/Section/story/Collapsible.example.tsx
@@ -7,6 +7,7 @@ import {
   Section,
   Container,
 } from '@toptal/picasso'
+import { SPACING_4 } from '@toptal/picasso/utils'
 
 const Example = () => {
   const content = (
@@ -72,7 +73,7 @@ const Example = () => {
 
       <Grid.Item sm={6}>
         <Typography>Collapsible section with header bar.</Typography>
-        <Container top='small'>
+        <Container top={SPACING_4}>
           <Section title='Details' collapsible variant='withHeaderBar'>
             Lorem, ipsum dolor sit amet consectetur adipisicing elit. Sint
             dolore, et ipsum eligendi sunt maiores aliquam blanditiis labore
@@ -86,7 +87,7 @@ const Example = () => {
 
       <Grid.Item sm={6}>
         <Typography>Collapsible bordered section.</Typography>
-        <Container top='small'>
+        <Container top={SPACING_4}>
           <Section title='Details' collapsible variant='bordered'>
             Lorem, ipsum dolor sit amet consectetur adipisicing elit. Sint
             dolore, et ipsum eligendi sunt maiores aliquam blanditiis labore

--- a/packages/picasso/src/Section/story/Variant.example.tsx
+++ b/packages/picasso/src/Section/story/Variant.example.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { Container, Table, Typography, Section } from '@toptal/picasso'
+import { SPACING_4, SPACING_8 } from '@toptal/picasso/utils'
 
 const TableDemo = () => (
   <Table>
@@ -33,7 +34,7 @@ const Example = () => {
         <Typography variant='heading' size='small'>
           Bordered
         </Typography>
-        <Container top='small'>
+        <Container top={SPACING_4}>
           <Section
             title='Talents'
             subtitle={`${data.length} people`}
@@ -43,11 +44,11 @@ const Example = () => {
           </Section>
         </Container>
       </Container>
-      <Container top='large'>
+      <Container top={SPACING_8}>
         <Typography variant='heading' size='small'>
           WithHeaderBar
         </Typography>
-        <Container top='small'>
+        <Container top={SPACING_4}>
           <Section
             title='Talents'
             subtitle={`${data.length} people`}

--- a/packages/picasso/src/Select/story/AutoFocus.example.tsx
+++ b/packages/picasso/src/Select/story/AutoFocus.example.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react'
 import { Select, Button, Container } from '@toptal/picasso'
+import { SPACING_4 } from '@toptal/picasso/utils'
 
 const Example = () => {
   const [value, setValue] = useState<string>('')
@@ -15,7 +16,7 @@ const Example = () => {
 
   return (
     <Container>
-      <Container bottom={1}>
+      <Container bottom={SPACING_4}>
         <Button onClick={handleClick}>{show ? 'Hide' : 'Show'}</Button>
       </Container>
       {show && (

--- a/packages/picasso/src/Select/story/Autofill.example.tsx
+++ b/packages/picasso/src/Select/story/Autofill.example.tsx
@@ -1,6 +1,7 @@
 import type { ChangeEvent } from 'react'
 import React, { useState } from 'react'
 import { Container, Form, Select } from '@toptal/picasso'
+import { SPACING_4 } from '@toptal/picasso/utils'
 
 const Example = () => {
   const [value, setValue] = useState<string>('')
@@ -16,7 +17,7 @@ const Example = () => {
 
   return (
     <Container flex>
-      <Container right='small'>
+      <Container right={SPACING_4}>
         <Form.Label>Autofill disabled</Form.Label>
         <Select
           onChange={handleChange}

--- a/packages/picasso/src/Select/story/Disabled.example.tsx
+++ b/packages/picasso/src/Select/story/Disabled.example.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react'
 import { Select, Container, Form } from '@toptal/picasso'
+import { SPACING_4 } from '@toptal/picasso/utils'
 
 const Example = () => {
   const [value, setValue] = useState<string>('')
@@ -9,7 +10,7 @@ const Example = () => {
   }
 
   return (
-    <Container flex gap='small'>
+    <Container flex gap={SPACING_4}>
       <Container>
         <Form.Field>
           <Form.Label>Select is disabled</Form.Label>

--- a/packages/picasso/src/Select/story/FilterOptions.example.tsx
+++ b/packages/picasso/src/Select/story/FilterOptions.example.tsx
@@ -1,6 +1,7 @@
 import type { ChangeEvent } from 'react'
 import React, { useState, useCallback } from 'react'
 import type { SelectOption } from '@toptal/picasso'
+import { SPACING_4 } from '@toptal/picasso/utils'
 import { Select, Container, Typography } from '@toptal/picasso'
 
 const FilterOptionsExample = () => {
@@ -36,7 +37,7 @@ const FilterOptionsExample = () => {
 
   return (
     <Container flex inline>
-      <Container right='small'>
+      <Container right={SPACING_4}>
         <Typography variant='heading' size='small'>
           Non grouped
         </Typography>
@@ -51,7 +52,7 @@ const FilterOptionsExample = () => {
           filterOptions={filterOptions}
         />
       </Container>
-      <Container right='small'>
+      <Container right={SPACING_4}>
         <Typography variant='heading' size='small'>
           Grouped
         </Typography>

--- a/packages/picasso/src/Select/story/Grouped.example.tsx
+++ b/packages/picasso/src/Select/story/Grouped.example.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react'
 import { Container, Select, Typography } from '@toptal/picasso'
+import { SPACING_4 } from '@toptal/picasso/utils'
 
 const OPTION_GROUPS = {
   'Group 1': [
@@ -37,7 +38,7 @@ const Example = () => {
 
   return (
     <Container flex inline>
-      <Container right='small'>
+      <Container right={SPACING_4}>
         <Typography variant='heading' size='small'>
           Native
         </Typography>
@@ -50,7 +51,7 @@ const Example = () => {
           native
         />
       </Container>
-      <Container right='small'>
+      <Container right={SPACING_4}>
         <Typography variant='heading' size='small'>
           Non native
         </Typography>

--- a/packages/picasso/src/Select/story/Limit.example.tsx
+++ b/packages/picasso/src/Select/story/Limit.example.tsx
@@ -1,6 +1,7 @@
 import type { ChangeEvent } from 'react'
 import React, { useState } from 'react'
 import { Select, Form, Container, NumberInput } from '@toptal/picasso'
+import { SPACING_4 } from '@toptal/picasso/utils'
 
 const SelectSearchBehaviourExample = () => {
   const [value, setValue] = useState<string>('')
@@ -32,7 +33,7 @@ const SelectSearchBehaviourExample = () => {
 
   return (
     <Container flex>
-      <Container right='small'>
+      <Container right={SPACING_4}>
         <Form.Field>
           <Form.Label>Flat options</Form.Label>
           <Select
@@ -46,7 +47,7 @@ const SelectSearchBehaviourExample = () => {
           />
         </Form.Field>
       </Container>
-      <Container right='small'>
+      <Container right={SPACING_4}>
         <Form.Field>
           <Form.Label>Grouped options</Form.Label>
           <Select

--- a/packages/picasso/src/Select/story/Loading.example.tsx
+++ b/packages/picasso/src/Select/story/Loading.example.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react'
 import { Container, Form, Select } from '@toptal/picasso'
+import { SPACING_4 } from '@toptal/picasso/utils'
 
 const Example = () => {
   const [value, setValue] = useState<string>('')
@@ -11,7 +12,7 @@ const Example = () => {
 
   return (
     <Container flex>
-      <Container right='small'>
+      <Container right={SPACING_4}>
         <Form.Label>Default</Form.Label>
         <Select
           loading

--- a/packages/picasso/src/Select/story/MenuWidth.example.tsx
+++ b/packages/picasso/src/Select/story/MenuWidth.example.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react'
 import { Select, Container } from '@toptal/picasso'
+import { SPACING_4 } from '@toptal/picasso/utils'
 
 const Example = () => {
   const [value, setValue] = useState<string>('')
@@ -10,7 +11,7 @@ const Example = () => {
 
   return (
     <Container flex inline>
-      <Container right='small'>
+      <Container right={SPACING_4}>
         <Select
           onChange={handleChange}
           options={OPTIONS}

--- a/packages/picasso/src/Select/story/Native.example.tsx
+++ b/packages/picasso/src/Select/story/Native.example.tsx
@@ -1,6 +1,7 @@
 import type { ChangeEvent } from 'react'
 import React, { useState } from 'react'
 import { Container, Form, Select } from '@toptal/picasso'
+import { SPACING_4 } from '@toptal/picasso/utils'
 
 const Example = () => {
   const [value, setValue] = useState<string>('')
@@ -16,7 +17,7 @@ const Example = () => {
 
   return (
     <Container flex>
-      <Container right='small'>
+      <Container right={SPACING_4}>
         <Form.Label>Reset disabled</Form.Label>
         <Select
           native

--- a/packages/picasso/src/Select/story/SearchBehavior.example.tsx
+++ b/packages/picasso/src/Select/story/SearchBehavior.example.tsx
@@ -1,6 +1,7 @@
 import type { ChangeEvent } from 'react'
 import React, { useState } from 'react'
 import { Select, Form, Container, NumberInput } from '@toptal/picasso'
+import { SPACING_4 } from '@toptal/picasso/utils'
 
 const SelectSearchBehaviourExample = () => {
   const [value, setValue] = useState<string>('')
@@ -23,7 +24,7 @@ const SelectSearchBehaviourExample = () => {
 
   return (
     <Container flex>
-      <Container right='small'>
+      <Container right={SPACING_4}>
         <Form.Field>
           <Form.Label>Search for an option</Form.Label>
           <Select

--- a/packages/picasso/src/Select/story/ShrinkWidth.example.tsx
+++ b/packages/picasso/src/Select/story/ShrinkWidth.example.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react'
 import { Select, Container } from '@toptal/picasso'
+import { SPACING_4 } from '@toptal/picasso/utils'
 import { Settings16 } from '@toptal/picasso/Icon'
 
 const Example = () => {
@@ -11,7 +12,7 @@ const Example = () => {
 
   return (
     <Container flex inline>
-      <Container right='small'>
+      <Container right={SPACING_4}>
         <Select
           onChange={handleChange}
           options={OPTIONS}
@@ -20,7 +21,7 @@ const Example = () => {
           width='shrink'
         />
       </Container>
-      <Container right='small'>
+      <Container right={SPACING_4}>
         <Select
           onChange={handleChange}
           options={OPTIONS}

--- a/packages/picasso/src/Select/story/Sizes.example.tsx
+++ b/packages/picasso/src/Select/story/Sizes.example.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react'
 import { Select, Container, Typography } from '@toptal/picasso'
+import { SPACING_4 } from '@toptal/picasso/utils'
 
 const Example = () => {
   const [value, setValue] = useState<string>('')
@@ -11,11 +12,11 @@ const Example = () => {
 
   return (
     <Container flex direction='column'>
-      <Container padded='small'>
+      <Container padded={SPACING_4}>
         <Typography variant='heading' size='small'>
           Small
         </Typography>
-        <Container top='small' bottom='small'>
+        <Container top={SPACING_4} bottom={SPACING_4}>
           <Select
             size='small'
             options={OPTIONS}
@@ -26,11 +27,11 @@ const Example = () => {
           />
         </Container>
       </Container>
-      <Container padded='small'>
+      <Container padded={SPACING_4}>
         <Typography variant='heading' size='small'>
           Medium (default)
         </Typography>
-        <Container top='small' bottom='small'>
+        <Container top={SPACING_4} bottom={SPACING_4}>
           <Select
             options={OPTIONS}
             value={value}
@@ -40,11 +41,11 @@ const Example = () => {
           />
         </Container>
       </Container>
-      <Container padded='small'>
+      <Container padded={SPACING_4}>
         <Typography variant='heading' size='small'>
           Large
         </Typography>
-        <Container top='small' bottom='small'>
+        <Container top={SPACING_4} bottom={SPACING_4}>
           <Select
             size='large'
             options={OPTIONS}

--- a/packages/picasso/src/Select/story/WithIcon.example.tsx
+++ b/packages/picasso/src/Select/story/WithIcon.example.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react'
 import { Select, Container } from '@toptal/picasso'
+import { SPACING_4 } from '@toptal/picasso/utils'
 import { Settings16 } from '@toptal/picasso/Icon'
 
 const Example = () => {
@@ -11,7 +12,7 @@ const Example = () => {
 
   return (
     <Container flex direction='column'>
-      <Container bottom='small'>
+      <Container bottom={SPACING_4}>
         <Select
           onChange={handleChange}
           options={OPTIONS}
@@ -21,7 +22,7 @@ const Example = () => {
           width='auto'
         />
       </Container>
-      <Container bottom='small'>
+      <Container bottom={SPACING_4}>
         <Select
           onChange={handleChange}
           options={OPTIONS}
@@ -32,7 +33,7 @@ const Example = () => {
           width='auto'
         />
       </Container>
-      <Container bottom='small'>
+      <Container bottom={SPACING_4}>
         <Select
           disabled
           onChange={handleChange}

--- a/packages/picasso/src/SidebarItem/story/Icons.example.tsx
+++ b/packages/picasso/src/SidebarItem/story/Icons.example.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { Page, Typography, Grid, Container } from '@toptal/picasso'
+import { SPACING_4 } from '@toptal/picasso/utils'
 import { Overview16, Referrals16 } from '@toptal/picasso/Icon'
 
 const sidebarWithIcons = (
@@ -50,7 +51,7 @@ const sidebarWithoutIcons = (
 const Example = () => (
   <Grid spacing={32}>
     <Grid.Item style={{ height: '24rem' }}>
-      <Container bottom='small'>
+      <Container bottom={SPACING_4}>
         <Typography variant='heading' size='small'>
           With icons
         </Typography>
@@ -59,7 +60,7 @@ const Example = () => (
     </Grid.Item>
 
     <Grid.Item style={{ height: '24rem' }}>
-      <Container bottom='small'>
+      <Container bottom={SPACING_4}>
         <Typography variant='heading' size='small'>
           Without icons
         </Typography>

--- a/packages/picasso/src/SidebarItem/story/WithBadgeAndTag.example.tsx
+++ b/packages/picasso/src/SidebarItem/story/WithBadgeAndTag.example.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { Page, Container } from '@toptal/picasso'
+import { SPACING_4 } from '@toptal/picasso/utils'
 import {
   Referrals16,
   Overview16,
@@ -64,7 +65,7 @@ const Menu = () => (
 )
 
 const Example = () => (
-  <Container flex gap='small'>
+  <Container flex gap={SPACING_4}>
     <Page.Sidebar size='large'>
       <Menu />
     </Page.Sidebar>

--- a/packages/picasso/src/SkeletonLoader/story/DarkBackground.example.tsx
+++ b/packages/picasso/src/SkeletonLoader/story/DarkBackground.example.tsx
@@ -1,24 +1,24 @@
 import React from 'react'
 import { Container, Grid, SkeletonLoader } from '@toptal/picasso'
-import { palette } from '@toptal/picasso/utils'
+import { SPACING_4, palette } from '@toptal/picasso/utils'
 
 type Props = {
   backgroundColor: string
 }
 
 const LoaderContent = ({ backgroundColor }: Props) => (
-  <Container style={{ backgroundColor, maxWidth: '32%' }} padded='small'>
+  <Container style={{ backgroundColor, maxWidth: '32%' }} padded={SPACING_4}>
     <Container
       flex
       justifyContent='space-between'
       alignItems='center'
-      bottom='small'
+      bottom={SPACING_4}
     >
       <SkeletonLoader.Header />
       <SkeletonLoader.Button />
     </Container>
 
-    <Container bottom='small'>
+    <Container bottom={SPACING_4}>
       <SkeletonLoader.Typography rows={2} />
     </Container>
 
@@ -28,7 +28,7 @@ const LoaderContent = ({ backgroundColor }: Props) => (
       </Grid.Item>
 
       <Grid.Item sm={6}>
-        <Container flex justifyContent='center' bottom='small'>
+        <Container flex justifyContent='center' bottom={SPACING_4}>
           <SkeletonLoader.Header />
         </Container>
         <SkeletonLoader.Typography rows={2} />

--- a/packages/picasso/src/SkeletonLoader/story/Default.example.tsx
+++ b/packages/picasso/src/SkeletonLoader/story/Default.example.tsx
@@ -14,6 +14,7 @@ import {
   Image,
   SkeletonLoader,
 } from '@toptal/picasso'
+import { SPACING_4 } from '@toptal/picasso/utils'
 
 const useGetData = (): [boolean, () => void] => {
   const [loading, setLoading] = useState(true)
@@ -114,19 +115,24 @@ const PageLoader = () => (
       flex
       justifyContent='space-between'
       alignItems='center'
-      bottom='small'
+      bottom={SPACING_4}
     >
       <SkeletonLoader.Header />
       <SkeletonLoader.Button />
     </Container>
 
-    <Container bottom='small'>
+    <Container bottom={SPACING_4}>
       <SkeletonLoader.Typography rows={4} />
     </Container>
 
     <Grid>
       <Grid.Item sm={6}>
-        <Container flex alignItems='center' bottom='small' direction='column'>
+        <Container
+          flex
+          alignItems='center'
+          bottom={SPACING_4}
+          direction='column'
+        >
           <SkeletonLoader.Header />
 
           <SkeletonLoader.Media variant='image' width='5rem' height='5rem' />
@@ -136,7 +142,7 @@ const PageLoader = () => (
       </Grid.Item>
 
       <Grid.Item sm={6}>
-        <Container flex justifyContent='center' bottom='small'>
+        <Container flex justifyContent='center' bottom={SPACING_4}>
           <SkeletonLoader.Header />
         </Container>
         <SkeletonLoader.Typography rows={8} />
@@ -160,10 +166,10 @@ const PageExample = () => {
           </SidebarMenu>
           <Container
             style={{ flex: 1 }}
-            top='small'
-            bottom='small'
-            left='small'
-            right='small'
+            top={SPACING_4}
+            bottom={SPACING_4}
+            left={SPACING_4}
+            right={SPACING_4}
           >
             {loading ? PageLoader() : <Content />}
           </Container>

--- a/packages/picasso/src/Slider/story/Range.example.tsx
+++ b/packages/picasso/src/Slider/story/Range.example.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { Slider, Typography, Container } from '@toptal/picasso'
+import { SPACING_10, SPACING_8 } from '@toptal/picasso/utils'
 
 type Value = number | number[]
 
@@ -23,7 +24,7 @@ const Example = () => {
       <Typography variant='heading' size='small'>
         Time Zone
       </Typography>
-      <Container top='xlarge' right='large' left='large'>
+      <Container top={SPACING_10} right={SPACING_8} left={SPACING_8}>
         <Slider
           value={value}
           min={0}

--- a/packages/picasso/src/Slider/story/Tooltip.example.tsx
+++ b/packages/picasso/src/Slider/story/Tooltip.example.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { Container, Slider, Typography } from '@toptal/picasso'
+import { SPACING_4, SPACING_8, SPACING_10 } from '@toptal/picasso/utils'
 
 const formatLabel = (val: any) => {
   const formattedVal = val.length === 2 ? val : '0' + val
@@ -9,28 +10,28 @@ const formatLabel = (val: any) => {
 
 const Example = () => {
   return (
-    <Container padded='small'>
+    <Container padded={SPACING_4}>
       <Container>
         <Typography variant='heading' size='small'>
           Display persistently
         </Typography>
-        <Container top='large'>
+        <Container top={SPACING_8}>
           <Slider tooltip='on' compact />
         </Container>
       </Container>
-      <Container top='large'>
+      <Container top={SPACING_8}>
         <Typography variant='heading' size='small'>
           Display when the thumb is hovered or focused
         </Typography>
-        <Container top='large'>
+        <Container top={SPACING_8}>
           <Slider tooltip='auto' compact />
         </Container>
       </Container>
-      <Container top='large'>
+      <Container top={SPACING_8}>
         <Typography variant='heading' size='small'>
           Custom rendered label
         </Typography>
-        <Container top='xlarge'>
+        <Container top={SPACING_10}>
           <Slider
             min={0}
             max={23}

--- a/packages/picasso/src/Stepper/story/Default.example.tsx
+++ b/packages/picasso/src/Stepper/story/Default.example.tsx
@@ -1,18 +1,19 @@
 import React from 'react'
 import { Stepper, Container } from '@toptal/picasso'
+import { SPACING_6, SPACING_4 } from '@toptal/picasso/utils'
 
 const Example = () => (
   <div>
-    <Container padded='medium'>
+    <Container padded={SPACING_6}>
       <Stepper steps={['Step 1', 'Step 2', 'Step 3', 'Step 4']} />
     </Container>
-    <Container top='small' padded='medium'>
+    <Container top={SPACING_4} padded={SPACING_6}>
       <Stepper active={1} steps={['Step 1', 'Step 2', 'Step 3', 'Step 4']} />
     </Container>
-    <Container top='small' padded='medium'>
+    <Container top={SPACING_4} padded={SPACING_6}>
       <Stepper active={3} steps={['Step 1', 'Step 2', 'Step 3', 'Step 4']} />
     </Container>
-    <Container top='small' padded='medium'>
+    <Container top={SPACING_4} padded={SPACING_6}>
       <Stepper active={4} steps={['Step 1', 'Step 2', 'Step 3', 'Step 4']} />
     </Container>
   </div>

--- a/packages/picasso/src/Stepper/story/Vertical.example.tsx
+++ b/packages/picasso/src/Stepper/story/Vertical.example.tsx
@@ -1,24 +1,25 @@
 import React from 'react'
 import { Stepper, Container } from '@toptal/picasso'
+import { SPACING_6, SPACING_10 } from '@toptal/picasso/utils'
 
 const Example = () => (
   <Container flex direction='row'>
-    <Container padded='medium'>
+    <Container padded={SPACING_6}>
       <Stepper.Vertical steps={['Step 1', 'Step 2', 'Step 3', 'Step 4']} />
     </Container>
-    <Container padded='medium' left='xlarge'>
+    <Container padded={SPACING_6} left={SPACING_10}>
       <Stepper.Vertical
         active={1}
         steps={['Step 1', 'Step 2', 'Step 3', 'Step 4']}
       />
     </Container>
-    <Container padded='medium' left='xlarge'>
+    <Container padded={SPACING_6} left={SPACING_10}>
       <Stepper.Vertical
         active={3}
         steps={['Step 1', 'Step 2', 'Step 3', 'Step 4']}
       />
     </Container>
-    <Container padded='medium' left='xlarge'>
+    <Container padded={SPACING_6} left={SPACING_10}>
       <Stepper.Vertical
         active={4}
         steps={['Step 1', 'Step 2', 'Step 3', 'Step 4']}

--- a/packages/picasso/src/Stepper/story/WithoutLabels.example.tsx
+++ b/packages/picasso/src/Stepper/story/WithoutLabels.example.tsx
@@ -1,26 +1,27 @@
 import React from 'react'
 import { Stepper, Container } from '@toptal/picasso'
+import { SPACING_6, SPACING_4 } from '@toptal/picasso/utils'
 
 const Example = () => (
   <div>
-    <Container padded='medium'>
+    <Container padded={SPACING_6}>
       <Stepper hideLabels steps={['Step 1', 'Step 2', 'Step 3', 'Step 4']} />
     </Container>
-    <Container top='small' padded='medium'>
+    <Container top={SPACING_4} padded={SPACING_6}>
       <Stepper
         hideLabels
         active={1}
         steps={['Step 1', 'Step 2', 'Step 3', 'Step 4']}
       />
     </Container>
-    <Container top='small' padded='medium'>
+    <Container top={SPACING_4} padded={SPACING_6}>
       <Stepper
         hideLabels
         active={3}
         steps={['Step 1', 'Step 2', 'Step 3', 'Step 4']}
       />
     </Container>
-    <Container top='small' padded='medium'>
+    <Container top={SPACING_4} padded={SPACING_6}>
       <Stepper
         hideLabels
         active={4}

--- a/packages/picasso/src/Tab/story/CustomValue.example.tsx
+++ b/packages/picasso/src/Tab/story/CustomValue.example.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { Container, Tabs } from '@toptal/picasso'
+import { SPACING_4 } from '@toptal/picasso/utils'
 
 type Value = number | string | boolean
 
@@ -18,7 +19,7 @@ const Example = () => {
         <Tabs.Tab value='interviews' label='Interviews' />
       </Tabs>
 
-      <Container top='small'>
+      <Container top={SPACING_4}>
         Current <i>value</i> is equal <code>{JSON.stringify(value)}</code>
       </Container>
     </div>

--- a/packages/picasso/src/Tab/story/Disabled.example.tsx
+++ b/packages/picasso/src/Tab/story/Disabled.example.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { Container, Tabs } from '@toptal/picasso'
+import { SPACING_4 } from '@toptal/picasso/utils'
 
 const Example = () => {
   const [value, setValue] = React.useState(0)
@@ -17,13 +18,13 @@ const Example = () => {
       </Tabs>
 
       {value === 0 && (
-        <Container top='small'>Content of the first tab</Container>
+        <Container top={SPACING_4}>Content of the first tab</Container>
       )}
       {value === 1 && (
-        <Container top='small'>Content of the second tab</Container>
+        <Container top={SPACING_4}>Content of the second tab</Container>
       )}
       {value === 2 && (
-        <Container top='small'>Content of the third tab</Container>
+        <Container top={SPACING_4}>Content of the third tab</Container>
       )}
     </div>
   )

--- a/packages/picasso/src/Tab/story/Icon.example.tsx
+++ b/packages/picasso/src/Tab/story/Icon.example.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { Container, Tabs, Tooltip } from '@toptal/picasso'
+import { SPACING_4 } from '@toptal/picasso/utils'
 import { Exclamation16 } from '@toptal/picasso/Icon'
 
 const Example = () => {
@@ -36,13 +37,13 @@ const Example = () => {
       </Tabs>
 
       {value === 0 && (
-        <Container top='small'>Content of the first tab</Container>
+        <Container top={SPACING_4}>Content of the first tab</Container>
       )}
       {value === 1 && (
-        <Container top='small'>Content of the second tab</Container>
+        <Container top={SPACING_4}>Content of the second tab</Container>
       )}
       {value === 2 && (
-        <Container top='small'>Content of the third tab</Container>
+        <Container top={SPACING_4}>Content of the third tab</Container>
       )}
     </div>
   )

--- a/packages/picasso/src/Tab/story/Vertical.example.tsx
+++ b/packages/picasso/src/Tab/story/Vertical.example.tsx
@@ -1,10 +1,10 @@
 import React from 'react'
 import { Container, Tabs, Typography } from '@toptal/picasso'
-import { palette } from '@toptal/picasso/utils'
+import { SPACING_8, SPACING_4, palette } from '@toptal/picasso/utils'
 
 const Example = () => {
   return (
-    <Container flex gap='large' padded='small'>
+    <Container flex gap={SPACING_8} padded={SPACING_4}>
       <ExampleDecorator title='With Title'>
         <Tabs value={0} orientation='vertical'>
           <Tabs.Tab label='Label' />

--- a/packages/picasso/src/Table/story/ExpandableRows.example.tsx
+++ b/packages/picasso/src/Table/story/ExpandableRows.example.tsx
@@ -10,6 +10,7 @@ import {
   Tag,
   Container,
 } from '@toptal/picasso'
+import { SPACING_4, SPACING_6 } from '@toptal/picasso/utils'
 import { Star16, ArrowDownMinor16, More16 } from '@toptal/picasso/Icon'
 
 type StyledArrowDownMinor16Props = {
@@ -24,7 +25,7 @@ const StyledArrowDownMinor16 = styled(ArrowDownMinor16)`
 `
 
 const ExpandableContent = () => (
-  <Container padded='small'>
+  <Container padded={SPACING_4}>
     <Tabs value={1}>
       <Tabs.Tab label='Job' />
       <Tabs.Tab label='Company' />
@@ -36,8 +37,8 @@ const ExpandableContent = () => (
       direction='row'
       alignItems='center'
       justifyContent='space-between'
-      top='medium'
-      bottom='medium'
+      top={SPACING_6}
+      bottom={SPACING_6}
     >
       <UserBadge
         name='Jacqueline Roque'
@@ -58,7 +59,7 @@ const ExpandableContent = () => (
       </Container>
     </Container>
 
-    <Container top='small'>
+    <Container top={SPACING_4}>
       <Tag>$2k Design Credit</Tag>
     </Container>
   </Container>

--- a/packages/picasso/src/Table/story/ExpandableRowsDefaultExpanded.example.tsx
+++ b/packages/picasso/src/Table/story/ExpandableRowsDefaultExpanded.example.tsx
@@ -10,6 +10,7 @@ import {
   Tag,
   Container,
 } from '@toptal/picasso'
+import { SPACING_4, SPACING_6 } from '@toptal/picasso/utils'
 import { Star16, ArrowDownMinor16, More16 } from '@toptal/picasso/Icon'
 
 type StyledArrowDownMinor16Props = {
@@ -24,7 +25,7 @@ const StyledArrowDownMinor16 = styled(ArrowDownMinor16)`
 `
 
 const ExpandableContent = () => (
-  <Container padded='small'>
+  <Container padded={SPACING_4}>
     <Tabs value={1}>
       <Tabs.Tab label='Job' />
       <Tabs.Tab label='Company' />
@@ -36,8 +37,8 @@ const ExpandableContent = () => (
       direction='row'
       alignItems='center'
       justifyContent='space-between'
-      top='medium'
-      bottom='medium'
+      top={SPACING_6}
+      bottom={SPACING_6}
     >
       <UserBadge
         name='Jacqueline Roque'
@@ -58,7 +59,7 @@ const ExpandableContent = () => (
       </Container>
     </Container>
 
-    <Container top='small'>
+    <Container top={SPACING_4}>
       <Tag>$2k Design Credit</Tag>
     </Container>
   </Container>
@@ -131,7 +132,7 @@ const TableExpandableRowsExample = () => {
         Toggle Table
       </Button>
       {isTableShown && (
-        <Container top='medium'>
+        <Container top={SPACING_6}>
           <TableWithExpandableRows />
         </Container>
       )}

--- a/packages/picasso/src/Table/story/Spacings.example.tsx
+++ b/packages/picasso/src/Table/story/Spacings.example.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react'
 import type { TableProps } from '@toptal/picasso'
+import { SPACING_4 } from '@toptal/picasso/utils'
 import { Table, Select, Container } from '@toptal/picasso'
 
 const data = [
@@ -50,7 +51,7 @@ const Example = () => {
 
   return (
     <>
-      <Container bottom='small'>
+      <Container bottom={SPACING_4}>
         <Select
           onChange={event => setSpacing(event.target.value)}
           options={[

--- a/packages/picasso/src/Table/story/Variants.example.tsx
+++ b/packages/picasso/src/Table/story/Variants.example.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react'
 import type { TableProps } from '@toptal/picasso'
+import { SPACING_4 } from '@toptal/picasso/utils'
 import { Table, Select, Container } from '@toptal/picasso'
 
 const data = [
@@ -50,7 +51,7 @@ const Example = () => {
 
   return (
     <>
-      <Container bottom='small'>
+      <Container bottom={SPACING_4}>
         <Select
           onChange={event => setVariant(event.target.value)}
           options={[

--- a/packages/picasso/src/Tabs/story/Default.example.tsx
+++ b/packages/picasso/src/Tabs/story/Default.example.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { Container, Tabs } from '@toptal/picasso'
+import { SPACING_4 } from '@toptal/picasso/utils'
 
 const Example = () => {
   const [value, setValue] = React.useState(0)
@@ -17,13 +18,13 @@ const Example = () => {
       </Tabs>
 
       {value === 0 && (
-        <Container top='small'>Content of the first tab</Container>
+        <Container top={SPACING_4}>Content of the first tab</Container>
       )}
       {value === 1 && (
-        <Container top='small'>Content of the second tab</Container>
+        <Container top={SPACING_4}>Content of the second tab</Container>
       )}
       {value === 2 && (
-        <Container top='small'>Content of the third tab</Container>
+        <Container top={SPACING_4}>Content of the third tab</Container>
       )}
     </div>
   )

--- a/packages/picasso/src/Tabs/story/FullWidth.example.tsx
+++ b/packages/picasso/src/Tabs/story/FullWidth.example.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable react/no-array-index-key */
 import React from 'react'
 import { Container, Tabs } from '@toptal/picasso'
-import { palette } from '@toptal/picasso/utils'
+import { SPACING_4, palette } from '@toptal/picasso/utils'
 
 const TAB_COUNT = 2
 
@@ -19,7 +19,7 @@ const Example = () => {
           <Tabs.Tab key={index} label='Label' />
         ))}
       </Tabs>
-      <Container padded='small'>Content of tab #{value}</Container>
+      <Container padded={SPACING_4}>Content of tab #{value}</Container>
     </div>
   )
 }

--- a/packages/picasso/src/Tabs/story/ScrollButtons.example.tsx
+++ b/packages/picasso/src/Tabs/story/ScrollButtons.example.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable react/no-array-index-key */
 import React from 'react'
 import { Container, Tabs } from '@toptal/picasso'
+import { SPACING_4 } from '@toptal/picasso/utils'
 
 const TAB_COUNT = 10
 
@@ -18,7 +19,7 @@ const Example = () => {
           <Tabs.Tab key={index} label='Label' />
         ))}
       </Tabs>
-      <Container top='small'>Content of tab #{value}</Container>
+      <Container top={SPACING_4}>Content of tab #{value}</Container>
     </div>
   )
 }

--- a/packages/picasso/src/Tabs/story/Vertical.example.tsx
+++ b/packages/picasso/src/Tabs/story/Vertical.example.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { Container, Tabs } from '@toptal/picasso'
-import { shadows, sizes, palette } from '@toptal/picasso/utils'
+import { SPACING_4, shadows, sizes, palette } from '@toptal/picasso/utils'
 
 type TabPanelProps = {
   children: React.ReactNode
@@ -23,7 +23,7 @@ const TabsContent = ({ children }: { children: React.ReactNode }) => {
         boxShadow: shadows[1],
         borderRadius: sizes.borderRadius.medium,
       }}
-      padded='small'
+      padded={SPACING_4}
     >
       {children}
     </Container>
@@ -42,7 +42,7 @@ const Example = () => {
       style={{
         backgroundColor: palette.grey.lighter,
       }}
-      padded='small'
+      padded={SPACING_4}
       flex
     >
       <Tabs onChange={handleChange} orientation='vertical' value={value}>

--- a/packages/picasso/src/Tag/story/Checkable.example.tsx
+++ b/packages/picasso/src/Tag/story/Checkable.example.tsx
@@ -1,13 +1,13 @@
 import React, { useState } from 'react'
 import { Tag, Container, Typography, Settings16 } from '@toptal/picasso'
-import { noop } from '@toptal/picasso/utils'
+import { SPACING_4, SPACING_2, noop } from '@toptal/picasso/utils'
 
 const Example = () => {
   const [checked, setChecked] = useState<boolean>(false)
 
   return (
-    <Container flex gap='small'>
-      <Container flex direction='column' gap='xsmall'>
+    <Container flex gap={SPACING_4}>
+      <Container flex direction='column' gap={SPACING_2}>
         <Typography>Regular</Typography>
         <div>
           <Tag.Checkable
@@ -21,7 +21,7 @@ const Example = () => {
           </Tag.Checkable>
         </div>
       </Container>
-      <Container flex direction='column' gap='xsmall'>
+      <Container flex direction='column' gap={SPACING_2}>
         <Typography>Hovered</Typography>
         <div>
           <Tag.Checkable icon={<Settings16 />} hovered onChange={noop}>
@@ -29,7 +29,7 @@ const Example = () => {
           </Tag.Checkable>
         </div>
       </Container>
-      <Container flex direction='column' gap='xsmall'>
+      <Container flex direction='column' gap={SPACING_2}>
         <Typography>Checked</Typography>
         <div>
           <Tag.Checkable icon={<Settings16 />} checked onChange={noop}>
@@ -37,7 +37,7 @@ const Example = () => {
           </Tag.Checkable>
         </div>
       </Container>
-      <Container flex direction='column' gap='xsmall'>
+      <Container flex direction='column' gap={SPACING_2}>
         <Typography>Hovered on Selected</Typography>
         <div>
           <Tag.Checkable icon={<Settings16 />} hovered checked onChange={noop}>
@@ -45,7 +45,7 @@ const Example = () => {
           </Tag.Checkable>
         </div>
       </Container>
-      <Container flex direction='column' gap='xsmall'>
+      <Container flex direction='column' gap={SPACING_2}>
         <Typography>Disabled</Typography>
         <div>
           <Tag.Checkable

--- a/packages/picasso/src/Tag/story/Default.example.tsx
+++ b/packages/picasso/src/Tag/story/Default.example.tsx
@@ -6,32 +6,33 @@ import {
   Typography,
   Tooltip,
 } from '@toptal/picasso'
+import { SPACING_4, SPACING_2 } from '@toptal/picasso/utils'
 
 const handleDelete = () => {
   window.alert('You clicked the delete icon.')
 }
 
 const Example = () => (
-  <Container flex gap='small'>
-    <Container flex direction='column' gap='xsmall'>
+  <Container flex gap={SPACING_4}>
+    <Container flex direction='column' gap={SPACING_2}>
       <Typography>Regular</Typography>
       <div>
         <Tag>Label</Tag>
       </div>
     </Container>
-    <Container flex direction='column' gap='xsmall'>
+    <Container flex direction='column' gap={SPACING_2}>
       <Typography>With Icon</Typography>
       <div>
         <Tag icon={<Settings16 />}>Label</Tag>
       </div>
     </Container>
-    <Container flex direction='column' gap='xsmall'>
+    <Container flex direction='column' gap={SPACING_2}>
       <Typography>With Remove</Typography>
       <div>
         <Tag onDelete={handleDelete}>Label</Tag>
       </div>
     </Container>
-    <Container flex direction='column' gap='xsmall'>
+    <Container flex direction='column' gap={SPACING_2}>
       <Typography>Disabled</Typography>
       <div>
         <Tag disabled>Label</Tag>
@@ -51,7 +52,7 @@ const Example = () => (
         </Tag>
       </div>
     </Container>
-    <Container flex direction='column' gap='xsmall'>
+    <Container flex direction='column' gap={SPACING_2}>
       <Typography>With Connection</Typography>
       <div>
         <Tag
@@ -62,7 +63,7 @@ const Example = () => (
         </Tag>
       </div>
     </Container>
-    <Container flex direction='column' gap='xsmall'>
+    <Container flex direction='column' gap={SPACING_2}>
       <Typography>With Tooltip</Typography>
       <div>
         <Tooltip interactive content='ssddssdsdsd'>

--- a/packages/picasso/src/Tag/story/Variants.example.tsx
+++ b/packages/picasso/src/Tag/story/Variants.example.tsx
@@ -1,37 +1,62 @@
 import React from 'react'
 import { Container, Settings16, Tag } from '@toptal/picasso'
+import { SPACING_4, SPACING_2 } from '@toptal/picasso/utils'
 
 const Example = () => (
   <Container flex>
-    <Container flex direction='column' gap='small' right='small' top={0.5}>
+    <Container
+      flex
+      direction='column'
+      gap={SPACING_4}
+      right={SPACING_4}
+      top={SPACING_2}
+    >
       <Tag variant='light-grey'>Light grey</Tag>
       <Tag icon={<Settings16 />} variant='light-grey'>
         Light grey
       </Tag>
     </Container>
 
-    <Container flex direction='column' gap='small' right='small' top={0.5}>
+    <Container
+      flex
+      direction='column'
+      gap={SPACING_4}
+      right={SPACING_4}
+      top={SPACING_2}
+    >
       <Tag variant='blue'>Blue</Tag>
       <Tag icon={<Settings16 />} variant='blue'>
         Blue
       </Tag>
     </Container>
 
-    <Container flex direction='column' gap='small' right='small' top={0.5}>
+    <Container
+      flex
+      direction='column'
+      gap={SPACING_4}
+      right={SPACING_4}
+      top={SPACING_2}
+    >
       <Tag variant='green'>Green</Tag>
       <Tag icon={<Settings16 />} variant='green'>
         Green
       </Tag>
     </Container>
 
-    <Container flex direction='column' gap='small' right='small' top={0.5}>
+    <Container
+      flex
+      direction='column'
+      gap={SPACING_4}
+      right={SPACING_4}
+      top={SPACING_2}
+    >
       <Tag variant='yellow'>Yellow</Tag>
       <Tag icon={<Settings16 />} variant='yellow'>
         Yellow
       </Tag>
     </Container>
 
-    <Container flex direction='column' gap='small' top={0.5}>
+    <Container flex direction='column' gap={SPACING_4} top={SPACING_2}>
       <Tag variant='red'>Red</Tag>
       <Tag icon={<Settings16 />} variant='red'>
         Red

--- a/packages/picasso/src/TagRectangular/story/Indicators.example.tsx
+++ b/packages/picasso/src/TagRectangular/story/Indicators.example.tsx
@@ -1,21 +1,22 @@
 import React from 'react'
 import { Container, Tag } from '@toptal/picasso'
+import { SPACING_4, SPACING_2 } from '@toptal/picasso/utils'
 
 const Example = () => (
   <Container flex>
-    <Container right='small' top={0.5}>
+    <Container right={SPACING_4} top={SPACING_2}>
       <Tag.Rectangular indicator='red'>Red</Tag.Rectangular>
     </Container>
-    <Container right='small' top={0.5}>
+    <Container right={SPACING_4} top={SPACING_2}>
       <Tag.Rectangular indicator='yellow'>Yellow</Tag.Rectangular>
     </Container>
-    <Container right='small' top={0.5}>
+    <Container right={SPACING_4} top={SPACING_2}>
       <Tag.Rectangular indicator='green'>Green</Tag.Rectangular>
     </Container>
-    <Container right='small' top={0.5}>
+    <Container right={SPACING_4} top={SPACING_2}>
       <Tag.Rectangular indicator='blue'>Blue</Tag.Rectangular>
     </Container>
-    <Container right='small' top={0.5}>
+    <Container right={SPACING_4} top={SPACING_2}>
       <Tag.Rectangular indicator='light-blue'>Light blue</Tag.Rectangular>
     </Container>
   </Container>

--- a/packages/picasso/src/TagRectangular/story/Variants.example.tsx
+++ b/packages/picasso/src/TagRectangular/story/Variants.example.tsx
@@ -1,8 +1,9 @@
 import React from 'react'
 import { Container, Tag } from '@toptal/picasso'
+import { SPACING_4 } from '@toptal/picasso/utils'
 
 const Example = () => (
-  <Container flex gap='small'>
+  <Container flex gap={SPACING_4}>
     <Tag.Rectangular variant='red'>Red</Tag.Rectangular>
     <Tag.Rectangular variant='yellow'>Yellow</Tag.Rectangular>
     <Tag.Rectangular variant='green'>Green</Tag.Rectangular>

--- a/packages/picasso/src/TagSelector/story/Status.example.tsx
+++ b/packages/picasso/src/TagSelector/story/Status.example.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { Container, TagSelector, Typography } from '@toptal/picasso'
+import { SPACING_4 } from '@toptal/picasso/utils'
 
 const value = [
   { value: 'AF', text: 'Afghanistan' },
@@ -10,19 +11,19 @@ const value = [
 const Example = () => {
   return (
     <Container flex direction='column'>
-      <Container padded='small'>
+      <Container padded={SPACING_4}>
         <Typography>Default</Typography>
         <TagSelector placeholder='default' status='default' value={value} />
       </Container>
-      <Container padded='small'>
+      <Container padded={SPACING_4}>
         <Typography>Error</Typography>
         <TagSelector placeholder='error' status='error' value={value} />
       </Container>
-      <Container padded='small'>
+      <Container padded={SPACING_4}>
         <Typography>Success with long placeholder</Typography>
         <TagSelector placeholder='Very long placeholder' status='success' />
       </Container>
-      <Container padded='small'>
+      <Container padded={SPACING_4}>
         <Typography>Success on one line</Typography>
         <TagSelector
           placeholder='success'
@@ -30,7 +31,7 @@ const Example = () => {
           value={value.slice(0, 2)}
         />
       </Container>
-      <Container padded='small'>
+      <Container padded={SPACING_4}>
         <Typography>Success</Typography>
         <TagSelector placeholder='success' status='success' value={value} />
       </Container>

--- a/packages/picasso/src/Timeline/story/Default.example.tsx
+++ b/packages/picasso/src/Timeline/story/Default.example.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { Timeline, Typography, Container } from '@toptal/picasso'
+import { SPACING_4 } from '@toptal/picasso/utils'
 
 const Example = () => (
   <Timeline>
@@ -7,7 +8,7 @@ const Example = () => (
       <Typography size='medium' variant='heading'>
         Founder
       </Typography>
-      <Container bottom='small'>
+      <Container bottom={SPACING_4}>
         <Typography size='xsmall'>Brutalism 2019 - PRESENT</Typography>
       </Container>
       <Typography size='medium'>
@@ -19,7 +20,7 @@ const Example = () => (
       <Typography size='medium' variant='heading'>
         Computational Geometry Engineer
       </Typography>
-      <Container bottom='small'>
+      <Container bottom={SPACING_4}>
         <Typography size='xsmall'>Arkio 2018 - 2019</Typography>
       </Container>
       <Typography size='medium'>

--- a/packages/picasso/src/Tooltip/story/Compact.example.tsx
+++ b/packages/picasso/src/Tooltip/story/Compact.example.tsx
@@ -1,8 +1,9 @@
 import React from 'react'
 import { Tooltip, Button, Container } from '@toptal/picasso'
+import { SPACING_8 } from '@toptal/picasso/utils'
 
 const Example = () => (
-  <Container top='large' left='large' inline>
+  <Container top={SPACING_8} left={SPACING_8} inline>
     <Tooltip content='Content' open placement='top' compact>
       <Button>Compact</Button>
     </Tooltip>

--- a/packages/picasso/src/Tooltip/story/ControlListeners.example.tsx
+++ b/packages/picasso/src/Tooltip/story/ControlListeners.example.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react'
 import { Tooltip, Button, Container } from '@toptal/picasso'
+import { SPACING_8 } from '@toptal/picasso/utils'
 
 const TooltipControlListenersExample = () => {
   const [listenersEnabled, setListenersEnabled] = useState(true)
@@ -20,7 +21,13 @@ const TooltipControlListenersExample = () => {
       <Button variant='secondary' onClick={toggleListeners}>
         {listenersEnabled ? 'Disable' : 'Enable'} listeners
       </Button>
-      <Container top='large' bottom='large' left='large' right='large' inline>
+      <Container
+        top={SPACING_8}
+        bottom={SPACING_8}
+        left={SPACING_8}
+        right={SPACING_8}
+        inline
+      >
         <Tooltip
           disableListeners={!listenersEnabled}
           content='Some content...'

--- a/packages/picasso/src/Tooltip/story/Default.example.tsx
+++ b/packages/picasso/src/Tooltip/story/Default.example.tsx
@@ -1,8 +1,9 @@
 import React from 'react'
 import { Tooltip, Button, Container } from '@toptal/picasso'
+import { SPACING_6 } from '@toptal/picasso/utils'
 
 const Example = () => (
-  <Container top='medium' left='medium'>
+  <Container top={SPACING_6} left={SPACING_6}>
     <Tooltip content='Content goes here...' open>
       <Button>Test me</Button>
     </Tooltip>

--- a/packages/picasso/src/Tooltip/story/Delay.example.tsx
+++ b/packages/picasso/src/Tooltip/story/Delay.example.tsx
@@ -1,14 +1,27 @@
 import React from 'react'
 import { Tooltip, Button, Container } from '@toptal/picasso'
+import { SPACING_8 } from '@toptal/picasso/utils'
 
 const Example = () => (
   <div style={{ textAlign: 'center' }}>
-    <Container top='large' bottom='large' left='large' right='large' inline>
+    <Container
+      top={SPACING_8}
+      bottom={SPACING_8}
+      left={SPACING_8}
+      right={SPACING_8}
+      inline
+    >
       <Tooltip content='Short delay is 200ms' delay='short' placement='top'>
         <Button>Short delay</Button>
       </Tooltip>
     </Container>
-    <Container top='large' bottom='large' left='large' right='large' inline>
+    <Container
+      top={SPACING_8}
+      bottom={SPACING_8}
+      left={SPACING_8}
+      right={SPACING_8}
+      inline
+    >
       <Tooltip content='Long delay is 500ms' delay='long' placement='top'>
         <Button>Long delay</Button>
       </Tooltip>

--- a/packages/picasso/src/Tooltip/story/DisabledElement.example.tsx
+++ b/packages/picasso/src/Tooltip/story/DisabledElement.example.tsx
@@ -1,10 +1,17 @@
 import React from 'react'
 import { Tooltip, Button, Container } from '@toptal/picasso'
+import { SPACING_8 } from '@toptal/picasso/utils'
 
 const TooltipControlListenersExample = () => {
   return (
     <div style={{ textAlign: 'center' }}>
-      <Container top='large' bottom='large' left='large' right='large' inline>
+      <Container
+        top={SPACING_8}
+        bottom={SPACING_8}
+        left={SPACING_8}
+        right={SPACING_8}
+        inline
+      >
         <Tooltip content='Some content...' placement='top'>
           <span>
             <Button disabled>Hover</Button>

--- a/packages/picasso/src/Tooltip/story/FollowCursor.example.tsx
+++ b/packages/picasso/src/Tooltip/story/FollowCursor.example.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { Tooltip, Container } from '@toptal/picasso'
+import { SPACING_8 } from '@toptal/picasso/utils'
 
 const longContent = `Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.`
 
@@ -7,7 +8,7 @@ const Example = () => (
   <Container
     flex
     justifyContent='space-between'
-    padded='large'
+    padded={SPACING_8}
     style={{ height: '240px', width: '1000px', padding: '2rem 10rem' }}
   >
     <Tooltip content={longContent} followCursor placement='right'>

--- a/packages/picasso/src/Tooltip/story/Interactive.example.tsx
+++ b/packages/picasso/src/Tooltip/story/Interactive.example.tsx
@@ -1,14 +1,27 @@
 import React from 'react'
 import { Tooltip, Button, Container } from '@toptal/picasso'
+import { SPACING_8 } from '@toptal/picasso/utils'
 
 const Example = () => (
   <div style={{ textAlign: 'center' }}>
-    <Container top='large' bottom='large' left='large' right='large' inline>
+    <Container
+      top={SPACING_8}
+      bottom={SPACING_8}
+      left={SPACING_8}
+      right={SPACING_8}
+      inline
+    >
       <Tooltip content='You can not hover inside!' placement='top'>
         <Button>Non interactive</Button>
       </Tooltip>
     </Container>
-    <Container top='large' bottom='large' left='large' right='large' inline>
+    <Container
+      top={SPACING_8}
+      bottom={SPACING_8}
+      left={SPACING_8}
+      right={SPACING_8}
+      inline
+    >
       <Tooltip content='Hover inside' interactive placement='top'>
         <Button>Interactive</Button>
       </Tooltip>

--- a/packages/picasso/src/Tooltip/story/MaxWidth.example.tsx
+++ b/packages/picasso/src/Tooltip/story/MaxWidth.example.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { Tooltip, Button, Container } from '@toptal/picasso'
+import { SPACING_8 } from '@toptal/picasso/utils'
 
 const longContent = `Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.`
 
@@ -7,7 +8,7 @@ const Example = () => (
   <Container
     flex
     justifyContent='space-between'
-    padded='large'
+    padded={SPACING_8}
     style={{ height: '240px', width: '1000px', padding: '2rem 10rem' }}
   >
     <Container>

--- a/packages/picasso/src/Tooltip/story/Placement.example.tsx
+++ b/packages/picasso/src/Tooltip/story/Placement.example.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { Tooltip, Button, Container, Grid } from '@toptal/picasso'
+import { SPACING_4 } from '@toptal/picasso/utils'
 
 const Example = () => (
   <Container style={{ padding: 100, width: 600 }}>
@@ -22,7 +23,7 @@ const Example = () => (
         </Grid.Item>
       </Grid>
     </Container>
-    <Container bottom='small'>
+    <Container bottom={SPACING_4}>
       <Grid direction='row'>
         <Grid.Item sm={4}>
           <Tooltip placement='left-start' content='Content' open>
@@ -37,7 +38,7 @@ const Example = () => (
         </Grid.Item>
       </Grid>
     </Container>
-    <Container bottom='small'>
+    <Container bottom={SPACING_4}>
       <Grid direction='row'>
         <Grid.Item sm={4}>
           <Tooltip placement='left' content='Content' open>
@@ -52,7 +53,7 @@ const Example = () => (
         </Grid.Item>
       </Grid>
     </Container>
-    <Container bottom='small'>
+    <Container bottom={SPACING_4}>
       <Grid direction='row'>
         <Grid.Item sm={4}>
           <Tooltip placement='left-end' content='Content' open>
@@ -67,7 +68,7 @@ const Example = () => (
         </Grid.Item>
       </Grid>
     </Container>
-    <Container bottom='small'>
+    <Container bottom={SPACING_4}>
       <Grid direction='row'>
         <Grid.Item sm={4}>
           <Tooltip placement='bottom-start' content='Content' open>

--- a/packages/picasso/src/Tooltip/story/Trigger.example.tsx
+++ b/packages/picasso/src/Tooltip/story/Trigger.example.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react'
 import { Tooltip, Button, Container } from '@toptal/picasso'
-import { ClickAwayListener } from '@toptal/picasso/utils'
+import { SPACING_8, ClickAwayListener } from '@toptal/picasso/utils'
 
 const Example = () => {
   const [open, setOpen] = useState(false)
@@ -10,13 +10,25 @@ const Example = () => {
 
   return (
     <div style={{ textAlign: 'center' }}>
-      <Container top='large' bottom='large' left='large' right='large' inline>
+      <Container
+        top={SPACING_8}
+        bottom={SPACING_8}
+        left={SPACING_8}
+        right={SPACING_8}
+        inline
+      >
         <Tooltip content='Some content...' placement='top'>
           <Button>Hover</Button>
         </Tooltip>
       </Container>
       <ClickAwayListener onClickAway={closeTooltip}>
-        <Container top='large' bottom='large' left='large' right='large' inline>
+        <Container
+          top={SPACING_8}
+          bottom={SPACING_8}
+          left={SPACING_8}
+          right={SPACING_8}
+          inline
+        >
           <Tooltip open={open} content='Some content...' placement='top'>
             <Button onClick={toogleTooltipOpen}>Click</Button>
           </Tooltip>

--- a/packages/picasso/src/TreeView/story/TreeNodeAvatar.example.tsx
+++ b/packages/picasso/src/TreeView/story/TreeNodeAvatar.example.tsx
@@ -1,12 +1,13 @@
 import React from 'react'
 import { TreeNodeAvatar, Container, Typography } from '@toptal/picasso'
+import { SPACING_6 } from '@toptal/picasso/utils'
 
 const Example = () => (
   <Container>
-    <Container bottom='medium'>
+    <Container bottom={SPACING_6}>
       <TreeNodeAvatar name='John Doe' size='xsmall' />
     </Container>
-    <Container bottom='medium'>
+    <Container bottom={SPACING_6}>
       <TreeNodeAvatar
         name='John Doe'
         src='jacqueline/128x128.jpg'
@@ -19,14 +20,14 @@ const Example = () => (
     <Typography variant='heading' size='medium'>
       objectFit=contain (default)
     </Typography>
-    <Container bottom='medium'>
+    <Container bottom={SPACING_6}>
       <TreeNodeAvatar
         name='John Doe'
         src='jacqueline/128x88.jpg'
         size='small'
       />
     </Container>
-    <Container bottom='medium'>
+    <Container bottom={SPACING_6}>
       <TreeNodeAvatar
         name='John Doe'
         src='jacqueline/88x128.jpg'
@@ -36,7 +37,7 @@ const Example = () => (
     <Typography variant='heading' size='medium'>
       objectFit=cover
     </Typography>
-    <Container bottom='medium'>
+    <Container bottom={SPACING_6}>
       <TreeNodeAvatar
         name='John Doe'
         objectFit='cover'
@@ -44,7 +45,7 @@ const Example = () => (
         size='small'
       />
     </Container>
-    <Container bottom='medium'>
+    <Container bottom={SPACING_6}>
       <TreeNodeAvatar
         name='John Doe'
         objectFit='cover'

--- a/packages/picasso/src/Typography/story/Alignment.example.tsx
+++ b/packages/picasso/src/Typography/story/Alignment.example.tsx
@@ -1,12 +1,13 @@
 import React from 'react'
 import { Typography, Container } from '@toptal/picasso'
+import { SPACING_4 } from '@toptal/picasso/utils'
 
 const Example = () => (
   <div>
-    <Container bottom='small'>
+    <Container bottom={SPACING_4}>
       <Typography align='left'>Left</Typography>
     </Container>
-    <Container bottom='small'>
+    <Container bottom={SPACING_4}>
       <Typography align='center'>Center</Typography>
     </Container>
     <Typography align='right'>Right</Typography>

--- a/packages/picasso/src/Typography/story/Colors.example.tsx
+++ b/packages/picasso/src/Typography/story/Colors.example.tsx
@@ -1,37 +1,40 @@
 import React from 'react'
 import { Typography, Container } from '@toptal/picasso'
-import { palette } from '@toptal/picasso/utils'
+import { SPACING_4, SPACING_2, palette } from '@toptal/picasso/utils'
 
 const Example = () => (
   <div>
-    <Container bottom={1}>
+    <Container bottom={SPACING_4}>
       <Typography color='green'>Green</Typography>
     </Container>
-    <Container bottom={1}>
+    <Container bottom={SPACING_4}>
       <Typography color='red'>Red</Typography>
     </Container>
-    <Container bottom={1}>
+    <Container bottom={SPACING_4}>
       <Typography color='yellow'>Yellow</Typography>
     </Container>
-    <Container bottom={1}>
+    <Container bottom={SPACING_4}>
       <Typography color='light-grey'>Light Grey</Typography>
     </Container>
-    <Container bottom={1}>
+    <Container bottom={SPACING_4}>
       <Typography color='grey'>Grey</Typography>
     </Container>
-    <Container bottom={1}>
+    <Container bottom={SPACING_4}>
       <Typography color='grey-main-2'>Grey Main 2</Typography>
     </Container>
-    <Container bottom={1}>
+    <Container bottom={SPACING_4}>
       <Typography color='dark-grey'>Dark Grey</Typography>
     </Container>
-    <Container bottom={1}>
+    <Container bottom={SPACING_4}>
       <Typography color='black'>Black</Typography>
     </Container>
-    <Container padded='xsmall' style={{ backgroundColor: palette.blue.dark }}>
+    <Container
+      padded={SPACING_2}
+      style={{ backgroundColor: palette.blue.dark }}
+    >
       <Typography invert>White for inverted backgrounds</Typography>
     </Container>
-    <Container padded='xsmall' style={{ color: palette.grey.main }}>
+    <Container padded={SPACING_2} style={{ color: palette.grey.main }}>
       <Typography color='inherit'>Inherit color</Typography>
     </Container>
   </div>

--- a/packages/picasso/src/Typography/story/Decoration.example.tsx
+++ b/packages/picasso/src/Typography/story/Decoration.example.tsx
@@ -1,15 +1,16 @@
 import React from 'react'
 import { Typography, Container } from '@toptal/picasso'
+import { SPACING_4 } from '@toptal/picasso/utils'
 
 const Example = () => (
   <div>
-    <Container bottom='small'>
+    <Container bottom={SPACING_4}>
       <Typography underline='solid'>solid</Typography>
     </Container>
-    <Container bottom='small'>
+    <Container bottom={SPACING_4}>
       <Typography underline='dashed'>dashed</Typography>
     </Container>
-    <Container bottom='small'>
+    <Container bottom={SPACING_4}>
       <Typography>
         This is how you can highlight text by making it{' '}
         <Typography as='span' inline weight='semibold'>

--- a/packages/picasso/src/Typography/story/Headings.example.tsx
+++ b/packages/picasso/src/Typography/story/Headings.example.tsx
@@ -1,19 +1,20 @@
 import React from 'react'
 import { Typography, Container } from '@toptal/picasso'
+import { SPACING_4 } from '@toptal/picasso/utils'
 
 const Example = () => (
   <div>
-    <Container bottom='small'>
+    <Container bottom={SPACING_4}>
       <Typography variant='heading' size='small'>
         Heading Small
       </Typography>
     </Container>
-    <Container bottom='small'>
+    <Container bottom={SPACING_4}>
       <Typography variant='heading' size='medium'>
         Heading Medium
       </Typography>
     </Container>
-    <Container bottom='small'>
+    <Container bottom={SPACING_4}>
       <Typography variant='heading' size='large'>
         Heading Large
       </Typography>

--- a/packages/picasso/src/Typography/story/Types.example.tsx
+++ b/packages/picasso/src/Typography/story/Types.example.tsx
@@ -1,26 +1,27 @@
 import React from 'react'
 import { Typography, Container } from '@toptal/picasso'
+import { SPACING_4 } from '@toptal/picasso/utils'
 
 const Example = () => (
   <div>
-    <Container bottom='small'>
+    <Container bottom={SPACING_4}>
       <Typography size='large'>Body Large</Typography>
     </Container>
-    <Container bottom='small'>
+    <Container bottom={SPACING_4}>
       <Typography color='black' size='medium'>
         Body Medium Black
       </Typography>
     </Container>
-    <Container bottom='small'>
+    <Container bottom={SPACING_4}>
       <Typography size='medium'>Body Medium Grey</Typography>
     </Container>
-    <Container bottom='small'>
+    <Container bottom={SPACING_4}>
       <Typography size='small'>Body Small Grey</Typography>
     </Container>
-    <Container bottom='small'>
+    <Container bottom={SPACING_4}>
       <Typography size='xsmall'>Body Xsmall Grey</Typography>
     </Container>
-    <Container bottom='small'>
+    <Container bottom={SPACING_4}>
       <Typography size='xxsmall'>Body Xxsmall Grey</Typography>
     </Container>
   </div>

--- a/packages/picasso/src/Typography/story/Weights.example.tsx
+++ b/packages/picasso/src/Typography/story/Weights.example.tsx
@@ -1,15 +1,16 @@
 import React from 'react'
 import { Typography, Container } from '@toptal/picasso'
+import { SPACING_4 } from '@toptal/picasso/utils'
 
 const Example = () => (
   <div>
-    <Container bottom='small'>
+    <Container bottom={SPACING_4}>
       <Typography weight='regular'>Regular</Typography>
     </Container>
-    <Container bottom='small'>
+    <Container bottom={SPACING_4}>
       <Typography weight='semibold'>Semibold</Typography>
     </Container>
-    <Container bottom='small'>
+    <Container bottom={SPACING_4}>
       <Typography weight='semibold' as='div'>
         <Typography weight='inherit'>Inherit Semibold</Typography>
       </Typography>

--- a/packages/picasso/src/TypographyLoader/story/Default.example.tsx
+++ b/packages/picasso/src/TypographyLoader/story/Default.example.tsx
@@ -1,24 +1,25 @@
 import React from 'react'
 import { SkeletonLoader, Typography, Container } from '@toptal/picasso'
+import { SPACING_6, SPACING_2 } from '@toptal/picasso/utils'
 
 const Example = () => (
   <>
-    <Container bottom='medium'>
-      <Container bottom='xsmall'>
+    <Container bottom={SPACING_6}>
+      <Container bottom={SPACING_2}>
         <Typography>One row</Typography>
       </Container>
       <SkeletonLoader.Typography />
     </Container>
 
-    <Container bottom='medium'>
-      <Container bottom='xsmall'>
+    <Container bottom={SPACING_6}>
+      <Container bottom={SPACING_2}>
         <Typography>Two rows</Typography>
       </Container>
       <SkeletonLoader.Typography rows={2} />
     </Container>
 
-    <Container bottom='medium'>
-      <Container bottom='xsmall'>
+    <Container bottom={SPACING_6}>
+      <Container bottom={SPACING_2}>
         <Typography>Three rows</Typography>
       </Container>
       <SkeletonLoader.Typography rows={3} />

--- a/packages/picasso/src/TypographyOverflow/story/Delay.example.tsx
+++ b/packages/picasso/src/TypographyOverflow/story/Delay.example.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { TypographyOverflow, Container } from '@toptal/picasso'
+import { SPACING_8 } from '@toptal/picasso/utils'
 
 const Example = () => {
   return (
@@ -11,7 +12,7 @@ const Example = () => {
         </TypographyOverflow>
       </div>
 
-      <Container left='large'>
+      <Container left={SPACING_8}>
         <div style={{ width: 300, marginTop: 100 }}>
           <TypographyOverflow
             tooltipDelay='long'

--- a/packages/picasso/src/UserBadge/story/Custom.example.tsx
+++ b/packages/picasso/src/UserBadge/story/Custom.example.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { UserBadge, Typography, Avatar, Container } from '@toptal/picasso'
+import { SPACING_2 } from '@toptal/picasso/utils'
 
 const Example = () => (
   <div>
@@ -17,7 +18,7 @@ const Example = () => (
       <Typography variant='body' size='xsmall'>
         Worked as
       </Typography>
-      <Container left='xsmall'>
+      <Container left={SPACING_2}>
         <Typography size='xsmall'>UI specialist</Typography>
         <Typography size='xsmall'>Painter</Typography>
         <Typography size='xsmall'>Student</Typography>

--- a/packages/picasso/src/utils/Breakpoints/story/Breakpoints.example.tsx
+++ b/packages/picasso/src/utils/Breakpoints/story/Breakpoints.example.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { breakpoints } from '@toptal/picasso/utils'
+import { breakpoints, SPACING_4 } from '@toptal/picasso/utils'
 import { Grid, Paper, Image, Typography, Container } from '@toptal/picasso'
 
 const breakpointsList = Object.entries(breakpoints)
@@ -31,7 +31,7 @@ const Example = () => (
                   !isLargestBreakpoint &&
                   `${breakpointValue} px ≤ ... < ${nextBreakpointValue} px`}
               </Typography>
-              <Container top={1}>
+              <Container top={SPACING_4}>
                 <Image
                   src={`./ico-breakpoint-${breakpointName}.svg`}
                   alt={`${breakpointName}`}

--- a/packages/picasso/src/utils/Breakpoints/story/useScreens.example.tsx
+++ b/packages/picasso/src/utils/Breakpoints/story/useScreens.example.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { useScreens } from '@toptal/picasso/utils'
+import { useScreens, SPACING_8 } from '@toptal/picasso/utils'
 import type { ButtonVariantType } from '@toptal/picasso'
 import { Typography, Button, Container } from '@toptal/picasso'
 
@@ -9,7 +9,7 @@ const Example = () => {
 
   return (
     <>
-      <Container bottom={2}>
+      <Container bottom={SPACING_8}>
         <Typography variant='heading' size='medium'>
           Current screen breakpoint:{' '}
           {screenTexts({

--- a/packages/picasso/src/utils/Colors/story/Default.example.tsx
+++ b/packages/picasso/src/utils/Colors/story/Default.example.tsx
@@ -1,5 +1,5 @@
 import React, { Fragment } from 'react'
-import { palette } from '@toptal/picasso/utils'
+import { palette, SPACING_8, SPACING_4 } from '@toptal/picasso/utils'
 import { Grid, Paper, Typography, Container } from '@toptal/picasso'
 
 const colorGroups = Object.entries(palette)
@@ -8,7 +8,7 @@ const Example = () => (
   <>
     {colorGroups.map(([colorGroupName, colorGroup]) => (
       <Fragment key={colorGroupName}>
-        <Container top={2} bottom={1}>
+        <Container top={SPACING_8} bottom={SPACING_4}>
           <Typography variant='heading' size='large'>
             {colorGroupName}
           </Typography>

--- a/packages/picasso/src/utils/Formatters/story/amount.example.tsx
+++ b/packages/picasso/src/utils/Formatters/story/amount.example.tsx
@@ -1,20 +1,20 @@
 import { Container, Typography } from '@toptal/picasso'
+import { SPACING_4, formatAmount } from '@toptal/picasso/utils'
 import React from 'react'
-import { formatAmount } from '@toptal/picasso/utils'
 
 const exampleAmount1 = 1575
 const exampleAmount2 = '890'
 
 const Example = () => (
   <div>
-    <Container bottom='small'>
+    <Container bottom={SPACING_4}>
       <Typography>
         This component exposes a currency formatting utility, which converts
         numbers, into string decorated with currency symbols/codes in the
         required locale format.
       </Typography>
     </Container>
-    <Container bottom='small'>
+    <Container bottom={SPACING_4}>
       <Typography variant='heading' size='medium'>
         Without using Amount format helper
       </Typography>
@@ -23,7 +23,7 @@ const Example = () => (
         €{exampleAmount2}.
       </Typography>
     </Container>
-    <Container bottom='small'>
+    <Container bottom={SPACING_4}>
       <Typography variant='heading' size='medium'>
         Using Amount format helper
       </Typography>
@@ -33,7 +33,7 @@ const Example = () => (
         {formatAmount({ amount: exampleAmount2, currency: 'EUR' })}.
       </Typography>
     </Container>
-    <Container bottom='small'>
+    <Container bottom={SPACING_4}>
       <Typography variant='heading' size='medium'>
         Using fraction digits options:
       </Typography>

--- a/packages/picasso/src/utils/Gradients/story/HowToUse.example.tsx
+++ b/packages/picasso/src/utils/Gradients/story/HowToUse.example.tsx
@@ -1,10 +1,10 @@
 import React from 'react'
-import { gradients } from '@toptal/picasso/utils'
+import { gradients, SPACING_4 } from '@toptal/picasso/utils'
 import { Typography, Container } from '@toptal/picasso'
 
 const Example = () => (
   <>
-    <Container bottom='small'>
+    <Container bottom={SPACING_4}>
       <Typography>
         Use the gradient just directly from Picasso and apply it to any element
         as{' '}

--- a/packages/picasso/src/utils/Notifications/story/GeneralNotifications.example.tsx
+++ b/packages/picasso/src/utils/Notifications/story/GeneralNotifications.example.tsx
@@ -1,14 +1,14 @@
 import React from 'react'
 import { Button, Container } from '@toptal/picasso'
+import { SPACING_4, useNotifications } from '@toptal/picasso/utils'
 import { Pencil16 } from '@toptal/picasso/Icon'
-import { useNotifications } from '@toptal/picasso/utils'
 
 const Example = () => {
   const { showInfo } = useNotifications()
 
   return (
     <Container flex>
-      <Container right={1}>
+      <Container right={SPACING_4}>
         <Button
           variant='secondary'
           onClick={() => showInfo('General information message')}

--- a/packages/picasso/src/utils/Notifications/story/MaxNotifications.example.tsx
+++ b/packages/picasso/src/utils/Notifications/story/MaxNotifications.example.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react'
 import { NotificationsProvider } from '@toptal/picasso-provider'
 import type { NotificationsProviderProps } from '@toptal/picasso-provider'
 import { Button, Slider, Typography, Container } from '@toptal/picasso'
-import { useNotifications } from '@toptal/picasso/utils'
+import { SPACING_8, useNotifications } from '@toptal/picasso/utils'
 
 const App = () => {
   const { showInfo } = useNotifications()
@@ -30,8 +30,8 @@ const Example = () => {
 
   return (
     <div style={{ width: 500 }}>
-      <Container bottom={2}>
-        <Container bottom={2}>
+      <Container bottom={SPACING_8}>
+        <Container bottom={SPACING_8}>
           <Typography variant='heading' size='small'>
             maxNotifications
           </Typography>

--- a/packages/picasso/src/utils/Notifications/story/Variants.example.tsx
+++ b/packages/picasso/src/utils/Notifications/story/Variants.example.tsx
@@ -1,13 +1,13 @@
 import React from 'react'
 import { Button, Container } from '@toptal/picasso'
-import { useNotifications } from '@toptal/picasso/utils'
+import { SPACING_4, useNotifications } from '@toptal/picasso/utils'
 
 const Example = () => {
   const { showError, showInfo, showSuccess } = useNotifications()
 
   return (
     <Container flex>
-      <Container right={1}>
+      <Container right={SPACING_4}>
         <Button
           data-testid='error-trigger'
           variant='secondary'
@@ -16,7 +16,7 @@ const Example = () => {
           Show error notification
         </Button>
       </Container>
-      <Container right={1}>
+      <Container right={SPACING_4}>
         <Button
           data-testid='success-trigger'
           variant='secondary'

--- a/packages/picasso/src/utils/Shadows/story/Default.example.tsx
+++ b/packages/picasso/src/utils/Shadows/story/Default.example.tsx
@@ -1,10 +1,10 @@
 import type { ReactNode } from 'react'
 import React from 'react'
-import { shadows } from '@toptal/picasso/utils'
+import { shadows, SPACING_6, SPACING_8, SPACING_4 } from '@toptal/picasso/utils'
 import { Container, Typography, Grid } from '@toptal/picasso'
 
 const Example = () => (
-  <Container flex direction='column' gap='medium' top='large'>
+  <Container flex direction='column' gap={SPACING_6} top={SPACING_8}>
     <Grid spacing={80}>
       <ShadowBox shadow={shadows[0]} index={0} description={'none'} />
       <ShadowBox
@@ -31,7 +31,7 @@ interface ShadowBoxProps {
 }
 const ShadowBox = ({ index, shadow, description }: ShadowBoxProps) => (
   <Grid.Item sm={4}>
-    <Container padded='small' style={{ boxShadow: shadow }}>
+    <Container padded={SPACING_4} style={{ boxShadow: shadow }}>
       <Typography variant='heading' size='large' align='center'>
         {index}
       </Typography>

--- a/packages/picasso/src/utils/Shadows/story/HowToUse.example.tsx
+++ b/packages/picasso/src/utils/Shadows/story/HowToUse.example.tsx
@@ -1,13 +1,13 @@
 import React from 'react'
-import { shadows } from '@toptal/picasso/utils'
+import { shadows, SPACING_4 } from '@toptal/picasso/utils'
 import { Container, Typography } from '@toptal/picasso'
 
 const Example = () => (
   <Typography>
     Use the shadow just directly from Picasso. For example,
     <Container
-      padded='small'
-      top='small'
+      padded={SPACING_4}
+      top={SPACING_4}
       style={{ boxShadow: shadows[4] }}
       rounded
     >

--- a/packages/picasso/src/utils/Transitions/Rotate180/story/Default.example.tsx
+++ b/packages/picasso/src/utils/Transitions/Rotate180/story/Default.example.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react'
-import { Transitions } from '@toptal/picasso/utils'
+import { Transitions, SPACING_6 } from '@toptal/picasso/utils'
 import { Button, Container } from '@toptal/picasso'
 import { ArrowDownMinor24 } from '@toptal/picasso/Icon'
 
@@ -10,7 +10,7 @@ const Example = () => {
     <>
       <Button onClick={() => setIsRotated(!isRotated)}>Rotate</Button>
 
-      <Container top='medium'>
+      <Container top={SPACING_6}>
         <Transitions.Rotate180 on={isRotated}>
           <ArrowDownMinor24 />
         </Transitions.Rotate180>


### PR DESCRIPTION
[FX-4261]

### Description

⚠️ The https://picasso.toptal.net/?path=/story/tutorials-how-to-use-spacings--how-to-use-spacings story is updated in https://github.com/toptal/picasso/pull/3871

This pull request updates spacings in Picasso Storybook. Most of the changes are coming from running the codemod

```
npx @toptal/picasso-codemod v38.1.0 **/*.example.ts*
npx @toptal/picasso-codemod v38.1.0 .storybook/**/*.example.ts*
```

There are custom adjustments (for example, converting `top={7}` to `style={{ paddingTop: '7rem' }}`), they were kept to have the same view of stories.

### How to test

<!-- The temploy link will be automatically updated when the temploy is deployed -->
- [Temploy](https://picasso.toptal.net/fx-4261-update-guidelines-on-spacing-usage)
- Check any story that uses `Container` with spacing properties, they should be updated


<img width="1209" alt="Screenshot 2023-09-14 at 22 56 28" src="https://github.com/toptal/picasso/assets/1390758/fdcd4d2c-8abf-499b-9119-6d7723388617">


### Development checks

- [N/A] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [N/A] Annotate all `props` in component with documentation
- [N/A] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [N/A] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [N/A] Covered with tests ([visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md) included)

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-4261]: https://toptal-core.atlassian.net/browse/FX-4261?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ