### PR TITLE
fix(picasso-charts): fix BarChart for cases with 0 values

### DIFF
--- a/.changeset/many-papayas-serve.md
+++ b/.changeset/many-papayas-serve.md
@@ -1,0 +1,5 @@
+---
+'@toptal/picasso-charts': patch
+---
+
+- fix BarChart for cases when data given doesn't allow to properly select value axis boundaries

--- a/cypress/component/BarChart.spec.tsx
+++ b/cypress/component/BarChart.spec.tsx
@@ -127,6 +127,34 @@ describe('BarChart', () => {
     })
   })
 
+  it('renders custom chart with customized indicators when values are 0s', () => {
+    cy.mount(
+      <TestBarChart
+        tooltip={false}
+        data={chartDataCustomTooltipZeroValue}
+        renderBarIndicators={({ dataKey }: any) => {
+          const indicator = INDICATORS[dataKey]
+
+          if (indicator) {
+            return (
+              <BarChartIndicator
+                label={indicator.label}
+                color={indicator.color}
+              />
+            )
+          }
+
+          return <></>
+        }}
+      />
+    )
+
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'custom-chart/custom-indicators-zero-value',
+    })
+  })
+
   it('hides label of each bar via passed `showBarLabel` prop being set to `false`', () => {
     cy.mount(<TestBarChart showBarLabel={false} tooltip={false} />)
 
@@ -187,5 +215,16 @@ const chartDataCustomTooltip = [
   {
     name: 'Los-Angeles',
     value: { infected: 2780, recovered: 3908 },
+  },
+]
+
+const chartDataCustomTooltipZeroValue = [
+  {
+    name: 'Berlin',
+    value: { infected: 0 },
+  },
+  {
+    name: 'Milan',
+    value: { infected: 0 },
   },
 ]

--- a/cypress/component/BarChart.spec.tsx
+++ b/cypress/component/BarChart.spec.tsx
@@ -127,34 +127,6 @@ describe('BarChart', () => {
     })
   })
 
-  it('renders custom chart with customized indicators when values are 0s', () => {
-    cy.mount(
-      <TestBarChart
-        tooltip={false}
-        data={chartDataCustomTooltipZeroValue}
-        renderBarIndicators={({ dataKey }: any) => {
-          const indicator = INDICATORS[dataKey]
-
-          if (indicator) {
-            return (
-              <BarChartIndicator
-                label={indicator.label}
-                color={indicator.color}
-              />
-            )
-          }
-
-          return <></>
-        }}
-      />
-    )
-
-    cy.get('body').happoScreenshot({
-      component,
-      variant: 'custom-chart/custom-indicators-zero-value',
-    })
-  })
-
   it('hides label of each bar via passed `showBarLabel` prop being set to `false`', () => {
     cy.mount(<TestBarChart showBarLabel={false} tooltip={false} />)
 
@@ -172,6 +144,36 @@ describe('BarChart', () => {
     cy.get('body').happoScreenshot({
       component,
       variant: 'vertical',
+    })
+  })
+
+  describe('when values are 0s', () => {
+    it('renders custom chart with customized indicators correctly', () => {
+      cy.mount(
+        <TestBarChart
+          tooltip={false}
+          data={chartDataCustomTooltipZeroValue}
+          renderBarIndicators={({ dataKey }: any) => {
+            const indicator = INDICATORS[dataKey]
+
+            if (indicator) {
+              return (
+                <BarChartIndicator
+                  label={indicator.label}
+                  color={indicator.color}
+                />
+              )
+            }
+
+            return <></>
+          }}
+        />
+      )
+
+      cy.get('body').happoScreenshot({
+        component,
+        variant: 'custom-chart/custom-indicators-zero-value',
+      })
     })
   })
 })

--- a/packages/picasso-charts/src/BarChart/BarChart.tsx
+++ b/packages/picasso-charts/src/BarChart/BarChart.tsx
@@ -161,14 +161,10 @@ const BarChart = <T extends string>({
     interval: 0,
     tick: { width: TICK_WIDTH },
   }
-  const valueDomain = [
-    BOTTOM_DOMAIN,
-    ticks.length >= 2 ? ticks[ticks.length - 1] : BOTTOM_DOMAIN + 10,
-  ]
   const valueAxisProps = {
     width: Y_AXIS_WIDTH,
     ticks: ticks,
-    domain: valueDomain,
+    domain: [ticks[0], ticks[ticks.length - 1]],
     tickFormatter: valueAxisTickFormatter,
   }
 

--- a/packages/picasso-charts/src/BarChart/BarChart.tsx
+++ b/packages/picasso-charts/src/BarChart/BarChart.tsx
@@ -161,10 +161,14 @@ const BarChart = <T extends string>({
     interval: 0,
     tick: { width: TICK_WIDTH },
   }
+  const valueDomain = [
+    BOTTOM_DOMAIN,
+    ticks.length >= 2 ? ticks[ticks.length - 1] : BOTTOM_DOMAIN + 10,
+  ]
   const valueAxisProps = {
     width: Y_AXIS_WIDTH,
     ticks: ticks,
-    domain: [ticks[0], ticks[ticks.length - 1]],
+    domain: valueDomain,
     tickFormatter: valueAxisTickFormatter,
   }
 

--- a/packages/picasso-charts/src/BarChart/utils/find-top-domain/find-top-domain.ts
+++ b/packages/picasso-charts/src/BarChart/utils/find-top-domain/find-top-domain.ts
@@ -41,7 +41,7 @@ const findTopDomain = (data: DataItem[], stackedBars?: string[][]) => {
   const roundedMaxValue = Math.pow(10, base10)
   const topDomain = roundedMaxValue * Math.ceil(maxValue / roundedMaxValue)
 
-  return Math.max(topDomain, 10)
+  return Math.max(topDomain || 0, 10)
 }
 
 export default findTopDomain


### PR DESCRIPTION
[SDE-1274]

### Description

Hi guys! We in Service Delivery are using `BarChart` to render spend chart and add label to all columns which are related to periods with breaks.

In some cases it may happen that we don't have spend data for given period but still want to show breaks icon. Currently it looks incorrect (see the original ticket). The reason for this is inability of BarChart to determine correct boundaries for value axis. In this PR I introduce a property that allows controlling boundaries of the axis manually.

Please let me know if the change is incorrect or there's a better way to achieve it. My goal here is to fix the bug so I'm pretty flexible with choosing the way to do it.

Update:
following comments to the PR I changed the implementation. Now instead of adding a prop to customize boundaries we just set default ones in case of too few ticks (0 or 1).

### How to test

<!-- The temploy link will be automatically updated when the temploy is deployed -->
- [Temploy](https://picasso.toptal.net/sde-1274-allow-passing-max-value-to-bar-chart)
- check example [here](https://picasso.toptal.net/sde-1274-allow-passing-max-value-to-bar-chart/?path=/story/picasso-charts-barchart--barchart#adjust-value-axis-boundaries)

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| ![image](https://github.com/toptal/picasso/assets/2178320/571cba0a-a826-47f9-b9c6-e8f61afc6bf3) | ![image](https://github.com/toptal/picasso/assets/2178320/f66fffaf-ecfd-4c4d-ae41-f6ae2102153e) |

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests ([visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md) included)

**Breaking change**

- [n/a] codemod is created and showcased in the changeset
- [n/a] test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[SDE-1274]: https://toptal-core.atlassian.net/browse/SDE-1274?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ