### PR TITLE
fix: disable toolbar when no selection is available

### DIFF
--- a/.changeset/curvy-papayas-explain.md
+++ b/.changeset/curvy-papayas-explain.md
@@ -1,0 +1,5 @@
+---
+'@toptal/picasso-rich-text-editor': patch
+---
+
+- disable toolbar when no selection is available

--- a/cypress/component/RichTextEditor/Default.spec.tsx
+++ b/cypress/component/RichTextEditor/Default.spec.tsx
@@ -440,7 +440,7 @@ describe('RichTextEditor', () => {
       cy.get('body').click(0, 0)
 
       cy.get('@headerSelect').find('input').should('have.attr', 'disabled')
-      cy.get('@headerSelect').click({ timeout: 100 })
+      cy.get('@editor').realClick()
       // the click should not open select but just simply trigger focus on whole editor
       cy.get('@headerSelect').find('input').should('not.have.attr', 'disabled')
     })
@@ -468,6 +468,17 @@ describe('RichTextEditor', () => {
       )
 
       cy.get('body').happoScreenshot({ component, variant: 'long-placeholder' })
+    })
+  })
+
+  describe('when enter the editor by clickint the toolbar area', () => {
+    it('focuses the editor, but the toolbar is disabled', () => {
+      cy.mount(renderEditor(defaultProps))
+      setAliases()
+
+      cy.get('#footoolbar').click()
+      cy.get('@headerSelect').find('input').should('have.attr', 'disabled')
+      cy.get('@boldButton').should('have.attr', 'disabled')
     })
   })
 })

--- a/cypress/component/RichTextEditor/Default.spec.tsx
+++ b/cypress/component/RichTextEditor/Default.spec.tsx
@@ -471,7 +471,7 @@ describe('RichTextEditor', () => {
     })
   })
 
-  describe('when enter the editor by clickint the toolbar area', () => {
+  describe('when enter the editor by clicking the toolbar area', () => {
     it('focuses the editor, but the toolbar is disabled', () => {
       cy.mount(renderEditor(defaultProps))
       setAliases()

--- a/packages/picasso-rich-text-editor/src/LexicalEditor/LexicalEditor.test.tsx
+++ b/packages/picasso-rich-text-editor/src/LexicalEditor/LexicalEditor.test.tsx
@@ -3,6 +3,8 @@ import { render, waitFor } from '@toptal/picasso/test-utils'
 import type { OmitInternalProps } from '@toptal/picasso-shared'
 import { OnChangePlugin } from '@lexical/react/LexicalOnChangePlugin'
 import { HistoryPlugin } from '@lexical/react/LexicalHistoryPlugin'
+import type { LexicalComposerContextWithEditor } from '@lexical/react/LexicalComposerContext'
+import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext'
 
 import LexicalEditor from './LexicalEditor'
 import type { Props } from './LexicalEditor'
@@ -19,6 +21,10 @@ jest.mock('../LexicalEditorToolbarPlugin', () => ({
   default: jest.fn(() => <div>LexicalEditorToolbarPlugin</div>),
 }))
 
+jest.mock('@lexical/react/LexicalComposerContext', () => ({
+  __esModule: true,
+  useLexicalComposerContext: jest.fn(() => [{}]),
+}))
 jest.mock('../plugins', () => ({
   __esModule: true,
   ListPlugin: jest.fn(),
@@ -29,10 +35,6 @@ jest.mock('../plugins', () => ({
   ImagePlugin: jest.fn(),
 }))
 
-jest.mock('@lexical/react/LexicalComposerContext', () => ({
-  __esModule: true,
-  useLexicalComposerContext: jest.fn(() => [{}]),
-}))
 jest.mock('@lexical/react/LexicalHistoryPlugin', () => ({
   __esModule: true,
   HistoryPlugin: jest.fn(() => [{}]),
@@ -52,6 +54,11 @@ jest.mock('@lexical/react/LexicalOnChangePlugin', () => ({
   __esModule: true,
   OnChangePlugin: jest.fn(() => <div>OnChangePlugin</div>),
 }))
+
+const mockedUseLexicalComposerContext =
+  useLexicalComposerContext as jest.MockedFunction<
+    typeof useLexicalComposerContext
+  >
 
 const mockedLexicalTextLengthPlugin = TextLengthPlugin as jest.MockedFunction<
   typeof TextLengthPlugin
@@ -98,6 +105,15 @@ describe('LexicalEditor', () => {
     mockedOnChangePlugin.mockImplementation(() => null)
     mockedLexicalListPlugin.mockImplementation(() => <div />)
     mockedLexicalLinkPlugin.mockImplementation(() => <div />)
+    mockedUseLexicalComposerContext.mockImplementation(
+      () =>
+        [
+          {
+            registerUpdateListener: jest.fn(() => () => {}),
+            registerCommand: jest.fn(() => () => {}),
+          },
+        ] as unknown as LexicalComposerContextWithEditor
+    )
   })
 
   afterEach(() => {
@@ -155,24 +171,6 @@ describe('LexicalEditor', () => {
 
       expect(mockedToolbarPlugin).toHaveBeenCalledWith(
         {
-          disabled: true,
-          id: 'id',
-          toolbarRef: {
-            current: null,
-          },
-        },
-        {}
-      )
-    })
-  })
-
-  describe('when disabled prop is passed', () => {
-    it('renders ToolbarPlugin with disabled prop', () => {
-      renderLexicalEditor({ disabled: true })
-
-      expect(mockedToolbarPlugin).toHaveBeenCalledWith(
-        {
-          disabled: true,
           id: 'id',
           toolbarRef: {
             current: null,
@@ -186,14 +184,12 @@ describe('LexicalEditor', () => {
   describe('when customEmojis and plugins prop is passed', () => {
     it('renders ToolbarPlugin with correct props', () => {
       renderLexicalEditor({
-        disabled: true,
         customEmojis: ['foo' as any],
         plugins: ['link'],
       })
 
       expect(mockedToolbarPlugin).toHaveBeenCalledWith(
         {
-          disabled: true,
           id: 'id',
           toolbarRef: {
             current: null,

--- a/packages/picasso-rich-text-editor/src/LexicalEditor/LexicalEditor.tsx
+++ b/packages/picasso-rich-text-editor/src/LexicalEditor/LexicalEditor.tsx
@@ -203,7 +203,6 @@ const LexicalEditor = forwardRef<HTMLDivElement, Props>(function LexicalEditor(
       <div onFocus={handleFocus} onBlur={handleBlur} tabIndex={-1}>
         <RTEPluginContextProvider disabled={disabled} focused={focused}>
           <ToolbarPlugin
-            disabled={disabled || !focused}
             toolbarRef={toolbarRef}
             // remount Toolbar when disabled
             key={`${disabled || !focused}`}

--- a/packages/picasso-rich-text-editor/src/LexicalEditorToolbarPlugin/LexicalEditorToolbarPlugin.tsx
+++ b/packages/picasso-rich-text-editor/src/LexicalEditorToolbarPlugin/LexicalEditorToolbarPlugin.tsx
@@ -29,7 +29,6 @@ import { useRTEPluginContext, useRTEUpdate } from '../plugins/api'
 import { $isCodeBlockNode } from '../plugins/CodeBlockPlugin/nodes'
 
 type Props = {
-  disabled?: boolean
   id: string
   toolbarRef: React.RefObject<HTMLDivElement>
   testIds?: {
@@ -43,12 +42,7 @@ type Props = {
   }
 }
 
-const LexicalEditorToolbarPlugin = ({
-  disabled = false,
-  toolbarRef,
-  testIds,
-  id,
-}: Props) => {
+const LexicalEditorToolbarPlugin = ({ toolbarRef, testIds, id }: Props) => {
   const [editor] = useLexicalComposerContext()
   const { setDisabledFormatting } = useRTEPluginContext()
   const [{ bold, italic, list, header }, dispatch] = useReducer(
@@ -134,7 +128,6 @@ const LexicalEditorToolbarPlugin = ({
       onBoldClick={handleBoldClick}
       onItalicClick={handleItalicClick}
       onHeaderChange={handleHeaderClick}
-      disabled={disabled}
       ref={toolbarRef}
       testIds={testIds}
       id={id}

--- a/packages/picasso-rich-text-editor/src/RichTextEditorToolbar/RichTextEditorToolbar.tsx
+++ b/packages/picasso-rich-text-editor/src/RichTextEditorToolbar/RichTextEditorToolbar.tsx
@@ -22,7 +22,6 @@ import type {
 } from './types'
 
 type Props = {
-  disabled: boolean
   id: string
   format: FormatType
   testIds?: {
@@ -50,7 +49,6 @@ export const ALLOWED_HEADER_TYPE = '3'
 export const RichTextEditorToolbar = forwardRef<HTMLDivElement, Props>(
   function RichTextEditorToolbar(props: Props, ref) {
     const {
-      disabled,
       format,
       onBoldClick,
       onItalicClick,
@@ -62,13 +60,15 @@ export const RichTextEditorToolbar = forwardRef<HTMLDivElement, Props>(
     } = props
 
     const { setToolbarPortalEl } = useToolbarPortalRegister()
-    const { disabledFormatting } = useRTEPluginContext()
+    const { disabledFormatting, disabled, focused } = useRTEPluginContext()
 
     const toolbarRef = useMultipleForwardRefs([ref, setToolbarPortalEl])
 
     const classes = useStyles(props)
 
-    const isInlineFormattingDisabled = disabled || disabledFormatting
+    const isInlineFormattingDisabled =
+      disabled || disabledFormatting || !focused
+    const isBlockFormattingDisabled = disabled || !focused
 
     return (
       <Container
@@ -78,7 +78,7 @@ export const RichTextEditorToolbar = forwardRef<HTMLDivElement, Props>(
       >
         <Container
           className={cx(classes.group, {
-            groupDisabled: disabled,
+            groupDisabled: isBlockFormattingDisabled,
           })}
         >
           <Select
@@ -91,7 +91,7 @@ export const RichTextEditorToolbar = forwardRef<HTMLDivElement, Props>(
             size='small'
             menuWidth='auto'
             className={classes.select}
-            disabled={disabled}
+            disabled={isBlockFormattingDisabled}
             data-testid={testIds?.headerSelect}
           />
         </Container>
@@ -116,14 +116,14 @@ export const RichTextEditorToolbar = forwardRef<HTMLDivElement, Props>(
             icon={<ListUnordered16 />}
             onClick={onUnorderedClick}
             active={format.list === 'bullet'}
-            disabled={disabled}
+            disabled={isBlockFormattingDisabled}
             data-testid={testIds?.unorderedListButton}
           />
           <TextEditorButton
             icon={<ListOrdered16 />}
             onClick={onOrderedClick}
             active={format.list === 'ordered'}
-            disabled={disabled}
+            disabled={isBlockFormattingDisabled}
             data-testid={testIds?.orderedListButton}
           />
         </Container>
@@ -133,7 +133,6 @@ export const RichTextEditorToolbar = forwardRef<HTMLDivElement, Props>(
 )
 
 RichTextEditorToolbar.defaultProps = {
-  disabled: false,
   format: {
     bold: false,
     italic: false,

--- a/packages/picasso-rich-text-editor/src/plugins/api.tsx
+++ b/packages/picasso-rich-text-editor/src/plugins/api.tsx
@@ -1,5 +1,5 @@
 import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext'
-import type { Klass, LexicalNode } from 'lexical'
+import { $getSelection, type Klass, type LexicalNode } from 'lexical'
 import type { ReactElement, ReactNode } from 'react'
 import React, { createContext, useContext, useEffect, useState } from 'react'
 
@@ -72,8 +72,27 @@ export const RTEPluginContextProvider = ({
 }: ToolbarPortalProviderProps) => {
   const [disabledFormatting, setDisabledFormatting] = useState(false)
 
+  /**
+   * When the editor renders, the selection is null.
+   * As soon as we focus the lexical editor (we can see the blinking "I"), the selection is not null.
+   * When the user focuses the editor for first time by clicking into the toolbar area,
+   * the selection is still null and this functionality is covering this edge case.
+   * When the lexical editor has no selection, we disable the toolbar buttons.
+   **/
+  const [toolbarDisabled, setToolbarDisabled] = useState(true)
+
+  useRTEUpdate(() => {
+    const selection = $getSelection()
+
+    if (selection === null) {
+      setToolbarDisabled(true)
+    } else {
+      setToolbarDisabled(false)
+    }
+  })
+
   const value: RTEPluginContextValue = {
-    disabled,
+    disabled: toolbarDisabled || disabled,
     disabledFormatting,
     setDisabledFormatting,
     focused,

--- a/packages/picasso-rich-text-editor/src/plugins/api.tsx
+++ b/packages/picasso-rich-text-editor/src/plugins/api.tsx
@@ -74,7 +74,8 @@ export const RTEPluginContextProvider = ({
 
   /**
    * When the editor renders, the selection is null.
-   * As soon as we focus the lexical editor (we can see the blinking "I"), the selection is not null.
+   * As soon as we focus the lexical editor (we can see the blinking text edit cursor),
+   * the selection is not null.
    * When the user focuses the editor for first time by clicking into the toolbar area,
    * the selection is still null and this functionality is covering this edge case.
    * When the lexical editor has no selection, we disable the toolbar buttons.


### PR DESCRIPTION
[FX-4435]

### Description

By default when the Lexical editor starts with the selection `null`, as soon as we enter the editable area, the selection is set. When we focus the editor for the first time by clicking in the toolbar area, the editor still does not have any selection, so clicking triggers no action as the editor does not know to what position to insert new nodes.

I fixed the issue by disabling the toolbar buttons until the selection is selected.

As mentioned, this edge case is only happening for the first focus of the editor.

### How to test

<!-- The temploy link will be automatically updated when the temploy is deployed -->
- [Temploy](https://picasso.toptal.net/fx-4435-rte-image-button)

1. check any story of RichTextEditor
2. click in the toolbar area of the editor
  - The toolbar should still be disabled
  - editor should be in focus state
3. click in the editable area
  - the toolbar should not be disabled anymore
4. click outside of the editor to lose focus
  - the toolbar should be disabled
5. click in the toolbar area again
  - the toolbar should not be disabled as the selection is saved inside inner state of lexical editor
  - try to use any button of toolbar and it should focus the editable area and apply expected format/block

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| https://github.com/toptal/picasso/assets/6830426/6dabda2c-801d-4c26-bbf8-a9cc02f90552 | https://github.com/toptal/picasso/assets/6830426/3832226d-d2de-4f00-ae13-a33c14a71e47 |

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests ([visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md) included)

**Breaking change**

- codemod is created and showcased in the changeset
- test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
8. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
9. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-4435]: https://toptal-core.atlassian.net/browse/FX-4435?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ