### PR TITLE
[FX-3114] Do not emit incorrect time values

### DIFF
--- a/.changeset/loud-geese-destroy.md
+++ b/.changeset/loud-geese-destroy.md
@@ -1,7 +1,8 @@
 ---
-'@toptal/picasso': patch
+'@toptal/picasso': major
 ---
 
 ### TimePicker
 
-- do not emit incorrect time values
+- change the signature of `onChange` handler to accept `string` instead of event object. In order to migrate, please replace usage of `event.target.value` with `value` in your `onChange` handler
+- do not emit incorrect time values, e.g. `12:--` or `60:00`. When input has incorrect value, the `onChange` handler will be called with empty string value

--- a/.changeset/loud-geese-destroy.md
+++ b/.changeset/loud-geese-destroy.md
@@ -1,0 +1,7 @@
+---
+'@toptal/picasso': patch
+---
+
+### TimePicker
+
+- do not emit incorrect time values

--- a/packages/picasso/src/TimePicker/TimePicker.tsx
+++ b/packages/picasso/src/TimePicker/TimePicker.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState } from 'react'
 import type { BaseProps } from '@toptal/picasso-shared'
 import type { Theme } from '@material-ui/core/styles'
 import { makeStyles } from '@material-ui/core/styles'
@@ -48,8 +48,8 @@ export interface Props
 
 export const TimePicker = (props: Props) => {
   const {
-    onChange,
-    value,
+    onChange: externalOnChange,
+    value: initialValue,
     width,
     className,
     error,
@@ -57,6 +57,29 @@ export const TimePicker = (props: Props) => {
     highlight,
     ...rest
   } = props
+
+  const [value, setValue] = useState(initialValue)
+
+  const onChange = (
+    event: React.ChangeEvent<
+      HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement
+    >
+  ) => {
+    const newValue = event.target.value
+
+    setValue(newValue)
+
+    console.log('@@@ newValue', newValue)
+
+    const regExp = new RegExp(/^([0-1][0-9]|2[0-3]):[0-5][0-9]$/)
+
+    if (newValue && regExp.test(newValue)) {
+      console.log('@@@ matches')
+      externalOnChange?.(event)
+    } else {
+      externalOnChange?.({ ...event, target: { ...event.target, value: '' } })
+    }
+  }
 
   usePropDeprecationWarning({
     props,

--- a/packages/picasso/src/TimePicker/TimePicker.tsx
+++ b/packages/picasso/src/TimePicker/TimePicker.tsx
@@ -46,6 +46,8 @@ export interface Props
   status?: Extract<Status, 'error' | 'default'>
 }
 
+const VALID_TIME_REGEX = new RegExp(/^([0-1][0-9]|2[0-3]):[0-5][0-9]$/)
+
 export const TimePicker = (props: Props) => {
   const {
     onChange: externalOnChange,
@@ -69,15 +71,11 @@ export const TimePicker = (props: Props) => {
 
     setValue(newValue)
 
-    console.log('@@@ newValue', newValue)
-
-    const regExp = new RegExp(/^([0-1][0-9]|2[0-3]):[0-5][0-9]$/)
-
-    if (newValue && regExp.test(newValue)) {
-      console.log('@@@ matches')
+    if (newValue && VALID_TIME_REGEX.test(newValue)) {
       externalOnChange?.(event)
     } else {
-      externalOnChange?.({ ...event, target: { ...event.target, value: '' } })
+      event.target.value = ''
+      externalOnChange?.(event)
     }
   }
 

--- a/packages/picasso/src/TimePicker/TimePicker.tsx
+++ b/packages/picasso/src/TimePicker/TimePicker.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import type { BaseProps } from '@toptal/picasso-shared'
 import type { Theme } from '@material-ui/core/styles'
 import { makeStyles } from '@material-ui/core/styles'
@@ -24,6 +24,7 @@ export interface Props
       | 'id'
       | 'value'
       | 'onSelect'
+      | 'onChange'
       | 'type'
       | 'multiline'
       | 'rows'
@@ -44,6 +45,8 @@ export interface Props
   value?: string
   /** Indicate whether `TimePicker` is in `error` or `default` state */
   status?: Extract<Status, 'error' | 'default'>
+  /** Called on input change */
+  onChange?: (value: string) => void
 }
 
 const VALID_TIME_REGEX = new RegExp(/^([0-1][0-9]|2[0-3]):[0-5][0-9]$/)
@@ -51,7 +54,7 @@ const VALID_TIME_REGEX = new RegExp(/^([0-1][0-9]|2[0-3]):[0-5][0-9]$/)
 export const TimePicker = (props: Props) => {
   const {
     onChange: externalOnChange,
-    value: initialValue,
+    value: externalValue,
     width,
     className,
     error,
@@ -60,7 +63,14 @@ export const TimePicker = (props: Props) => {
     ...rest
   } = props
 
-  const [value, setValue] = useState(initialValue)
+  const [value, setValue] = useState(externalValue)
+
+  useEffect(() => {
+    // Set internal value based on the provided one if the later is correct
+    if (externalValue && VALID_TIME_REGEX.test(externalValue)) {
+      setValue(externalValue)
+    }
+  }, [externalValue])
 
   const onChange = (
     event: React.ChangeEvent<
@@ -72,10 +82,9 @@ export const TimePicker = (props: Props) => {
     setValue(newValue)
 
     if (newValue && VALID_TIME_REGEX.test(newValue)) {
-      externalOnChange?.(event)
+      externalOnChange?.(newValue)
     } else {
-      event.target.value = ''
-      externalOnChange?.(event)
+      externalOnChange?.('')
     }
   }
 

--- a/packages/picasso/src/TimePicker/story/Default.example.tsx
+++ b/packages/picasso/src/TimePicker/story/Default.example.tsx
@@ -1,28 +1,10 @@
-// TODO: revert before merge
-import React from 'react'
-import { Container } from '@toptal/picasso'
-import { SPACING_4 } from '@toptal/picasso/utils'
-import {
-  FormNonCompound as Form,
-  SubmitButton,
-  DatePicker,
-  TimePicker,
-} from '@toptal/picasso-forms'
+import React, { useState } from 'react'
+import { TimePicker } from '@toptal/picasso'
 
-const Example = () => {
-  return (
-    <Form
-      autoComplete='off'
-      onSubmit={values => window.alert(JSON.stringify(values, undefined, 2))}
-      initialValues={{}}
-    >
-      <DatePicker required name='default-dateOfBirth' label='Date of birth' />
-      <TimePicker required name='default-timeOfBirth' label='Time of birth' />
-      <Container top={SPACING_4}>
-        <SubmitButton>Submit</SubmitButton>
-      </Container>
-    </Form>
-  )
+const DefaultExample = () => {
+  const [timepickerValue, setTimepickerValue] = useState<string>('18:00')
+
+  return <TimePicker onChange={setTimepickerValue} value={timepickerValue} />
 }
 
-export default Example
+export default DefaultExample

--- a/packages/picasso/src/TimePicker/story/Default.example.tsx
+++ b/packages/picasso/src/TimePicker/story/Default.example.tsx
@@ -1,18 +1,28 @@
-import React, { useState } from 'react'
-import { TimePicker } from '@toptal/picasso'
+// TODO: revert before merge
+import React from 'react'
+import { Container } from '@toptal/picasso'
+import { SPACING_4 } from '@toptal/picasso/utils'
+import {
+  FormNonCompound as Form,
+  SubmitButton,
+  DatePicker,
+  TimePicker,
+} from '@toptal/picasso-forms'
 
-const DefaultExample = () => {
-  const [timepickerValue, setTimepickerValue] = useState<string>('18:00')
-
-  const handleChange = (
-    e: React.ChangeEvent<
-      HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement
+const Example = () => {
+  return (
+    <Form
+      autoComplete='off'
+      onSubmit={values => window.alert(JSON.stringify(values, undefined, 2))}
+      initialValues={{}}
     >
-  ) => {
-    setTimepickerValue(e.target.value)
-  }
-
-  return <TimePicker onChange={handleChange} value={timepickerValue} />
+      <DatePicker required name='default-dateOfBirth' label='Date of birth' />
+      <TimePicker required name='default-timeOfBirth' label='Time of birth' />
+      <Container top={SPACING_4}>
+        <SubmitButton>Submit</SubmitButton>
+      </Container>
+    </Form>
+  )
 }
 
-export default DefaultExample
+export default Example

--- a/packages/picasso/src/TimePicker/test.tsx
+++ b/packages/picasso/src/TimePicker/test.tsx
@@ -42,21 +42,13 @@ describe('TimePicker', () => {
 
       fireEvent.change(input, { target: { value: '12:--' } })
       expect(handleChange).toHaveBeenCalledTimes(1)
-      expect(handleChange).toHaveBeenCalledWith(
-        expect.objectContaining({
-          target: expect.objectContaining({ value: '' }),
-        })
-      )
+      expect(handleChange).toHaveBeenCalledWith('')
 
       const newTime = '12:12'
 
       fireEvent.change(input, { target: { value: newTime } })
       expect(handleChange).toHaveBeenCalledTimes(2)
-      expect(handleChange).toHaveBeenCalledWith(
-        expect.objectContaining({
-          target: expect.objectContaining({ value: newTime }),
-        })
-      )
+      expect(handleChange).toHaveBeenCalledWith(newTime)
     })
   })
 })

--- a/packages/picasso/src/TimePicker/test.tsx
+++ b/packages/picasso/src/TimePicker/test.tsx
@@ -29,4 +29,34 @@ describe('TimePicker', () => {
 
     expect(handleChange).toHaveBeenCalledTimes(1)
   })
+
+  describe('when invalid time is entered', () => {
+    it('calls onChange with empty value', () => {
+      const time = '09:00'
+      const handleChange = jest.fn()
+      const { getByDisplayValue } = render(
+        <TimePicker value={time} onChange={handleChange} />
+      )
+
+      const input = getByDisplayValue(time)
+
+      fireEvent.change(input, { target: { value: '12:--' } })
+      expect(handleChange).toHaveBeenCalledTimes(1)
+      expect(handleChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          target: expect.objectContaining({ value: '' }),
+        })
+      )
+
+      const newTime = '12:12'
+
+      fireEvent.change(input, { target: { value: newTime } })
+      expect(handleChange).toHaveBeenCalledTimes(2)
+      expect(handleChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          target: expect.objectContaining({ value: newTime }),
+        })
+      )
+    })
+  })
 })


### PR DESCRIPTION
[FX-3114]

### Description

This pull request fixes the behavior of `TimePicker`. It **no longer emits incorrect time values** like "12:--", it either emits proper value that was entered or it emits empty value so the form validation is properly triggered.

Chrome and Firefox prove their own in-browser validation, but even latest Safari fails to do so, so we should not rely on the browser-implementation.

**Chrome**

<img width="564" alt="Screenshot 2023-11-29 at 10 23 55" src="https://github.com/toptal/picasso/assets/1390758/62d6029a-dc12-42f0-a87e-823468786cbb">

**Firefox**

<img width="376" alt="Screenshot 2023-11-29 at 10 23 18" src="https://github.com/toptal/picasso/assets/1390758/af19efc8-69d8-40d5-8db9-26edc33c6909">

**Safari** 

<img width="371" alt="Screenshot 2023-11-29 at 10 23 39" src="https://github.com/toptal/picasso/assets/1390758/9a792bd5-a15f-488b-b81c-d277b8b1f6da">


### How to test

<!-- The temploy link will be automatically updated when the temploy is deployed -->
- Check the very first example in [temploy](https://picasso.toptal.net/fx-3114-timepicker-validation-of-the-value-is-not-working-properly-in-safari?path=/story/forms-timepicker--timepicker) and try to submit the form

### Screenshots from Safari

Before

https://github.com/toptal/picasso/assets/1390758/0620c7fa-e868-49bb-8c08-8545116c7c28

After

https://github.com/toptal/picasso/assets/1390758/de4b2d2d-a60e-4f2c-94ff-086c14f967da

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [N/A] Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [N/A] Annotate all `props` in component with documentation
- [N/A] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests ([visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md) included)

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-3114]: https://toptal-core.atlassian.net/browse/FX-3114?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ