### PR TITLE
[CPT-1480] Prevent multiple Select from closing when search was clicked

### DIFF
--- a/.changeset/friendly-avocados-unite.md
+++ b/.changeset/friendly-avocados-unite.md
@@ -2,5 +2,5 @@
 '@toptal/picasso': minor
 ---
 
-- select input no longer closes when it is multiple and its search input has been focused
-- select input no longer clear the search when it is multiple and an item has been selected
+- select input no longer closes after searched option is selected (when select works in multiple values mode)
+- select input no longer reset the search input when an option is selected (when select works in multiple values mode)

--- a/.changeset/friendly-avocados-unite.md
+++ b/.changeset/friendly-avocados-unite.md
@@ -3,4 +3,4 @@
 ---
 
 - select input no longer closes after searched option is selected (when select works in multiple values mode)
-- select input no longer reset the search input when an option is selected (when select works in multiple values mode)
+- select input no longer resets the search input when an option is selected (when select works in multiple values mode)

--- a/.changeset/friendly-avocados-unite.md
+++ b/.changeset/friendly-avocados-unite.md
@@ -3,3 +3,4 @@
 ---
 
 - select input no longer closes when it is multiple and its search input has been focused
+- select input no longer clear the search when it is multiple and an item has been selected

--- a/.changeset/friendly-avocados-unite.md
+++ b/.changeset/friendly-avocados-unite.md
@@ -1,0 +1,5 @@
+---
+'@toptal/picasso': minor
+---
+
+- select input no longer closes when it is multiple and its search input has been focused

--- a/packages/picasso/src/SelectBase/hooks/use-select-props/use-item-on-click-handler/test.ts
+++ b/packages/picasso/src/SelectBase/hooks/use-select-props/use-item-on-click-handler/test.ts
@@ -2,7 +2,6 @@ import { renderHook } from '@testing-library/react-hooks'
 
 import { getUseSelectPropsMock } from '../mocks'
 import useItemOnClickHandler from './use-item-on-click-handler'
-import focusRef from '../../../utils/focus-ref'
 
 describe('useItemOnClickHandler', () => {
   it('closes and handles select', () => {
@@ -36,6 +35,5 @@ describe('useItemOnClickHandler', () => {
 
     expect(handleSelect).toHaveBeenCalledTimes(1)
     expect(handleSelect).toHaveBeenCalledWith(event, item)
-    expect(focusRef).toHaveBeenCalledWith(props.selectRef)
   })
 })

--- a/packages/picasso/src/SelectBase/hooks/use-select-props/use-item-on-click-handler/test.ts
+++ b/packages/picasso/src/SelectBase/hooks/use-select-props/use-item-on-click-handler/test.ts
@@ -2,6 +2,7 @@ import { renderHook } from '@testing-library/react-hooks'
 
 import { getUseSelectPropsMock } from '../mocks'
 import useItemOnClickHandler from './use-item-on-click-handler'
+import focusRef from '../../../utils/focus-ref'
 
 describe('useItemOnClickHandler', () => {
   it('closes and handles select', () => {
@@ -35,5 +36,6 @@ describe('useItemOnClickHandler', () => {
 
     expect(handleSelect).toHaveBeenCalledTimes(1)
     expect(handleSelect).toHaveBeenCalledWith(event, item)
+    expect(focusRef).toHaveBeenCalledWith(props.selectRef)
   })
 })

--- a/packages/picasso/src/SelectBase/hooks/use-select-props/use-item-on-click-handler/use-item-on-click-handler.ts
+++ b/packages/picasso/src/SelectBase/hooks/use-select-props/use-item-on-click-handler/use-item-on-click-handler.ts
@@ -1,12 +1,14 @@
 import { useCallback } from 'react'
 
-import type { UseSelectProps, ValueType, Option } from '../../../types'
+import type { Option, UseSelectProps, ValueType } from '../../../types'
 import type useSelectHandler from '../use-select-handler'
+import { focusRef } from '../../../utils'
 
 const useItemOnClick = <T extends ValueType, M extends boolean = false>({
   selectState: { close },
   selectProps: { multiple },
   handleSelect,
+  selectRef,
 }: UseSelectProps<T, M> & {
   handleSelect: ReturnType<typeof useSelectHandler>
 }) =>
@@ -14,11 +16,12 @@ const useItemOnClick = <T extends ValueType, M extends boolean = false>({
     (event: React.MouseEvent, item: Option) => {
       if (!multiple) {
         close()
+        focusRef(selectRef)
       }
 
       handleSelect(event, item)
     },
-    [close, handleSelect, multiple]
+    [close, handleSelect, multiple, selectRef]
   )
 
 export default useItemOnClick

--- a/packages/picasso/src/SelectBase/hooks/use-select-props/use-select-handler/test.ts
+++ b/packages/picasso/src/SelectBase/hooks/use-select-props/use-select-handler/test.ts
@@ -69,7 +69,7 @@ describe('useSelectHandler', () => {
 
       result.current(event, OPTIONS[1])
 
-      expect(props.selectState.setFilterOptionsValue).toHaveBeenCalledTimes(1)
+      expect(props.selectState.setFilterOptionsValue).toHaveBeenCalledTimes(0)
       expect(props.selectProps.onChange).toHaveBeenCalledWith({
         ...event,
         target: {
@@ -77,10 +77,10 @@ describe('useSelectHandler', () => {
           value: [OPTIONS[1].value],
         },
       })
-      expect(props.selectState.setFilterOptionsValue).toHaveBeenCalledWith('')
+      expect(props.selectState.setFilterOptionsValue).toHaveBeenCalledTimes(0)
     })
 
-    it('resets value', () => {
+    it(`doesn't resets value`, () => {
       const props = getUseSelectPropsMock()
 
       props.selectProps.options = OPTIONS
@@ -93,7 +93,7 @@ describe('useSelectHandler', () => {
 
       result.current(event, OPTIONS[0])
 
-      expect(props.selectState.setFilterOptionsValue).toHaveBeenCalledTimes(1)
+      expect(props.selectState.setFilterOptionsValue).toHaveBeenCalledTimes(0)
       expect(props.selectProps.onChange).toHaveBeenCalledWith({
         ...event,
         target: {
@@ -101,7 +101,7 @@ describe('useSelectHandler', () => {
           value: [],
         },
       })
-      expect(props.selectState.setFilterOptionsValue).toHaveBeenCalledWith('')
+      expect(props.selectState.setFilterOptionsValue).toHaveBeenCalledTimes(0)
     })
   })
 })

--- a/packages/picasso/src/SelectBase/hooks/use-select-props/use-select-handler/test.ts
+++ b/packages/picasso/src/SelectBase/hooks/use-select-props/use-select-handler/test.ts
@@ -2,9 +2,6 @@ import { renderHook } from '@testing-library/react-hooks'
 
 import { getUseSelectPropsMock } from '../mocks'
 import useSelectHandler from './use-select-handler'
-import focusRef from '../../../utils/focus-ref'
-
-const mockedFocusRef = focusRef as jest.MockedFunction<typeof focusRef>
 
 jest.mock('../../../utils/focus-ref', () => jest.fn())
 
@@ -15,10 +12,6 @@ const OPTIONS = [
 ]
 
 describe('useSelectHandler', () => {
-  beforeEach(() => {
-    mockedFocusRef.mockClear()
-  })
-
   describe('single mode', () => {
     it('selects option', () => {
       const props = getUseSelectPropsMock()
@@ -37,7 +30,6 @@ describe('useSelectHandler', () => {
         target: { name: undefined, value: OPTIONS[1].value },
       })
       expect(props.selectState.setFilterOptionsValue).toHaveBeenCalledWith('')
-      expect(focusRef).toHaveBeenCalledWith(props.selectRef)
     })
 
     it('resets value', () => {
@@ -61,7 +53,6 @@ describe('useSelectHandler', () => {
         },
       })
       expect(props.selectState.setFilterOptionsValue).toHaveBeenCalledWith('')
-      expect(focusRef).toHaveBeenCalledWith(props.selectRef)
     })
   })
 
@@ -87,7 +78,6 @@ describe('useSelectHandler', () => {
         },
       })
       expect(props.selectState.setFilterOptionsValue).toHaveBeenCalledWith('')
-      expect(focusRef).toHaveBeenCalledWith(props.selectRef)
     })
 
     it('resets value', () => {
@@ -112,7 +102,6 @@ describe('useSelectHandler', () => {
         },
       })
       expect(props.selectState.setFilterOptionsValue).toHaveBeenCalledWith('')
-      expect(focusRef).toHaveBeenCalledWith(props.selectRef)
     })
   })
 })

--- a/packages/picasso/src/SelectBase/hooks/use-select-props/use-select-handler/use-select-handler.ts
+++ b/packages/picasso/src/SelectBase/hooks/use-select-props/use-select-handler/use-select-handler.ts
@@ -28,7 +28,9 @@ const useSelectHandler = <T extends ValueType, M extends boolean = false>({
       }
 
       fireOnChangeEvent({ event, value: newValue, name, onChange })
-      setFilterOptionsValue(EMPTY_INPUT_VALUE)
+      if (!multiple) {
+        setFilterOptionsValue(EMPTY_INPUT_VALUE)
+      }
     },
     [name, onChange, emptySelectValue, setFilterOptionsValue, multiple, value]
   )

--- a/packages/picasso/src/SelectBase/hooks/use-select-props/use-select-handler/use-select-handler.ts
+++ b/packages/picasso/src/SelectBase/hooks/use-select-props/use-select-handler/use-select-handler.ts
@@ -5,14 +5,12 @@ import type { Option, ValueType, UseSelectProps } from '../../../types'
 import {
   EMPTY_INPUT_VALUE,
   toggleMultipleSelectValue,
-  focusRef,
   fireOnChangeEvent,
 } from '../../../utils'
 
 const useSelectHandler = <T extends ValueType, M extends boolean = false>({
   selectState: { emptySelectValue, setFilterOptionsValue },
   selectProps: { multiple, value, name, onChange },
-  selectRef,
 }: UseSelectProps<T, M>) =>
   useCallback(
     (event: React.SyntheticEvent, option: Option | null) => {
@@ -31,18 +29,8 @@ const useSelectHandler = <T extends ValueType, M extends boolean = false>({
 
       fireOnChangeEvent({ event, value: newValue, name, onChange })
       setFilterOptionsValue(EMPTY_INPUT_VALUE)
-
-      focusRef(selectRef)
     },
-    [
-      name,
-      onChange,
-      emptySelectValue,
-      setFilterOptionsValue,
-      multiple,
-      value,
-      selectRef,
-    ]
+    [name, onChange, emptySelectValue, setFilterOptionsValue, multiple, value]
   )
 
 export default useSelectHandler


### PR DESCRIPTION
[CPT-1480]

### Description

The select input gains focus after clicking on a menu item only when the select is not multiple. This prevents it from closing on multiple selections when the user clicks/focuses on the search input.

### How to test

<!-- The temploy link will be automatically updated when the temploy is deployed -->
- [Temploy](https://picasso.toptal.net/CPT-1480-fe-keep-picasso-select-dropdown-open-when-a-selection-is-made-in-search-mode)

#### Select (multiple)
- Open the Picasso Select
- Go to Limit section.
- Click on the search input.
- Then click on any option.
- The search options should remain visible.

#### Select (single)
- Open the Picasso Select
- Go to Limit section.
- Enter anything or click on the search
- Click on any field.
- The search options should close.



### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- n/a Annotate all `props` in component with documentation
- n/a Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- n/a Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests ([visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md) included)

**Breaking change**

- [x] codemod is created and showcased in the changeset
- [x] test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[CPT-1480]: https://toptal-core.atlassian.net/browse/CPT-1480?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ