### PR TITLE
fix: display of formatted text in links

### DIFF
--- a/.changeset/stale-cherries-clap.md
+++ b/.changeset/stale-cherries-clap.md
@@ -1,0 +1,7 @@
+---
+'@toptal/picasso-rich-text-editor': patch
+---
+
+### RichTextEditor
+
+- fix display of bold and italic text in links

--- a/packages/picasso-rich-text-editor/src/RichText/hooks/useRichText/styles.ts
+++ b/packages/picasso-rich-text-editor/src/RichText/hooks/useRichText/styles.ts
@@ -1,0 +1,11 @@
+import { createStyles } from '@material-ui/core/styles'
+import type { Theme } from '@material-ui/core/styles'
+
+export default ({ palette }: Theme) =>
+  createStyles({
+    visitedLinkChild: {
+      '&:visited > strong, &:visited > em': {
+        color: palette.purple.main,
+      },
+    },
+  })

--- a/packages/picasso-rich-text-editor/src/RichText/hooks/useRichText/useRichText.tsx
+++ b/packages/picasso-rich-text-editor/src/RichText/hooks/useRichText/useRichText.tsx
@@ -1,15 +1,20 @@
 import toH from 'hast-to-hyperscript'
 import type { ReactElement, ReactNode, FC } from 'react'
+import type { Theme } from '@material-ui/core/styles'
 import React, { useMemo, createElement, isValidElement } from 'react'
 import Typography from '@toptal/picasso/Typography'
 import Container from '@toptal/picasso/Container'
 import List from '@toptal/picasso/List'
 import ListItem from '@toptal/picasso/ListItem'
 import Link from '@toptal/picasso/Link'
+import { makeStyles } from '@material-ui/core'
 
 import type { ASTType } from '../../types'
 import { Emoji, Image, Code, CodeBlock } from '../../components'
 import { isCustomEmoji } from '../../../utils'
+import styles from './styles'
+
+const useStyles = makeStyles<Theme>(styles, { name: 'PicassoRichText' })
 
 type Props = {
   children?: React.ReactNode
@@ -25,15 +30,17 @@ const P = ({ children }: Props) => (
   <Typography size='medium'>{children}</Typography>
 )
 const Strong = ({ children }: Props) => (
-  <Typography size='inherit' as='strong' weight='semibold'>
+  <Typography size='inherit' as='strong' weight='semibold' color='inherit'>
     {children}
   </Typography>
 )
+
 const Em = ({ children }: Props) => (
-  <Typography size='inherit' as='em'>
+  <Typography size='inherit' as='em' color='inherit'>
     {children}
   </Typography>
 )
+
 const H3 = ({ children }: Props) => (
   <Container top='xsmall'>
     <Typography as='h3' variant='heading' size='medium'>
@@ -43,7 +50,16 @@ const H3 = ({ children }: Props) => (
 )
 const Ul = ({ children }: Props) => <List variant='unordered'>{children}</List>
 const Ol = ({ children }: Props) => <List variant='ordered'>{children}</List>
-const A = ({ children, ...props }: Props) => <Link {...props}>{children}</Link>
+const A = ({ children, ...props }: Props) => {
+  const classes = useStyles()
+
+  return (
+    <Link {...props} className={classes.visitedLinkChild}>
+      {children}
+    </Link>
+  )
+}
+
 const Img = ({ ...props }: Props) =>
   isCustomEmoji(props) ? <Emoji {...props} /> : <Image {...props} />
 

--- a/packages/picasso-rich-text-editor/src/RichText/story/HTML.example.tsx
+++ b/packages/picasso-rich-text-editor/src/RichText/story/HTML.example.tsx
@@ -141,7 +141,23 @@ const defaultValue: ASTType = {
           type: 'element',
           tagName: 'a',
           properties: { href: 'https://toptal.com' },
-          children: [{ type: 'text', value: 'Toptal' }],
+          children: [
+            { type: 'text', value: 'Toptal, ' },
+            {
+              type: 'element',
+              tagName: 'strong',
+              properties: {},
+              children: [
+                { type: 'text', value: 'the greatest talent company ' },
+              ],
+            },
+            {
+              type: 'element',
+              tagName: 'em',
+              properties: {},
+              children: [{ type: 'text', value: 'in the world' }],
+            },
+          ],
         },
         { type: 'text', value: ' 💪' },
       ],


### PR DESCRIPTION
[FX-4302]

### Description

This pull request fixes the display of formatted text inside of links. The color should follow the link color, plus it should react when link is visited.

### How to test

- [Temploy](https://picasso.toptal.net/fx-4302-rte-link-formatting-is-missing-when-italic-bold-is-applied)
- Play around with links at https://picasso.toptal.net/fx-4302-rte-link-formatting-is-missing-when-italic-bold-is-applied?path=/story/components-richtext--richtext

### Screenshots

Before

https://github.com/toptal/picasso/assets/1390758/cf720963-3362-4e97-8c18-089b3340a622

After

https://github.com/toptal/picasso/assets/1390758/570ba7cd-95b5-44ea-a786-d70f0701cf40

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [N/A] Annotate all `props` in component with documentation
- [N/A] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests ([visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md) included)

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-4302]: https://toptal-core.atlassian.net/browse/FX-4302?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ