### PR TITLE
[FX-3913] Remove GCR from Jenkinsfile

### DIFF
--- a/ci/jobs/build-image/Jenkinsfile
+++ b/ci/jobs/build-image/Jenkinsfile
@@ -1,7 +1,6 @@
 @Library('globalLibrary@master') _
 
 image = null
-image2 = null
 
 pipeline {
   agent { label 'docker' }
@@ -46,15 +45,8 @@ pipeline {
 
           sh 'gcloud auth activate-service-account --key-file=$GCE_ACCOUNT_KEY'
 
-          if (!isDockerImagePresentRemotely("gcr.io/toptal-hub/${IMAGE_NAME}", VERSION)) {
-            image = docker.build("toptal-hub/${IMAGE_NAME}:${VERSION}")
-            success "== Built image for version ${VERSION} =="
-          } else {
-            success "== Found image for version ${VERSION} =="
-          }
-
           if (!isDockerImagePresentRemotely("us-central1-docker.pkg.dev/toptal-hub/containers/${IMAGE_NAME}", VERSION)) {
-            image2 = docker.build("us-central1-docker.pkg.dev/toptal-hub/containers/${IMAGE_NAME}:${VERSION}")
+            image = docker.build("us-central1-docker.pkg.dev/toptal-hub/containers/${IMAGE_NAME}:${VERSION}")
             success "== Built image for version ${VERSION} =="
           } else {
             success "== Found image for version ${VERSION} =="
@@ -67,13 +59,8 @@ pipeline {
       steps {
         script {
           if (image) {
-            docker.withRegistry('https://gcr.io/toptal-hub/') {
-              image.push(VERSION)
-            }
-          }
-          if (image2) {
             docker.withRegistry('https://us-central1-docker.pkg.dev/toptal-hub/containers/') {
-              image2.push(VERSION)
+              image.push(VERSION)
             }
             success "== Pushed image with tag ${VERSION} =="
           }


### PR DESCRIPTION
[FX-3913]

### Description

This pull request removes extra check for existing image in Google Container Registry (GCR), we no longer hope there there is anything there due to migration to Google Artifact Registry (GAR). Also, we no longer push anything to GCR, only to GAR.

### How to test

<!-- The temploy link will be automatically updated when the temploy is deployed -->
- [Temploy](https://picasso.toptal.net/fx-3913-replace-gcr-with-ar-in-temploy-helm-run-in-davinci)
- The ✅ https://jenkins-build.toptal.net/job/picasso-build-image/13963/console was built, it
  - reuses updated Jenkinsfile from this branch
  - builds image for the last commit from this branch
  - the image is created in https://console.cloud.google.com/artifacts/docker/toptal-hub/us-central1/containers/picasso/sha256:767105823eadf9b0c1104137a5164cd553c2044f0d1fbd53147194302081adb3?authuser=1&hl=en&project=toptal-hub (`us-central1-docker.pkg.dev/toptal-hub/containers/picasso:54726d5e38bcfad3db5eecff773bd6e4c5b304f3`)

### Development checks

- [N/A] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [N/A] Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [N/A] Annotate all `props` in component with documentation
- [N/A] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [N/A] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [N/A] Covered with tests ([visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md) included)
- [x] ⚠️ **Revert changes in https://jenkins-build.toptal.net/job/picasso-build-image/configure**

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-3913]: https://toptal-core.atlassian.net/browse/FX-3913?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ