### PR TITLE
Add BASE spacings to the theme config

### DIFF
--- a/.changeset/tender-crabs-accept.md
+++ b/.changeset/tender-crabs-accept.md
@@ -1,5 +1,5 @@
 ---
-'@toptal/picasso-tailwind': minor
+'@toptal/picasso-tailwind': major
 ---
 
-- add BASE spacings to the theme
+- override default Tailwind spacings with BASE spacings

--- a/.changeset/tender-crabs-accept.md
+++ b/.changeset/tender-crabs-accept.md
@@ -1,0 +1,5 @@
+---
+'@toptal/picasso-tailwind': minor
+---
+
+- add BASE spacings to the theme

--- a/packages/picasso-tailwind/src/index.js
+++ b/packages/picasso-tailwind/src/index.js
@@ -8,6 +8,17 @@ module.exports = {
       lg: '1024px',
       xl: '1440px',
     },
+    spacing: {
+      0: '0',
+      1: '0.25rem',
+      2: '0.5rem',
+      3: '0.75rem',
+      4: '1rem',
+      6: '1.5rem',
+      8: '2rem',
+      10: '2.5rem',
+      12: '3rem',
+    },
     borderRadius: {
       sm: '4px',
       md: '8px',

--- a/packages/picasso-tailwind/src/index.js
+++ b/packages/picasso-tailwind/src/index.js
@@ -8,6 +8,7 @@ module.exports = {
       lg: '1024px',
       xl: '1440px',
     },
+    // https://toptal-core.atlassian.net/wiki/spaces/Base/pages/3217031216/Spacing
     spacing: {
       0: '0',
       1: '0.25rem',


### PR DESCRIPTION
[FX-NNNN]

### Description

We don't have BASE spacing in the TailwindCSS config, this PR fixes it.

### How to test

<!-- The temploy link will be automatically updated when the temploy is deployed -->
- [Temploy](https://picasso.toptal.net/fx-null-tailwind-spacing)
- FIXME: Add the steps describing how to verify your changes

### Screenshots

![image](https://github.com/toptal/picasso/assets/6830426/3643a933-2957-4f03-9690-39a03ef5962b)

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- Annotate all `props` in component with documentation
- Create `examples` for component
- Ensure that deployed demo has expected results and good examples
- Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- Covered with tests ([visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md) included)

**Breaking change**

- codemod is created and showcased in the changeset
- test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>
