### PR TITLE
fix: notifications display in drawer

### DIFF
--- a/.changeset/gold-toys-unite.md
+++ b/.changeset/gold-toys-unite.md
@@ -1,0 +1,7 @@
+---
+'@toptal/picasso-provider': patch
+---
+
+### Notifications
+
+- fix notifications display when drawer is opened

--- a/cypress/component/Page.spec.tsx
+++ b/cypress/component/Page.spec.tsx
@@ -293,7 +293,7 @@ describe('Page', () => {
         cy.getByTestId(TestIds.NOTIFICATION_CONTENT).contains('Test content')
         cy.get('body').happoScreenshot({
           component,
-          variant: `notification-display-with-top-bar-and-drawer`,
+          variant: `notification-display-with-top-bar`,
         })
       })
     })

--- a/cypress/component/Page.spec.tsx
+++ b/cypress/component/Page.spec.tsx
@@ -286,7 +286,7 @@ describe('Page', () => {
 
   describe('when TopBar exists', () => {
     describe('when drawer is open', () => {
-      it('renders notifications with extra top padding', () => {
+      it('renders notifications without extra top padding', () => {
         cy.mount(<DrawerContent />)
         cy.getByTestId(TestIds.DRAWER_BUTTON).click()
         cy.getByTestId(TestIds.NOTIFICATION_BUTTON_DRAWER).click()
@@ -299,7 +299,7 @@ describe('Page', () => {
     })
 
     describe('when drawer is not open', () => {
-      it('renders notifications without extra top padding', () => {
+      it('renders notifications with extra top padding', () => {
         cy.mount(<DrawerContent />)
         cy.getByTestId(TestIds.NOTIFICATION_BUTTON_PAGE).click()
         cy.getByTestId(TestIds.NOTIFICATION_CONTENT).contains('Test content')

--- a/cypress/component/Page.spec.tsx
+++ b/cypress/component/Page.spec.tsx
@@ -91,7 +91,11 @@ const RightContent = () => (
   </Page.TopBarMenu>
 )
 
-const Content = () => {
+const Content = ({
+  showNotificationButton,
+}: {
+  showNotificationButton?: boolean
+}) => {
   const { showInfo } = useNotifications()
 
   return (
@@ -101,22 +105,24 @@ const Content = () => {
           Banner example
         </Typography>
       </Container>
-      <Container>
-        <Button
-          data-testid={TestIds.NOTIFICATION_BUTTON_PAGE}
-          onClick={() =>
-            showInfo(
-              <div data-testid={TestIds.NOTIFICATION_CONTENT}>
-                Test content
-              </div>,
-              undefined,
-              { persist: true }
-            )
-          }
-        >
-          Show notification
-        </Button>
-      </Container>
+      {showNotificationButton && (
+        <Container>
+          <Button
+            data-testid={TestIds.NOTIFICATION_BUTTON_PAGE}
+            onClick={() =>
+              showInfo(
+                <div data-testid={TestIds.NOTIFICATION_CONTENT}>
+                  Test content
+                </div>,
+                undefined,
+                { persist: true }
+              )
+            }
+          >
+            Show notification
+          </Button>
+        </Container>
+      )}
       <Paragraph />
       <Paragraph />
       <Paragraph />
@@ -129,7 +135,11 @@ const Content = () => {
   )
 }
 
-const DrawerContent = () => {
+const DrawerContent = ({
+  showNotificationButton,
+}: {
+  showNotificationButton?: boolean
+}) => {
   const [open, setOpen] = React.useState(false)
   const { showInfo } = useNotifications()
 
@@ -153,24 +163,26 @@ const DrawerContent = () => {
           </Page.Sidebar.Menu>
         </Page.Sidebar>
         <Page.Article>
-          <Content />
+          <Content showNotificationButton />
           <Drawer onClose={() => setOpen(false)} open={open}>
             <Container>Drawer Content</Container>
             <Container>
-              <Button
-                data-testid={TestIds.NOTIFICATION_BUTTON_DRAWER}
-                onClick={() =>
-                  showInfo(
-                    <div data-testid={TestIds.NOTIFICATION_CONTENT}>
-                      Test content
-                    </div>,
-                    undefined,
-                    { persist: true }
-                  )
-                }
-              >
-                Show notification
-              </Button>
+              {showNotificationButton && (
+                <Button
+                  data-testid={TestIds.NOTIFICATION_BUTTON_DRAWER}
+                  onClick={() =>
+                    showInfo(
+                      <div data-testid={TestIds.NOTIFICATION_CONTENT}>
+                        Test content
+                      </div>,
+                      undefined,
+                      { persist: true }
+                    )
+                  }
+                >
+                  Show notification
+                </Button>
+              )}
             </Container>
           </Drawer>
           <Button
@@ -287,7 +299,7 @@ describe('Page', () => {
   describe('when TopBar exists', () => {
     describe('when drawer is open', () => {
       it('renders notifications without extra top padding', () => {
-        cy.mount(<DrawerContent />)
+        cy.mount(<DrawerContent showNotificationButton />)
         cy.getByTestId(TestIds.DRAWER_BUTTON).click()
         cy.getByTestId(TestIds.NOTIFICATION_BUTTON_DRAWER).click()
         cy.getByTestId(TestIds.NOTIFICATION_CONTENT).contains('Test content')
@@ -300,7 +312,7 @@ describe('Page', () => {
 
     describe('when drawer is not open', () => {
       it('renders notifications with extra top padding', () => {
-        cy.mount(<DrawerContent />)
+        cy.mount(<DrawerContent showNotificationButton />)
         cy.getByTestId(TestIds.NOTIFICATION_BUTTON_PAGE).click()
         cy.getByTestId(TestIds.NOTIFICATION_CONTENT).contains('Test content')
         cy.get('body').happoScreenshot({

--- a/cypress/component/Page.spec.tsx
+++ b/cypress/component/Page.spec.tsx
@@ -9,6 +9,7 @@ import {
   Typography,
 } from '@toptal/picasso'
 import { HAPPO_TARGETS, getHappoTargets } from '@toptal/picasso/test-utils'
+import { useNotifications } from '@toptal/picasso/utils'
 
 const component = 'Page'
 const containerHeight = '30rem'
@@ -19,6 +20,9 @@ enum TestIds {
   MENU_CONTAINER = 'menu-container',
   DRAWER_BUTTON = 'drawer-button',
   MENU_ITEM = 'menu_item',
+  NOTIFICATION_BUTTON_PAGE = 'notification-button-page',
+  NOTIFICATION_BUTTON_DRAWER = 'notification-button-drawer',
+  NOTIFICATION_CONTENT = 'notification-content',
 }
 
 const Paragraph = () => (
@@ -87,26 +91,47 @@ const RightContent = () => (
   </Page.TopBarMenu>
 )
 
-const Content = () => (
-  <Container top='small' bottom='small'>
-    <Container bottom='small'>
-      <Typography align='center' variant='heading' size='large'>
-        Banner example
-      </Typography>
+const Content = () => {
+  const { showInfo } = useNotifications()
+
+  return (
+    <Container top='small' bottom='small'>
+      <Container bottom='small'>
+        <Typography align='center' variant='heading' size='large'>
+          Banner example
+        </Typography>
+      </Container>
+      <Container>
+        <Button
+          data-testid={TestIds.NOTIFICATION_BUTTON_PAGE}
+          onClick={() =>
+            showInfo(
+              <div data-testid={TestIds.NOTIFICATION_CONTENT}>
+                Test content
+              </div>,
+              undefined,
+              { persist: true }
+            )
+          }
+        >
+          Show notification
+        </Button>
+      </Container>
+      <Paragraph />
+      <Paragraph />
+      <Paragraph />
+      <Paragraph />
+      <Paragraph />
+      <Paragraph />
+      <Paragraph />
+      <Paragraph />
     </Container>
-    <Paragraph />
-    <Paragraph />
-    <Paragraph />
-    <Paragraph />
-    <Paragraph />
-    <Paragraph />
-    <Paragraph />
-    <Paragraph />
-  </Container>
-)
+  )
+}
 
 const DrawerContent = () => {
   const [open, setOpen] = React.useState(false)
+  const { showInfo } = useNotifications()
 
   return (
     <Page data-testid={TestIds.WRAPPER}>
@@ -130,7 +155,23 @@ const DrawerContent = () => {
         <Page.Article>
           <Content />
           <Drawer onClose={() => setOpen(false)} open={open}>
-            Drawer Content
+            <Container>Drawer Content</Container>
+            <Container>
+              <Button
+                data-testid={TestIds.NOTIFICATION_BUTTON_DRAWER}
+                onClick={() =>
+                  showInfo(
+                    <div data-testid={TestIds.NOTIFICATION_CONTENT}>
+                      Test content
+                    </div>,
+                    undefined,
+                    { persist: true }
+                  )
+                }
+              >
+                Show notification
+              </Button>
+            </Container>
           </Drawer>
           <Button
             data-testid={TestIds.DRAWER_BUTTON}
@@ -239,6 +280,33 @@ describe('Page', () => {
       cy.get('body').happoScreenshot({
         component,
         variant: 'default/sidebar-scroll-bottom',
+      })
+    })
+  })
+
+  describe.only('when TopBar exists', () => {
+    describe('when drawer is open', () => {
+      it('renders notifications with extra top padding', () => {
+        cy.mount(<DrawerContent />)
+        cy.getByTestId(TestIds.DRAWER_BUTTON).click()
+        cy.getByTestId(TestIds.NOTIFICATION_BUTTON_DRAWER).click()
+        cy.getByTestId(TestIds.NOTIFICATION_CONTENT).contains('Test content')
+        cy.get('body').happoScreenshot({
+          component,
+          variant: `notification-display-with-top-bar-and-drawer`,
+        })
+      })
+    })
+
+    describe('when drawer is not open', () => {
+      it('renders notifications without extra top padding', () => {
+        cy.mount(<DrawerContent />)
+        cy.getByTestId(TestIds.NOTIFICATION_BUTTON_PAGE).click()
+        cy.getByTestId(TestIds.NOTIFICATION_CONTENT).contains('Test content')
+        cy.get('body').happoScreenshot({
+          component,
+          variant: `notification-display-with-top-bar-and-drawer`,
+        })
       })
     })
   })

--- a/cypress/component/Page.spec.tsx
+++ b/cypress/component/Page.spec.tsx
@@ -284,7 +284,7 @@ describe('Page', () => {
     })
   })
 
-  describe.only('when TopBar exists', () => {
+  describe('when TopBar exists', () => {
     describe('when drawer is open', () => {
       it('renders notifications with extra top padding', () => {
         cy.mount(<DrawerContent />)

--- a/packages/picasso-provider/src/Picasso/NotificationsProvider/NotificationsProvider.tsx
+++ b/packages/picasso-provider/src/Picasso/NotificationsProvider/NotificationsProvider.tsx
@@ -3,7 +3,7 @@ import { makeStyles } from '@material-ui/core/styles'
 import { SnackbarProvider } from 'notistack'
 import React from 'react'
 
-import { usePageDrawer, usePageTopBar } from '../RootContext'
+import { useDrawer, usePageTopBar } from '../RootContext'
 import styles from './styles'
 
 const useStyles = makeStyles<Theme>(styles, {
@@ -25,7 +25,7 @@ const NotificationsProvider = ({
   maxNotifications = 5,
 }: NotificationsProviderProps) => {
   const { hasTopBar } = usePageTopBar()
-  const { hasDrawer } = usePageDrawer()
+  const { hasDrawer } = useDrawer()
   const classes = useStyles()
 
   const containerAnchorOriginTop =

--- a/packages/picasso-provider/src/Picasso/NotificationsProvider/NotificationsProvider.tsx
+++ b/packages/picasso-provider/src/Picasso/NotificationsProvider/NotificationsProvider.tsx
@@ -3,7 +3,7 @@ import { makeStyles } from '@material-ui/core/styles'
 import { SnackbarProvider } from 'notistack'
 import React from 'react'
 
-import { usePageTopBar } from '../RootContext'
+import { usePageDrawer, usePageTopBar } from '../RootContext'
 import styles from './styles'
 
 const useStyles = makeStyles<Theme>(styles, {
@@ -25,11 +25,11 @@ const NotificationsProvider = ({
   maxNotifications = 5,
 }: NotificationsProviderProps) => {
   const { hasTopBar } = usePageTopBar()
+  const { hasDrawer } = usePageDrawer()
   const classes = useStyles()
 
-  const containerAnchorOriginTop = hasTopBar
-    ? classes.rootWithMargin
-    : undefined
+  const containerAnchorOriginTop =
+    hasTopBar && !hasDrawer ? classes.rootWithMargin : undefined
 
   return (
     <SnackbarProvider

--- a/packages/picasso-provider/src/Picasso/RootContext.ts
+++ b/packages/picasso-provider/src/Picasso/RootContext.ts
@@ -46,15 +46,6 @@ export const usePageTopBar = () => {
   }
 }
 
-export const usePageDrawer = () => {
-  const context = useContext(RootContext)
-
-  return {
-    hasDrawer: context.hasDrawer,
-    setHasDrawer: context.setHasDrawer,
-  }
-}
-
 export const useDrawer = () => {
   const context = useContext(RootContext)
 

--- a/packages/picasso-provider/src/Picasso/RootContext.ts
+++ b/packages/picasso-provider/src/Picasso/RootContext.ts
@@ -46,6 +46,15 @@ export const usePageTopBar = () => {
   }
 }
 
+export const usePageDrawer = () => {
+  const context = useContext(RootContext)
+
+  return {
+    hasDrawer: context.hasDrawer,
+    setHasDrawer: context.setHasDrawer,
+  }
+}
+
 export const useDrawer = () => {
   const context = useContext(RootContext)
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -15207,14 +15207,14 @@ json-stringify-safe@^5.0.1, json-stringify-safe@~5.0.1:
   resolved "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
   integrity sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==
 
-json5@1, json5@^1.0.1, json5@^2.1.1:
+json5@1, json5@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/json5/-/json5-1.0.2.tgz#63d98d60f21b313b77c4d6da18bfa69d80e1d593"
   integrity sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==
   dependencies:
     minimist "^1.2.0"
 
-json5@2.2.3, json5@^2.1.0, json5@^2.1.2, json5@^2.1.3, json5@^2.2.0, json5@^2.2.2, json5@^2.2.3, json5@^2.x:
+json5@2.2.3, json5@^2.1.0, json5@^2.1.1, json5@^2.1.2, json5@^2.1.3, json5@^2.2.0, json5@^2.2.2, json5@^2.2.3, json5@^2.x:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.3.tgz#78cd6f1a19bdc12b73db5ad0c61efd66c1e29283"
   integrity sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==


### PR DESCRIPTION
[FX-4367]

### Description

This pull request fixes the notifications display when drawer is opened on the page – even if there is a TopBar on the page, notifications should not have `4.5rem` top padding when the drawer is opened (discussed in https://toptal-core.slack.com/archives/GG3F4AS4T/p1695287511772779).

⚠️ This fix is blocking the https://toptal-core.atlassian.net/browse/FX-4344

### How to test

<!-- The temploy link will be automatically updated when the temploy is deployed -->
- [Temploy](https://picasso.toptal.net/FX-NULL-fix-notifications-in-drawer)
- Test in Staff Portal
  - check out https://github.com/toptal/staff-portal/pull/11085, run `yarn install`
  - log in as any user who has open operational issues (for example, https://staff-portal.toptal.net/staff/3254509)
  - run Staff Portal via `yarn start`, open operational issues drawer, and click `Resolve` button for any of issues
  - the notification should not have extra space from the top (please see the **Screenshots** section for details)

### Screen recordings

**Before**

📹 Please see the https://drive.google.com/file/d/1QQcSyZqk_oDXj9qL_lI5AL27ltSQz-mr/view?usp=sharing

**After**

📹 Please see the https://drive.google.com/file/d/1L3d-X5BBwKS88GOtZtRycJ-Idtkht6GK/view?usp=sharing


### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [N/A] Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [N/A] Annotate all `props` in component with documentation
- [N/A] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [N/A] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests ([visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md) included)
- [x] ⚠️ Delete https://github.com/toptal/staff-portal/pull/11085 before merge

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-4367]: https://toptal-core.atlassian.net/browse/FX-4367?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ