### PR TITLE
[CI-3043] Switch to actions/create-jira-deployment

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,7 +29,6 @@ jobs:
       issues: write
       pull-requests: write
     timeout-minutes: 45
-
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -164,7 +163,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions: write-all
     needs: [static-checks]
-
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -224,7 +222,6 @@ jobs:
       contents: write
       id-token: write
     needs: [build-docker-image]
-
     steps:
       - name: GSM Secrets
         id: secrets_manager
@@ -265,11 +262,12 @@ jobs:
           repository: toptal/actions
           token: ${{ steps.parse_secrets.outputs.TOPTAL_REPOACCESSBOT_TOKEN }}
           path: ./.github/actions/
-      
+
       - name: Replace toptal/actions/get-job-url@main from trigger-jenkins-job/action.yml
+        shell: bash
         run: |
           sed -i 's|toptal/actions/get-job-url@main|./.github/actions/get-job-url|' ./.github/actions/trigger-jenkins-job/action.yml
-        shell: bash
+          sed -i 's|toptal/actions/trigger-jenkins-job@main|./.github/actions/trigger-jenkins-job|' ./.github/actions/create-jira-deployment/action.yml
 
       - name: Trigger doc deployment job
         uses: ./.github/actions/trigger-jenkins-job/
@@ -291,9 +289,14 @@ jobs:
           job_timeout: "3600"
 
       - name: Create Jira Deployment
-        uses: toptal/davinci-github-actions/create-jira-deployment@v12.5.1
+        uses: ./.github/actions/create-jira-deployment/
         if: ${{ always() }}
         with:
+          jenkins_url: ${{ steps.parse_secrets.outputs.JENKINS_BUILD_URL }}
+          jenkins_user: ${{ steps.parse_secrets.outputs.TOPTAL_TRIGGERBOT_USERNAME }}
+          jenkins_token: ${{ steps.parse_secrets.outputs.TOPTAL_TRIGGERBOT_BUILD_TOKEN }}
+          jenkins_client_id: ${{ steps.parse_secrets.outputs.JENKINS_BUILD_CLIENT_ID }}
+          jenkins_sa_credentials: ${{ steps.parse_secrets.outputs.JENKINS_SA_CREDENTIALS }}
           token: ${{ env.TOPTAL_DEVBOT_TOKEN }}
           environment: staging
           environment-url: ${{ steps.temploy.outputs.temployURL }}

--- a/.github/workflows/davinci-alpha-package.yml
+++ b/.github/workflows/davinci-alpha-package.yml
@@ -28,9 +28,12 @@ jobs:
           workload_identity_provider: ${{ secrets.IDENTITY_POOL }}
           service_account: ${{ secrets.SA_IDENTITY_POOL }}
           secrets_name: |-
-            HTTP_PROXY:toptal-ci/HTTP_PROXY
+            JENKINS_BUILD_CLIENT_ID:toptal-ci/JENKINS_BUILD_CLIENT_ID
+            JENKINS_BUILD_URL:toptal-ci/JENKINS_BUILD_URL
+            JENKINS_SA_CREDENTIALS:toptal-ci/JENKINS_SA_CREDENTIALS
             NPM_TOKEN_PUBLISH:toptal-ci/NPM_TOKEN_PUBLISH
             TOPTAL_DEVBOT_TOKEN:toptal-ci/TOPTAL_DEVBOT_TOKEN
+            TOPTAL_REPOACCESSBOT_TOKEN:toptal-ci/TOPTAL_REPOACCESSBOT_TOKEN
             TOPTAL_TRIGGERBOT_BUILD_TOKEN:toptal-ci/TOPTAL_TRIGGERBOT_BUILD_TOKEN
             TOPTAL_TRIGGERBOT_USERNAME:toptal-ci/TOPTAL_TRIGGERBOT_USERNAME
 
@@ -132,13 +135,27 @@ jobs:
               target_url: process.env.STATUS_TARGET_URL
             })
 
-      - uses: toptal/davinci-github-actions/create-jira-deployment@v12.5.1
-        name: Create Jira deployment
-        env:
-          JENKINS_USER: ${{ steps.parse_secrets.outputs.TOPTAL_TRIGGERBOT_USERNAME }}
-          JENKINS_BUILD_TOKEN: ${{ steps.parse_secrets.outputs.TOPTAL_TRIGGERBOT_BUILD_TOKEN }}
-          PROXY: http://${{ steps.parse_secrets.outputs.HTTP_PROXY }}
+      - name: Get toptal/actions
+        uses: actions/checkout@v4
         with:
+          repository: toptal/actions
+          token: ${{ steps.parse_secrets.outputs.TOPTAL_REPOACCESSBOT_TOKEN }}
+          path: ./.github/actions/
+
+      - name: Replace toptal/actions/get-job-url@main from trigger-jenkins-job/action.yml
+        shell: bash
+        run: |
+          sed -i 's|toptal/actions/get-job-url@main|./.github/actions/get-job-url|' ./.github/actions/trigger-jenkins-job/action.yml
+          sed -i 's|toptal/actions/trigger-jenkins-job@main|./.github/actions/trigger-jenkins-job|' ./.github/actions/create-jira-deployment/action.yml
+
+      - name: Create Jira deployment
+        uses: ./.github/actions/create-jira-deployment/
+        with:
+          jenkins_url: ${{ steps.parse_secrets.outputs.JENKINS_BUILD_URL }}
+          jenkins_user: ${{ steps.parse_secrets.outputs.TOPTAL_TRIGGERBOT_USERNAME }}
+          jenkins_token: ${{ steps.parse_secrets.outputs.TOPTAL_TRIGGERBOT_BUILD_TOKEN }}
+          jenkins_client_id: ${{ steps.parse_secrets.outputs.JENKINS_BUILD_CLIENT_ID }}
+          jenkins_sa_credentials: ${{ steps.parse_secrets.outputs.JENKINS_SA_CREDENTIALS }}
           token: ${{ env.GITHUB_TOKEN }}
           environment: development
           environment-url: https://www.npmjs.com/package/@toptal/picasso?activeTab=versions

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,6 @@ jobs:
           workload_identity_provider: ${{ secrets.IDENTITY_POOL }}
           service_account: ${{ secrets.SA_IDENTITY_POOL }}
           secrets_name: |-
-            HTTP_PROXY:toptal-ci/HTTP_PROXY
             NPM_TOKEN_PUBLISH:toptal-ci/NPM_TOKEN_PUBLISH
             SLACK_BOT_TOKEN:toptal-ci/SLACK_BOT_TOKEN
             TOPTAL_BUILD_BOT_TOKEN:toptal-ci/TOPTAL_BUILD_BOT_TOKEN
@@ -80,11 +79,13 @@ jobs:
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn-
+
       - name: Install Dependencies (from network)
         if: ${{ steps.yarn-cache.outputs.cache-hit != 'true' }}
         run: |
           yarn policies set-version
           yarn install --frozen-lockfile
+
       - name: Install Dependencies (from cache)
         if: ${{ steps.yarn-cache.outputs.cache-hit == 'true' }}
         run: |
@@ -149,9 +150,10 @@ jobs:
           path: ./.github/actions/
 
       - name: Replace toptal/actions/get-job-url@main from trigger-jenkins-job/action.yml
+        shell: bash
         run: |
           sed -i 's|toptal/actions/get-job-url@main|./.github/actions/get-job-url|' ./.github/actions/trigger-jenkins-job/action.yml
-        shell: bash
+          sed -i 's|toptal/actions/trigger-jenkins-job@main|./.github/actions/trigger-jenkins-job|' ./.github/actions/create-jira-deployment/action.yml
 
       - name: Trigger build image job
         uses: ./.github/actions/trigger-jenkins-job
@@ -211,6 +213,7 @@ jobs:
           slack-message: "Current master version of Picasso successfully released :green_heart:"
         env:
           SLACK_BOT_TOKEN: ${{ env.SLACK_BOT_TOKEN }}
+
       - name: Send a Slack notification on success PR merge
         if: ${{ success() && steps.changesets.outputs.published != 'true'}}
         uses: slackapi/slack-github-action@v1.24.0
@@ -220,14 +223,15 @@ jobs:
         env:
           SLACK_BOT_TOKEN: ${{ env.SLACK_BOT_TOKEN }}
 
-      - uses: toptal/davinci-github-actions/create-jira-deployment@v12.5.1
-        name: Create Jira deployment
+      - name: Create Jira deployment
+        uses: ./.github/actions/create-jira-deployment/
         if: ${{ steps.changesets.outputs.published == 'true' }}
-        env:
-          JENKINS_USER: ${{ steps.parse_secrets.outputs.TOPTAL_TRIGGERBOT_USERNAME }}
-          JENKINS_BUILD_TOKEN: ${{ steps.parse_secrets.outputs.TOPTAL_TRIGGERBOT_BUILD_TOKEN }}
-          PROXY: http://${{ steps.parse_secrets.outputs.HTTP_PROXY }}
         with:
+          jenkins_url: ${{ steps.parse_secrets.outputs.JENKINS_BUILD_URL }}
+          jenkins_user: ${{ steps.parse_secrets.outputs.TOPTAL_TRIGGERBOT_USERNAME }}
+          jenkins_token: ${{ steps.parse_secrets.outputs.TOPTAL_TRIGGERBOT_BUILD_TOKEN }}
+          jenkins_client_id: ${{ steps.parse_secrets.outputs.JENKINS_BUILD_CLIENT_ID }}
+          jenkins_sa_credentials: ${{ steps.parse_secrets.outputs.JENKINS_SA_CREDENTIALS }}
           token: ${{ env.DEVBOT_TOKEN }}
           environment: production
           environment-url: https://www.npmjs.com/package/@toptal/picasso?activeTab=versions


### PR DESCRIPTION
[CI-3043]

### Description
The CI team is currently working on replacing the `external-proxy` with Google Identity Aware Proxy (IAP). More info [here](https://cloud.google.com/iap/docs/concepts-overview).

IAP is a Google service that allows control access to web applications running on GCP. It provides a security layer for applications by ensuring that only authenticated and authorized users/service accounts can access them. To programmatically access a resource protected by the IAP, we need to generate a JWT token and pass it alongside the request to authenticate before accessing the protected resource.

Currently, we use the `jenkins-job-trigger-action` to trigger Jenkins jobs from a GH workflow. Since this is a public action repo and to not expose our internal infrastructure implementation, we created the new private action ([trigger-jenkins-job](https://github.com/toptal/actions/tree/main/trigger-jenkins-job)) to implement the IAP necessary steps for authentication and authorization. This new action requires some new inputs (secrets) used in the action’s steps to generate the authentication token.

The IAP is already enabled for our Jenkins servers in alternative URLs during the migration, that’s why we use the input `jenkins_url` as a secret. Its main role is to make it easier and transparent when we turn the key to enable IAP in the production’s Jenkins URLs.

In this PR, we switch to the `actions/create-jira-deployment` action, which uses the new `trigger-jenkins-job` action that implements the underlying steps to authenticate with IAP when triggering a Jenkins job from a GitHub workflow.

### Review
- [x] Get 👍 from code review
- [x] Squashed related commits together
- [x] Removed labels that block merging (wip, do-not-merge, needs-management-approval)

[CI-3043]: https://toptal-core.atlassian.net/browse/CI-3043?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ