### PR TITLE
fix: keep classes for string and base spacings

### DIFF
--- a/jest.spec.mjs
+++ b/jest.spec.mjs
@@ -11,6 +11,12 @@ const config = {
     '^@toptal/picasso$': '<rootDir>/packages/picasso/src/index.ts',
     '^@toptal/picasso-provider$':
       '<rootDir>/packages/picasso-provider/src/index.ts',
+    '^@toptal/picasso-provider/utils$':
+      '<rootDir>/packages/picasso-provider/src/utils/index.ts',
+    '^@toptal/picasso-provider/Picasso/config$':
+      '<rootDir>/packages/picasso-provider/src/Picasso/config/index.ts',      
+    '^@toptal/picasso-provider/index$':
+      '<rootDir>/packages/picasso-provider/src/index.ts',      
     '^@toptal/picasso-pictograms$':
       '<rootDir>/packages/picasso-pictograms/src/index.ts',
     '^@toptal/picasso-rich-text-editor$':

--- a/packages/picasso-provider/src/Picasso/config/index.ts
+++ b/packages/picasso-provider/src/Picasso/config/index.ts
@@ -20,6 +20,7 @@ export {
   default as spacings,
   SpacingEnum,
   isResponsiveSpacing,
+  isPicassoSpacing,
 } from './spacings'
 export type {
   Sizes,

--- a/packages/picasso-provider/src/Picasso/config/spacings.ts
+++ b/packages/picasso-provider/src/Picasso/config/spacings.ts
@@ -36,13 +36,19 @@ export enum SpacingEnum {
 
 class PicassoSpacing {
   #value: PicassoSpacingValues
+  #index: number
 
-  private constructor(value: PicassoSpacingValues) {
+  private constructor(value: PicassoSpacingValues, index: number) {
     this.#value = value
+    this.#index = index
   }
 
-  static create(value: PicassoSpacingValues): PicassoSpacing {
-    return new PicassoSpacing(value)
+  static create(value: PicassoSpacingValues, index: number): PicassoSpacing {
+    return new PicassoSpacing(value, index)
+  }
+
+  indexOf(): number {
+    return this.#index
   }
 
   valueOf(): PicassoSpacingValues {
@@ -65,15 +71,15 @@ export const isResponsiveSpacing = (
 ): spacing is ResponsiveSpacingType =>
   typeof spacing == 'object' && !isPicassoSpacing(spacing)
 
-export const SPACING_0 = PicassoSpacing.create(0)
-export const SPACING_1 = PicassoSpacing.create(0.25)
-export const SPACING_2 = PicassoSpacing.create(0.5)
-export const SPACING_3 = PicassoSpacing.create(0.75)
-export const SPACING_4 = PicassoSpacing.create(1)
-export const SPACING_6 = PicassoSpacing.create(1.5)
-export const SPACING_8 = PicassoSpacing.create(2)
-export const SPACING_10 = PicassoSpacing.create(2.5)
-export const SPACING_12 = PicassoSpacing.create(3)
+export const SPACING_0 = PicassoSpacing.create(0, 0)
+export const SPACING_1 = PicassoSpacing.create(0.25, 1)
+export const SPACING_2 = PicassoSpacing.create(0.5, 2)
+export const SPACING_3 = PicassoSpacing.create(0.75, 3)
+export const SPACING_4 = PicassoSpacing.create(1, 4)
+export const SPACING_6 = PicassoSpacing.create(1.5, 6)
+export const SPACING_8 = PicassoSpacing.create(2, 8)
+export const SPACING_10 = PicassoSpacing.create(2.5, 10)
+export const SPACING_12 = PicassoSpacing.create(3, 12)
 
 export default {
   SPACING_0,
@@ -85,4 +91,4 @@ export default {
   SPACING_8,
   SPACING_10,
   SPACING_12,
-}
+} as Record<string, PicassoSpacing>

--- a/packages/picasso-provider/src/utils/index.ts
+++ b/packages/picasso-provider/src/utils/index.ts
@@ -1,2 +1,3 @@
 export { default as isBrowser } from './is-browser'
 export { default as kebabToCamelCase } from './kebab-to-camel-case'
+export { default as snakeToCamelCase } from './snake-to-camel-case'

--- a/packages/picasso-provider/src/utils/snake-to-camel-case.test.ts
+++ b/packages/picasso-provider/src/utils/snake-to-camel-case.test.ts
@@ -1,0 +1,41 @@
+import { default as snakeToCamelCase } from './snake-to-camel-case'
+
+describe('snakeToCamelCase', () => {
+  it('converts a capitalized snake case string to camel case', () => {
+    const snakeCaseString = 'CAPITALISED_SNAKE_CASE'
+    const expectedCamelCaseString = 'capitalisedSnakeCase'
+
+    const result = snakeToCamelCase(snakeCaseString)
+
+    expect(result).toBe(expectedCamelCaseString)
+  })
+
+  it('converts a single word to camel case', () => {
+    const snakeCaseString = 'SINGLE'
+    const expectedCamelCaseString = 'single'
+
+    const result = snakeToCamelCase(snakeCaseString)
+
+    expect(result).toBe(expectedCamelCaseString)
+  })
+
+  it('converts an empty string to an empty camel case string', () => {
+    const snakeCaseString = ''
+    const expectedCamelCaseString = ''
+
+    const result = snakeToCamelCase(snakeCaseString)
+
+    expect(result).toBe(expectedCamelCaseString)
+  })
+
+  describe('when "capitalise" is true', () => {
+    it('capitalises first word', () => {
+      const snakeCaseString = 'SOME_TEST_TEXT1'
+      const expectedCamelCaseString = 'SomeTestText1'
+
+      const result = snakeToCamelCase(snakeCaseString, true)
+
+      expect(result).toBe(expectedCamelCaseString)
+    })
+  })
+})

--- a/packages/picasso-provider/src/utils/snake-to-camel-case.ts
+++ b/packages/picasso-provider/src/utils/snake-to-camel-case.ts
@@ -1,0 +1,16 @@
+const snakeToCamelCase = (snakeCase: string, capitalise = false): string => {
+  const words = snakeCase.toLowerCase().split('_')
+  const camelCase = words
+    .map((word, index) => {
+      if (!capitalise && index === 0) {
+        return word
+      }
+
+      return word.charAt(0).toUpperCase() + word.slice(1)
+    })
+    .join('')
+
+  return camelCase
+}
+
+export default snakeToCamelCase

--- a/packages/picasso/src/AccountSelect/__snapshots__/test.tsx.snap
+++ b/packages/picasso/src/AccountSelect/__snapshots__/test.tsx.snap
@@ -29,8 +29,7 @@ exports[`AccountSelect renders 1`] = `
                 class="MuiTypography-root MuiLink-root MuiLink-underlineHover PicassoLink-root PicassoAccountSelect-accountLink PicassoLink-blue PicassoLink-noUnderline MuiTypography-colorPrimary"
               >
                 <div
-                  class="PicassoContainer-centerAlignItems PicassoContainer-spaceBetweenJustifyContent PicassoContainer-flex"
-                  style="padding: 1.5rem;"
+                  class="PicassoContainer-mediumPadding PicassoContainer-centerAlignItems PicassoContainer-spaceBetweenJustifyContent PicassoContainer-flex"
                 >
                   <div
                     class="PicassoContainer-flexStartAlignItems PicassoContainer-flex PicassoUserBadge-root"
@@ -102,8 +101,7 @@ exports[`AccountSelect renders 1`] = `
                 href="#"
               >
                 <div
-                  class="PicassoContainer-centerAlignItems PicassoContainer-spaceBetweenJustifyContent PicassoContainer-flex"
-                  style="padding: 1.5rem;"
+                  class="PicassoContainer-mediumPadding PicassoContainer-centerAlignItems PicassoContainer-spaceBetweenJustifyContent PicassoContainer-flex"
                 >
                   <div
                     class="PicassoContainer-flexStartAlignItems PicassoContainer-flex PicassoUserBadge-root"
@@ -175,8 +173,7 @@ exports[`AccountSelect renders 1`] = `
                 href="#"
               >
                 <div
-                  class="PicassoContainer-centerAlignItems PicassoContainer-spaceBetweenJustifyContent PicassoContainer-flex"
-                  style="padding: 1.5rem;"
+                  class="PicassoContainer-mediumPadding PicassoContainer-centerAlignItems PicassoContainer-spaceBetweenJustifyContent PicassoContainer-flex"
                 >
                   <div
                     class="PicassoContainer-flexStartAlignItems PicassoContainer-flex PicassoUserBadge-root"

--- a/packages/picasso/src/Alert/__snapshots__/test.tsx.snap
+++ b/packages/picasso/src/Alert/__snapshots__/test.tsx.snap
@@ -6,16 +6,14 @@ exports[`Alert renders 1`] = `
     class="Picasso-root"
   >
     <div
-      class="PicassoContainer-yellowVariant PicassoContainer-spaceBetweenJustifyContent PicassoContainer-rounded PicassoContainer-flex"
+      class="PicassoContainer-yellowVariant PicassoContainer-smallPadding PicassoContainer-spaceBetweenJustifyContent PicassoContainer-rounded PicassoContainer-flex"
       role="alert"
-      style="padding: 1rem;"
     >
       <div
         class="PicassoContainer-flex PicassoContainer-inline PicassoAlert-root"
       >
         <div
-          class="PicassoContainer-centerAlignItems PicassoContainer-flex PicassoAlert-iconWrapper"
-          style="margin-right: 1rem;"
+          class="PicassoContainer-rightsmallMargin PicassoContainer-centerAlignItems PicassoContainer-flex PicassoAlert-iconWrapper"
         >
           <svg
             class="PicassoSvgExclamation16-root PicassoSvgExclamation16-yellow"

--- a/packages/picasso/src/AlertInline/__snapshots__/test.tsx.snap
+++ b/packages/picasso/src/AlertInline/__snapshots__/test.tsx.snap
@@ -9,8 +9,7 @@ exports[`Alert renders 1`] = `
       class="PicassoContainer-flex PicassoContainer-inline PicassoAlertInline-root"
     >
       <div
-        class="PicassoContainer-centerAlignItems PicassoContainer-flex PicassoAlertInline-iconWrapper"
-        style="margin-right: 0.5rem;"
+        class="PicassoContainer-rightxsmallMargin PicassoContainer-centerAlignItems PicassoContainer-flex PicassoAlertInline-iconWrapper"
       >
         <svg
           class="PicassoSvgExclamationSolid16-root PicassoSvgExclamationSolid16-yellow"

--- a/packages/picasso/src/ApplicationUpdateNotification/__snapshots__/test.tsx.snap
+++ b/packages/picasso/src/ApplicationUpdateNotification/__snapshots__/test.tsx.snap
@@ -30,8 +30,7 @@ exports[`ApplicationUpdateNotification renders 1`] = `
           Please reload to update.
         </h3>
         <div
-          class="ApplicationUpdateNotification-positionRelative"
-          style="margin-top: 0.5rem;"
+          class="PicassoContainer-topxsmallMargin ApplicationUpdateNotification-positionRelative"
         >
           <p
             class="MuiTypography-root PicassoTypography-bodyMedium PicassoTypography-inherit MuiTypography-body1"
@@ -40,8 +39,7 @@ exports[`ApplicationUpdateNotification renders 1`] = `
           </p>
         </div>
         <div
-          class=""
-          style="margin-top: 1rem;"
+          class="PicassoContainer-topsmallMargin"
         >
           <button
             class="MuiButtonBase-root PicassoButton-medium PicassoButton-secondary PicassoButton-root"

--- a/packages/picasso/src/ButtonSplit/__snapshots__/test.tsx.snap
+++ b/packages/picasso/src/ButtonSplit/__snapshots__/test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`ButtonSplit closes menu on click to the item 1`] = `
 <svg
-  class="PicassoSvgArrowDownMinor24-root-162"
+  class="PicassoSvgArrowDownMinor24-root-206"
   style="min-width: 24px; min-height: 24px;"
   viewBox="0 0 24 24"
 >
@@ -67,7 +67,7 @@ exports[`ButtonSplit default render 1`] = `
 
 exports[`ButtonSplit renders arrow down icon for a closed menu 1`] = `
 <svg
-  class="PicassoSvgArrowDownMinor16-root-162"
+  class="PicassoSvgArrowDownMinor16-root-206"
   style="min-width: 16px; min-height: 16px;"
   viewBox="0 0 16 16"
 >
@@ -79,7 +79,7 @@ exports[`ButtonSplit renders arrow down icon for a closed menu 1`] = `
 
 exports[`ButtonSplit renders arrow up icon for an opened menu 1`] = `
 <svg
-  class="PicassoSvgArrowDownMinor16-root-162 PicassoButtonSplit-rotated-12"
+  class="PicassoSvgArrowDownMinor16-root-206 PicassoButtonSplit-rotated-12"
   style="min-width: 16px; min-height: 16px;"
   viewBox="0 0 16 16"
 >

--- a/packages/picasso/src/ButtonSplit/__snapshots__/test.tsx.snap
+++ b/packages/picasso/src/ButtonSplit/__snapshots__/test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`ButtonSplit closes menu on click to the item 1`] = `
 <svg
-  class="PicassoSvgArrowDownMinor24-root-122"
+  class="PicassoSvgArrowDownMinor24-root-152"
   style="min-width: 24px; min-height: 24px;"
   viewBox="0 0 24 24"
 >
@@ -67,7 +67,7 @@ exports[`ButtonSplit default render 1`] = `
 
 exports[`ButtonSplit renders arrow down icon for a closed menu 1`] = `
 <svg
-  class="PicassoSvgArrowDownMinor16-root-122"
+  class="PicassoSvgArrowDownMinor16-root-152"
   style="min-width: 16px; min-height: 16px;"
   viewBox="0 0 16 16"
 >
@@ -79,7 +79,7 @@ exports[`ButtonSplit renders arrow down icon for a closed menu 1`] = `
 
 exports[`ButtonSplit renders arrow up icon for an opened menu 1`] = `
 <svg
-  class="PicassoSvgArrowDownMinor16-root-122 PicassoButtonSplit-rotated-12"
+  class="PicassoSvgArrowDownMinor16-root-152 PicassoButtonSplit-rotated-12"
   style="min-width: 16px; min-height: 16px;"
   viewBox="0 0 16 16"
 >

--- a/packages/picasso/src/ButtonSplit/__snapshots__/test.tsx.snap
+++ b/packages/picasso/src/ButtonSplit/__snapshots__/test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`ButtonSplit closes menu on click to the item 1`] = `
 <svg
-  class="PicassoSvgArrowDownMinor24-root-152"
+  class="PicassoSvgArrowDownMinor24-root-162"
   style="min-width: 24px; min-height: 24px;"
   viewBox="0 0 24 24"
 >
@@ -67,7 +67,7 @@ exports[`ButtonSplit default render 1`] = `
 
 exports[`ButtonSplit renders arrow down icon for a closed menu 1`] = `
 <svg
-  class="PicassoSvgArrowDownMinor16-root-152"
+  class="PicassoSvgArrowDownMinor16-root-162"
   style="min-width: 16px; min-height: 16px;"
   viewBox="0 0 16 16"
 >
@@ -79,7 +79,7 @@ exports[`ButtonSplit renders arrow down icon for a closed menu 1`] = `
 
 exports[`ButtonSplit renders arrow up icon for an opened menu 1`] = `
 <svg
-  class="PicassoSvgArrowDownMinor16-root-152 PicassoButtonSplit-rotated-12"
+  class="PicassoSvgArrowDownMinor16-root-162 PicassoButtonSplit-rotated-12"
   style="min-width: 16px; min-height: 16px;"
   viewBox="0 0 16 16"
 >

--- a/packages/picasso/src/Calendar/__snapshots__/test.tsx.snap
+++ b/packages/picasso/src/Calendar/__snapshots__/test.tsx.snap
@@ -19,8 +19,7 @@ exports[`Calendar renders 1`] = `
               class="rdp-month rdp-caption_start rdp-caption_end"
             >
               <div
-                class="PicassoContainer-spaceBetweenJustifyContent PicassoContainer-flex"
-                style="margin-bottom: 1.5rem;"
+                class="PicassoContainer-bottommediumMargin PicassoContainer-spaceBetweenJustifyContent PicassoContainer-flex"
               >
                 <button
                   aria-label="Previous month"

--- a/packages/picasso/src/Container/Container.tsx
+++ b/packages/picasso/src/Container/Container.tsx
@@ -15,6 +15,10 @@ import { documentable, forwardRef } from '../utils/forward-ref'
 import kebabToCamelCase from '../utils/kebab-to-camel-case'
 import type { AlignItemsType, JustifyContentType, VariantType } from './styles'
 import styles from './styles'
+import {
+  filterOutStringAndPicassoSpacing,
+  getBaseSpacingClasses,
+} from './utils'
 
 type ContainerType = 'div' | 'span'
 
@@ -28,9 +32,6 @@ const useStyles = makeStyles<
 >(styles, {
   name: 'PicassoContainer',
 })
-
-const filterStringValue = (value?: SpacingType) =>
-  typeof value === 'string' ? undefined : value
 
 const useResponsiveProps = makeResponsiveSpacingProps(
   [
@@ -166,13 +167,18 @@ export const Container: ContainerProps = documentable(
       const classes = useStyles(props)
       const { className: responsiveClasses, style: responsiveStyle } =
         useResponsiveProps({
-          'margin-top': filterStringValue(top),
-          'margin-bottom': filterStringValue(bottom),
-          'margin-left': filterStringValue(left),
-          'margin-right': filterStringValue(right),
-          padding: filterStringValue(padded),
-          gap: filterStringValue(gap),
+          'margin-top': filterOutStringAndPicassoSpacing(top),
+          'margin-bottom': filterOutStringAndPicassoSpacing(bottom),
+          'margin-left': filterOutStringAndPicassoSpacing(left),
+          'margin-right': filterOutStringAndPicassoSpacing(right),
+          padding: filterOutStringAndPicassoSpacing(padded),
+          gap: filterOutStringAndPicassoSpacing(gap),
         })
+
+      const baseSpacingClasses = getBaseSpacingClasses(
+        { top, left, bottom, right, gap, padded },
+        classes
+      )
 
       return (
         <Component
@@ -205,6 +211,7 @@ export const Container: ContainerProps = documentable(
               [classes[kebabToCamelCase(direction || '')]]:
                 direction && direction !== 'row',
             },
+            baseSpacingClasses,
             responsiveClasses,
             className
           )}

--- a/packages/picasso/src/Container/Container.tsx
+++ b/packages/picasso/src/Container/Container.tsx
@@ -29,6 +29,9 @@ const useStyles = makeStyles<
   name: 'PicassoContainer',
 })
 
+const filterStringValue = (value?: SpacingType) =>
+  typeof value === 'string' ? undefined : value
+
 const useResponsiveProps = makeResponsiveSpacingProps(
   [
     'margin-top',
@@ -163,12 +166,12 @@ export const Container: ContainerProps = documentable(
       const classes = useStyles(props)
       const { className: responsiveClasses, style: responsiveStyle } =
         useResponsiveProps({
-          'margin-top': top,
-          'margin-bottom': bottom,
-          'margin-left': left,
-          'margin-right': right,
-          padding: padded,
-          gap,
+          'margin-top': filterStringValue(top),
+          'margin-bottom': filterStringValue(bottom),
+          'margin-left': filterStringValue(left),
+          'margin-right': filterStringValue(right),
+          padding: filterStringValue(padded),
+          gap: filterStringValue(gap),
         })
 
       return (
@@ -178,6 +181,14 @@ export const Container: ContainerProps = documentable(
           className={cx(
             classes[`${variant}Variant`],
             {
+              [classes[`${padded}Padding`]]: typeof padded === 'string',
+              [classes[`${gap}Gap`]]: typeof gap === 'string',
+
+              [classes[`top${top}Margin`]]: typeof top === 'string',
+              [classes[`bottom${bottom}Margin`]]: typeof bottom === 'string',
+              [classes[`left${left}Margin`]]: typeof left === 'string',
+              [classes[`right${right}Margin`]]: typeof right === 'string',
+
               [classes[`${align}TextAlign`]]: typeof align === 'string',
 
               [classes[`${kebabToCamelCase(alignItems || '')}AlignItems`]]:

--- a/packages/picasso/src/Container/styles.ts
+++ b/packages/picasso/src/Container/styles.ts
@@ -2,10 +2,16 @@ import type { Theme } from '@material-ui/core/styles'
 import { createStyles } from '@material-ui/core/styles'
 import { capitalize, type Color } from '@material-ui/core'
 import type { SimplePaletteColorOptions } from '@material-ui/core/styles/createPalette'
-import { spacingToRem } from '@toptal/picasso-shared'
-import type { DeprecatedSpacingType } from '@toptal/picasso-provider/index'
-
-import kebabToCamelCase from '../utils/kebab-to-camel-case'
+import {
+  spacingToRem,
+  type DeprecatedSpacingType,
+  type PicassoSpacing,
+  spacings,
+} from '@toptal/picasso-provider/index'
+import {
+  kebabToCamelCase,
+  snakeToCamelCase,
+} from '@toptal/picasso-provider/utils'
 
 const textAlignVariants = [
   'inherit',
@@ -78,9 +84,27 @@ const paddings = spacingVariants.reduce((acc, variant) => {
   return acc
 }, Object.create(null))
 
+const basePaddings = Object.keys(spacings).reduce((acc, spacingKey) => {
+  acc[`${snakeToCamelCase(spacingKey)}Padding`] = {
+    padding: spacingToRem(spacings[spacingKey] as PicassoSpacing),
+  }
+
+  return acc
+}, Object.create(null))
+
+console.log('@@@ paddings', paddings, basePaddings)
+
 const gaps = spacingVariants.reduce((acc, variant) => {
   acc[`${variant}Gap`] = {
     gap: spacingToRem(variant as DeprecatedSpacingType),
+  }
+
+  return acc
+}, Object.create(null))
+
+const baseGaps = Object.keys(spacings).reduce((acc, spacingKey) => {
+  acc[`${snakeToCamelCase(spacingKey)}Gap`] = {
+    gap: spacingToRem(spacings[spacingKey] as PicassoSpacing),
   }
 
   return acc
@@ -100,11 +124,28 @@ const marginClasses = (direction: Direction) => {
   }
 }
 
+const baseMarginClasses = (direction: Direction) => {
+  return Object.keys(spacings).reduce((acc, spacingKey) => {
+    acc[`${direction}${snakeToCamelCase(spacingKey, true)}Margin`] = {
+      [`margin${capitalize(direction)}`]: spacingToRem(spacings[spacingKey]),
+    }
+
+    return acc
+  }, Object.create(null))
+}
+
 const margins: MapOfClasses = {
   ...marginClasses('top'),
   ...marginClasses('left'),
   ...marginClasses('bottom'),
   ...marginClasses('right'),
+}
+
+const baseMargins: MapOfClasses = {
+  ...baseMarginClasses('top'),
+  ...baseMarginClasses('left'),
+  ...baseMarginClasses('bottom'),
+  ...baseMarginClasses('right'),
 }
 
 const alignItems: MapOfClasses = {}
@@ -180,9 +221,12 @@ export default ({ palette, sizes: { borderRadius } }: Theme) =>
     greyVariant: colorVariant(palette.grey),
 
     ...paddings,
+    ...basePaddings,
     ...margins,
+    ...baseMargins,
     ...alignItems,
     ...justifyContent,
     ...textAlignItems,
     ...gaps,
+    ...baseGaps,
   })

--- a/packages/picasso/src/Container/styles.ts
+++ b/packages/picasso/src/Container/styles.ts
@@ -1,7 +1,9 @@
 import type { Theme } from '@material-ui/core/styles'
 import { createStyles } from '@material-ui/core/styles'
-import type { Color } from '@material-ui/core'
+import { capitalize, type Color } from '@material-ui/core'
 import type { SimplePaletteColorOptions } from '@material-ui/core/styles/createPalette'
+import { spacingToRem } from '@toptal/picasso-shared'
+import type { DeprecatedSpacingType } from '@toptal/picasso-provider/index'
 
 import kebabToCamelCase from '../utils/kebab-to-camel-case'
 
@@ -53,6 +55,56 @@ const colorVariant = (colorOptions?: SimplePaletteColorOptions | Color) => {
   return {
     backgroundColor: colorOptions.lighter2 ?? colorOptions.lighter,
   }
+}
+
+const directionVariants = ['top', 'left', 'bottom', 'right'] as const
+
+const spacingVariants = [
+  'xsmall',
+  'small',
+  'medium',
+  'large',
+  'xlarge',
+] as const
+
+type Direction = (typeof directionVariants)[number]
+type Spacing = (typeof spacingVariants)[number]
+
+const paddings = spacingVariants.reduce((acc, variant) => {
+  acc[`${variant}Padding`] = {
+    padding: spacingToRem(variant as DeprecatedSpacingType),
+  }
+
+  return acc
+}, Object.create(null))
+
+const gaps = spacingVariants.reduce((acc, variant) => {
+  acc[`${variant}Gap`] = {
+    gap: spacingToRem(variant as DeprecatedSpacingType),
+  }
+
+  return acc
+}, Object.create(null))
+
+const marginClassDef = (direction: Direction, spacing: Spacing) => ({
+  [`margin${capitalize(direction)}`]: spacingToRem(spacing),
+})
+
+const marginClasses = (direction: Direction) => {
+  return {
+    [`${direction}${'xsmall'}Margin`]: marginClassDef(direction, 'xsmall'),
+    [`${direction}${'small'}Margin`]: marginClassDef(direction, 'small'),
+    [`${direction}${'medium'}Margin`]: marginClassDef(direction, 'medium'),
+    [`${direction}${'large'}Margin`]: marginClassDef(direction, 'large'),
+    [`${direction}${'xlarge'}Margin`]: marginClassDef(direction, 'xlarge'),
+  }
+}
+
+const margins: MapOfClasses = {
+  ...marginClasses('top'),
+  ...marginClasses('left'),
+  ...marginClasses('bottom'),
+  ...marginClasses('right'),
 }
 
 const alignItems: MapOfClasses = {}
@@ -127,7 +179,10 @@ export default ({ palette, sizes: { borderRadius } }: Theme) =>
 
     greyVariant: colorVariant(palette.grey),
 
+    ...paddings,
+    ...margins,
     ...alignItems,
     ...justifyContent,
     ...textAlignItems,
+    ...gaps,
   })

--- a/packages/picasso/src/Container/styles.ts
+++ b/packages/picasso/src/Container/styles.ts
@@ -92,8 +92,6 @@ const basePaddings = Object.keys(spacings).reduce((acc, spacingKey) => {
   return acc
 }, Object.create(null))
 
-console.log('@@@ paddings', paddings, basePaddings)
-
 const gaps = spacingVariants.reduce((acc, variant) => {
   acc[`${variant}Gap`] = {
     gap: spacingToRem(variant as DeprecatedSpacingType),

--- a/packages/picasso/src/Container/utils/filter-out-strings-and-picasso-spacings.test.ts
+++ b/packages/picasso/src/Container/utils/filter-out-strings-and-picasso-spacings.test.ts
@@ -1,0 +1,28 @@
+import { SPACING_12 } from '../../utils'
+import filterOutStringAndPicassoSpacing from './filter-out-strings-and-picasso-spacings'
+
+describe('filterOutStringAndPicassoSpacing', () => {
+  describe('when PicassoSpacing value is provded', () => {
+    it('returns undefined', () => {
+      const result = filterOutStringAndPicassoSpacing(SPACING_12)
+
+      expect(result).toBeUndefined()
+    })
+  })
+
+  describe('when string constant value is provded', () => {
+    it('returns undefined', () => {
+      const result = filterOutStringAndPicassoSpacing('small')
+
+      expect(result).toBeUndefined()
+    })
+  })
+
+  describe('when number value is provded', () => {
+    it('returns number value', () => {
+      const result = filterOutStringAndPicassoSpacing(100)
+
+      expect(result).toBe(100)
+    })
+  })
+})

--- a/packages/picasso/src/Container/utils/filter-out-strings-and-picasso-spacings.ts
+++ b/packages/picasso/src/Container/utils/filter-out-strings-and-picasso-spacings.ts
@@ -1,0 +1,9 @@
+import type { SpacingType } from '@toptal/picasso-provider/Picasso/config'
+import { isPicassoSpacing } from '@toptal/picasso-provider/Picasso/config'
+
+const filterOutStringAndPicassoSpacing = (value?: SpacingType) =>
+  typeof value === 'string' || (value && isPicassoSpacing(value))
+    ? undefined
+    : value
+
+export default filterOutStringAndPicassoSpacing

--- a/packages/picasso/src/Container/utils/get-base-spacing-classes.test.ts
+++ b/packages/picasso/src/Container/utils/get-base-spacing-classes.test.ts
@@ -1,0 +1,44 @@
+import {
+  SPACING_1,
+  SPACING_2,
+  SPACING_3,
+  SPACING_4,
+  SPACING_6,
+  SPACING_8,
+} from '../../utils'
+import getBaseSpacingClasses from './get-base-spacing-classes'
+
+describe('getBaseSpacingClasses', () => {
+  describe('when spacing properties are provided as BASE spacings', () => {
+    it('returns list of matching CSS classes', () => {
+      const result = getBaseSpacingClasses(
+        {
+          gap: SPACING_1,
+          padded: SPACING_2,
+          top: SPACING_3,
+          right: SPACING_4,
+          bottom: SPACING_6,
+          left: SPACING_8,
+          randomProperty: SPACING_6,
+        },
+        {
+          spacing1Gap: 'spacing1Gap-class',
+          spacing2Padding: 'spacing2Padding-class',
+          topSpacing3Margin: 'topSpacing3Margin-class',
+          rightSpacing4Margin: 'rightSpacing4Margin-class',
+          bottomSpacing6Margin: 'bottomSpacing6Margin-class',
+          leftSpacing8Margin: 'leftSpacing8Margin-class',
+        }
+      )
+
+      expect(result).toEqual([
+        'spacing2Padding-class',
+        'spacing1Gap-class',
+        'topSpacing3Margin-class',
+        'rightSpacing4Margin-class',
+        'bottomSpacing6Margin-class',
+        'leftSpacing8Margin-class',
+      ])
+    })
+  })
+})

--- a/packages/picasso/src/Container/utils/get-base-spacing-classes.ts
+++ b/packages/picasso/src/Container/utils/get-base-spacing-classes.ts
@@ -1,0 +1,33 @@
+import type { ClassNameMap } from '@material-ui/core/styles/withStyles'
+import type { SpacingType } from '@toptal/picasso-provider/Picasso/config'
+import { isPicassoSpacing } from '@toptal/picasso-provider/Picasso/config'
+
+const getBaseSpacingClasses = (
+  properties: Record<string, SpacingType | undefined>,
+  classes: ClassNameMap<string>
+) => {
+  const baseSpacingClasses = []
+  const { padded, gap } = properties
+
+  if (padded && isPicassoSpacing(padded)) {
+    baseSpacingClasses.push(classes[`spacing${padded.indexOf()}Padding`])
+  }
+
+  if (gap && isPicassoSpacing(gap)) {
+    baseSpacingClasses.push(classes[`spacing${gap.indexOf()}Gap`])
+  }
+
+  ;['top', 'right', 'bottom', 'left'].forEach(property => {
+    const value = properties[property]
+
+    if (value && isPicassoSpacing(value)) {
+      baseSpacingClasses.push(
+        classes[`${property}Spacing${value.indexOf()}Margin`]
+      )
+    }
+  })
+
+  return baseSpacingClasses
+}
+
+export default getBaseSpacingClasses

--- a/packages/picasso/src/Container/utils/index.ts
+++ b/packages/picasso/src/Container/utils/index.ts
@@ -1,0 +1,2 @@
+export { default as getBaseSpacingClasses } from './get-base-spacing-classes'
+export { default as filterOutStringAndPicassoSpacing } from './filter-out-strings-and-picasso-spacings'

--- a/packages/picasso/src/FileList/__snapshots__/test.tsx.snap
+++ b/packages/picasso/src/FileList/__snapshots__/test.tsx.snap
@@ -18,8 +18,7 @@ exports[`FileList renders 1`] = `
             class="PicassoContainer-flex"
           >
             <div
-              class=""
-              style="margin-right: 0.5rem;"
+              class="PicassoContainer-rightxsmallMargin"
             >
               <svg
                 class="PicassoSvgAttachment16-root PicassoSvgAttachment16-darkGrey"

--- a/packages/picasso/src/FileListItem/__snapshots__/test.tsx.snap
+++ b/packages/picasso/src/FileListItem/__snapshots__/test.tsx.snap
@@ -15,8 +15,7 @@ exports[`FileListItem renders 1`] = `
           class="PicassoContainer-flex"
         >
           <div
-            class=""
-            style="margin-right: 0.5rem;"
+            class="PicassoContainer-rightxsmallMargin"
           >
             <svg
               class="PicassoSvgAttachment16-root PicassoSvgAttachment16-darkGrey"

--- a/packages/picasso/src/Helpbox/__snapshots__/test.tsx.snap
+++ b/packages/picasso/src/Helpbox/__snapshots__/test.tsx.snap
@@ -6,12 +6,10 @@ exports[`Helpbox renders 1`] = `
     class="Picasso-root"
   >
     <div
-      class="PicassoContainer-bordered PicassoContainer-rounded PicassoHelpbox-root"
-      style="padding: 1.5rem;"
+      class="PicassoContainer-mediumPadding PicassoContainer-bordered PicassoContainer-rounded PicassoHelpbox-root"
     >
       <div
-        class=""
-        style="margin-bottom: 1rem;"
+        class="PicassoContainer-bottomsmallMargin"
       >
         <h4
           class="MuiTypography-root MuiTypography-h4"

--- a/packages/picasso/src/MenuItem/__snapshots__/test.tsx.snap
+++ b/packages/picasso/src/MenuItem/__snapshots__/test.tsx.snap
@@ -54,8 +54,7 @@ exports[`MenuItem renders checkmarked 1`] = `
             class="PicassoContainer-centerAlignItems PicassoContainer-flex"
           >
             <div
-              class="PicassoContainer-flex PicassoContainer-inline PicassoMenuItem-iconContainer"
-              style="margin-right: 0.5rem;"
+              class="PicassoContainer-rightxsmallMargin PicassoContainer-flex PicassoContainer-inline PicassoMenuItem-iconContainer"
             >
               <svg
                 class="PicassoSvgCheckMinor16-root"
@@ -176,8 +175,7 @@ exports[`MenuItem renders with a sub menu arrow 1`] = `
               1
             </span>
             <div
-              class="PicassoContainer-flex PicassoContainer-inline"
-              style="margin-left: 0.5rem;"
+              class="PicassoContainer-leftxsmallMargin PicassoContainer-flex PicassoContainer-inline"
             >
               <svg
                 class="PicassoSvgChevronMinor16-root"

--- a/packages/picasso/src/NonNativeSelect/__snapshots__/test.tsx.snap
+++ b/packages/picasso/src/NonNativeSelect/__snapshots__/test.tsx.snap
@@ -85,8 +85,7 @@ exports[`NonNativeSelect renders custom options 1`] = `
               class="PicassoContainer-centerAlignItems PicassoContainer-flex"
             >
               <div
-                class="PicassoContainer-flex PicassoContainer-inline PicassoMenuItem-iconContainer"
-                style="margin-right: 0.5rem;"
+                class="PicassoContainer-rightxsmallMargin PicassoContainer-flex PicassoContainer-inline PicassoMenuItem-iconContainer"
               />
               <div
                 data-testid="custom-option-1"
@@ -116,8 +115,7 @@ exports[`NonNativeSelect renders custom options 1`] = `
               class="PicassoContainer-centerAlignItems PicassoContainer-flex"
             >
               <div
-                class="PicassoContainer-flex PicassoContainer-inline PicassoMenuItem-iconContainer"
-                style="margin-right: 0.5rem;"
+                class="PicassoContainer-rightxsmallMargin PicassoContainer-flex PicassoContainer-inline PicassoMenuItem-iconContainer"
               />
               <div
                 data-testid="custom-option-2"
@@ -147,8 +145,7 @@ exports[`NonNativeSelect renders custom options 1`] = `
               class="PicassoContainer-centerAlignItems PicassoContainer-flex"
             >
               <div
-                class="PicassoContainer-flex PicassoContainer-inline PicassoMenuItem-iconContainer"
-                style="margin-right: 0.5rem;"
+                class="PicassoContainer-rightxsmallMargin PicassoContainer-flex PicassoContainer-inline PicassoMenuItem-iconContainer"
               />
               <div
                 data-testid="custom-option-3"
@@ -195,8 +192,7 @@ exports[`NonNativeSelect renders description 1`] = `
               class="PicassoContainer-centerAlignItems PicassoContainer-flex"
             >
               <div
-                class="PicassoContainer-flex PicassoContainer-inline PicassoMenuItem-iconContainer"
-                style="margin-right: 0.5rem;"
+                class="PicassoContainer-rightxsmallMargin PicassoContainer-flex PicassoContainer-inline PicassoMenuItem-iconContainer"
               />
               <span
                 class="PicassoMenuItem-stringContent"
@@ -205,8 +201,8 @@ exports[`NonNativeSelect renders description 1`] = `
               </span>
             </div>
             <div
-              class="PicassoMenuItem-description"
-              style="margin-top: 0.25rem; margin-left: 1.5rem;"
+              class="PicassoContainer-leftmediumMargin PicassoMenuItem-description"
+              style="margin-top: 0.25rem;"
             >
               description1
             </div>
@@ -232,8 +228,7 @@ exports[`NonNativeSelect renders description 1`] = `
               class="PicassoContainer-centerAlignItems PicassoContainer-flex"
             >
               <div
-                class="PicassoContainer-flex PicassoContainer-inline PicassoMenuItem-iconContainer"
-                style="margin-right: 0.5rem;"
+                class="PicassoContainer-rightxsmallMargin PicassoContainer-flex PicassoContainer-inline PicassoMenuItem-iconContainer"
               />
               <span
                 class="PicassoMenuItem-stringContent"
@@ -242,8 +237,8 @@ exports[`NonNativeSelect renders description 1`] = `
               </span>
             </div>
             <div
-              class="PicassoMenuItem-description"
-              style="margin-top: 0.25rem; margin-left: 1.5rem;"
+              class="PicassoContainer-leftmediumMargin PicassoMenuItem-description"
+              style="margin-top: 0.25rem;"
             >
               description2
             </div>
@@ -269,8 +264,7 @@ exports[`NonNativeSelect renders description 1`] = `
               class="PicassoContainer-centerAlignItems PicassoContainer-flex"
             >
               <div
-                class="PicassoContainer-flex PicassoContainer-inline PicassoMenuItem-iconContainer"
-                style="margin-right: 0.5rem;"
+                class="PicassoContainer-rightxsmallMargin PicassoContainer-flex PicassoContainer-inline PicassoMenuItem-iconContainer"
               />
               <span
                 class="PicassoMenuItem-stringContent"
@@ -279,8 +273,8 @@ exports[`NonNativeSelect renders description 1`] = `
               </span>
             </div>
             <div
-              class="PicassoMenuItem-description"
-              style="margin-top: 0.25rem; margin-left: 1.5rem;"
+              class="PicassoContainer-leftmediumMargin PicassoMenuItem-description"
+              style="margin-top: 0.25rem;"
             >
               description3
             </div>

--- a/packages/picasso/src/NonNativeSelectLoader/__snapshots__/test.tsx.snap
+++ b/packages/picasso/src/NonNativeSelectLoader/__snapshots__/test.tsx.snap
@@ -17,8 +17,7 @@ exports[`NonNativeSelectLoader renders 1`] = `
           class="PicassoScrollMenu-scrollView"
         >
           <div
-            class=""
-            style="padding: 1rem;"
+            class="PicassoContainer-smallPadding"
           >
             <div
               class="PicassoLoader-root"

--- a/packages/picasso/src/NonNativeSelectOption/__snapshots__/test.tsx.snap
+++ b/packages/picasso/src/NonNativeSelectOption/__snapshots__/test.tsx.snap
@@ -24,8 +24,7 @@ exports[`NonNativeSelectOption renders 1`] = `
             class="PicassoContainer-centerAlignItems PicassoContainer-flex"
           >
             <div
-              class="PicassoContainer-flex PicassoContainer-inline PicassoMenuItem-iconContainer"
-              style="margin-right: 0.5rem;"
+              class="PicassoContainer-rightxsmallMargin PicassoContainer-flex PicassoContainer-inline PicassoMenuItem-iconContainer"
             />
             <span
               class="PicassoMenuItem-stringContent"
@@ -34,8 +33,8 @@ exports[`NonNativeSelectOption renders 1`] = `
             </span>
           </div>
           <div
-            class="PicassoMenuItem-description"
-            style="margin-top: 0.25rem; margin-left: 1.5rem;"
+            class="PicassoContainer-leftmediumMargin PicassoMenuItem-description"
+            style="margin-top: 0.25rem;"
           >
             Test description
           </div>
@@ -70,8 +69,7 @@ exports[`NonNativeSelectOption sets attributes correctly 1`] = `
             class="PicassoContainer-centerAlignItems PicassoContainer-flex"
           >
             <div
-              class="PicassoContainer-flex PicassoContainer-inline PicassoMenuItem-iconContainer"
-              style="margin-right: 0.5rem;"
+              class="PicassoContainer-rightxsmallMargin PicassoContainer-flex PicassoContainer-inline PicassoMenuItem-iconContainer"
             >
               <svg
                 class="PicassoSvgCheckMinor16-root"
@@ -90,8 +88,8 @@ exports[`NonNativeSelectOption sets attributes correctly 1`] = `
             </span>
           </div>
           <div
-            class="PicassoMenuItem-description"
-            style="margin-top: 0.25rem; margin-left: 1.5rem;"
+            class="PicassoContainer-leftmediumMargin PicassoMenuItem-description"
+            style="margin-top: 0.25rem;"
           >
             Test description
           </div>

--- a/packages/picasso/src/Note/__snapshots__/test.tsx.snap
+++ b/packages/picasso/src/Note/__snapshots__/test.tsx.snap
@@ -18,8 +18,7 @@ exports[`Note renders 1`] = `
         </h4>
       </div>
       <div
-        class=""
-        style="margin-bottom: 1rem;"
+        class="PicassoContainer-bottomsmallMargin"
       >
         <p
           class="MuiTypography-root PicassoTypography-bodyXsmall PicassoTypography-darkGrey MuiTypography-body1"

--- a/packages/picasso/src/NotificationActions/__snapshots__/test.tsx.snap
+++ b/packages/picasso/src/NotificationActions/__snapshots__/test.tsx.snap
@@ -33,8 +33,7 @@ exports[`NotificationActions renders 1`] = `
           >
             The time zone in your profile is set to (UTC -08:00) America - Los
             <div
-              class="PicassoContainer-flex"
-              style="margin-top: 0.5rem;"
+              class="PicassoContainer-topxsmallMargin PicassoContainer-flex"
             >
               Test
             </div>

--- a/packages/picasso/src/PageTopBar/__snapshots__/test.tsx.snap
+++ b/packages/picasso/src/PageTopBar/__snapshots__/test.tsx.snap
@@ -18,8 +18,7 @@ exports[`Page.TopBar render with custom logo 1`] = `
             class="PicassoTopBar-left"
           >
             <div
-              class="PicassoContainer-centerAlignItems PicassoContainer-flex"
-              style="gap: 1rem;"
+              class="PicassoContainer-smallGap PicassoContainer-centerAlignItems PicassoContainer-flex"
             >
               <div
                 class="PicassoDropdown-root PageHamburger-root PageHamburger-hidden"
@@ -77,8 +76,7 @@ exports[`Page.TopBar render with custom logo 1`] = `
                   class="PicassoTopBar-divider"
                 />
                 <div
-                  class=""
-                  style="margin-left: 1rem;"
+                  class="PicassoContainer-leftsmallMargin"
                 >
                   <p
                     class="MuiTypography-root PicassoTypography-bodyInherit PicassoTypography-invert MuiTypography-body1"
@@ -117,8 +115,7 @@ exports[`Page.TopBar render with link 1`] = `
             class="PicassoTopBar-left"
           >
             <div
-              class="PicassoContainer-centerAlignItems PicassoContainer-flex"
-              style="gap: 1rem;"
+              class="PicassoContainer-smallGap PicassoContainer-centerAlignItems PicassoContainer-flex"
             >
               <div
                 class="PicassoDropdown-root PageHamburger-root PageHamburger-hidden"
@@ -202,8 +199,7 @@ exports[`Page.TopBar render with link 1`] = `
                   class="PicassoTopBar-divider"
                 />
                 <div
-                  class=""
-                  style="margin-left: 1rem;"
+                  class="PicassoContainer-leftsmallMargin"
                 >
                   <p
                     class="MuiTypography-root PicassoTypography-bodyInherit PicassoTypography-invert MuiTypography-body1"
@@ -242,8 +238,7 @@ exports[`Page.TopBar renders 1`] = `
             class="PicassoTopBar-left"
           >
             <div
-              class="PicassoContainer-centerAlignItems PicassoContainer-flex"
-              style="gap: 1rem;"
+              class="PicassoContainer-smallGap PicassoContainer-centerAlignItems PicassoContainer-flex"
             >
               <div
                 class="PicassoDropdown-root PageHamburger-root PageHamburger-hidden"
@@ -322,8 +317,7 @@ exports[`Page.TopBar renders 1`] = `
                   class="PicassoTopBar-divider"
                 />
                 <div
-                  class=""
-                  style="margin-left: 1rem;"
+                  class="PicassoContainer-leftsmallMargin"
                 >
                   <p
                     class="MuiTypography-root PicassoTypography-bodyInherit PicassoTypography-invert MuiTypography-body1"

--- a/packages/picasso/src/ProgressBar/__snapshots__/test.tsx.snap
+++ b/packages/picasso/src/ProgressBar/__snapshots__/test.tsx.snap
@@ -38,8 +38,7 @@ exports[`ProgressBar renders with percentage 1`] = `
         />
       </div>
       <div
-        class=""
-        style="margin-left: 0.5rem;"
+        class="PicassoContainer-leftxsmallMargin"
       >
         <p
           class="MuiTypography-root PicassoTypography-bodyXsmall PicassoTypography-semibold PicassoProgressBar-percentageValue MuiTypography-body1"

--- a/packages/picasso/src/Quote/__snapshots__/test.tsx.snap
+++ b/packages/picasso/src/Quote/__snapshots__/test.tsx.snap
@@ -9,8 +9,7 @@ exports[`Quote renders 1`] = `
       class="PicassoContainer-flex"
     >
       <div
-        class=""
-        style="margin-right: 1rem;"
+        class="PicassoContainer-rightsmallMargin"
       >
         <svg
           class="PicassoQuoteMark-root"

--- a/packages/picasso/src/SidebarItem/__snapshots__/test.tsx.snap
+++ b/packages/picasso/src/SidebarItem/__snapshots__/test.tsx.snap
@@ -51,8 +51,7 @@ exports[`SidebarItem collapsible menu is expanded when one of the children is se
                           class="PicassoContainer-centerAlignItems PicassoContainer-flex"
                         >
                           <div
-                            class="PicassoContainer-centerAlignItems PicassoContainer-flex PicassoContainer-inline PicassoSidebarItemContent-noWrap"
-                            style="gap: 0.5rem;"
+                            class="PicassoContainer-xsmallGap PicassoContainer-centerAlignItems PicassoContainer-flex PicassoContainer-inline PicassoSidebarItemContent-noWrap"
                           >
                             <div
                               class="PicassoContainer-centerAlignItems PicassoContainer-flex PicassoSidebarItemContent-noWrap"
@@ -116,8 +115,7 @@ exports[`SidebarItem collapsible menu is expanded when one of the children is se
                                   class="PicassoContainer-centerAlignItems PicassoContainer-flex"
                                 >
                                   <div
-                                    class="PicassoContainer-centerAlignItems PicassoContainer-flex PicassoContainer-inline PicassoSidebarItemContent-noWrap"
-                                    style="gap: 0.5rem;"
+                                    class="PicassoContainer-xsmallGap PicassoContainer-centerAlignItems PicassoContainer-flex PicassoContainer-inline PicassoSidebarItemContent-noWrap"
                                   >
                                     <div
                                       class="PicassoContainer-centerAlignItems PicassoContainer-flex PicassoSidebarItemContent-noWrap"
@@ -199,8 +197,7 @@ exports[`SidebarItem collapsible menu is expanded when one of the children is se
                           class="PicassoContainer-centerAlignItems PicassoContainer-flex"
                         >
                           <div
-                            class="PicassoContainer-centerAlignItems PicassoContainer-flex PicassoContainer-inline PicassoSidebarItemContent-noWrap"
-                            style="gap: 0.5rem;"
+                            class="PicassoContainer-xsmallGap PicassoContainer-centerAlignItems PicassoContainer-flex PicassoContainer-inline PicassoSidebarItemContent-noWrap"
                           >
                             <div
                               class="PicassoContainer-centerAlignItems PicassoContainer-flex PicassoSidebarItemContent-noWrap"
@@ -264,8 +261,7 @@ exports[`SidebarItem collapsible menu is expanded when one of the children is se
                                   class="PicassoContainer-centerAlignItems PicassoContainer-flex"
                                 >
                                   <div
-                                    class="PicassoContainer-centerAlignItems PicassoContainer-flex PicassoContainer-inline PicassoSidebarItemContent-noWrap"
-                                    style="gap: 0.5rem;"
+                                    class="PicassoContainer-xsmallGap PicassoContainer-centerAlignItems PicassoContainer-flex PicassoContainer-inline PicassoSidebarItemContent-noWrap"
                                   >
                                     <div
                                       class="PicassoContainer-centerAlignItems PicassoContainer-flex PicassoSidebarItemContent-noWrap"
@@ -317,8 +313,7 @@ exports[`SidebarItem don't use accordion for non-collapsible with menu 1`] = `
             class="PicassoContainer-centerAlignItems PicassoContainer-flex"
           >
             <div
-              class="PicassoContainer-centerAlignItems PicassoContainer-flex PicassoContainer-inline PicassoSidebarItemContent-noWrap"
-              style="gap: 0.5rem;"
+              class="PicassoContainer-xsmallGap PicassoContainer-centerAlignItems PicassoContainer-flex PicassoContainer-inline PicassoSidebarItemContent-noWrap"
             >
               <svg
                 class="PicassoSvgCandidates16-root"
@@ -365,8 +360,7 @@ exports[`SidebarItem don't use accordion for non-collapsible with menu 1`] = `
                 class="PicassoContainer-centerAlignItems PicassoContainer-flex"
               >
                 <div
-                  class="PicassoContainer-centerAlignItems PicassoContainer-flex PicassoContainer-inline PicassoSidebarItemContent-noWrap"
-                  style="gap: 0.5rem;"
+                  class="PicassoContainer-xsmallGap PicassoContainer-centerAlignItems PicassoContainer-flex PicassoContainer-inline PicassoSidebarItemContent-noWrap"
                 >
                   <div
                     class="PicassoContainer-centerAlignItems PicassoContainer-flex PicassoSidebarItemContent-noWrap"
@@ -409,8 +403,7 @@ exports[`SidebarItem is selected 1`] = `
             class="PicassoContainer-centerAlignItems PicassoContainer-flex"
           >
             <div
-              class="PicassoContainer-centerAlignItems PicassoContainer-flex PicassoContainer-inline PicassoSidebarItemContent-noWrap"
-              style="gap: 0.5rem;"
+              class="PicassoContainer-xsmallGap PicassoContainer-centerAlignItems PicassoContainer-flex PicassoContainer-inline PicassoSidebarItemContent-noWrap"
             >
               <svg
                 class="PicassoSvgCandidates16-root"
@@ -460,8 +453,7 @@ exports[`SidebarItem renders 1`] = `
             class="PicassoContainer-centerAlignItems PicassoContainer-flex"
           >
             <div
-              class="PicassoContainer-centerAlignItems PicassoContainer-flex PicassoContainer-inline PicassoSidebarItemContent-noWrap"
-              style="gap: 0.5rem;"
+              class="PicassoContainer-xsmallGap PicassoContainer-centerAlignItems PicassoContainer-flex PicassoContainer-inline PicassoSidebarItemContent-noWrap"
             >
               <div
                 class="PicassoContainer-centerAlignItems PicassoContainer-flex PicassoSidebarItemContent-noWrap"
@@ -515,8 +507,7 @@ exports[`SidebarItem use accordion for collapsible with menu 1`] = `
                   class="PicassoContainer-centerAlignItems PicassoContainer-flex"
                 >
                   <div
-                    class="PicassoContainer-centerAlignItems PicassoContainer-flex PicassoContainer-inline PicassoSidebarItemContent-noWrap"
-                    style="gap: 0.5rem;"
+                    class="PicassoContainer-xsmallGap PicassoContainer-centerAlignItems PicassoContainer-flex PicassoContainer-inline PicassoSidebarItemContent-noWrap"
                   >
                     <svg
                       class="PicassoSvgCandidates16-root"
@@ -589,8 +580,7 @@ exports[`SidebarItem use accordion for collapsible with menu 1`] = `
                           class="PicassoContainer-centerAlignItems PicassoContainer-flex"
                         >
                           <div
-                            class="PicassoContainer-centerAlignItems PicassoContainer-flex PicassoContainer-inline PicassoSidebarItemContent-noWrap"
-                            style="gap: 0.5rem;"
+                            class="PicassoContainer-xsmallGap PicassoContainer-centerAlignItems PicassoContainer-flex PicassoContainer-inline PicassoSidebarItemContent-noWrap"
                           >
                             <div
                               class="PicassoContainer-centerAlignItems PicassoContainer-flex PicassoSidebarItemContent-noWrap"
@@ -638,8 +628,7 @@ exports[`SidebarItem with icon 1`] = `
             class="PicassoContainer-centerAlignItems PicassoContainer-flex"
           >
             <div
-              class="PicassoContainer-centerAlignItems PicassoContainer-flex PicassoContainer-inline PicassoSidebarItemContent-noWrap"
-              style="gap: 0.5rem;"
+              class="PicassoContainer-xsmallGap PicassoContainer-centerAlignItems PicassoContainer-flex PicassoContainer-inline PicassoSidebarItemContent-noWrap"
             >
               <svg
                 class="PicassoSvgCandidates16-root"

--- a/packages/picasso/src/SidebarLogo/__snapshots__/test.tsx.snap
+++ b/packages/picasso/src/SidebarLogo/__snapshots__/test.tsx.snap
@@ -6,8 +6,7 @@ exports[`SidebarLogo renders 1`] = `
     class="Picasso-root"
   >
     <div
-      class="PicassoContainer-centerAlignItems PicassoContainer-flex PicassoSidebarLogo-root"
-      style="margin-bottom: 0.5rem; margin-left: 2rem;"
+      class="PicassoContainer-bottomxsmallMargin PicassoContainer-leftlargeMargin PicassoContainer-centerAlignItems PicassoContainer-flex PicassoSidebarLogo-root"
     >
       <svg
         class="PicassoSvgLogo-root PicassoLogo-root PicassoLogo-default"

--- a/packages/picasso/src/Timeline/__snapshots__/test.tsx.snap
+++ b/packages/picasso/src/Timeline/__snapshots__/test.tsx.snap
@@ -15,8 +15,7 @@ exports[`Timeline renders 1`] = `
           class="PicassoContainer-flex PicassoTimelineRow-root"
         >
           <div
-            class="PicassoContainer-centerAlignItems PicassoContainer-flex PicassoContainer-column"
-            style="margin-right: 1.5rem;"
+            class="PicassoContainer-rightmediumMargin PicassoContainer-centerAlignItems PicassoContainer-flex PicassoContainer-column"
           >
             <div
               class="PicassoTimelineRow-dot"
@@ -27,8 +26,7 @@ exports[`Timeline renders 1`] = `
             />
           </div>
           <div
-            class="PicassoTimelineRow-content"
-            style="margin-bottom: 2rem;"
+            class="PicassoContainer-bottomlargeMargin PicassoTimelineRow-content"
           >
             Row #1
           </div>
@@ -37,8 +35,7 @@ exports[`Timeline renders 1`] = `
           class="PicassoContainer-flex PicassoTimelineRow-root"
         >
           <div
-            class="PicassoContainer-centerAlignItems PicassoContainer-flex PicassoContainer-column"
-            style="margin-right: 1.5rem;"
+            class="PicassoContainer-rightmediumMargin PicassoContainer-centerAlignItems PicassoContainer-flex PicassoContainer-column"
           >
             <div
               class="PicassoTimelineRow-dot"
@@ -49,8 +46,7 @@ exports[`Timeline renders 1`] = `
             />
           </div>
           <div
-            class="PicassoTimelineRow-content"
-            style="margin-bottom: 2rem;"
+            class="PicassoContainer-bottomlargeMargin PicassoTimelineRow-content"
           >
             Row #2
           </div>
@@ -59,8 +55,7 @@ exports[`Timeline renders 1`] = `
           class="PicassoContainer-flex PicassoTimelineRow-root"
         >
           <div
-            class="PicassoContainer-centerAlignItems PicassoContainer-flex PicassoContainer-column"
-            style="margin-right: 1.5rem;"
+            class="PicassoContainer-rightmediumMargin PicassoContainer-centerAlignItems PicassoContainer-flex PicassoContainer-column"
           >
             <div
               class="PicassoTimelineRow-dot"
@@ -71,8 +66,7 @@ exports[`Timeline renders 1`] = `
             />
           </div>
           <div
-            class="PicassoTimelineRow-content"
-            style="margin-bottom: 2rem;"
+            class="PicassoContainer-bottomlargeMargin PicassoTimelineRow-content"
           >
             Row #3
           </div>
@@ -98,8 +92,7 @@ exports[`Timeline renders with dates 1`] = `
           class="PicassoContainer-flex PicassoTimelineRow-root"
         >
           <div
-            class="PicassoContainer-centerAlignItems PicassoContainer-flex PicassoContainer-column"
-            style="margin-right: 1.5rem;"
+            class="PicassoContainer-rightmediumMargin PicassoContainer-centerAlignItems PicassoContainer-flex PicassoContainer-column"
           >
             <div
               class="PicassoTimelineRow-dot"
@@ -109,8 +102,7 @@ exports[`Timeline renders with dates 1`] = `
             />
           </div>
           <div
-            class="PicassoTimelineRow-date"
-            style="margin-right: 2rem;"
+            class="PicassoContainer-rightlargeMargin PicassoTimelineRow-date"
           >
             <p
               class="MuiTypography-root PicassoTypography-bodyMedium PicassoTypography-semibold PicassoTimelineRow-dateText MuiTypography-body1"
@@ -119,8 +111,7 @@ exports[`Timeline renders with dates 1`] = `
             </p>
           </div>
           <div
-            class="PicassoTimelineRow-content"
-            style="margin-bottom: 2rem;"
+            class="PicassoContainer-bottomlargeMargin PicassoTimelineRow-content"
           >
             Row #1
           </div>
@@ -129,8 +120,7 @@ exports[`Timeline renders with dates 1`] = `
           class="PicassoContainer-flex PicassoTimelineRow-root"
         >
           <div
-            class="PicassoContainer-centerAlignItems PicassoContainer-flex PicassoContainer-column"
-            style="margin-right: 1.5rem;"
+            class="PicassoContainer-rightmediumMargin PicassoContainer-centerAlignItems PicassoContainer-flex PicassoContainer-column"
           >
             <div
               class="PicassoTimelineRow-dot"
@@ -140,8 +130,7 @@ exports[`Timeline renders with dates 1`] = `
             />
           </div>
           <div
-            class="PicassoTimelineRow-date"
-            style="margin-right: 2rem;"
+            class="PicassoContainer-rightlargeMargin PicassoTimelineRow-date"
           >
             <p
               class="MuiTypography-root PicassoTypography-bodyMedium PicassoTypography-semibold PicassoTimelineRow-dateText MuiTypography-body1"
@@ -150,8 +139,7 @@ exports[`Timeline renders with dates 1`] = `
             </p>
           </div>
           <div
-            class="PicassoTimelineRow-content"
-            style="margin-bottom: 2rem;"
+            class="PicassoContainer-bottomlargeMargin PicassoTimelineRow-content"
           >
             Row #2
           </div>
@@ -160,8 +148,7 @@ exports[`Timeline renders with dates 1`] = `
           class="PicassoContainer-flex PicassoTimelineRow-root"
         >
           <div
-            class="PicassoContainer-centerAlignItems PicassoContainer-flex PicassoContainer-column"
-            style="margin-right: 1.5rem;"
+            class="PicassoContainer-rightmediumMargin PicassoContainer-centerAlignItems PicassoContainer-flex PicassoContainer-column"
           >
             <div
               class="PicassoTimelineRow-dot"
@@ -171,8 +158,7 @@ exports[`Timeline renders with dates 1`] = `
             />
           </div>
           <div
-            class="PicassoTimelineRow-date"
-            style="margin-right: 2rem;"
+            class="PicassoContainer-rightlargeMargin PicassoTimelineRow-date"
           >
             <p
               class="MuiTypography-root PicassoTypography-bodyMedium PicassoTypography-semibold PicassoTimelineRow-dateText MuiTypography-body1"
@@ -181,8 +167,7 @@ exports[`Timeline renders with dates 1`] = `
             </p>
           </div>
           <div
-            class="PicassoTimelineRow-content"
-            style="margin-bottom: 2rem;"
+            class="PicassoContainer-bottomlargeMargin PicassoTimelineRow-content"
           >
             Row #3
           </div>
@@ -208,8 +193,7 @@ exports[`Timeline renders with icons 1`] = `
           class="PicassoContainer-flex PicassoTimelineRow-root"
         >
           <div
-            class="PicassoContainer-centerAlignItems PicassoContainer-flex PicassoContainer-column"
-            style="margin-right: 1.5rem;"
+            class="PicassoContainer-rightmediumMargin PicassoContainer-centerAlignItems PicassoContainer-flex PicassoContainer-column"
           >
             <span
               class="PicassoTimelineRow-icon"
@@ -220,8 +204,7 @@ exports[`Timeline renders with icons 1`] = `
             />
           </div>
           <div
-            class="PicassoTimelineRow-content"
-            style="margin-bottom: 2rem;"
+            class="PicassoContainer-bottomlargeMargin PicassoTimelineRow-content"
           >
             Row #1
           </div>
@@ -230,8 +213,7 @@ exports[`Timeline renders with icons 1`] = `
           class="PicassoContainer-flex PicassoTimelineRow-root"
         >
           <div
-            class="PicassoContainer-centerAlignItems PicassoContainer-flex PicassoContainer-column"
-            style="margin-right: 1.5rem;"
+            class="PicassoContainer-rightmediumMargin PicassoContainer-centerAlignItems PicassoContainer-flex PicassoContainer-column"
           >
             <span
               class="PicassoTimelineRow-icon"
@@ -242,8 +224,7 @@ exports[`Timeline renders with icons 1`] = `
             />
           </div>
           <div
-            class="PicassoTimelineRow-content"
-            style="margin-bottom: 2rem;"
+            class="PicassoContainer-bottomlargeMargin PicassoTimelineRow-content"
           >
             Row #2
           </div>
@@ -252,8 +233,7 @@ exports[`Timeline renders with icons 1`] = `
           class="PicassoContainer-flex PicassoTimelineRow-root"
         >
           <div
-            class="PicassoContainer-centerAlignItems PicassoContainer-flex PicassoContainer-column"
-            style="margin-right: 1.5rem;"
+            class="PicassoContainer-rightmediumMargin PicassoContainer-centerAlignItems PicassoContainer-flex PicassoContainer-column"
           >
             <span
               class="PicassoTimelineRow-icon"
@@ -264,8 +244,7 @@ exports[`Timeline renders with icons 1`] = `
             />
           </div>
           <div
-            class="PicassoTimelineRow-content"
-            style="margin-bottom: 2rem;"
+            class="PicassoContainer-bottomlargeMargin PicassoTimelineRow-content"
           >
             Row #3
           </div>
@@ -291,8 +270,7 @@ exports[`Timeline renders without a connector 1`] = `
           class="PicassoContainer-flex PicassoTimelineRow-root"
         >
           <div
-            class="PicassoContainer-centerAlignItems PicassoContainer-flex PicassoContainer-column"
-            style="margin-right: 1.5rem;"
+            class="PicassoContainer-rightmediumMargin PicassoContainer-centerAlignItems PicassoContainer-flex PicassoContainer-column"
           >
             <div
               class="PicassoTimelineRow-dot"
@@ -304,8 +282,7 @@ exports[`Timeline renders without a connector 1`] = `
             />
           </div>
           <div
-            class="PicassoTimelineRow-content"
-            style="margin-bottom: 2rem;"
+            class="PicassoContainer-bottomlargeMargin PicassoTimelineRow-content"
           >
             Row #1
           </div>
@@ -314,8 +291,7 @@ exports[`Timeline renders without a connector 1`] = `
           class="PicassoContainer-flex PicassoTimelineRow-root"
         >
           <div
-            class="PicassoContainer-centerAlignItems PicassoContainer-flex PicassoContainer-column"
-            style="margin-right: 1.5rem;"
+            class="PicassoContainer-rightmediumMargin PicassoContainer-centerAlignItems PicassoContainer-flex PicassoContainer-column"
           >
             <div
               class="PicassoTimelineRow-dot"
@@ -327,8 +303,7 @@ exports[`Timeline renders without a connector 1`] = `
             />
           </div>
           <div
-            class="PicassoTimelineRow-content"
-            style="margin-bottom: 2rem;"
+            class="PicassoContainer-bottomlargeMargin PicassoTimelineRow-content"
           >
             Row #2
           </div>
@@ -337,8 +312,7 @@ exports[`Timeline renders without a connector 1`] = `
           class="PicassoContainer-flex PicassoTimelineRow-root"
         >
           <div
-            class="PicassoContainer-centerAlignItems PicassoContainer-flex PicassoContainer-column"
-            style="margin-right: 1.5rem;"
+            class="PicassoContainer-rightmediumMargin PicassoContainer-centerAlignItems PicassoContainer-flex PicassoContainer-column"
           >
             <div
               class="PicassoTimelineRow-dot"
@@ -346,8 +320,7 @@ exports[`Timeline renders without a connector 1`] = `
             />
           </div>
           <div
-            class="PicassoTimelineRow-content"
-            style="margin-bottom: 2rem;"
+            class="PicassoContainer-bottomlargeMargin PicassoTimelineRow-content"
           >
             Row #3
           </div>

--- a/packages/picasso/src/YearSelect/__snapshots__/test.tsx.snap
+++ b/packages/picasso/src/YearSelect/__snapshots__/test.tsx.snap
@@ -31,8 +31,7 @@ exports[`YearSelect render in descending order 1`] = `
               class="PicassoContainer-centerAlignItems PicassoContainer-flex"
             >
               <div
-                class="PicassoContainer-flex PicassoContainer-inline PicassoMenuItem-iconContainer"
-                style="margin-right: 0.5rem;"
+                class="PicassoContainer-rightxsmallMargin PicassoContainer-flex PicassoContainer-inline PicassoMenuItem-iconContainer"
               />
               <span
                 class="PicassoMenuItem-stringContent"
@@ -62,8 +61,7 @@ exports[`YearSelect render in descending order 1`] = `
               class="PicassoContainer-centerAlignItems PicassoContainer-flex"
             >
               <div
-                class="PicassoContainer-flex PicassoContainer-inline PicassoMenuItem-iconContainer"
-                style="margin-right: 0.5rem;"
+                class="PicassoContainer-rightxsmallMargin PicassoContainer-flex PicassoContainer-inline PicassoMenuItem-iconContainer"
               />
               <span
                 class="PicassoMenuItem-stringContent"
@@ -93,8 +91,7 @@ exports[`YearSelect render in descending order 1`] = `
               class="PicassoContainer-centerAlignItems PicassoContainer-flex"
             >
               <div
-                class="PicassoContainer-flex PicassoContainer-inline PicassoMenuItem-iconContainer"
-                style="margin-right: 0.5rem;"
+                class="PicassoContainer-rightxsmallMargin PicassoContainer-flex PicassoContainer-inline PicassoMenuItem-iconContainer"
               />
               <span
                 class="PicassoMenuItem-stringContent"
@@ -124,8 +121,7 @@ exports[`YearSelect render in descending order 1`] = `
               class="PicassoContainer-centerAlignItems PicassoContainer-flex"
             >
               <div
-                class="PicassoContainer-flex PicassoContainer-inline PicassoMenuItem-iconContainer"
-                style="margin-right: 0.5rem;"
+                class="PicassoContainer-rightxsmallMargin PicassoContainer-flex PicassoContainer-inline PicassoMenuItem-iconContainer"
               />
               <span
                 class="PicassoMenuItem-stringContent"
@@ -155,8 +151,7 @@ exports[`YearSelect render in descending order 1`] = `
               class="PicassoContainer-centerAlignItems PicassoContainer-flex"
             >
               <div
-                class="PicassoContainer-flex PicassoContainer-inline PicassoMenuItem-iconContainer"
-                style="margin-right: 0.5rem;"
+                class="PicassoContainer-rightxsmallMargin PicassoContainer-flex PicassoContainer-inline PicassoMenuItem-iconContainer"
               />
               <span
                 class="PicassoMenuItem-stringContent"

--- a/packages/picasso/src/utils/index.ts
+++ b/packages/picasso/src/utils/index.ts
@@ -67,6 +67,8 @@ export {
   usePropDeprecationWarning,
 } from './use-deprecation-warnings'
 
+export { spacings }
+
 export const {
   SPACING_0,
   SPACING_1,

--- a/yarn.lock
+++ b/yarn.lock
@@ -15203,14 +15203,14 @@ json-stringify-safe@^5.0.1, json-stringify-safe@~5.0.1:
   resolved "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
   integrity sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==
 
-json5@1, json5@^1.0.1, json5@^2.1.1:
+json5@1, json5@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/json5/-/json5-1.0.2.tgz#63d98d60f21b313b77c4d6da18bfa69d80e1d593"
   integrity sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==
   dependencies:
     minimist "^1.2.0"
 
-json5@2.2.3, json5@^2.1.0, json5@^2.1.2, json5@^2.1.3, json5@^2.2.0, json5@^2.2.2, json5@^2.2.3, json5@^2.x:
+json5@2.2.3, json5@^2.1.0, json5@^2.1.1, json5@^2.1.2, json5@^2.1.3, json5@^2.2.0, json5@^2.2.2, json5@^2.2.3, json5@^2.x:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.3.tgz#78cd6f1a19bdc12b73db5ad0c61efd66c1e29283"
   integrity sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==


### PR DESCRIPTION
[FX-4262]

### Description

This pull request
- restores original implementation of strings constants (`xsmall`, `small`, etc.) as Container spacing properties values. This is needed to ensure the same representation of components after consumers update to the picasso version with BASE spacings.
- implements Container spacing properties in a way, that when BASE spacing values are provided, CSS classes are also used to ease the migration to TailwindCSS

**What is the problem?**

Let's take`top` and `bottom` spacing properties as an example

- `master` branch implementation creates dedicated CSS class if spacing is provided as string constant. If it is provided as number, then the `style` attribute is added to the container

<img width="646" alt="Screenshot 2023-09-22 at 18 44 32" src="https://github.com/toptal/picasso/assets/1390758/693416f2-978c-45f9-91f1-a45c3f83f325">

- https://github.com/toptal/picasso/tree/feature/base-spacing branch implementation treats any spacing (string constant, number, or BASE spacing) the same way and adds the `style` attribute to the container

<img width="664" alt="Screenshot 2023-09-22 at 18 49 12" src="https://github.com/toptal/picasso/assets/1390758/56d301db-0344-4621-886f-0e5f3fe45983">

❗ The problem is that in rare cases consumers rely on the fact that **string constants spacing is set via CSS classes**, so they implement custom styling via CSS classes that is supposed to overwrite the CSS classes coming from Picasso. The example above has the custom CSS styling as below, so it stops working if the implementation via only `style` attribute is kept.

<img width="373" alt="Screenshot 2023-09-22 at 18 52 08" src="https://github.com/toptal/picasso/assets/1390758/b79d26d4-0315-47fd-84e7-8661119dccd5">

### How to test

<!-- The temploy link will be automatically updated when the temploy is deployed -->
- [Temploy](https://picasso.toptal.net/FX-4262-restore-classes)
- Compare same story in https://picasso.toptal.net/fx-4262-merge-base-spacing-into-master-and-announce-the-change/?path=/story/components-timeline--timeline and https://picasso.toptal.net/FX-4262-restore-classes/?path=/story/components-timeline--timeline, it should have different bottom padding (as highlighted in example) and should be the same as `master` https://picasso.toptal.net/?path=/story/components-timeline--timeline

### Development checks

- [N/A] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [N/A] Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [N/A] Annotate all `props` in component with documentation
- [N/A] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [N/A] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [N/A] Covered with tests ([visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md) included)

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-4262]: https://toptal-core.atlassian.net/browse/FX-4262?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ