### PR TITLE
fix: disable mui scroll lock

### DIFF
--- a/.changeset/blue-tables-vanish.md
+++ b/.changeset/blue-tables-vanish.md
@@ -1,0 +1,7 @@
+---
+'@toptal/picasso': patch
+---
+
+### Modal
+
+- remove MUI container scroll lock as we already use body scroll lock when open

--- a/packages/picasso/src/Modal/Modal.tsx
+++ b/packages/picasso/src/Modal/Modal.tsx
@@ -240,6 +240,7 @@ export const Modal = forwardRef<HTMLElement, Props>(function Modal(props, ref) {
       maxWidth={false}
       disableEnforceFocus // we need our own mechanism to keep focus inside the Modals
       TransitionProps={transitionProps}
+      disableScrollLock
     >
       <ModalContext.Provider value>{children}</ModalContext.Provider>
 

--- a/packages/picasso/src/Modal/__snapshots__/test.tsx.snap
+++ b/packages/picasso/src/Modal/__snapshots__/test.tsx.snap
@@ -3,7 +3,6 @@
 exports[`Modal renders 1`] = `
 <div
   id="modal-root"
-  style="overflow: hidden;"
 >
   <div
     aria-hidden="true"
@@ -115,7 +114,6 @@ exports[`Modal useModal opens and closes modal 1`] = `
   <div>
     <div
       class="Picasso-root"
-      style="overflow: hidden;"
     >
       <button
         aria-hidden="true"
@@ -186,7 +184,6 @@ exports[`Modal useModal opens and closes modal 2`] = `
   <div>
     <div
       class="Picasso-root"
-      style=""
     >
       <button
         class="MuiButtonBase-root PicassoButton-medium PicassoButton-primary PicassoButton-root"
@@ -210,7 +207,6 @@ exports[`Modal useModal shows multiple modals at the same time 1`] = `
   <div>
     <div
       class="Picasso-root"
-      style="overflow: hidden;"
     >
       <button
         aria-hidden="true"

--- a/packages/picasso/src/PromptModal/__snapshots__/test.tsx.snap
+++ b/packages/picasso/src/PromptModal/__snapshots__/test.tsx.snap
@@ -1,9 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`PromptModal renders 1`] = `
-<body
-  style="padding-right: 0px; overflow: hidden;"
->
+<body>
   <div
     aria-hidden="true"
   >
@@ -96,9 +94,7 @@ exports[`PromptModal renders 1`] = `
 `;
 
 exports[`PromptModal showPrompt opens and closes modal on Submit action 1`] = `
-<body
-  style=""
->
+<body>
   <div>
     <div
       class="Picasso-root"
@@ -121,13 +117,10 @@ exports[`PromptModal showPrompt opens and closes modal on Submit action 1`] = `
 `;
 
 exports[`PromptModal showPrompt opens and closes modal on Submit action 2`] = `
-<body
-  style=""
->
+<body>
   <div>
     <div
       class="Picasso-root"
-      style="overflow: hidden;"
     >
       <button
         aria-hidden="true"
@@ -229,13 +222,10 @@ exports[`PromptModal showPrompt opens and closes modal on Submit action 2`] = `
 `;
 
 exports[`PromptModal showPrompt opens and closes modal on Submit action 3`] = `
-<body
-  style=""
->
+<body>
   <div>
     <div
       class="Picasso-root"
-      style=""
     >
       <button
         class="MuiButtonBase-root PicassoButton-medium PicassoButton-primary PicassoButton-root"
@@ -255,13 +245,10 @@ exports[`PromptModal showPrompt opens and closes modal on Submit action 3`] = `
 `;
 
 exports[`PromptModal showPrompt with input returns result on Submit action 1`] = `
-<body
-  style=""
->
+<body>
   <div>
     <div
       class="Picasso-root"
-      style=""
     >
       <button
         class="MuiButtonBase-root PicassoButton-medium PicassoButton-primary PicassoButton-root"

--- a/packages/picasso/src/utils/Modal/__snapshots__/test.tsx.snap
+++ b/packages/picasso/src/utils/Modal/__snapshots__/test.tsx.snap
@@ -8,7 +8,6 @@ exports[`Modal useModal opens and closes modal 1`] = `
   <div>
     <div
       class="Picasso-root"
-      style="overflow: hidden;"
     >
       <button
         aria-hidden="true"
@@ -82,7 +81,6 @@ exports[`Modal useModal opens and closes modal 2`] = `
   <div>
     <div
       class="Picasso-root"
-      style=""
     >
       <button
         class="MuiButtonBase-root PicassoButton-medium PicassoButton-primary PicassoButton-root"
@@ -109,7 +107,6 @@ exports[`Modal useModal shows multiple modals at the same time 1`] = `
   <div>
     <div
       class="Picasso-root"
-      style="overflow: hidden;"
     >
       <button
         aria-hidden="true"


### PR DESCRIPTION
[FX-4353]

### Description

We have the same issue as we had with Drawer before. We use Dialog from MUI, which is not using body lock, but container lock. We already use our custom body scroll lock, so we just need to disable the one from MUI. 

### How to test

You can use this [codesandbox](https://codesandbox.io/s/picasso-master-39-forked-ysl6g8?file=/package.json) with alpha package. The easiest is to check the page in [full screen](https://ysl6g8.csb.app/) and just try to open the modal. The sidebar should look the same as when closed.

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| ![image](https://github.com/toptal/picasso/assets/6830426/1c4533b1-2365-470a-a196-0ca892023ce7) | ![image](https://github.com/toptal/picasso/assets/6830426/e4117342-63b8-4931-9f37-f16a8c01237a) |

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests ([visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md) included)

**Breaking change**

- [x] codemod is created and showcased in the changeset
- [x] test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-4353]: https://toptal-core.atlassian.net/browse/FX-4353?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ