### PR TITLE
[FX-4554] Export useFieldsLayoutContext hook

### DIFF
--- a/.changeset/brown-pigs-tie.md
+++ b/.changeset/brown-pigs-tie.md
@@ -1,0 +1,5 @@
+---
+'@toptal/picasso-forms': minor
+---
+
+- mention `useFieldsLayoutContext` hook in forms documentation

--- a/.changeset/neat-lies-mate.md
+++ b/.changeset/neat-lies-mate.md
@@ -1,0 +1,5 @@
+---
+'@toptal/picasso': minor
+---
+
+- export `useFieldsLayoutContext()` hook

--- a/packages/picasso-forms/src/Form/story/index.jsx
+++ b/packages/picasso-forms/src/Form/story/index.jsx
@@ -163,7 +163,7 @@ types supported by picasso-forms.
     {
       title: 'Horizontal',
       description:
-        'Horizontal form with responsive design. Use `useFieldsLayoutContext()` hook to get access to the current layout depending on the screen size.',
+        'Horizontal form with responsive design. Use "useFieldsLayoutContext()" hook from "@toptal/picasso" to get access to the current layout depending on the screen size.',
       screenshotBreakpoints: true,
     },
     'picasso-form'

--- a/packages/picasso-forms/src/Form/story/index.jsx
+++ b/packages/picasso-forms/src/Form/story/index.jsx
@@ -162,7 +162,8 @@ types supported by picasso-forms.
     'Form/story/Horizontal.example.tsx',
     {
       title: 'Horizontal',
-      description: 'Horizontal form with responsive design',
+      description:
+        'Horizontal form with responsive design. Use `useFieldsLayoutContext()` hook to get access to the current layout depending on the screen size.',
       screenshotBreakpoints: true,
     },
     'picasso-form'

--- a/packages/picasso/src/index.ts
+++ b/packages/picasso/src/index.ts
@@ -211,6 +211,7 @@ export type {
   FileRejection as AvatarUploadFileRejection,
   DropEvent as AvatarUploadDropEvent,
 } from './AvatarUpload'
+export * from './FieldsLayout'
 
 export { default as Carousel } from './Carousel'
 export type { CarouselProps } from './Carousel'


### PR DESCRIPTION
[FX-4554]

### Description

This pull requests exports `useFieldsLayoutContext()` hook, so consumers can build their own form extensions to match the layout.

### How to test

<!-- The temploy link will be automatically updated when the temploy is deployed -->
- [Temploy](https://picasso.toptal.net/FX-NULL-export-useFieldsLayoutContext)
- Test the code below in Storybook, the buttons form footer should be adaptable

```
import React from 'react'
import { Container } from '@toptal/picasso'
import { useFieldsLayoutContext } from '@toptal/picasso'
import {
  FormNonCompound as Form,
  Input,
  SubmitButton,
  Switch,
} from '@toptal/picasso-forms'

const initialValues = {}

const Buttons = () => {
  const { layout } = useFieldsLayoutContext()
  return (
    <Container style={layout === 'horizontal' ? {
      display: 'grid',
      gridTemplateRows: 'auto auto',
      gridTemplateAreas: `"label input" "hint error"`,
      gridTemplateColumns: '272px 1fr',
      paddingTop: '1rem',
      gap: '0 32px'
    } : {}}
  >
    <div>AAAA</div>
    <div><SubmitButton>Submit</SubmitButton></div>
  </Container>
  )
}

const Example = () => {
  return (
    <Form
      autoComplete='off'
      onSubmit={values => window.alert(JSON.stringify(values, undefined, 2))}
      initialValues={initialValues}
      layout='horizontal'
    >
      <Input
        enableReset
        onResetClick={(set: (value: string) => void) => {
          set('')
        }}
        required
        name='default-firstName'
        label='First name'
        placeholder='e.g. Bruce'
      />
      <Switch
        name='default-publicProfile'
        label='Public Profile'
        width='auto'
      />
        <Buttons/>
    </Form>
  )
}

export default Example

```

https://github.com/toptal/picasso/assets/1390758/85287a00-fa3f-4703-9337-c678ee077f43


### Screenshots

Tested locally on sample app

https://github.com/toptal/picasso/assets/1390758/4cfe172a-a756-4aec-835b-30b2716184df


### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [N/A] Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [N/A] Annotate all `props` in component with documentation
- [N/A] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [N/A] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [N/A] Covered with tests ([visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md) included)

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-4554]: https://toptal-core.atlassian.net/browse/FX-4554?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ