### PR TITLE
[FX-4802] Fix flaky happo visual test

### DIFF
--- a/.storybook/components/PicassoBook/Page.js
+++ b/.storybook/components/PicassoBook/Page.js
@@ -99,6 +99,10 @@ class Page extends Base {
           happoConfig.delay = 500
         }
 
+        if (section.waitFor) {
+          happoConfig.waitFor = section.waitFor
+        }
+
         if (!section.screenshotBreakpoints) {
           happoConfig.targets = [DEFAULT_HAPPO_TARGET]
         }

--- a/cypress/component/BarChart.spec.tsx
+++ b/cypress/component/BarChart.spec.tsx
@@ -63,7 +63,7 @@ describe('BarChart', () => {
   it('renders default chart with default tooltip on hover', () => {
     cy.mount(<TestBarChart />)
 
-    // fix flakiness, somtimes it does not respond to hover
+    // fix flakiness, sometimes it does not respond to hover
     cy.get('.recharts-surface').realClick()
     hoverOverBar('Apple').get('body').happoScreenshot({
       component,
@@ -92,6 +92,8 @@ describe('BarChart', () => {
       />
     )
 
+    // fix flakiness, sometimes it does not respond to hover
+    cy.get('.recharts-surface').realClick()
     hoverOverBar('Berlin').get('body').happoScreenshot({
       component,
       variant: 'custom-chart/custom-tooltip',

--- a/packages/picasso-forms/src/Form/story/HighlightAutofill.example.tsx
+++ b/packages/picasso-forms/src/Form/story/HighlightAutofill.example.tsx
@@ -85,7 +85,9 @@ const Example = () => (
       <TimePicker label='timepicker' name='highlight-timepicker' />
 
       <Container top={SPACING_4}>
-        <SubmitButton>Submit</SubmitButton>
+        <SubmitButton id='highlight-autofill-submit-button'>
+          Submit
+        </SubmitButton>
       </Container>
     </FormNonCompound>
   </ConfigProvider>

--- a/packages/picasso-forms/src/Form/story/index.jsx
+++ b/packages/picasso-forms/src/Form/story/index.jsx
@@ -275,4 +275,5 @@ however, you may need custom validators for more complex types of fields.
   })
   .addExample('Form/story/HighlightAutofill.example.tsx', {
     title: 'Highlight fields with default value',
+    waitFor: () => document.querySelector('#highlight-autofill-submit-button'),
   })


### PR DESCRIPTION
[FX-4802]

### Description

* Cypress Test `Highlight fields with default value` is flaky. We need to wait for appearance of `Button` element on the page before taking a screenshot

* Visual Test `renders custom chart with custom tooltip on hover` is flaky. Need to click on area before triggering `hover` event

### How to test

- Run Happo Visual tests


### Development checks

- N/A Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- N/A Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- N/A Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- N/A Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- N/A Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- N/A Covered with tests ([visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md) included)

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-4802]: https://toptal-core.atlassian.net/browse/FX-4802?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ