### PR TITLE
[CPT-1479] Enable select clear button for the qb

### DIFF
--- a/.changeset/few-buckets-knock.md
+++ b/.changeset/few-buckets-knock.md
@@ -1,0 +1,5 @@
+---
+'@toptal/picasso-query-builder': minor
+---
+
+- add `enableReset` property for `multiselect` filter type

--- a/packages/picasso-query-builder/package.json
+++ b/packages/picasso-query-builder/package.json
@@ -23,7 +23,7 @@
     "url": "https://github.com/toptal/picasso/issues"
   },
   "peerDependencies": {
-    "@toptal/picasso": ">=38.0.0",
+    "@toptal/picasso": "^42.0.0",
     "react": ">=16.12.0 < 19.0.0",
     "react-dom": ">=16.12.0 < 19.0.0",
     "typescript": "~4.7.0"

--- a/packages/picasso-query-builder/src/MultiSelect/MultiSelect.tsx
+++ b/packages/picasso-query-builder/src/MultiSelect/MultiSelect.tsx
@@ -57,6 +57,7 @@ export const MultiSelect = ({
         value={values}
         status={hasError ? 'error' : undefined}
         data-testid={valueEditorTestId}
+        enableReset={fieldData?.enableReset}
         enableResetSearch={fieldData?.enableResetSearch}
       />
     </Container>

--- a/packages/picasso-query-builder/src/QueryBuilder/story/Default.example.tsx
+++ b/packages/picasso-query-builder/src/QueryBuilder/story/Default.example.tsx
@@ -200,6 +200,7 @@ const fields: Field[] = [
     label: 'Also plays',
     valueEditorType: 'multiselect',
     enableResetSearch: true,
+    enableReset: true,
     values: musicalInstruments,
     defaultValue: 'More cowbell',
   },

--- a/packages/picasso-query-builder/src/types/query-builder.ts
+++ b/packages/picasso-query-builder/src/types/query-builder.ts
@@ -1,3 +1,4 @@
+import type { SelectProps } from '@toptal/picasso'
 import type { ReactNode } from 'react'
 import type {
   Field as QueryBuilderField,
@@ -36,12 +37,8 @@ interface BooleanField
 }
 interface MultiSelectField
   extends Omit<QueryBuilderField, 'inputType' | 'valueEditorType'> {
-  valueEditorType?: 'multiselect'
-  /**
-   * Allow search input reset
-   */
-  enableResetSearch?: boolean
-  enableReset?: boolean
+  valueEditorType?: 'multiselect' &
+    Pick<SelectProps, 'enableReset' | 'enableResetSearch'>
 }
 
 interface AutoCompleteField

--- a/packages/picasso-query-builder/src/types/query-builder.ts
+++ b/packages/picasso-query-builder/src/types/query-builder.ts
@@ -41,6 +41,7 @@ interface MultiSelectField
    * Allow search input reset
    */
   enableResetSearch?: boolean
+  enableReset?: boolean
 }
 
 interface AutoCompleteField


### PR DESCRIPTION
[CPT-1479](https://toptal-core.atlassian.net/browse/CPT-1479)

### Description

Describe the changes and motivations for the pull request.

### How to test

<!-- The temploy link will be automatically updated when the temploy is deployed -->
- [Temploy](https://picasso.toptal.net/CPT-1479-enable-select-clear-button-for-the-qb)
- Open Query builder story
- On the Default story select `Also plays` rule
- Check if `enableReset` property is working as expected

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| ![image](https://github.com/toptal/picasso/assets/112090359/94e1520e-90fc-4d8f-8b6f-d1708850b5e1)| ![Screenshot from 2024-01-10 10-50-17](https://github.com/toptal/picasso/assets/112090359/d41f3590-5b0b-4d83-9c85-1f767215aec9)|

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests ([visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md) included)

**Breaking change**

- n/a codemod is created and showcased in the changeset
- [x] test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[CPT-1479]: https://toptal-core.atlassian.net/browse/CPT-1479?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ