### PR TITLE
fix: set delay for the screenshot

### DIFF
--- a/.storybook/components/PicassoBook/Page.js
+++ b/.storybook/components/PicassoBook/Page.js
@@ -95,6 +95,9 @@ class Page extends Base {
       const stories = storiesOf(storyName, module)
       chapter.sections.forEach(section => {
         const happoConfig = {}
+        if (section.delay) {
+          happoConfig.delay = 500
+        }
 
         if (!section.screenshotBreakpoints) {
           happoConfig.targets = [DEFAULT_HAPPO_TARGET]

--- a/packages/picasso-rich-text-editor/src/RichText/story/index.jsx
+++ b/packages/picasso-rich-text-editor/src/RichText/story/index.jsx
@@ -32,4 +32,5 @@ page
   })
   .addExample('RichText/story/HTML.example.tsx', {
     title: 'HTML from FE for live-editing preview',
+    delay: true,
   })


### PR DESCRIPTION
[FX-4437]

### Description

Visual test for rich text (_HTML from FE for live-editing preview_ in https://picasso.toptal.net/?path=/story/components-richtext--richtext) is flaky and sometimes does not have enough time to render fully, so the screenshot is taken before it renders.

This pull request sets delay so story can properly render (there are other approaches available in https://docs.happo.io/docs/storybook#setting-delay-for-a-story).

### Making sure it is no longer flaky

The delay is applied

<img width="901" alt="Screenshot 2023-10-24 at 17 02 05" src="https://github.com/toptal/picasso/assets/1390758/e975518e-6248-4fdb-bac5-722fc00470a7">

### How to test

<!-- The temploy link will be automatically updated when the temploy is deployed -->
- [Temploy](https://picasso.toptal.net/fx-4437-fix-flaky-rich-text-visual-test)
- All checks should pass

### Screenshots

The behaviour can be observed by going to https://picasso.toptal.net/?path=/story/components-richtext--richtext and quickly scrolling to the story

https://github.com/toptal/picasso/assets/1390758/262681b2-c31d-4fa5-89fa-a8c78fc1c4df

### Development checks

- [N/A] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [N/A] Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [N/A] Annotate all `props` in component with documentation
- [N/A] Create `examples` for component
- [N/A] Ensure that deployed demo has expected results and good examples
- [N/A] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [N/A] Covered with tests ([visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md) included)

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-4437]: https://toptal-core.atlassian.net/browse/FX-4437?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ