### PR TITLE
[FX-4486] Lint all deprecation warnings to have a ticket number

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -43,8 +43,22 @@ module.exports = {
     './node_modules/@toptal/davinci-syntax/src/configs/.eslintrc.cjs',
     'plugin:ssr-friendly/recommended',
   ],
-  plugins: ['ssr-friendly'],
+  plugins: ['ssr-friendly', 'eslint-plugin-local-rules'],
   rules: {
+    // When a deprecation warning hook is used, it must be preceded by a comment. Having a ticket
+    // reference in the comment is enforced by the next rule.
+    'local-rules/future-proof-deprecation-warning': 'warn',
+    // When @deprecated is used, it must be followed by a Jira issue either in a short form [ABC-1234] or a full URL
+    'todo-plz/ticket-ref': [
+      'warn',
+      {
+        terms: ['TODO', 'FIXME', '@deprecated'],
+        commentPattern:
+          '(TODO:|FIXME:|@deprecated) ((\\n|.)*(\\[([A-Z]+-\\d+)+]|https:\\/\\/toptal-core\\.atlassian\\.net\\/browse\\/([A-Z]+-\\d+)))+',
+        description:
+          'Please add either a full URL to Jira issue or a short form: [ABC-1234] ',
+      },
+    ],
     '@toptal/davinci/no-private-package-imports': 'off',
     '@toptal/davinci/no-package-self-imports': [
       'error',

--- a/eslint-local-rules.js
+++ b/eslint-local-rules.js
@@ -1,0 +1,40 @@
+const FUNCTION_NAMES = ['usePropDeprecationWarning', 'useDeprecationWarning']
+
+module.exports = {
+  'future-proof-deprecation-warning': {
+    meta: {
+      type: 'suggestion',
+      fixable: null,
+      docs: {
+        description:
+          'Ensure a deprecation warning is preceded by a TODO comment',
+        category: 'Picasso Best Practices',
+        recommended: false,
+      },
+      schema: [],
+    },
+    create: function (context) {
+      return {
+        CallExpression(node) {
+          if (FUNCTION_NAMES.includes(node.callee.name)) {
+            const sourceCode = context.getSourceCode()
+            const commentBefore = sourceCode.getCommentsBefore(node)
+
+            const hasTodoComment = commentBefore.some(
+              comment =>
+                (comment.type === 'Line' && comment.value.includes('TODO')) ||
+                (comment.type === 'Block' && comment.value.includes('TODO'))
+            )
+
+            if (!hasTodoComment) {
+              context.report({
+                node,
+                message: `${node.callee.name} must be preceded by a TODO comment `,
+              })
+            }
+          }
+        },
+      }
+    },
+  },
+}

--- a/eslint-local-rules.js
+++ b/eslint-local-rules.js
@@ -22,8 +22,8 @@ module.exports = {
 
             const hasTodoComment = commentBefore.some(
               comment =>
-                (comment.type === 'Line' && comment.value.includes('TODO')) ||
-                (comment.type === 'Block' && comment.value.includes('TODO'))
+                comment.value.includes('TODO') ||
+                comment.value.includes('FIXME')
             )
 
             if (!hasTodoComment) {

--- a/eslint-local-rules.js
+++ b/eslint-local-rules.js
@@ -7,7 +7,7 @@ module.exports = {
       fixable: null,
       docs: {
         description:
-          'Ensure a deprecation warning is preceded by a TODO comment',
+          'Ensure a deprecation warning is preceded by a TODO comment with a ticket reference',
         category: 'Picasso Best Practices',
         recommended: false,
       },
@@ -29,7 +29,7 @@ module.exports = {
             if (!hasTodoComment) {
               context.report({
                 node,
-                message: `${node.callee.name} must be preceded by a TODO comment `,
+                message: `${node.callee.name} must be preceded by a TODO comment with a ticket reference `,
               })
             }
           }

--- a/package.json
+++ b/package.json
@@ -107,6 +107,7 @@
     "debounce": "^1.2.1",
     "ejs": "^3.1.8",
     "escodegen": "^2.1.0",
+    "eslint-plugin-local-rules": "^2.0.1",
     "eslint-plugin-ssr-friendly": "^1.3.0",
     "esprima": "^4.0.1",
     "esprima-walk": "^0.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11190,6 +11190,11 @@ eslint-plugin-jest@^26.4.5:
   dependencies:
     "@typescript-eslint/utils" "^5.10.0"
 
+eslint-plugin-local-rules@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-local-rules/-/eslint-plugin-local-rules-2.0.1.tgz#b9245e5def0d4ce698d062fb058fe16571805aa5"
+  integrity sha512-AJhGd+GcI5r2dbjiGPixM8jnBl0XFxqoVbqzwKbYz+nTk+Cj5dNE3+OlhC176bl5r25KsGsIthLi1VqIW5Ga+A==
+
 eslint-plugin-markdownlint@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-markdownlint/-/eslint-plugin-markdownlint-0.4.0.tgz#ee70192efb05d451d5287c1b0454a280e5568f30"


### PR DESCRIPTION
[FX-4486](https://toptal-core.atlassian.net/browse/FX-4486)

### Description

When we deprecate something, it MUST have a referencing ticket number for the scheduled removal.
This new set of eslint rules covers that, both `@deprecated` comments and deprecation warning hooks.

### How to test

<!-- The temploy link will be automatically updated when the temploy is deployed -->
- [Temploy](https://picasso.toptal.net/fx-4486-create-eslint-rule-to-catch-deprecated-parts-not-scheduled-for-removal)
- Check out the branch
- Search for `@deprecated` comments, they should now all be warnings
- Try to add a ticket number to it, the warning should go away
- Look for `usePropDeprecationWarning` or `useDeprecationWarning` calls in the codebase
- it should also not be possible to use a hook without a TODO + ticket comment combo without spawning a warning

### Screenshots

![image (17)](https://github.com/toptal/picasso/assets/18409292/1c48d8dc-a363-421c-b06c-45a15e988f0c)
![image (16)](https://github.com/toptal/picasso/assets/18409292/26e32476-bb69-4a59-83e3-6e40ce79088e)


### Development checks

- [n/a] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [n/a] Annotate all `props` in component with documentation
- [n/a] Create `examples` for component
- [n/a] Ensure that deployed demo has expected results and good examples
- [n/a] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [n/a] Covered with tests ([visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md) included)

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-4486]: https://toptal-core.atlassian.net/browse/FX-4486?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ