### PR TITLE
[FX-4737] Do not pass enableResetSearch property

### DIFF
--- a/.changeset/four-chairs-call.md
+++ b/.changeset/four-chairs-call.md
@@ -1,0 +1,5 @@
+---
+'@toptal/picasso': patch
+---
+
+- do not pass `enableResetSearch` property further

--- a/packages/picasso/src/NativeSelect/NativeSelect.tsx
+++ b/packages/picasso/src/NativeSelect/NativeSelect.tsx
@@ -63,6 +63,8 @@ export const NativeSelect = documentable(
         native,
         testIds,
         highlight,
+        /* eslint-disable @typescript-eslint/no-unused-vars */
+        enableResetSearch,
         /* eslint-enable @typescript-eslint/no-unused-vars */
         ...rest
       } = props


### PR DESCRIPTION
[FX-4737]

### Description

This pull request fixes the bug with passed `enableResetSearch ` prop, introduced in https://github.com/toptal/picasso/pull/4075.

Reason – spread operator is not type safe in this case (`packages/picasso/src/NativeSelect/NativeSelect.tsx`)

No type check using spread operator (no error detected)

<img width="460" alt="Screenshot 2024-01-11 at 17 58 33" src="https://github.com/toptal/picasso/assets/1390758/2b7ea1d3-3025-4233-be84-ff24f57157d9">

Normal typescheck when passing prop directly (error is detected)

<img width="462" alt="Screenshot 2024-01-11 at 17 58 59" src="https://github.com/toptal/picasso/assets/1390758/1b60e88d-9c66-4566-9078-b4247815b73c">


### How to test

<!-- The temploy link will be automatically updated when the temploy is deployed -->
- [Temploy](https://picasso.toptal.net/FX-NULL-fix-passing-of-property)
- Tests pass when alpha package is applied in Staff Portal in (please check out https://github.com/toptal/staff-portal/pull/11832 locally and run `yarn test namespaces/jobs/libs/jobs/src/containers/SendJobAwayModal/test.tsx`)
- Another error in Staff Portal Jest tests that appears is fixed in https://toptal-core.atlassian.net/browse/FX-4727

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [N/A] Annotate all `props` in component with documentation
- [N/A] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [N/A] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [N/A] Covered with tests ([visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md) included)
- [x] ⚠️ Delete https://github.com/toptal/staff-portal/pull/11832 before merge

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-4737]: https://toptal-core.atlassian.net/browse/FX-4737?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ