### PR TITLE
[FX-4635] Pass data-private to some components manually

### DIFF
--- a/.changeset/stale-geese-carry.md
+++ b/.changeset/stale-geese-carry.md
@@ -1,0 +1,8 @@
+---
+'@toptal/picasso-shared': minor
+'@toptal/picasso': patch
+---
+
+### Radio, Checkbox, Tooltip, Avatar, Page.TopBarMenu
+
+- pass `data-private` to relevant DOM elements

--- a/packages/picasso/src/Avatar/Avatar.tsx
+++ b/packages/picasso/src/Avatar/Avatar.tsx
@@ -50,6 +50,7 @@ export const Avatar = (props: Props) => {
     variant,
     testIds,
     onEdit,
+    'data-private': dataPrivate,
     ...rest
   } = props
 
@@ -65,6 +66,7 @@ export const Avatar = (props: Props) => {
           src={src}
           style={style}
           data-testid={testIds?.image}
+          data-private={dataPrivate}
         />
       )
     }
@@ -80,6 +82,7 @@ export const Avatar = (props: Props) => {
           /* eslint-disable-next-line @typescript-eslint/no-non-null-assertion */
           size={size!}
           data-testid={testIds?.text}
+          data-private={dataPrivate}
         >
           {initials}
         </TextAvatar>
@@ -92,6 +95,7 @@ export const Avatar = (props: Props) => {
         className={className}
         /* eslint-disable-next-line @typescript-eslint/no-non-null-assertion */
         size={size!}
+        data-private={dataPrivate}
       />
     )
   }, [

--- a/packages/picasso/src/Avatar/Avatar.tsx
+++ b/packages/picasso/src/Avatar/Avatar.tsx
@@ -95,7 +95,6 @@ export const Avatar = (props: Props) => {
         className={className}
         /* eslint-disable-next-line @typescript-eslint/no-non-null-assertion */
         size={size!}
-        data-private={dataPrivate}
       />
     )
   }, [

--- a/packages/picasso/src/Avatar/ImageAvatar/ImageAvatar.tsx
+++ b/packages/picasso/src/Avatar/ImageAvatar/ImageAvatar.tsx
@@ -50,6 +50,7 @@ const ImageAvatar = (props: Props) => {
     src,
     style,
     'data-testid': dataTestId,
+    'data-private': dataPrivate,
   } = props
   const classes = useStyles(props)
 
@@ -61,6 +62,7 @@ const ImageAvatar = (props: Props) => {
         src={src}
         style={style}
         data-testid={dataTestId}
+        data-private={dataPrivate}
       />
       <AvatarLogo classes={classes} size={size} />
     </>

--- a/packages/picasso/src/Avatar/TextAvatar/TextAvatar.tsx
+++ b/packages/picasso/src/Avatar/TextAvatar/TextAvatar.tsx
@@ -25,6 +25,7 @@ const TextAvatar = ({
   'data-testid': dataTestID,
   fontSize,
   size,
+  'data-private': dataPrivate,
 }: Props) => {
   const classes = useStyles()
 
@@ -33,6 +34,7 @@ const TextAvatar = ({
       /* eslint-disable-next-line @typescript-eslint/no-non-null-assertion */
       className={cx(classes.root, className, classes[size!])}
       style={style}
+      data-private={dataPrivate}
     >
       <Typography
         data-testid={dataTestID}

--- a/packages/picasso/src/Checkbox/Checkbox.tsx
+++ b/packages/picasso/src/Checkbox/Checkbox.tsx
@@ -65,7 +65,7 @@ export const Checkbox = forwardRef<HTMLButtonElement | HTMLLabelElement, Props>(
       disabled: classes.disabled,
     }
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const { color, ...checkboxAttributes } = rest
+    const { color, 'data-private': dataPrivate, ...checkboxAttributes } = rest
 
     const muiCheckbox = (
       <Container as='span' flex inline className={classes.checkboxWrapper}>
@@ -116,6 +116,7 @@ export const Checkbox = forwardRef<HTMLButtonElement | HTMLLabelElement, Props>(
         label={label}
         titleCase={titleCase}
         className='picasso-checkbox'
+        data-private={dataPrivate}
       />
     )
   }

--- a/packages/picasso/src/PageTopBarMenu/PageTopBarMenu.tsx
+++ b/packages/picasso/src/PageTopBarMenu/PageTopBarMenu.tsx
@@ -30,7 +30,16 @@ export interface Props extends BaseProps, HTMLAttributes<HTMLDivElement> {
 
 export const PageTopBarMenu = forwardRef<HTMLDivElement, Props>(
   function PageTopBarMenu(props, ref) {
-    const { name, meta, avatar, className, style, children, ...rest } = props
+    const {
+      name,
+      meta,
+      avatar,
+      className,
+      style,
+      children,
+      'data-private': dataPrivate,
+      ...rest
+    } = props
     const classes = useStyles()
 
     const isCompactLayout = useBreakpoint(['xs', 'sm', 'md'])
@@ -41,6 +50,7 @@ export const PageTopBarMenu = forwardRef<HTMLDivElement, Props>(
           className={classes.truncateText}
           invert={!isCompactLayout}
           size='xsmall'
+          data-private={dataPrivate}
         >
           {meta}
         </Typography>
@@ -53,6 +63,7 @@ export const PageTopBarMenu = forwardRef<HTMLDivElement, Props>(
         <UserBadge
           center
           size='xxsmall'
+          data-private={dataPrivate}
           classes={{
             root: classes.contentUserBadge,
             avatar: classes.avatar,
@@ -70,7 +81,12 @@ export const PageTopBarMenu = forwardRef<HTMLDivElement, Props>(
     )
 
     const trigger = isCompactLayout ? (
-      <Avatar size='xxsmall' name={name} src={avatar as string} />
+      <Avatar
+        size='xxsmall'
+        data-private={dataPrivate}
+        name={name}
+        src={avatar as string}
+      />
     ) : (
       <UserBadge
         invert
@@ -80,6 +96,7 @@ export const PageTopBarMenu = forwardRef<HTMLDivElement, Props>(
           name: cx(classes.name, classes.truncateText),
         }}
         name={name}
+        data-private={dataPrivate}
         avatar={avatar}
       >
         {meta && metaContent}

--- a/packages/picasso/src/Radio/Radio.tsx
+++ b/packages/picasso/src/Radio/Radio.tsx
@@ -48,6 +48,7 @@ export const Radio = forwardRef<HTMLButtonElement | HTMLLabelElement, Props>(
       value,
       onChange,
       titleCase,
+      'data-private': dataPrivate,
       ...rest
     } = props
     const classes = useStyles(props)
@@ -96,6 +97,7 @@ export const Radio = forwardRef<HTMLButtonElement | HTMLLabelElement, Props>(
         }}
         style={style}
         label={label}
+        data-private={dataPrivate}
         disabled={disabled}
         titleCase={titleCase}
       />

--- a/packages/picasso/src/Tooltip/Tooltip.tsx
+++ b/packages/picasso/src/Tooltip/Tooltip.tsx
@@ -96,6 +96,7 @@ export const Tooltip = forwardRef<unknown, Props>((props, ref) => {
     followCursor = false,
     tooltipRef,
     container,
+    'data-private': dataPrivate,
     ...rest
   } = props
 
@@ -123,7 +124,12 @@ export const Tooltip = forwardRef<unknown, Props>((props, ref) => {
   })
 
   const title = (
-    <Typography as='div' size='small' color='inherit'>
+    <Typography
+      data-private={dataPrivate}
+      as='div'
+      size='small'
+      color='inherit'
+    >
       {content}
     </Typography>
   )

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -23,6 +23,7 @@ export interface BaseProps {
   /** Style applied to root element */
   style?: CSSProperties
   'data-testid'?: string
+  'data-private'?: string
 }
 
 export interface JssProps {


### PR DESCRIPTION
[FX-4635](https://toptal-core.atlassian.net/browse/FX-4635)

### Description

Some components pass `{...rest}` to a particular DOM element, however `data-private` sometimes has to be set for different DOM elements (for example, for Checkbox, label has to be private, not the checkbox itself).

This PR adresses most problems we found.

### How to test

<!-- The temploy link will be automatically updated when the temploy is deployed -->
- [Temploy](https://picasso.toptal.net/fx-4635-adjust-picasso-components-to-properly-handle-data-private-attribute)
- Tests should pass
- Code should look good, attributes should be passed to proper elements


### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests ([visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md) included)


> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-4635]: https://toptal-core.atlassian.net/browse/FX-4635?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ