### PR TITLE
[FX-4504] Move RTE to a direct dependency of forms

### DIFF
--- a/.changeset/red-tigers-join.md
+++ b/.changeset/red-tigers-join.md
@@ -1,0 +1,7 @@
+---
+'@toptal/picasso-forms': minor
+---
+
+### picasso-forms
+
+- change @toptal/picasso-rich-text-editor dependency from `peerDependency` to direct dependency

--- a/packages/picasso-forms/package.json
+++ b/packages/picasso-forms/package.json
@@ -25,12 +25,12 @@
   "peerDependencies": {
     "@toptal/picasso": "^41.0.0",
     "@toptal/picasso-shared": "^13.0.0",
-    "@toptal/picasso-rich-text-editor": "9.0.1",
     "react": ">=16.12.0 < 19.0.0",
     "react-dom": ">=16.12.0 < 19.0.0",
     "typescript": "~4.7.0"
   },
   "dependencies": {
+    "@toptal/picasso-rich-text-editor": "9.0.1",
     "classnames": "^2.3.1",
     "debounce": "^1.2.1",
     "detect-browser": "^5.3.0",


### PR DESCRIPTION
[FX-4504]

### Description

To make the work easy for users using RTE we don't require it as a `peerDependency` anymore, but as direct dependency. This effectively removes the need to install RTE as a dependency on the host project

### How to test

<!-- The temploy link will be automatically updated when the temploy is deployed -->
- [Temploy](https://picasso.toptal.net/fx-4504-set-rich-text-editor-as-direct-dependency-in-forms)
- Check temploy if RTE is working

### Screenshots

No screenshots

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [x] Annotate all `props` in component with documentation
- [NA] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests ([visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md) included)

**Breaking change**

- [x] codemod is created and showcased in the changeset
- [x] test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-4504]: https://toptal-core.atlassian.net/browse/FX-4504?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ