### PR TITLE
Revert IAP changes and fix proxy

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,11 +35,6 @@ jobs:
           service_account: ${{ secrets.SA_IDENTITY_POOL }}
           secrets_name: |-
             HTTP_PROXY:toptal-ci/HTTP_PROXY
-            JENKINS_BUILD_URL:toptal-ci/JENKINS_BUILD_URL
-            JENKINS_BUILD_CLIENT_ID:toptal-ci/JENKINS_BUILD_CLIENT_ID
-            JENKINS_DEPLOYMENT_URL:toptal-ci/JENKINS_DEPLOYMENT_URL
-            JENKINS_DEPLOYMENT_CLIENT_ID:toptal-ci/JENKINS_DEPLOYMENT_CLIENT_ID
-            JENKINS_SA_CREDENTIALS:toptal-ci/JENKINS_SA_CREDENTIALS
             NPM_TOKEN_PUBLISH:toptal-ci/NPM_TOKEN_PUBLISH
             SLACK_BOT_TOKEN:toptal-ci/SLACK_BOT_TOKEN
             TOPTAL_BUILD_BOT_TOKEN:toptal-ci/TOPTAL_BUILD_BOT_TOKEN
@@ -141,17 +136,16 @@ jobs:
             }
 
       - name: Trigger build image job
-        uses: toptal/actions/trigger-jenkins-job@main
+        uses: toptal/jenkins-job-trigger-action@1.0.1
         id: trigger-build
         env:
           JENKINS_JOB_NAME: ${{ env.REPOSITORY_NAME }}-build-image
           JENKINS_USER: ${{ steps.parse_secrets.outputs.TOPTAL_TRIGGERBOT_USERNAME }}
         with:
-          jenkins_url: ${{ steps.parse_secrets.outputs.JENKINS_BUILD_URL }}
-          jenkins_user: ${{ steps.parse_secrets.outputs.TOPTAL_TRIGGERBOT_USERNAME }}
-          jenkins_token: ${{ steps.parse_secrets.outputs.TOPTAL_TRIGGERBOT_BUILD_TOKEN }}
-          jenkins_client_id: ${{ steps.parse_secrets.outputs.JENKINS_BUILD_CLIENT_ID }}
-          jenkins_sa_credentials: ${{ steps.parse_secrets.outputs.JENKINS_SA_CREDENTIALS }}
+          jenkins_url: https://jenkins-build.toptal.net/
+          jenkins_user: ${{ env.JENKINS_USER }}
+          jenkins_token: ${{ env.TOPTAL_JENKINS_BUILD_TOKEN }}
+          proxy: http://${{ steps.parse_secrets.outputs.HTTP_PROXY }}
           job_name: ${{ env.JENKINS_JOB_NAME }}
           job_params: |
             {
@@ -163,15 +157,14 @@ jobs:
 
       - name: Trigger deployment job
         id: trigger-deploy
-        uses: toptal/actions/trigger-jenkins-job@main
+        uses: toptal/jenkins-job-trigger-action@1.0.1
         env:
           JENKINS_JOB_NAME: ${{ env.REPOSITORY_NAME }}-docs
         with:
-          jenkins_url: ${{ steps.parse_secrets.outputs.JENKINS_DEPLOYMENT_URL }}
-          jenkins_user: ${{ steps.parse_secrets.outputs.TOPTAL_TRIGGERBOT_USERNAME }}
-          jenkins_token: ${{ steps.parse_secrets.outputs.TOPTAL_TRIGGERBOT_DEPLOYMENT_TOKEN }}
-          jenkins_client_id: ${{ steps.parse_secrets.outputs.JENKINS_DEPLOYMENT_CLIENT_ID }}
-          jenkins_sa_credentials: ${{ steps.parse_secrets.outputs.JENKINS_SA_CREDENTIALS }}
+          jenkins_url: https://jenkins-deployment.toptal.net/
+          jenkins_user: ${{ env.TOPTAL_BOT_USERNAME }}
+          jenkins_token: ${{ env.TOPTAL_BOT_JENKINS_DEPLOYMENT_TOKEN }}
+          proxy: http://${{ steps.parse_secrets.outputs.HTTP_PROXY }}
           job_name: ${{ env.JENKINS_JOB_NAME }}
           job_params: |
             {


### PR DESCRIPTION
### Description

Reverting changes because IAP supporting jenkins actions doesn't work with public repositories yet.

A bit of context https://toptal-core.slack.com/archives/C03GLMT6L7N/p1700480270433659

### How to test

Run the workflows

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| Insert screenshots or screen recordings | Insert screenshots or screen recordings |

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests ([visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md) included)

**Breaking change**

- [x] codemod is created and showcased in the changeset
- [x] test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>
