### PR TITLE
Fix data-private type to allow lipsum value

### DIFF
--- a/.changeset/tidy-crabs-hammer.md
+++ b/.changeset/tidy-crabs-hammer.md
@@ -1,0 +1,8 @@
+---
+'@toptal/picasso': patch
+'@toptal/picasso-shared': patch
+---
+
+### picasso-shared types
+
+- fixed `data-private` type to allow `lipsum` value as well

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -23,7 +23,7 @@ export interface BaseProps {
   /** Style applied to root element */
   style?: CSSProperties
   'data-testid'?: string
-  'data-private'?: boolean
+  'data-private'?: boolean | 'lipsum'
 }
 
 export interface JssProps {


### PR DESCRIPTION
### Description

The `data-private` attribute can have a value of `lipsum` (https://docs.logrocket.com/docs/privacy)
This PR amends the base type to accommodate that

Related thread https://toptal-core.slack.com/archives/CERF5NHT3/p1703713796242789

### How to test

<!-- The temploy link will be automatically updated when the temploy is deployed -->
- Typechecks pass

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [-] Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [-] Annotate all `props` in component with documentation
- [-] Create `examples` for component
- [-] Ensure that deployed demo has expected results and good examples
- [-] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [-] Covered with tests ([visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md) included)

**Breaking change**

- [-] codemod is created and showcased in the changeset
- [-] test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>
