### PR TITLE
fix: make field public

### DIFF
--- a/.changeset/tender-boxes-marry.md
+++ b/.changeset/tender-boxes-marry.md
@@ -1,0 +1,7 @@
+---
+'@toptal/picasso-provider': patch
+---
+
+### Spacing
+
+- make spacing index field public

--- a/packages/picasso-provider/src/Picasso/config/spacings.ts
+++ b/packages/picasso-provider/src/Picasso/config/spacings.ts
@@ -36,11 +36,11 @@ export enum SpacingEnum {
 
 class PicassoSpacing {
   #value: PicassoSpacingValues
-  index: number
+  baseTokenIndex: number
 
   private constructor(value: PicassoSpacingValues, index: number) {
     this.#value = value
-    this.index = index
+    this.baseTokenIndex = index
   }
 
   static create(value: PicassoSpacingValues, index: number): PicassoSpacing {
@@ -51,7 +51,7 @@ class PicassoSpacing {
    * @deprecated Use "index" property directly
    */
   indexOf(): number {
-    return this.index
+    return this.baseTokenIndex
   }
 
   valueOf(): PicassoSpacingValues {

--- a/packages/picasso-provider/src/Picasso/config/spacings.ts
+++ b/packages/picasso-provider/src/Picasso/config/spacings.ts
@@ -48,7 +48,6 @@ class PicassoSpacing {
   }
 
   /**
-   *
    * @deprecated Use "index" property directly
    */
   indexOf(): number {

--- a/packages/picasso-provider/src/Picasso/config/spacings.ts
+++ b/packages/picasso-provider/src/Picasso/config/spacings.ts
@@ -36,19 +36,23 @@ export enum SpacingEnum {
 
 class PicassoSpacing {
   #value: PicassoSpacingValues
-  #index: number
+  index: number
 
   private constructor(value: PicassoSpacingValues, index: number) {
     this.#value = value
-    this.#index = index
+    this.index = index
   }
 
   static create(value: PicassoSpacingValues, index: number): PicassoSpacing {
     return new PicassoSpacing(value, index)
   }
 
+  /**
+   *
+   * @deprecated Use "index" property directly
+   */
   indexOf(): number {
-    return this.#index
+    return this.index
   }
 
   valueOf(): PicassoSpacingValues {

--- a/packages/picasso-provider/src/Picasso/config/spacings.ts
+++ b/packages/picasso-provider/src/Picasso/config/spacings.ts
@@ -36,6 +36,9 @@ export enum SpacingEnum {
 
 class PicassoSpacing {
   #value: PicassoSpacingValues
+  /**
+   * Corresponds to token index in https://toptal-core.atlassian.net/wiki/spaces/Base/pages/3217031216/Spacing
+   */
   baseTokenIndex: number
 
   private constructor(value: PicassoSpacingValues, index: number) {


### PR DESCRIPTION
[FX-4379]

### Description

This pull request makes at least one property of the `PicassoSpacing` class public. It is needed for Jest comparison to work, as now Jest does not see difference between `SPACING_2` and `SPACING_4` as both spacings are just `{ }`.

```jsx
<Container left={SPACING_2} />
...
expect.objectContaining({
  left: SPACING_2, // succeeds, as there is no difference between SPACING_2, SPACING_4, etc. as all of them are { }
})
```

This pull request makes the code below fail and actually check if the proper spacing is provided

```jsx
<Container left={SPACING_2} />
...
expect.objectContaining({
  left: SPACING_4, // fails
})
```

### How to test

<!-- The temploy link will be automatically updated when the temploy is deployed -->
- [Temploy](https://picasso.toptal.net/FX-NULL-introduce-public-property)
- All checks should pass

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [N/A] Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [N/A] Annotate all `props` in component with documentation
- [N/A] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [N/A] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [N/A] Covered with tests ([visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md) included)

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-4379]: https://toptal-core.atlassian.net/browse/FX-4379?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ