### PR TITLE
[FX-4630] Add aria-current to the active button in Pagination

### DIFF
--- a/.changeset/lemon-chairs-compare.md
+++ b/.changeset/lemon-chairs-compare.md
@@ -2,4 +2,6 @@
 '@toptal/picasso': patch
 ---
 
-- add aria-current to Pagination buttons
+### Pagination
+
+- add aria-current to buttons

--- a/.changeset/lemon-chairs-compare.md
+++ b/.changeset/lemon-chairs-compare.md
@@ -1,0 +1,5 @@
+---
+'@toptal/picasso': patch
+---
+
+- add aria-current to Pagination buttons

--- a/packages/picasso/src/Pagination/__snapshots__/test.tsx.snap
+++ b/packages/picasso/src/Pagination/__snapshots__/test.tsx.snap
@@ -21,6 +21,7 @@ exports[`Pagination renders 1`] = `
         </span>
       </button>
       <button
+        aria-current="false"
         class="MuiButtonBase-root PicassoButton-small PicassoButton-secondary PicassoButton-root PicassoPaginationButton-root PicassoPagination-button"
         data-component-type="button"
         tabindex="0"
@@ -42,6 +43,7 @@ exports[`Pagination renders 1`] = `
         </p>
       </div>
       <button
+        aria-current="false"
         class="MuiButtonBase-root PicassoButton-small PicassoButton-secondary PicassoButton-root PicassoPaginationButton-root PicassoPagination-button"
         data-component-type="button"
         tabindex="0"
@@ -54,6 +56,7 @@ exports[`Pagination renders 1`] = `
         </span>
       </button>
       <button
+        aria-current="false"
         class="MuiButtonBase-root PicassoButton-small PicassoButton-secondary PicassoButton-root PicassoPaginationButton-root PicassoPagination-button"
         data-component-type="button"
         tabindex="0"
@@ -79,6 +82,7 @@ exports[`Pagination renders 1`] = `
         </span>
       </button>
       <button
+        aria-current="false"
         class="MuiButtonBase-root PicassoButton-small PicassoButton-secondary PicassoButton-root PicassoPaginationButton-root PicassoPagination-button"
         data-component-type="button"
         tabindex="0"
@@ -91,6 +95,7 @@ exports[`Pagination renders 1`] = `
         </span>
       </button>
       <button
+        aria-current="false"
         class="MuiButtonBase-root PicassoButton-small PicassoButton-secondary PicassoButton-root PicassoPaginationButton-root PicassoPagination-button"
         data-component-type="button"
         tabindex="0"
@@ -112,6 +117,7 @@ exports[`Pagination renders 1`] = `
         </p>
       </div>
       <button
+        aria-current="false"
         class="MuiButtonBase-root PicassoButton-small PicassoButton-secondary PicassoButton-root PicassoPaginationButton-root PicassoPagination-button"
         data-component-type="button"
         tabindex="0"
@@ -162,6 +168,7 @@ exports[`Pagination renders disabled 1`] = `
         </span>
       </button>
       <button
+        aria-current="false"
         class="MuiButtonBase-root PicassoButton-disabled PicassoButton-small PicassoButton-secondary PicassoButton-root PicassoPaginationButton-root PicassoPagination-button Mui-disabled"
         data-component-type="button"
         disabled=""
@@ -184,6 +191,7 @@ exports[`Pagination renders disabled 1`] = `
         </p>
       </div>
       <button
+        aria-current="false"
         class="MuiButtonBase-root PicassoButton-disabled PicassoButton-small PicassoButton-secondary PicassoButton-root PicassoPaginationButton-root PicassoPagination-button Mui-disabled"
         data-component-type="button"
         disabled=""
@@ -197,6 +205,7 @@ exports[`Pagination renders disabled 1`] = `
         </span>
       </button>
       <button
+        aria-current="false"
         class="MuiButtonBase-root PicassoButton-disabled PicassoButton-small PicassoButton-secondary PicassoButton-root PicassoPaginationButton-root PicassoPagination-button Mui-disabled"
         data-component-type="button"
         disabled=""
@@ -224,6 +233,7 @@ exports[`Pagination renders disabled 1`] = `
         </span>
       </button>
       <button
+        aria-current="false"
         class="MuiButtonBase-root PicassoButton-disabled PicassoButton-small PicassoButton-secondary PicassoButton-root PicassoPaginationButton-root PicassoPagination-button Mui-disabled"
         data-component-type="button"
         disabled=""
@@ -237,6 +247,7 @@ exports[`Pagination renders disabled 1`] = `
         </span>
       </button>
       <button
+        aria-current="false"
         class="MuiButtonBase-root PicassoButton-disabled PicassoButton-small PicassoButton-secondary PicassoButton-root PicassoPaginationButton-root PicassoPagination-button Mui-disabled"
         data-component-type="button"
         disabled=""
@@ -259,6 +270,7 @@ exports[`Pagination renders disabled 1`] = `
         </p>
       </div>
       <button
+        aria-current="false"
         class="MuiButtonBase-root PicassoButton-disabled PicassoButton-small PicassoButton-secondary PicassoButton-root PicassoPaginationButton-root PicassoPagination-button Mui-disabled"
         data-component-type="button"
         disabled=""

--- a/packages/picasso/src/Pagination/__snapshots__/test.tsx.snap
+++ b/packages/picasso/src/Pagination/__snapshots__/test.tsx.snap
@@ -66,6 +66,7 @@ exports[`Pagination renders 1`] = `
         </span>
       </button>
       <button
+        aria-current="true"
         class="MuiButtonBase-root PicassoButton-active PicassoButton-small PicassoButton-secondary PicassoButton-root PicassoPaginationButton-root PicassoPaginationButton-active PicassoPagination-button"
         data-component-type="button"
         tabindex="0"
@@ -209,6 +210,7 @@ exports[`Pagination renders disabled 1`] = `
         </span>
       </button>
       <button
+        aria-current="true"
         class="MuiButtonBase-root PicassoButton-active PicassoButton-disabled PicassoButton-small PicassoButton-secondary PicassoButton-root PicassoPaginationButton-root PicassoPaginationButton-active PicassoPagination-button Mui-disabled"
         data-component-type="button"
         disabled=""

--- a/packages/picasso/src/PaginationButton/PaginationButton.tsx
+++ b/packages/picasso/src/PaginationButton/PaginationButton.tsx
@@ -26,7 +26,7 @@ const PaginationButton = (props: Props) => {
   return (
     <Button
       className={cx(classes.root, { [classes.active]: isActive }, className)}
-      aria-current={isActive ? true : undefined}
+      aria-current={isActive}
       active={isActive}
       disabled={disabled}
       onClick={() => onClick(page)}

--- a/packages/picasso/src/PaginationButton/PaginationButton.tsx
+++ b/packages/picasso/src/PaginationButton/PaginationButton.tsx
@@ -20,17 +20,14 @@ export interface Props extends StandardProps {
 
 const PaginationButton = (props: Props) => {
   const { page, activePage, disabled, onClick, className } = props
-
   const classes = useStyles()
+  const isActive = page === activePage
 
   return (
     <Button
-      className={cx(
-        classes.root,
-        { [classes.active]: page === activePage },
-        className
-      )}
-      active={activePage === page}
+      className={cx(classes.root, { [classes.active]: isActive }, className)}
+      aria-current={isActive ? true : undefined}
+      active={isActive}
       disabled={disabled}
       onClick={() => onClick(page)}
       variant='secondary'


### PR DESCRIPTION
[FX-4630]

### Description

Add aria-current to the active button in Pagination

### How to test

<!-- The temploy link will be automatically updated when the temploy is deployed -->
- [Temploy](https://picasso.toptal.net/fx-4630-archive-template-project-frontend-monorepo-repository)
- Open http://localhost:9001/?path=/story/components-pagination--pagination
- Inspect page
- See `aria-current="true"` is added to all active buttons on the page

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests ([visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md) included)

**Breaking change**

- [x] codemod is created and showcased in the changeset
- [x] test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-4630]: https://toptal-core.atlassian.net/browse/FX-4630?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ