### PR TITLE
Add extra check for sidebar item type

### DIFF
--- a/.changeset/little-avocados-invite.md
+++ b/.changeset/little-avocados-invite.md
@@ -1,0 +1,7 @@
+---
+'@toptal/picasso': patch
+---
+
+### SidebarMenu
+
+- add extra check for sidebar item type

--- a/packages/picasso/src/SidebarMenu/SidebarMenu.tsx
+++ b/packages/picasso/src/SidebarMenu/SidebarMenu.tsx
@@ -8,7 +8,7 @@ import React, { forwardRef, useCallback, useEffect } from 'react'
 import Menu from '../Menu'
 import { useSidebarContext } from '../PageSidebar/SidebarContextProvider'
 import type { SidebarItemProps } from '../SidebarItem'
-import { useSubMenuContext } from '../SidebarItem'
+import SidebarItem, { useSubMenuContext } from '../SidebarItem'
 import styles from './styles'
 
 export interface Props extends BaseProps, HTMLAttributes<HTMLUListElement> {
@@ -50,7 +50,7 @@ export const SidebarMenu = forwardRef<HTMLUListElement, Props>(
     }, [parentSidebarItemIndex, setExpandedItemKey, children])
 
     const items = React.Children.map(children, (child, index) => {
-      if (React.isValidElement(child)) {
+      if (React.isValidElement(child) && child.type === SidebarItem) {
         const itemProps: Partial<SidebarItemProps> = {
           variant,
           isSubMenu,


### PR DESCRIPTION
### Description

This PR aims to add extra check for sidebar item type.
To fixes the two warnings in Client Portal:
![image](https://github.com/toptal/picasso/assets/4816942/f9fb0570-7d7a-4f0e-b161-aaa838144446)
![image](https://github.com/toptal/picasso/assets/4816942/e6932118-bca0-45fe-9e7f-e6ae4505002d)

Here is how our Sidebar looks like in CP:
<img src="https://github.com/toptal/picasso/assets/4816942/098f7f67-cb8c-4708-9c3e-ce166dc8f0fe" width="150" />
As you can see we have additional banner between the items.

### How to test
- checkout [branch](https://github.com/toptal/client-portal/pull/7745) locally
- run project
- open console
- you should not see mentioned warnings anymore

### Development checks
- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- n/a Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- n/a Annotate all `props` in component with documentation
- n/a Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- n/a Covered with tests ([visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md) included)

**Breaking change**

- n/a codemod is created and showcased in the changeset
- [x] test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>
