### PR TITLE
[FX-4529] Add split button support to `Alert`

### DIFF
--- a/.changeset/perfect-apricots-buy.md
+++ b/.changeset/perfect-apricots-buy.md
@@ -1,5 +1,5 @@
 ---
-'@toptal/picasso': patch
+'@toptal/picasso': minor
 ---
 
 ### Alert

--- a/.changeset/perfect-apricots-buy.md
+++ b/.changeset/perfect-apricots-buy.md
@@ -1,0 +1,7 @@
+---
+'@toptal/picasso': patch
+---
+
+### Alert
+
+- add support for split buttons to `Alert` actions

--- a/packages/picasso/src/Alert/Alert.tsx
+++ b/packages/picasso/src/Alert/Alert.tsx
@@ -4,14 +4,17 @@ import type { Theme } from '@material-ui/core'
 import { makeStyles } from '@material-ui/core'
 import type { BaseProps } from '@toptal/picasso-shared'
 
+import { SPACING_4 } from '../utils'
 import type { ButtonProps } from '../Button'
+import type { ButtonSplitProps } from '../ButtonSplit'
 import type { VariantType as ContainerVariants } from '../Container'
 import Container from '../Container'
 import Typography from '../Typography'
 import ButtonCircular from '../ButtonCircular'
 import { CloseMinor16, Exclamation16, Done16, Info16 } from '../Icon'
 import styles from './styles'
-import { Button } from '../Button'
+import Button from '../Button'
+import ButtonSplit from '../ButtonSplit'
 
 export type VariantType = Extract<
   'red' | 'green' | 'yellow' | 'blue',
@@ -22,6 +25,7 @@ type ButtonAction = Omit<ButtonProps, 'size' | 'variant' | 'children'> & {
   // Button content is restricted to string instead of ReactNode
   // because we specifically don't want to allow any custom content
   label: string
+  menu?: ButtonSplitProps['menu']
 }
 
 type Actions = {
@@ -52,13 +56,41 @@ const renderAlertCloseButton = ({ onClose }: Pick<Props, 'onClose'>) => (
 )
 
 const renderActionButton = (
-  variant: ButtonProps['variant'],
+  variant: ButtonSplitProps['variant'],
   props: ButtonAction
-) => (
-  <Button {...props} variant={variant} size='small'>
-    {props.label}
-  </Button>
-)
+) => {
+  const { label, menu, ...rest } = props
+
+  if (menu) {
+    return (
+      <Container inline>
+        <ButtonSplit
+          menu={menu}
+          variant={variant}
+          size='small'
+          onClick={rest.onClick}
+          actionButtonProps={{ ...rest }}
+          data-testid='action-button'
+        >
+          {label}
+        </ButtonSplit>
+      </Container>
+    )
+  }
+
+  return (
+    <Container inline>
+      <Button
+        {...rest}
+        variant={variant}
+        size='small'
+        data-testid='action-button'
+      >
+        {label}
+      </Button>
+    </Container>
+  )
+}
 
 const icons = {
   red: <Exclamation16 color='red' />,
@@ -104,9 +136,11 @@ export const Alert = forwardRef<HTMLDivElement, Props>(function Alert(
         </Typography>
       </Container>
       <Container inline flex>
-        {actions?.primary && renderActionButton('primary', actions.primary)}
-        {actions?.secondary &&
-          renderActionButton('secondary', actions.secondary)}
+        <Container inline flex gap={SPACING_4}>
+          {actions?.primary && renderActionButton('primary', actions.primary)}
+          {actions?.secondary &&
+            renderActionButton('secondary', actions.secondary)}
+        </Container>
         {onClose && renderAlertCloseButton({ onClose })}
       </Container>
     </Container>

--- a/packages/picasso/src/Alert/__snapshots__/test.tsx.snap
+++ b/packages/picasso/src/Alert/__snapshots__/test.tsx.snap
@@ -34,32 +34,44 @@ exports[`Alert renders 1`] = `
       <div
         class="PicassoContainer-flex PicassoContainer-inline"
       >
-        <button
-          class="MuiButtonBase-root PicassoButton-small PicassoButton-primary PicassoButton-root"
-          data-component-type="button"
-          label="Primary"
-          tabindex="0"
-          type="button"
+        <div
+          class="PicassoContainer-flex PicassoContainer-inline PicassoContainer-spacing4Gap"
         >
-          <span
-            class="PicassoContainer-centerAlignItems PicassoContainer-flex PicassoContainer-inline PicassoButton-content"
+          <div
+            class="PicassoContainer-inline"
           >
-            Primary
-          </span>
-        </button>
-        <button
-          class="MuiButtonBase-root PicassoButton-small PicassoButton-secondary PicassoButton-root"
-          data-component-type="button"
-          label="Secondary"
-          tabindex="0"
-          type="button"
-        >
-          <span
-            class="PicassoContainer-centerAlignItems PicassoContainer-flex PicassoContainer-inline PicassoButton-content"
+            <button
+              class="MuiButtonBase-root PicassoButton-small PicassoButton-primary PicassoButton-root"
+              data-component-type="button"
+              data-testid="action-button"
+              tabindex="0"
+              type="button"
+            >
+              <span
+                class="PicassoContainer-centerAlignItems PicassoContainer-flex PicassoContainer-inline PicassoButton-content"
+              >
+                Primary
+              </span>
+            </button>
+          </div>
+          <div
+            class="PicassoContainer-inline"
           >
-            Secondary
-          </span>
-        </button>
+            <button
+              class="MuiButtonBase-root PicassoButton-small PicassoButton-secondary PicassoButton-root"
+              data-component-type="button"
+              data-testid="action-button"
+              tabindex="0"
+              type="button"
+            >
+              <span
+                class="PicassoContainer-centerAlignItems PicassoContainer-flex PicassoContainer-inline PicassoButton-content"
+              >
+                Secondary
+              </span>
+            </button>
+          </div>
+        </div>
       </div>
     </div>
   </div>

--- a/packages/picasso/src/Alert/story/Actions.example.tsx
+++ b/packages/picasso/src/Alert/story/Actions.example.tsx
@@ -1,8 +1,11 @@
 import React from 'react'
-import { Alert } from '@toptal/picasso'
+import { Alert, Container, Menu } from '@toptal/picasso'
 
 const mockOnClose = () => {
   window.alert('Close icon')
+}
+const mockOnMenuClick = () => {
+  window.alert('Menu item clicked')
 }
 
 const actions = {
@@ -17,9 +20,31 @@ const actions = {
 }
 
 const Example = () => (
-  <Alert onClose={mockOnClose} actions={actions}>
-    This is a warning alert with actions
-  </Alert>
+  <Container flex direction='column'>
+    <Container bottom='small'>
+      <Alert actions={actions}>This is a warning alert with actions</Alert>
+    </Container>
+    <Container>
+      <Alert
+        onClose={mockOnClose}
+        actions={{
+          ...actions,
+          primary: {
+            ...actions.primary,
+            menu: (
+              <Menu data-testid='menu'>
+                <Menu.Item onClick={mockOnMenuClick}>First item</Menu.Item>
+                <Menu.Item onClick={mockOnMenuClick}>Second item</Menu.Item>
+                <Menu.Item onClick={mockOnMenuClick}>Third item</Menu.Item>
+              </Menu>
+            ),
+          },
+        }}
+      >
+        Actions can also be split buttons with menus!
+      </Alert>
+    </Container>
+  </Container>
 )
 
 export default Example


### PR DESCRIPTION
[FX-4529](https://toptal-core.atlassian.net/browse/FX-4529)

### Description

According to BASE, the action buttons in `Alert` should also support their split variants with dropdown menus. 
Each button can either be normal or split, with only two variants available (one of each at the time only).

### How to test

<!-- The temploy link will be automatically updated when the temploy is deployed -->
- [Temploy](https://picasso.toptal.net/fx-4529-extend-cta-button-in-the-alert-component-to-use-the-split-button-variant-as-well)
- See if the code and API looks good
- Look at the new examples for `Alert` on the temploy
- Tests should pass

### Screenshots

![image](https://github.com/toptal/picasso/assets/18409292/951f7fb7-5043-42b6-8b17-31b7d299b3ac)

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests ([visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md) included)


> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-4529]: https://toptal-core.atlassian.net/browse/FX-4529?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ