### PR TITLE
[FX-4509] Add a possibility to show an error status on tags

### DIFF
--- a/.changeset/pink-carrots-protect.md
+++ b/.changeset/pink-carrots-protect.md
@@ -1,0 +1,7 @@
+---
+'@toptal/picasso': minor
+---
+
+### TagSelector
+
+- add a possibility to show an error status on tags

--- a/packages/picasso/src/TagSelector/TagSelector.tsx
+++ b/packages/picasso/src/TagSelector/TagSelector.tsx
@@ -24,6 +24,7 @@ import type { Status } from '../OutlinedInput'
 
 export interface Item extends AutocompleteItem {
   value?: string
+  status?: 'error'
 }
 
 const EMPTY_INPUT_VALUE = ''
@@ -209,6 +210,7 @@ export const TagSelector = forwardRef<HTMLInputElement, Props>(
     const renderLabel = (item: Item) => {
       const displayValue = getDisplayValue(item)
       const handleItemDelete = () => handleDelete(item)
+      const hasError = item.status === 'error'
 
       if (customRenderLabel) {
         return customRenderLabel({
@@ -220,7 +222,11 @@ export const TagSelector = forwardRef<HTMLInputElement, Props>(
       }
 
       return (
-        <TagSelectorLabel disabled={disabled} onDelete={handleItemDelete}>
+        <TagSelectorLabel
+          variant={hasError ? 'red' : undefined}
+          disabled={disabled}
+          onDelete={handleItemDelete}
+        >
           {displayValue}
         </TagSelectorLabel>
       )

--- a/packages/picasso/src/TagSelector/story/Status.example.tsx
+++ b/packages/picasso/src/TagSelector/story/Status.example.tsx
@@ -17,7 +17,17 @@ const Example = () => {
       </Container>
       <Container padded={SPACING_4}>
         <Typography>Error</Typography>
-        <TagSelector placeholder='error' status='error' value={value} />
+        <Container flex gap={'small'}>
+          <TagSelector placeholder='error' status='error' value={value} />
+          <TagSelector
+            placeholder='error'
+            status='error'
+            value={[
+              ...value,
+              { value: 'CZE', text: 'Czech Republic', status: 'error' },
+            ]}
+          />
+        </Container>
       </Container>
       <Container padded={SPACING_4}>
         <Typography>Success with long placeholder</Typography>


### PR DESCRIPTION
[FX-4509]

### Description

Users want to be able to highlight problematic tag inside tag selector.

### How to test

<!-- The temploy link will be automatically updated when the temploy is deployed -->
- [Temploy](https://picasso.toptal.net/fx-4509-tagselector)


### Screenshots

![image](https://github.com/toptal/picasso/assets/6830426/4ce5ee69-257b-4ad5-aa88-b90e027346b2)

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests ([visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md) included)

**Breaking change**

- [x] codemod is created and showcased in the changeset
- [x] test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-4509]: https://toptal-core.atlassian.net/browse/FX-4509?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ