### PR TITLE
[FX-4492] Remove unwanted tag transitions

### DIFF
--- a/.changeset/lovely-pumpkins-help.md
+++ b/.changeset/lovely-pumpkins-help.md
@@ -2,6 +2,6 @@
 '@toptal/picasso': patch
 ---
 
-### Tag, Tag.Reactangular
+### Tag, Tag.Rectangular
 
-- removed unwanted transitions for background-color and box-shadow
+- remove unwanted transitions for background-color and box-shadow

--- a/.changeset/lovely-pumpkins-help.md
+++ b/.changeset/lovely-pumpkins-help.md
@@ -1,0 +1,7 @@
+---
+'@toptal/picasso': patch
+---
+
+### Tag, Tag.Reactangular
+
+- removed unwanted transitions for background-color and box-shadow

--- a/packages/picasso/src/Tag/styles.ts
+++ b/packages/picasso/src/Tag/styles.ts
@@ -8,6 +8,7 @@ export default ({ palette, transitions }: Theme) =>
     root: {
       fontSize: '1rem',
       maxWidth: '100%',
+      transition: 'none',
     },
     blue: {
       color: palette.blue.main,

--- a/packages/picasso/src/TagRectangular/styles.ts
+++ b/packages/picasso/src/TagRectangular/styles.ts
@@ -4,6 +4,7 @@ import { createStyles } from '@material-ui/core/styles'
 export default ({ palette }: Theme) =>
   createStyles({
     root: {
+      transition: 'none',
       fontSize: '1rem',
       borderRadius: '0.25rem',
       height: '1rem',


### PR DESCRIPTION
[FX-4492](https://toptal-core.atlassian.net/browse/FX-4492)

### Description

Remove the default transitions from all `Tag` components.
I was not able to disable them in a single place (in theory, it should be possible to use `overrides` in `PicassoProvider`, however, in practice it just didn't work at all, probably due to class overrides inside components).

### How to test

<!-- The temploy link will be automatically updated when the temploy is deployed -->
- [Temploy](https://picasso.toptal.net/fx-4492-tag-components-have-leftover-styles-from-mui)
- You can use the code below to test the transition, both on master and temploy
```
import React, { useState } from 'react'
import { Button, Container, Tag } from '@toptal/picasso'

const Example = () => {
    const [type, setType] = useState('red')

    return (
        <Container flex>
            <Button
                onClick={() =>
                    setType(prevType => (prevType === 'green' ? 'red' : 'green'))
                }
                size='small'
            >
                Change color
            </Button>
            <Tag.Rectangular variant={type}>Tag</Tag.Rectangular>
        </Container>
    )
}

export default Example

```

### Screenshots

**Before**

https://github.com/toptal/picasso/assets/18409292/05409c53-22fc-4384-83b9-2868a5878a8d


**After**

https://github.com/toptal/picasso/assets/18409292/892ccfd2-1722-4ddc-9111-42860644170e



### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [n/a] Covered with tests ([visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md) included)


> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-4492]: https://toptal-core.atlassian.net/browse/FX-4492?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ