### PR TITLE
[FX-4727] Remove injectFirst and styles import from TestingPicasso

### DIFF
--- a/.changeset/violet-shoes-rhyme.md
+++ b/.changeset/violet-shoes-rhyme.md
@@ -1,0 +1,5 @@
+---
+'@toptal/picasso': patch
+---
+
+- remove injectFirst and styles import from TestingPicasso

--- a/packages/picasso/src/test-utils/TestingPicasso.tsx
+++ b/packages/picasso/src/test-utils/TestingPicasso.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import Picasso from '@toptal/picasso-provider'
 import type { TextLabelProps } from '@toptal/picasso-shared'
-import './styles.css'
 
 export type Props = TextLabelProps & {
   children: React.ReactNode
@@ -16,7 +15,6 @@ export const TestingPicasso = ({ children, titleCase }: Props) => {
       preventPageWidthChangeOnScrollbar={false}
       titleCase={titleCase}
       disableTransitions
-      injectFirst
     >
       {children}
     </Picasso>

--- a/yarn.lock
+++ b/yarn.lock
@@ -15470,14 +15470,14 @@ json-stringify-safe@^5.0.1, json-stringify-safe@~5.0.1:
   resolved "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
   integrity sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==
 
-json5@1, json5@^1.0.1, json5@^2.1.1:
+json5@1, json5@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/json5/-/json5-1.0.2.tgz#63d98d60f21b313b77c4d6da18bfa69d80e1d593"
   integrity sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==
   dependencies:
     minimist "^1.2.0"
 
-json5@2.2.3, json5@^2.1.0, json5@^2.1.2, json5@^2.2.0, json5@^2.2.2, json5@^2.2.3, json5@^2.x:
+json5@2.2.3, json5@^2.1.0, json5@^2.1.1, json5@^2.1.2, json5@^2.2.0, json5@^2.2.2, json5@^2.2.3, json5@^2.x:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.3.tgz#78cd6f1a19bdc12b73db5ad0c61efd66c1e29283"
   integrity sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==


### PR DESCRIPTION
[FX-4727]

### Description

This pull request removes `Picasso.injectFirst` directive as it is not relevant to testing environment and removes styles import to avoid errors like

```bash
// Staff Portal

ERROR in ../../../../node_modules/@toptal/picasso/test-utils/TestingPicasso.js 3:0-22
Module not found: Error: Can't resolve './styles.css' in '/Users/aleksandr/toptal/staff-portal/node_modules/@toptal/picasso/test-utils'
resolve './styles.css' in '/Users/aleksandr/toptal/staff-portal/node_modules/@toptal/picasso/test-utils'
  using description file: /Users/aleksandr/toptal/staff-portal/node_modules/@toptal/picasso/package.json (relative path: ./test-utils)
    Field 'browser' doesn't contain a valid alias configuration
    using description file: /Users/aleksandr/toptal/staff-portal/node_modules/@toptal/picasso/package.json (relative path: ./test-utils/styles.css)
      no extension
```

### How to test

<!-- The temploy link will be automatically updated when the temploy is deployed -->
- [Temploy](https://picasso.toptal.net/FX-4727-clean-up-testing-picasso)
- https://github.com/toptal/staff-portal/pull/11865 has green Jest and Cypress tests (except for timing out Cypress tests  chunk)

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [N/A] Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [N/A] Annotate all `props` in component with documentation
- [N/A] Create `examples` for component
- [N/A] Ensure that deployed demo has expected results and good examples
- [N/A] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [N/A] Covered with tests ([visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md) included)

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-4727]: https://toptal-core.atlassian.net/browse/FX-4727?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ