### PR TITLE
[FX-4409] Change commit format to Toptal's

### DIFF
--- a/.github/workflows/format-dependabot-prs.yml
+++ b/.github/workflows/format-dependabot-prs.yml
@@ -10,4 +10,4 @@ jobs:
     if: startsWith(github.head_ref, 'dependabot-')
     runs-on: ubuntu-latest
     steps:
-      - uses: toptal/davinci-github-actions/pr-conventional-to-toptal-commits@master
+      - uses: toptal/davinci-github-actions/pr-conventional-to-toptal-commits@v12.1.0

--- a/.github/workflows/format-dependabot-prs.yml
+++ b/.github/workflows/format-dependabot-prs.yml
@@ -1,0 +1,13 @@
+name: Format dependabot PR title to Totpal's commit format
+on:
+  pull_request:
+    types: [opened]
+    branches: [master]
+
+jobs:
+  format_title:
+    name: Format title
+    if: startsWith(github.head_ref, 'dependabot-')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: toptal/davinci-github-actions/pr-conventional-to-toptal-commits@master

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+yarn davinci-ci danger --local

--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ In order to run storybook you need to execute `yarn start` which will spin up st
 | --------------------------- | ----------------------------------------------------------------------------------- |
 | **build:package**           | Build the packages                                                                  |
 | **build:storybook**         | Build Storybook as static website                                                   |
-| **commit**                  | Interactive conventional commits                                                    |
 | **generate:component**      | Generate a new component template                                                   |
 | **generate:example**        | Generate a new component component code example                                     |
 | **generate:svg-components** | [Generate JSX components from SVGs](#adding-icons-and-pictograms)                   |
@@ -110,7 +109,6 @@ After Picasso will be released with your changes you can start using your icons 
    # Change Log
 
    All notable changes to this project will be documented in this file.
-   See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
    ```
 
 2. Add the new package to:

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,7 +1,0 @@
-module.exports = {
-  extends: ['@commitlint/config-conventional'],
-  rules: {
-    'type-enum': [1, 'always', ['chore', 'feat', 'fix', 'docs']],
-    'scope-case': [2, 'always', ['pascal-case', 'lowercase']],
-  },
-}

--- a/davinci.yaml
+++ b/davinci.yaml
@@ -1,4 +1,3 @@
 master:
-  conventional_commits: true
   require_assignee: true
   require_assignee_whitelist: []

--- a/docs/contribution/github-workflow.md
+++ b/docs/contribution/github-workflow.md
@@ -1,6 +1,8 @@
 # GitHub Workflow
 
-In order to maintain good strict [semver](https://semver.org/) versioning of `Picasso` our commit convention follows [conventionalcommits.org](https://www.conventionalcommits.org) workflow. This helps us to automatically determine version change by automatic analysis of git commits between two given releases.
+In order to maintain good strict [semver](https://semver.org/) versioning of
+`Picasso`. We utilize [changesets](https://github.com/changesets/changesets/)
+for versioning and managing releases on monorepo packages.
 
 ## PR workflow
 Every PR’s is checked against several automatic jobs which are always automatically run on every push. You don’t need to trigger any special phrase as running all jobs takes ~4minutes we currently run all on every commit.
@@ -10,7 +12,7 @@ Every PR’s is checked against several automatic jobs which are always automati
 To make reviews easier we have automatic "temploy" like deployment for every commit pushed to your PR. It's being run and published regardless of any errors, therefore even if you have known problems you can just create a PR and you will get automatically link to the online storybook built against your branch.
 
 ### CI Jobs ran on every commit
-* Danger - Checks for non-conformities inside a PR. Currently, it is used for checking non-conformities against conventional commits described in the next section.
+* Danger - Checks for non-conformities inside a PR. Currently, it is used for checking non-conformities against commit conventions described in the next section.
 * Jest Test - Runs Jest snapshots. (not visual tests)
 * Lint - Runs code linter.
 * Visual Tests - Runs visual regression tests. [See how to update them]
@@ -20,42 +22,19 @@ To make reviews easier we have automatic "temploy" like deployment for every com
 ## CI Release workflow and commit messages
 Automatic analysis is run by NPM package [semantic-release](https://semantic-release.gitbook.io) which does all the work under the cover. The main script which runs from the CI job [./bin/release](https://github.com/toptal/picasso/blob/master/bin/release) is checking all commits pushed to the `master` branch since the last release published to GitHub. Based on those commits it automatically bumps the version.
 
-### Commit messages patterns
-Commits messages need to follow patterns to let `semantic-release` correctly check which version needs to be published.
+### Commit conventions
 
-#### General commit message pattern
-`type(scope?): description`
+- Starts with a capital letter;
+- Does not end with a full-stop (i.e .);
+- Starts with a word in the imperative mood (i.e Build instead of Built);
+- Not longer than 79 chars.
 
-* `type` - Possible values are `feat | fix | chore | refactor | style | ci`
-* `scope` - Any scope to which `type` applies, usually we either omit scope or use the component name.
-* `description` - Description of changes, needs to start with **lowercase** character to pass checks.
+_Fixup and squash commits (i.e. commits starting with fixup! or squash!) are
+ignored by these validations._
 
-Let’s assume that we are fixing expected behavior inside `Button` component and we are not in any way changing API of components which could lead to non-backward compatible issues.
-Commit message could be following:
-`fix(button): fix onChange handler incorrect execution`
-
-💡 ***TIP:*** If you see that danger is still failing make sure that everything is `lowercased`! This applies to all `type`, `scope` and `description`
-💡 ***TIP:*** Those rules are also enforced to titles of all PR's
-
-#### Introducing breaking changes
-We try to always provide backward compatible changes to component’s API but if it’s necessary we might introduce a breaking change, we can do it by adding magic constant `BREAKING CHANGE` somewhere to commit description. This keyword will trigger `major` version bump to `Picasso` version.
-
-#### Version determination
-To better illustrate how versions are bumped let’s assume that the current version of `Picasso` is `0.1.0`.
-
-If we create `chore | docs | fix | style | refactor`  commit type,  `semantic-release` will initiative `patch` version bump. Therefore our version will be the following:
-
-`0.1.0 -> 0.1.1`
-
-If we create `feat` commit type, change we will be following:
-
-`0.1.0 -> 0.2.0`
-
-If we will create `BREAKING CHANGE` commit type, the change will be following:
-
-`0.1.0 -> 1.0.0`
-
-More about default rules could be found here  [semantic-release/lib/default-release-rules.js](https://github.com/semantic-release/commit-analyzer/blob/master/lib/default-release-rules.js)
+> [!NOTE]
+> See also this article about how to write good commit messages:
+> https://chris.beams.io/posts/git-commit/
 
 #### CI Jobs schema
 ![ci-schema](https://user-images.githubusercontent.com/324488/57615639-7c1a3e80-757c-11e9-8edb-3b358a42949a.png)

--- a/lerna.json
+++ b/lerna.json
@@ -5,7 +5,6 @@
   "command": {
     "publish": {
       "ignoreChanges": ["*.md"],
-      "conventionalCommits": true,
       "createRelease": "github",
       "yes": true,
       "message": "chore(release): publish [skip ci]"


### PR DESCRIPTION
[FX-4409]

### Description

After [RFC-39](https://toptal-core.atlassian.net/wiki/spaces/TECHX/pages/3243901281/RFC-39+Unify+commit+messages+and+PR+titles) being completed, we now need to move on to [Toptal commit messages](https://toptal-core.atlassian.net/wiki/spaces/ENG/pages/210665897/Commit+Message+Quality)

### How to test

<!-- The temploy link will be automatically updated when the temploy is deployed -->
- [Temploy](https://picasso.toptal.net/fx-4409-adoption-of-toptal-commit-message-format)
- Checkout branch and try to commit something and push, it should fail when the message follows conventional commits and succeed on Toptal's format

### Screenshots

No screnshots

### Development checks

- [NA] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [NA] Covered with tests ([visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md) included)

**Breaking change**

- [NA] codemod is created and showcased in the changeset
- [NA] test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-4409]: https://toptal-core.atlassian.net/browse/FX-4409?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ