### PR TITLE
[CRT-6946][FX-4808] Adjust form labels alignement

### DIFF
--- a/.changeset/good-crabs-obey.md
+++ b/.changeset/good-crabs-obey.md
@@ -1,0 +1,9 @@
+---
+'@toptal/picasso-forms': minor
+'@toptal/picasso': minor
+---
+
+### Forms
+
+- the labels for fields with heights up to 48px are center-aligned with their respective inputs.
+- for larger fields, such as text areas and avatars, which are significantly taller, the labels are aligned to the top of the field.

--- a/packages/picasso-forms/src/AvatarUpload/AvatarUpload.tsx
+++ b/packages/picasso-forms/src/AvatarUpload/AvatarUpload.tsx
@@ -17,6 +17,7 @@ const AvatarUpload = (props: Props) => {
   const {
     label,
     titleCase,
+    size = 'small',
     // dropping 'src' value here out from 'rest'. 'src' value should be provided via form context
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     src,
@@ -40,8 +41,17 @@ const AvatarUpload = (props: Props) => {
     }
   }
 
+  const horizontalLayoutAlignedToTopSizes: AvatarUploadProps['size'][] = [
+    'small',
+    'medium',
+    'large',
+  ]
+  const horizontalLayoutAlignedToTop =
+    horizontalLayoutAlignedToTopSizes.includes(size)
+
   return (
     <InputField<AvatarUploadProps, AvatarUploadFileUpload | undefined>
+      size={size}
       {...rest}
       label={
         label ? (
@@ -50,6 +60,7 @@ const AvatarUpload = (props: Props) => {
             required={props.required}
             label={label}
             titleCase={titleCase}
+            horizontalLayoutAlignedToTop={horizontalLayoutAlignedToTop}
           />
         ) : null
       }

--- a/packages/picasso-forms/src/AvatarUpload/AvatarUpload.tsx
+++ b/packages/picasso-forms/src/AvatarUpload/AvatarUpload.tsx
@@ -41,13 +41,12 @@ const AvatarUpload = (props: Props) => {
     }
   }
 
-  const horizontalLayoutAlignedToTopSizes: AvatarUploadProps['size'][] = [
+  const alignmentTopSizes: AvatarUploadProps['size'][] = [
     'small',
     'medium',
     'large',
   ]
-  const horizontalLayoutAlignedToTop =
-    horizontalLayoutAlignedToTopSizes.includes(size)
+  const alignment = alignmentTopSizes.includes(size) ? 'top' : 'middle'
 
   return (
     <InputField<AvatarUploadProps, AvatarUploadFileUpload | undefined>
@@ -60,7 +59,7 @@ const AvatarUpload = (props: Props) => {
             required={props.required}
             label={label}
             titleCase={titleCase}
-            horizontalLayoutAlignedToTop={horizontalLayoutAlignedToTop}
+            alignment={alignment}
           />
         ) : null
       }

--- a/packages/picasso-forms/src/CheckboxGroup/CheckboxGroup.tsx
+++ b/packages/picasso-forms/src/CheckboxGroup/CheckboxGroup.tsx
@@ -14,7 +14,7 @@ export type Props = CheckboxGroupProps & FieldProps<ValueType>
 export const CheckboxGroup = (props: Props) => {
   const { children, titleCase, label, initialValue, ...rest } = props
 
-  const horizontalLayoutAlignedToTop = Children.count(children) > 2
+  const alignment = Children.count(children) > 2 ? 'top' : 'middle'
 
   return (
     <CheckboxGroupContext.Provider value={props.name}>
@@ -29,7 +29,7 @@ export const CheckboxGroup = (props: Props) => {
               required={props.required}
               label={label}
               titleCase={titleCase}
-              horizontalLayoutAlignedToTop={horizontalLayoutAlignedToTop}
+              alignment={alignment}
             />
           ) : null
         }

--- a/packages/picasso-forms/src/CheckboxGroup/CheckboxGroup.tsx
+++ b/packages/picasso-forms/src/CheckboxGroup/CheckboxGroup.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable react/jsx-props-no-spreading */
-import React from 'react'
+import React, { Children } from 'react'
 import type { CheckboxGroupProps } from '@toptal/picasso'
 import { Checkbox as PicassoCheckbox } from '@toptal/picasso'
 
@@ -14,6 +14,8 @@ export type Props = CheckboxGroupProps & FieldProps<ValueType>
 export const CheckboxGroup = (props: Props) => {
   const { children, titleCase, label, initialValue, ...rest } = props
 
+  const horizontalLayoutAlignedToTop = Children.count(children) > 2
+
   return (
     <CheckboxGroupContext.Provider value={props.name}>
       <PicassoField
@@ -27,6 +29,7 @@ export const CheckboxGroup = (props: Props) => {
               required={props.required}
               label={label}
               titleCase={titleCase}
+              horizontalLayoutAlignedToTop={horizontalLayoutAlignedToTop}
             />
           ) : null
         }

--- a/packages/picasso-forms/src/Dropzone/Dropzone.tsx
+++ b/packages/picasso-forms/src/Dropzone/Dropzone.tsx
@@ -63,7 +63,7 @@ const Dropzone = ({ dropzoneHint, ...props }: Props) => {
           required={props.required}
           label={props.label}
           titleCase={props.titleCase}
-          horizontalLayoutAlignedToTop
+          alignment='top'
         />
       }
     >

--- a/packages/picasso-forms/src/Dropzone/Dropzone.tsx
+++ b/packages/picasso-forms/src/Dropzone/Dropzone.tsx
@@ -63,6 +63,7 @@ const Dropzone = ({ dropzoneHint, ...props }: Props) => {
           required={props.required}
           label={props.label}
           titleCase={props.titleCase}
+          horizontalLayoutAlignedToTop
         />
       }
     >

--- a/packages/picasso-forms/src/FieldLabel/FieldLabel.tsx
+++ b/packages/picasso-forms/src/FieldLabel/FieldLabel.tsx
@@ -10,6 +10,7 @@ export type Props = {
   name?: string
   label?: React.ReactNode
   required?: boolean
+  horizontalLayoutAlignedToTop?: boolean
 } & TextLabelProps
 
 const getRequiredDecoration = (
@@ -31,7 +32,8 @@ const getRequiredDecoration = (
 }
 
 const FieldLabel = (props: Props) => {
-  const { label, required, titleCase, name } = props
+  const { label, required, titleCase, name, horizontalLayoutAlignedToTop } =
+    props
 
   const formConfig = useFormConfig()
 
@@ -49,6 +51,7 @@ const FieldLabel = (props: Props) => {
       requiredDecoration={requiredDecoration}
       htmlFor={name}
       titleCase={titleCase}
+      horizontalLayoutAlignedToTop={horizontalLayoutAlignedToTop}
     >
       {label}
     </PicassoForm.Label>

--- a/packages/picasso-forms/src/FieldLabel/FieldLabel.tsx
+++ b/packages/picasso-forms/src/FieldLabel/FieldLabel.tsx
@@ -10,7 +10,7 @@ export type Props = {
   name?: string
   label?: React.ReactNode
   required?: boolean
-  horizontalLayoutAlignedToTop?: boolean
+  alignment?: 'top' | 'middle'
 } & TextLabelProps
 
 const getRequiredDecoration = (
@@ -32,8 +32,7 @@ const getRequiredDecoration = (
 }
 
 const FieldLabel = (props: Props) => {
-  const { label, required, titleCase, name, horizontalLayoutAlignedToTop } =
-    props
+  const { label, required, titleCase, name, alignment } = props
 
   const formConfig = useFormConfig()
 
@@ -51,7 +50,7 @@ const FieldLabel = (props: Props) => {
       requiredDecoration={requiredDecoration}
       htmlFor={name}
       titleCase={titleCase}
-      horizontalLayoutAlignedToTop={horizontalLayoutAlignedToTop}
+      alignment={alignment}
     >
       {label}
     </PicassoForm.Label>

--- a/packages/picasso-forms/src/Form/story/Horizontal.example.tsx
+++ b/packages/picasso-forms/src/Form/story/Horizontal.example.tsx
@@ -23,6 +23,7 @@ import {
   TagSelector,
   Select,
   Switch,
+  RichTextEditor,
 } from '@toptal/picasso-forms'
 
 const countries = [
@@ -62,6 +63,7 @@ const initialValues = {
   'default-gender': 'female',
 }
 
+// eslint-disable-next-line max-lines-per-function
 const Example = () => {
   const [skillInputValue, setSkillInputValue] =
     useState<string>(EMPTY_INPUT_VALUE)
@@ -95,6 +97,56 @@ const Example = () => {
         name='default-lastName'
         label='Last name'
         placeholder='e.g. Wayne'
+        size='small'
+      />
+      <Input
+        required
+        name='default-nickName'
+        label='Nick name'
+        placeholder='e.g. Batman'
+      />
+      <Input
+        required
+        name='default-website'
+        label='Website'
+        placeholder='e.g. google.com'
+        size='large'
+      />
+      <Input name='default-multiline' label='Description' multiline rows={4} />
+      <RichTextEditor
+        name='default-richTextEditorName'
+        id='default-richTextEditorName'
+        label='Rich text editor'
+      />
+      <Dropzone label='Attachments' required name='default-attachments' />
+      <AvatarUpload
+        label='Profile photo xxsmall'
+        required
+        name='default-avatarUpload-xxsmall'
+        size='xxsmall'
+      />
+      <AvatarUpload
+        label='Profile photo xsmall'
+        required
+        name='default-avatarUpload-xsmall'
+        size='xsmall'
+      />
+      <AvatarUpload
+        label='Profile photo'
+        required
+        name='default-avatarUpload-small'
+      />
+      <AvatarUpload
+        label='Profile photo medium'
+        required
+        name='default-avatarUpload-medium'
+        size='medium'
+      />
+      <AvatarUpload
+        label='Profile photo large'
+        required
+        name='default-avatarUpload-large'
+        size='large'
       />
       <NumberInput
         enableReset
@@ -107,10 +159,34 @@ const Example = () => {
         <Radio label='Male' value='male' />
         <Radio label='Female' value='female' />
       </RadioGroup>
+      <RadioGroup name='default-language-radio' label='Languages'>
+        <Radio label='English' value='english' />
+        <Radio label='French' value='french' />
+        <Radio label='German' value='german' />
+      </RadioGroup>
       <RadioGroup name='default-gender' label='Gender' horizontal spacing={8}>
         <ButtonRadio value='male'>Male</ButtonRadio>
         <ButtonRadio value='female'>Female</ButtonRadio>
       </RadioGroup>
+      <CheckboxGroup name='default-hobbies' label='Hobbies'>
+        <Checkbox label='Skiing' value='skiing' />
+        <Checkbox label='Free diving' value='freeDiving' />
+        <Checkbox label='Dancing' value='dancing' />
+      </CheckboxGroup>
+      <CheckboxGroup name='default-language' label='Languages'>
+        <Checkbox label='English' value='english' />
+        <Checkbox label='French' value='french' />
+      </CheckboxGroup>
+      <CheckboxGroup
+        name='default-hobbies-buttons'
+        label='Hobbies'
+        horizontal
+        spacing={8}
+      >
+        <ButtonCheckbox value='skiing'>Skiing</ButtonCheckbox>
+        <ButtonCheckbox value='freeDiving'>Free diving</ButtonCheckbox>
+        <ButtonCheckbox value='dancing'>Dancing</ButtonCheckbox>
+      </CheckboxGroup>
       <DatePicker name='default-dateOfBirth' label='Date of birth' />
       <TimePicker name='default-timeOfBirth' label='Time of birth' />
       <TagSelector
@@ -120,21 +196,13 @@ const Example = () => {
         options={skillOptions}
         onInputChange={setSkillInputValue}
       />
-      <CheckboxGroup name='default-hobbies' label='Hobbies'>
-        <Checkbox label='Skiing' value='skiing' />
-        <Checkbox label='Free diving' value='freeDiving' />
-        <Checkbox label='Dancing' value='dancing' />
-      </CheckboxGroup>
-      <CheckboxGroup
-        name='default-hobbies'
-        label='Hobbies'
-        horizontal
-        spacing={8}
-      >
-        <ButtonCheckbox value='skiing'>Skiing</ButtonCheckbox>
-        <ButtonCheckbox value='freeDiving'>Free diving</ButtonCheckbox>
-        <ButtonCheckbox value='dancing'>Dancing</ButtonCheckbox>
-      </CheckboxGroup>
+      <FileInput
+        name='file'
+        id='file'
+        label='Upload file'
+        buttonLabel='Upload File'
+        hint='Max file size: 25MB'
+      />
       <Select
         enableReset
         required
@@ -183,7 +251,7 @@ const Example = () => {
       />
       <Rating.Thumbs
         name='default-thumbs'
-        label='Would you recommend picasso?'
+        label='Would you recommend Picasso?'
         required
       />
       <FileInput
@@ -191,12 +259,6 @@ const Example = () => {
         name='default-resume'
         label='Resume'
         status='No file selected.'
-      />
-      <Dropzone label='Attachments' required name='default-attachments' />
-      <AvatarUpload
-        label='Profile photo'
-        required
-        name='default-avatarUpload'
       />
       <Checkbox
         required

--- a/packages/picasso-forms/src/Input/Input.tsx
+++ b/packages/picasso-forms/src/Input/Input.tsx
@@ -40,10 +40,17 @@ export const Input = React.forwardRef<HTMLInputElement, Props>((props, ref) => {
   const { label, titleCase, ...rest } = props
   const { multiline, rows, rowsMax } = props
 
-  const horizontalLayoutAlignedToTop = useMemo(
-    () => multiline && (Number(rows ?? 1) >= 2 || Number(rowsMax ?? 1) >= 2),
-    [multiline, rows, rowsMax]
-  )
+  const alignment = useMemo(() => {
+    if (!multiline) {
+      return 'middle'
+    }
+
+    if (Number(rows ?? 1) >= 2 || Number(rowsMax ?? 1) >= 2) {
+      return 'top'
+    }
+
+    return 'middle'
+  }, [multiline, rows, rowsMax])
 
   return (
     <InputField<FormInputProps>
@@ -56,7 +63,7 @@ export const Input = React.forwardRef<HTMLInputElement, Props>((props, ref) => {
             required={props.required}
             label={label}
             titleCase={titleCase}
-            horizontalLayoutAlignedToTop={horizontalLayoutAlignedToTop}
+            alignment={alignment}
           />
         ) : null
       }

--- a/packages/picasso-forms/src/Input/Input.tsx
+++ b/packages/picasso-forms/src/Input/Input.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react'
+import React, { useEffect, useMemo } from 'react'
 import type { InputProps } from '@toptal/picasso'
 import { Input as PicassoInput } from '@toptal/picasso'
 import { useForm } from 'react-final-form'
@@ -38,6 +38,12 @@ export const Input = React.forwardRef<HTMLInputElement, Props>((props, ref) => {
   } = useForm()
 
   const { label, titleCase, ...rest } = props
+  const { multiline, rows, rowsMax } = props
+
+  const horizontalLayoutAlignedToTop = useMemo(
+    () => multiline && (Number(rows ?? 1) >= 2 || Number(rowsMax ?? 1) >= 2),
+    [multiline, rows, rowsMax]
+  )
 
   return (
     <InputField<FormInputProps>
@@ -50,6 +56,7 @@ export const Input = React.forwardRef<HTMLInputElement, Props>((props, ref) => {
             required={props.required}
             label={label}
             titleCase={titleCase}
+            horizontalLayoutAlignedToTop={horizontalLayoutAlignedToTop}
           />
         ) : null
       }

--- a/packages/picasso-forms/src/RadioGroup/RadioGroup.tsx
+++ b/packages/picasso-forms/src/RadioGroup/RadioGroup.tsx
@@ -12,7 +12,7 @@ export type Props = RadioGroupProps & FieldProps<RadioProps['value']>
 export const RadioGroup = (props: Props) => {
   const { children, label, titleCase, ...rest } = props
 
-  const horizontalLayoutAlignedToTop = Children.count(children) > 2
+  const alignment = Children.count(children) > 2 ? 'top' : 'middle'
 
   return (
     <RadioGroupContext.Provider value={props.name}>
@@ -26,7 +26,7 @@ export const RadioGroup = (props: Props) => {
               required={props.required}
               label={label}
               titleCase={titleCase}
-              horizontalLayoutAlignedToTop={horizontalLayoutAlignedToTop}
+              alignment={alignment}
             />
           ) : null
         }

--- a/packages/picasso-forms/src/RadioGroup/RadioGroup.tsx
+++ b/packages/picasso-forms/src/RadioGroup/RadioGroup.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { Children } from 'react'
 import type { RadioProps, RadioGroupProps } from '@toptal/picasso'
 import { Radio as PicassoRadio } from '@toptal/picasso'
 
@@ -12,6 +12,8 @@ export type Props = RadioGroupProps & FieldProps<RadioProps['value']>
 export const RadioGroup = (props: Props) => {
   const { children, label, titleCase, ...rest } = props
 
+  const horizontalLayoutAlignedToTop = Children.count(children) > 2
+
   return (
     <RadioGroupContext.Provider value={props.name}>
       <PicassoField
@@ -24,6 +26,7 @@ export const RadioGroup = (props: Props) => {
               required={props.required}
               label={label}
               titleCase={titleCase}
+              horizontalLayoutAlignedToTop={horizontalLayoutAlignedToTop}
             />
           ) : null
         }

--- a/packages/picasso-forms/src/RichTextEditor/RichTextEditor.tsx
+++ b/packages/picasso-forms/src/RichTextEditor/RichTextEditor.tsx
@@ -65,7 +65,7 @@ export const RichTextEditor = (props: Props) => {
             required={props.required}
             label={label}
             titleCase={titleCase}
-            horizontalLayoutAlignedToTop
+            alignment='top'
           />
         ) : null
       }

--- a/packages/picasso-forms/src/RichTextEditor/RichTextEditor.tsx
+++ b/packages/picasso-forms/src/RichTextEditor/RichTextEditor.tsx
@@ -65,6 +65,7 @@ export const RichTextEditor = (props: Props) => {
             required={props.required}
             label={label}
             titleCase={titleCase}
+            horizontalLayoutAlignedToTop
           />
         ) : null
       }

--- a/packages/picasso/src/FormField/styles.ts
+++ b/packages/picasso/src/FormField/styles.ts
@@ -86,7 +86,6 @@ export const createStylesForHorizontalLayout = (theme: Theme) => {
 export default (theme: Theme) =>
   createStyles({
     root: {
-      alignItems: 'start',
       fontSize: '1rem',
 
       '& + &': {

--- a/packages/picasso/src/FormLabel/FormLabel.tsx
+++ b/packages/picasso/src/FormLabel/FormLabel.tsx
@@ -36,7 +36,7 @@ export interface Props
   /** Component size */
   size?: SizeType<'medium' | 'large'>
   /** Whether label should be aligned to top of the container or not */
-  horizontalLayoutAlignedToTop?: boolean
+  alignment?: 'top' | 'middle'
 }
 
 const useStyles = makeStyles<Theme, Props>(styles, { name: 'PicassoFormLabel' })
@@ -56,7 +56,7 @@ export const FormLabel = forwardRef<HTMLLabelElement, Props>(function FormLabel(
     titleCase: propsTitleCase,
     requiredDecoration,
     size = 'medium',
-    horizontalLayoutAlignedToTop,
+    alignment = 'middle',
     ...rest
   } = props
 
@@ -77,8 +77,8 @@ export const FormLabel = forwardRef<HTMLLabelElement, Props>(function FormLabel(
           [classes.disabled]: disabled,
           [classes.inline]: isInline,
           [classes.horizontalLayout]: layout === 'horizontal',
-          [classes.horizontalLayoutAlignedToTop]:
-            layout === 'horizontal' && horizontalLayoutAlignedToTop,
+          [classes.alignmentTop]:
+            layout === 'horizontal' && alignment === 'top',
         },
         className
       )}

--- a/packages/picasso/src/FormLabel/FormLabel.tsx
+++ b/packages/picasso/src/FormLabel/FormLabel.tsx
@@ -35,6 +35,8 @@ export interface Props
   as?: ComponentType
   /** Component size */
   size?: SizeType<'medium' | 'large'>
+  /** Whether label should be aligned to top of the container or not */
+  horizontalLayoutAlignedToTop?: boolean
 }
 
 const useStyles = makeStyles<Theme, Props>(styles, { name: 'PicassoFormLabel' })
@@ -54,6 +56,7 @@ export const FormLabel = forwardRef<HTMLLabelElement, Props>(function FormLabel(
     titleCase: propsTitleCase,
     requiredDecoration,
     size = 'medium',
+    horizontalLayoutAlignedToTop,
     ...rest
   } = props
 
@@ -74,6 +77,8 @@ export const FormLabel = forwardRef<HTMLLabelElement, Props>(function FormLabel(
           [classes.disabled]: disabled,
           [classes.inline]: isInline,
           [classes.horizontalLayout]: layout === 'horizontal',
+          [classes.horizontalLayoutAlignedToTop]:
+            layout === 'horizontal' && horizontalLayoutAlignedToTop,
         },
         className
       )}

--- a/packages/picasso/src/FormLabel/styles.ts
+++ b/packages/picasso/src/FormLabel/styles.ts
@@ -48,7 +48,7 @@ export default ({ palette }: Theme) =>
       alignItems: 'center',
       marginBottom: 0,
     },
-    horizontalLayoutAlignedToTop: {
+    alignmentTop: {
       alignItems: 'start',
       paddingTop: '0.5rem',
     },

--- a/packages/picasso/src/FormLabel/styles.ts
+++ b/packages/picasso/src/FormLabel/styles.ts
@@ -48,4 +48,8 @@ export default ({ palette }: Theme) =>
       alignItems: 'center',
       marginBottom: 0,
     },
+    horizontalLayoutAlignedToTop: {
+      alignItems: 'start',
+      paddingTop: '0.5rem',
+    },
   })


### PR DESCRIPTION
[CRT-6946]
[FX-4808]

### Description

This PR aims to adjust form labels alignement.
As of today I wasn't able to find any generic CSS solution to apply styles only for FormField and/or FormLabel. That is proposed solution is based on the knowledge that the specific form component has height above 48px, in that case we align label to the top.

### How to test

1. Here is a PR in Client Portal with updated Picasso https://github.com/toptal/client-portal/pull/8013
    - as you can see in [generated Happo screenshots in Client Portal](https://happo.io/a/431/p/1314/compare/75ec96db99c080bfbcf5b8d2288225b33bd85105/8fcd8ee9535e680b56c4993fdd71c99a889be6d6) there are no diffs, which is good, as we fixed alignment in this PR
3. review `Form*` Happo screenshots in Picasso

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| <img src="https://github.com/toptal/picasso/assets/4816942/82cee0a7-29d5-423d-b942-343ce62aa6ac" width="400" /> | <img src="https://github.com/toptal/picasso/assets/4816942/2be9231b-1a8a-44af-978f-a2ffb03ec6c2" width="400" /> |

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- n/a Covered with tests ([visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md) included)

**Breaking change**

- n/a codemod is created and showcased in the changeset
- n/a test alpha package of Picasso in Staff Portal
- [x] test alpha package of Picasso in Client Portal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
4. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
5. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[CRT-6946]: https://toptal-core.atlassian.net/browse/CRT-6946?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FX-4808]: https://toptal-core.atlassian.net/browse/FX-4808?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ