### PR TITLE
[FX-NULL] Revert debounce update

### DIFF
--- a/.changeset/dry-insects-wink.md
+++ b/.changeset/dry-insects-wink.md
@@ -1,0 +1,7 @@
+---
+'@toptal/picasso-charts': patch
+'@toptal/picasso-forms': patch
+'@toptal/picasso': patch
+---
+
+- revert `debounce` update

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "cypress-plugin-tab": "^1.0.5",
     "cypress-real-events": "^1.11.0",
     "date-fns": "^2.30.0",
-    "debounce": "^2.0.0",
+    "debounce": "^1.2.1",
     "ejs": "^3.1.8",
     "escodegen": "^2.1.0",
     "eslint-plugin-local-rules": "^2.0.1",

--- a/packages/picasso-charts/package.json
+++ b/packages/picasso-charts/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "classnames": "^2.3.1",
     "d3-array": "^3.2.2",
-    "debounce": "^2.0.0",
+    "debounce": "^1.2.1",
     "recharts": "^2.9.0"
   }
 }

--- a/packages/picasso-forms/package.json
+++ b/packages/picasso-forms/package.json
@@ -32,7 +32,7 @@
   "dependencies": {
     "@toptal/picasso-rich-text-editor": "10.0.0",
     "classnames": "^2.3.1",
-    "debounce": "^2.0.0",
+    "debounce": "^1.2.1",
     "detect-browser": "^5.3.0",
     "final-form": "^4.20.9",
     "final-form-arrays": "3.0.2",

--- a/packages/picasso/package.json
+++ b/packages/picasso/package.json
@@ -39,7 +39,7 @@
     "d3-zoom": "^3",
     "date-fns": "^2.30.0",
     "date-fns-tz": "^2.0.0",
-    "debounce": "^2.0.0",
+    "debounce": "^1.2.1",
     "detect-browser": "^5.3.0",
     "glider-js": "^1.7.8",
     "react-content-loader": "^6.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10002,10 +10002,10 @@ dayjs@1.11.10, dayjs@^1.10.4:
   resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.11.10.tgz#68acea85317a6e164457d6d6947564029a6a16a0"
   integrity sha512-vjAczensTgRcqDERK0SR2XMwsF/tSvnvlv6VcF2GIhg6Sx4yOIt/irsr1RDJsKiIyBzJDpCoXiWWq28MqH2cnQ==
 
-debounce@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/debounce/-/debounce-2.0.0.tgz#b2f914518a1481466f4edaee0b063e4d473ad549"
-  integrity sha512-xRetU6gL1VJbs85Mc4FoEGSjQxzpdxRyFhe3lmWFyy2EzydIcD4xzUvRJMD+NPDfMwKNhxa3PvsIOU32luIWeA==
+debounce@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/debounce/-/debounce-1.2.1.tgz#38881d8f4166a5c5848020c11827b834bcb3e0a5"
+  integrity sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug==
 
 debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0, debug@^2.6.9:
   version "2.6.9"


### PR DESCRIPTION
[FX-4727]

### Description

This pull request reverts `debounce@2.0` update (https://github.com/toptal/picasso/pull/4079), as it causes Staff Portal Cypress tests to fail with the following error

```
@staff-portal/clients-profile-app:   2) Enable Embedded Contract Signing
@staff-portal/clients-profile-app:        when the mutation is not successful
@staff-portal/clients-profile-app:          does not enable embedded contract signing and displays a form error:
@staff-portal/clients-profile-app:      Error: The following error originated from your application code, not from Cypress.
@staff-portal/clients-profile-app:   > Debounced method called with different contexts.
@staff-portal/clients-profile-app: When Cypress detects uncaught errors originating from your application it will automatically fail the current test.
@staff-portal/clients-profile-app: This behavior is configurable, and you can choose to turn this off by listening to the `uncaught:exception` event.
@staff-portal/clients-profile-app: https://on.cypress.io/uncaught-exception-from-application
@staff-portal/clients-profile-app:       at MutationObserver.debounced (http://localhost:8080/__cypress/src/main.js:726794:19)
@staff-portal/clients-profile-app: 
@staff-portal/clients-profile-app:   (Results)
@staff-portal/clients-profile-app:   ┌────────────────────────────────────────────────────────────────────────────────────────────────┐
@staff-portal/clients-profile-app:   │ Tests:        2                                                                                │
@staff-portal/clients-profile-app:   │ Passing:      0                                                                                │
@staff-portal/clients-profile-app:   │ Failing:      2                                                                                │
@staff-portal/clients-profile-app:   │ Pending:      0                                                                                │
@staff-portal/clients-profile-app:   │ Skipped:      0                                                                                │
@staff-portal/clients-profile-app:   │ Screenshots:  0                                                                                │
@staff-portal/clients-profile-app:   │ Video:        false                                                                            │
@staff-portal/clients-profile-app:   │ Duration:     31 seconds                                                                       │
@staff-portal/clients-profile-app:   │ Spec Ran:     profile-page/pages/ClientProfile/__tests__/profile-actions/enable-embedded-contr │
@staff-portal/clients-profile-app:   │               act-signing.cy.ts                                                                │
@staff-portal/clients-profile-app:   └────────────────────────────────────────────────────────────────────────────────────────────────┘
@staff-portal/clients-profile-app: ────────────────────────────────────────────────────────────────────────────────────────────────────
@staff-portal/clients-profile-app:             
```

The error is caused from latest major version of `debounce` and by https://github.com/sindresorhus/debounce/commit/95eef872be4d812c129fcc976caddc0a3446b5e6#diff-e727e4bdf3657fd1d798edcd6b099d6e092f8573cba266154583a746bba0f346R28 in particular.


### How to test

<!-- The temploy link will be automatically updated when the temploy is deployed -->
- [Temploy](https://picasso.toptal.net/FX-NULL-revert-debounce-update)

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [N/A] Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [N/A] Annotate all `props` in component with documentation
- [N/A] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [N/A] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [N/A] Covered with tests ([visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md) included)

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-4727]: https://toptal-core.atlassian.net/browse/FX-4727?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ