### PR TITLE
fix: always keep date picker calendar popup inside of viewport

### DIFF
--- a/.changeset/two-foxes-type.md
+++ b/.changeset/two-foxes-type.md
@@ -1,5 +1,5 @@
 ---
-'@toptal/picasso': minor
+'@toptal/picasso': patch
 ---
 
 - make date picker calendar popup fit the screen on small screens

--- a/.changeset/two-foxes-type.md
+++ b/.changeset/two-foxes-type.md
@@ -1,0 +1,5 @@
+---
+'@toptal/picasso': minor
+---
+
+- make date picker calendar popup fit the screen on small screens

--- a/packages/picasso/src/DatePicker/DatePicker.tsx
+++ b/packages/picasso/src/DatePicker/DatePicker.tsx
@@ -26,7 +26,7 @@ import Calendar from '../Calendar'
 import {
   DEFAULT_DATE_PICKER_DISPLAY_DATE_FORMAT,
   DEFAULT_DATE_PICKER_EDIT_DATE_FORMAT,
-  DEFAULT_POPPER_OPTIONS,
+  POPPER_OPTIONS,
 } from './constants'
 import styles from './styles'
 import type { DatePickerValue, DatePickerInputCustomValueParser } from './types'
@@ -430,7 +430,7 @@ export const DatePicker = (props: Props) => {
           autoWidth={false}
           enableCompactMode
           container={popperContainer}
-          popperOptions={DEFAULT_POPPER_OPTIONS}
+          popperOptions={POPPER_OPTIONS}
           ref={popperRef}
           {...popperProps}
         >

--- a/packages/picasso/src/DatePicker/constants.ts
+++ b/packages/picasso/src/DatePicker/constants.ts
@@ -1,12 +1,15 @@
+import type { PopperOptions } from 'popper.js'
+
 export const DEFAULT_DATE_PICKER_EDIT_DATE_FORMAT = 'MM-dd-yyyy'
 export const DEFAULT_DATE_PICKER_DISPLAY_DATE_FORMAT = 'MMM d, yyyy'
-export const DEFAULT_POPPER_OPTIONS = {
+export const POPPER_OPTIONS: PopperOptions = {
   modifiers: {
     hide: {
       enabled: false,
     },
     preventOverflow: {
-      enabled: false,
+      enabled: true,
+      boundariesElement: 'viewport',
     },
   },
 }

--- a/packages/picasso/src/Modal/story/Default.example.tsx
+++ b/packages/picasso/src/Modal/story/Default.example.tsx
@@ -1,8 +1,26 @@
 import React, { useState } from 'react'
-import { Modal, Button, Form, DatePicker } from '@toptal/picasso'
+import {
+  Modal,
+  Button,
+  Input,
+  Checkbox,
+  Select,
+  Form,
+  DatePicker,
+} from '@toptal/picasso'
 import { useModal } from '@toptal/picasso/utils'
 
-// TODO: revert to the original file before the merge
+const STATES = [
+  {
+    text: 'Alabama',
+    value: 'Alabama',
+  },
+  {
+    text: 'Utah',
+    value: 'Utah',
+  },
+]
+
 const ModalDialog = ({
   open,
   onClose,
@@ -10,12 +28,22 @@ const ModalDialog = ({
   open: boolean
   onClose: () => void
 }) => {
+  const [isLoading, setLoading] = useState(false)
   const [date, setDate] = useState<Date>()
 
   return (
     <Modal onClose={onClose} open={open}>
       <Modal.Title>Edit address details</Modal.Title>
       <Modal.Content>
+        <Form.Field>
+          <Input width='full' placeholder='City' value='Alabaster' />
+        </Form.Field>
+        <Form.Field>
+          <Input width='full' placeholder='Street' value='John Fruit' />
+        </Form.Field>
+        <Form.Field>
+          <Select placeholder='State' options={STATES} value='Alabama' />
+        </Form.Field>
         <Form.Field>
           <DatePicker
             width='full'
@@ -28,10 +56,28 @@ const ModalDialog = ({
             }}
           />
         </Form.Field>
+        <Form.Field>
+          <Checkbox label='Use shipping address for billing' />
+        </Form.Field>
       </Modal.Content>
       <Modal.Actions>
-        <Button variant='secondary' onClick={onClose}>
+        <Button disabled={isLoading} variant='secondary' onClick={onClose}>
           Cancel
+        </Button>
+        <Button
+          data-testid='close'
+          loading={isLoading}
+          onClick={() => {
+            setLoading(true)
+
+            setTimeout(() => {
+              setLoading(false)
+              onClose()
+            }, 1000)
+          }}
+          variant='positive'
+        >
+          Update
         </Button>
       </Modal.Actions>
     </Modal>

--- a/packages/picasso/src/Modal/story/Default.example.tsx
+++ b/packages/picasso/src/Modal/story/Default.example.tsx
@@ -1,26 +1,8 @@
 import React, { useState } from 'react'
-import {
-  Modal,
-  Button,
-  Input,
-  Checkbox,
-  Select,
-  Form,
-  DatePicker,
-} from '@toptal/picasso'
+import { Modal, Button, Form, DatePicker } from '@toptal/picasso'
 import { useModal } from '@toptal/picasso/utils'
 
-const STATES = [
-  {
-    text: 'Alabama',
-    value: 'Alabama',
-  },
-  {
-    text: 'Utah',
-    value: 'Utah',
-  },
-]
-
+// TODO: revert to the original file before the merge
 const ModalDialog = ({
   open,
   onClose,
@@ -28,22 +10,12 @@ const ModalDialog = ({
   open: boolean
   onClose: () => void
 }) => {
-  const [isLoading, setLoading] = useState(false)
   const [date, setDate] = useState<Date>()
 
   return (
     <Modal onClose={onClose} open={open}>
       <Modal.Title>Edit address details</Modal.Title>
       <Modal.Content>
-        <Form.Field>
-          <Input width='full' placeholder='City' value='Alabaster' />
-        </Form.Field>
-        <Form.Field>
-          <Input width='full' placeholder='Street' value='John Fruit' />
-        </Form.Field>
-        <Form.Field>
-          <Select placeholder='State' options={STATES} value='Alabama' />
-        </Form.Field>
         <Form.Field>
           <DatePicker
             width='full'
@@ -56,28 +28,10 @@ const ModalDialog = ({
             }}
           />
         </Form.Field>
-        <Form.Field>
-          <Checkbox label='Use shipping address for billing' />
-        </Form.Field>
       </Modal.Content>
       <Modal.Actions>
-        <Button disabled={isLoading} variant='secondary' onClick={onClose}>
+        <Button variant='secondary' onClick={onClose}>
           Cancel
-        </Button>
-        <Button
-          data-testid='close'
-          loading={isLoading}
-          onClick={() => {
-            setLoading(true)
-
-            setTimeout(() => {
-              setLoading(false)
-              onClose()
-            }, 1000)
-          }}
-          variant='positive'
-        >
-          Update
         </Button>
       </Modal.Actions>
     </Modal>

--- a/yarn.lock
+++ b/yarn.lock
@@ -15613,14 +15613,14 @@ json-stringify-safe@^5.0.1, json-stringify-safe@~5.0.1:
   resolved "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
   integrity sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==
 
-json5@1, json5@^1.0.1, json5@^2.1.1:
+json5@1, json5@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/json5/-/json5-1.0.2.tgz#63d98d60f21b313b77c4d6da18bfa69d80e1d593"
   integrity sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==
   dependencies:
     minimist "^1.2.0"
 
-json5@2.2.3, json5@^2.1.0, json5@^2.1.2, json5@^2.1.3, json5@^2.2.0, json5@^2.2.2, json5@^2.2.3, json5@^2.x:
+json5@2.2.3, json5@^2.1.0, json5@^2.1.1, json5@^2.1.2, json5@^2.1.3, json5@^2.2.0, json5@^2.2.2, json5@^2.2.3, json5@^2.x:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.3.tgz#78cd6f1a19bdc12b73db5ad0c61efd66c1e29283"
   integrity sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==


### PR DESCRIPTION
[FX-4445]

### Description

This pull request makes DatePicker popper fit the **viewport** in the most extreme cases when the screen is small, so overlapping the input is allowed ([confirmed with Design Team in Slack](https://toptal-core.slack.com/archives/CERF5NHT3/p1698319400470039?thread_ts=1697120927.351179&cid=CERF5NHT3))

### How to test

<!-- The temploy link will be automatically updated when the temploy is deployed -->
- [Temploy](https://picasso.toptal.net/FX-NULL-fit-date-picker)
- [Storybook] Navigate to https://picasso.toptal.net/FX-NULL-fit-date-picker/?path=/story/overlays-modal--modal and trigger the date picker from the `Default` case modal on different screen sizes
- [Talent Portal] Follow the steps
  - check out branch from https://github.com/toptal/talent-portal-frontend/pull/5535
  - run `yarn install`
  - log in as https://staff-portal.toptal.net/talents/4220731
  - run `yarn start:staging`
  - navigate to https://local-development.staging.toptal.net:8443/portal/payments and click `Download payment` button to open the modal

https://github.com/toptal/picasso/assets/1390758/6bfcadad-831e-4941-8427-713d7012960d

### Screenshots

https://github.com/toptal/picasso/assets/1390758/e5e64eec-0ff8-4e18-b2c6-66eb195207e1

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [N/A] Annotate all `props` in component with documentation
- [N/A] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [N/A] Covered with tests ([visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md) included)
- [x] ⚠️ **Revert changes made in Storybook before the merge**

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-4445]: https://toptal-core.atlassian.net/browse/FX-4445?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ