### PR TITLE
[FX-4502] Add actions to Alert

### DIFF
--- a/.changeset/few-deers-care.md
+++ b/.changeset/few-deers-care.md
@@ -4,4 +4,4 @@
 
 ### Alert
 
-- add `actions` prop that allows for passing `primary` and `secondary` action buttons
+- add `actions` prop that allows passing `primary` and `secondary` action buttons

--- a/.changeset/few-deers-care.md
+++ b/.changeset/few-deers-care.md
@@ -1,0 +1,7 @@
+---
+'@toptal/picasso': minor
+---
+
+### Alert
+
+- add `actions` prop that allows for passing `primary` and `secondary` action buttons

--- a/packages/picasso/src/Alert/Alert.tsx
+++ b/packages/picasso/src/Alert/Alert.tsx
@@ -19,6 +19,8 @@ export type VariantType = Extract<
 >
 
 type ButtonAction = Omit<ButtonProps, 'size' | 'variant' | 'children'> & {
+  // Button content is restricted to string instead of ReactNode
+  // because we specifically don't want to allow any custom content
   label: string
 }
 

--- a/packages/picasso/src/Alert/Alert.tsx
+++ b/packages/picasso/src/Alert/Alert.tsx
@@ -4,17 +4,28 @@ import type { Theme } from '@material-ui/core'
 import { makeStyles } from '@material-ui/core'
 import type { BaseProps } from '@toptal/picasso-shared'
 
+import type { ButtonProps } from '../Button'
 import type { VariantType as ContainerVariants } from '../Container'
 import Container from '../Container'
 import Typography from '../Typography'
 import ButtonCircular from '../ButtonCircular'
 import { CloseMinor16, Exclamation16, Done16, Info16 } from '../Icon'
 import styles from './styles'
+import { Button } from '../Button'
 
 export type VariantType = Extract<
   'red' | 'green' | 'yellow' | 'blue',
   ContainerVariants
 >
+
+type ButtonAction = Omit<ButtonProps, 'size' | 'variant' | 'children'> & {
+  label: string
+}
+
+type Actions = {
+  primary?: ButtonAction
+  secondary?: ButtonAction
+}
 
 export interface Props extends BaseProps {
   /** Main content of the Alert */
@@ -23,6 +34,8 @@ export interface Props extends BaseProps {
   variant?: VariantType
   /** Callback invoked when close is clicked */
   onClose?: (event: MouseEvent<HTMLButtonElement>) => void
+  /** Optional button actions */
+  actions?: Actions
 }
 
 const renderAlertCloseButton = ({ onClose }: Pick<Props, 'onClose'>) => (
@@ -52,7 +65,7 @@ export const Alert = forwardRef<HTMLDivElement, Props>(function Alert(
   ref
 ) {
   const classes = useStyles()
-  const { children, variant, onClose, className } = props
+  const { children, variant, onClose, className, actions } = props
   const icon = icons[variant!]
 
   return (
@@ -79,7 +92,19 @@ export const Alert = forwardRef<HTMLDivElement, Props>(function Alert(
           {children}
         </Typography>
       </Container>
-      {onClose && renderAlertCloseButton({ onClose })}
+      <Container inline flex>
+        {actions?.primary && (
+          <Button {...actions?.primary} variant='primary' size='small'>
+            {actions?.primary?.label}
+          </Button>
+        )}
+        {actions?.secondary && (
+          <Button {...actions?.secondary} variant='secondary' size='small'>
+            {actions?.secondary?.label}
+          </Button>
+        )}
+        {onClose && renderAlertCloseButton({ onClose })}
+      </Container>
     </Container>
   )
 })

--- a/packages/picasso/src/Alert/Alert.tsx
+++ b/packages/picasso/src/Alert/Alert.tsx
@@ -49,6 +49,15 @@ const renderAlertCloseButton = ({ onClose }: Pick<Props, 'onClose'>) => (
   </Container>
 )
 
+const renderActionButton = (
+  variant: ButtonProps['variant'],
+  props: ButtonAction
+) => (
+  <Button {...props} variant={variant} size='small'>
+    {props.label}
+  </Button>
+)
+
 const icons = {
   red: <Exclamation16 color='red' />,
   green: <Done16 color='dark-green' />,
@@ -93,16 +102,9 @@ export const Alert = forwardRef<HTMLDivElement, Props>(function Alert(
         </Typography>
       </Container>
       <Container inline flex>
-        {actions?.primary && (
-          <Button {...actions?.primary} variant='primary' size='small'>
-            {actions?.primary?.label}
-          </Button>
-        )}
-        {actions?.secondary && (
-          <Button {...actions?.secondary} variant='secondary' size='small'>
-            {actions?.secondary?.label}
-          </Button>
-        )}
+        {actions?.primary && renderActionButton('primary', actions.primary)}
+        {actions?.secondary &&
+          renderActionButton('secondary', actions.secondary)}
         {onClose && renderAlertCloseButton({ onClose })}
       </Container>
     </Container>

--- a/packages/picasso/src/Alert/__snapshots__/test.tsx.snap
+++ b/packages/picasso/src/Alert/__snapshots__/test.tsx.snap
@@ -31,6 +31,36 @@ exports[`Alert renders 1`] = `
           test example string
         </div>
       </div>
+      <div
+        class="PicassoContainer-flex PicassoContainer-inline"
+      >
+        <button
+          class="MuiButtonBase-root PicassoButton-small PicassoButton-primary PicassoButton-root"
+          data-component-type="button"
+          label="Primary"
+          tabindex="0"
+          type="button"
+        >
+          <span
+            class="PicassoContainer-centerAlignItems PicassoContainer-flex PicassoContainer-inline PicassoButton-content"
+          >
+            Primary
+          </span>
+        </button>
+        <button
+          class="MuiButtonBase-root PicassoButton-small PicassoButton-secondary PicassoButton-root"
+          data-component-type="button"
+          label="Secondary"
+          tabindex="0"
+          type="button"
+        >
+          <span
+            class="PicassoContainer-centerAlignItems PicassoContainer-flex PicassoContainer-inline PicassoButton-content"
+          >
+            Secondary
+          </span>
+        </button>
+      </div>
     </div>
   </div>
 </div>

--- a/packages/picasso/src/Alert/story/Actions.example.tsx
+++ b/packages/picasso/src/Alert/story/Actions.example.tsx
@@ -1,0 +1,25 @@
+import React from 'react'
+import { Alert } from '@toptal/picasso'
+
+const mockOnClose = () => {
+  window.alert('Close icon')
+}
+
+const actions = {
+  primary: {
+    onClick: () => window.alert('Primary action button'),
+    label: 'Primary',
+  },
+  secondary: {
+    onClick: () => window.alert('Secondary action button'),
+    label: 'Secondary',
+  },
+}
+
+const Example = () => (
+  <Alert onClose={mockOnClose} actions={actions}>
+    This is a warning alert with actions
+  </Alert>
+)
+
+export default Example

--- a/packages/picasso/src/Alert/story/index.jsx
+++ b/packages/picasso/src/Alert/story/index.jsx
@@ -27,5 +27,6 @@ page
   .createChapter()
   .addExample('Alert/story/Default.example.tsx', 'Default')
   .addExample('Alert/story/Close.example.tsx', 'Closable alert')
+  .addExample('Alert/story/Actions.example.tsx', 'Alert with actions')
 
 page.connect(alertInlineStory.chapter)

--- a/packages/picasso/src/Alert/test.tsx
+++ b/packages/picasso/src/Alert/test.tsx
@@ -3,6 +3,7 @@ import React from 'react'
 import { render, fireEvent } from '@toptal/picasso/test-utils'
 import type { OmitInternalProps } from '@toptal/picasso-shared'
 
+import { noop } from '../utils'
 import type { Props } from './Alert'
 import Alert from './Alert'
 
@@ -10,14 +11,28 @@ const renderAlert = (
   children: ReactNode,
   props: OmitInternalProps<Props, 'children'>
 ) => {
-  const { onClose } = props
+  const { onClose, actions } = props
 
-  return render(<Alert onClose={onClose}>{children}</Alert>)
+  return render(
+    <Alert onClose={onClose} actions={actions}>
+      {children}
+    </Alert>
+  )
 }
 
 describe('Alert', () => {
   it('renders', () => {
-    const { container } = renderAlert('test example string', {})
+    const actions = {
+      primary: {
+        onClick: noop,
+        label: 'Primary',
+      },
+      secondary: {
+        onClick: noop,
+        label: 'Secondary',
+      },
+    }
+    const { container } = renderAlert('test example string', { actions })
 
     expect(container).toMatchSnapshot()
   })


### PR DESCRIPTION
[FX-4502](https://toptal-core.atlassian.net/browse/FX-4502)

### Description

An ability to add action buttons has been added. Either `primary` or `secondary` can be passed, size and variants can't be changed beyond what's dictated by BASE. 

### How to test

<!-- The temploy link will be automatically updated when the temploy is deployed -->
- [Temploy](https://picasso.toptal.net/fx-4502-add-option-for-a-cta-button-in-the-alert-component)
- Play around with the `Alert` component on the temploy, there is a new story for alert with actions
- See if the code looks good
- Existing visual tests should not break

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| ![image](https://github.com/toptal/picasso/assets/18409292/6108dfa2-57e5-4b5e-8183-df28bbf1e0c4) | ![image](https://github.com/toptal/picasso/assets/18409292/825dc49e-887a-4d50-bbf0-d4f238cc3fb7)|

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests ([visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md) included)

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-4502]: https://toptal-core.atlassian.net/browse/FX-4502?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ