### PR TITLE
[FX-4541] Use BASE viewports in Picasso Storybook

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -4,7 +4,7 @@ import 'happo-plugin-storybook/register'
 
 import Picasso from '@toptal/picasso-provider'
 
-const PICASSO_VIEWPORTS = {
+const BASE_VIEWPORTS = {
   'extra-small': {
     name: 'extra-small',
     styles: {
@@ -48,7 +48,7 @@ export const parameters = {
     element: '.component-section-container',
   },
   viewport: {
-    viewports: PICASSO_VIEWPORTS,
+    viewports: BASE_VIEWPORTS,
   },
 }
 

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -4,10 +4,53 @@ import 'happo-plugin-storybook/register'
 
 import Picasso from '@toptal/picasso-provider'
 
+import { INITIAL_VIEWPORTS } from '@storybook/addon-viewport'
+
+const PICASSO_VIEWPORTS = {
+  'extra-small': {
+    name: 'extra-small',
+    styles: {
+      height: '600px',
+      width: '479px',
+    },
+  },
+  small: {
+    name: 'small',
+    styles: {
+      height: '800px',
+      width: '767px',
+    },
+  },
+  medium: {
+    name: 'medium',
+    styles: {
+      height: '1000px',
+      width: '1023px',
+    },
+  },
+  large: {
+    name: 'large',
+    styles: {
+      height: '1200px',
+      width: '1439px',
+    },
+  },
+  'extra-large': {
+    name: 'extra-large',
+    styles: {
+      height: '1400px',
+      width: '1600px',
+    },
+  },
+}
+
 export const parameters = {
   layout: 'padded',
   a11y: {
     element: '.component-section-container',
+  },
+  viewport: {
+    viewports: PICASSO_VIEWPORTS,
   },
 }
 

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -4,8 +4,6 @@ import 'happo-plugin-storybook/register'
 
 import Picasso from '@toptal/picasso-provider'
 
-import { INITIAL_VIEWPORTS } from '@storybook/addon-viewport'
-
 const PICASSO_VIEWPORTS = {
   'extra-small': {
     name: 'extra-small',

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,43 +1,46 @@
 import React from 'react'
 import 'github-markdown-css/github-markdown-light.css'
 import 'happo-plugin-storybook/register'
+import { getCheckpoints } from '../packages/picasso/src/test-utils/get-happo-targets/get-checkpoints.ts'
 
 import Picasso from '@toptal/picasso-provider'
 
+const baseViewportCheckpoints = getCheckpoints()
 const BASE_VIEWPORTS = {
   'extra-small': {
     name: 'extra-small',
     styles: {
       height: '600px',
-      width: '479px',
+      width: baseViewportCheckpoints[0] + 'px',
     },
   },
   small: {
     name: 'small',
     styles: {
       height: '800px',
-      width: '767px',
+      width: baseViewportCheckpoints[1] + 'px',
     },
   },
   medium: {
     name: 'medium',
     styles: {
       height: '1000px',
-      width: '1023px',
+      width: baseViewportCheckpoints[2] + 'px',
     },
   },
   large: {
     name: 'large',
     styles: {
       height: '1200px',
-      width: '1439px',
+      width: baseViewportCheckpoints[3] + 'px',
     },
   },
   'extra-large': {
     name: 'extra-large',
     styles: {
       height: '1400px',
-      width: '1600px',
+      // Add 200px of width, otherwise the difference with the previous breakpoint viewport is too small
+      width: baseViewportCheckpoints[3] + 200 + 'px',
     },
   },
 }


### PR DESCRIPTION
[FX-4541]

### Description

This pull requests adds BASE viewports to Storybook `@storybook/addon-viewport` addon configuration (https://storybook.js.org/docs/react/essentials/viewport).

### How to test

<!-- The temploy link will be automatically updated when the temploy is deployed -->
- [Temploy](https://picasso.toptal.net/FX-NULL-tune-storybook)
- Verify new viewports at the temploy

### Screenshots


https://github.com/toptal/picasso/assets/1390758/af6063a3-96f0-4982-a14e-8f13787f3636



### Development checks

- [N/A] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [N/A] Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [N/A] Annotate all `props` in component with documentation
- [N/A] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [N/A] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [N/A] Covered with tests ([visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md) included)

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-4541]: https://toptal-core.atlassian.net/browse/FX-4541?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ