### PR TITLE
[TACO] Fix PasswordInput size prop

### DIFF
--- a/.changeset/beige-clocks-float.md
+++ b/.changeset/beige-clocks-float.md
@@ -1,6 +1,5 @@
 ---
 '@toptal/picasso': patch
-'@toptal/picasso-forms': patch
 ---
 
 ### PasswordInput

--- a/.changeset/beige-clocks-float.md
+++ b/.changeset/beige-clocks-float.md
@@ -1,0 +1,8 @@
+---
+'@toptal/picasso': patch
+'@toptal/picasso-forms': patch
+---
+
+### PasswordInput
+
+- fix `size` prop not having effect on component size

--- a/packages/picasso/src/PasswordInput/PasswordInput.tsx
+++ b/packages/picasso/src/PasswordInput/PasswordInput.tsx
@@ -51,6 +51,7 @@ export const PasswordInput = forwardRef<HTMLInputElement, Props>(
       disabled,
       error,
       status,
+      size,
       width,
       style,
       className,
@@ -102,6 +103,7 @@ export const PasswordInput = forwardRef<HTMLInputElement, Props>(
           ...rest,
           'data-testid': testIds?.input,
         }}
+        size={size}
         width={width}
         status={error ? 'error' : status}
         inputRef={ref}

--- a/packages/picasso/src/PasswordInput/story/Sizes.example.tsx
+++ b/packages/picasso/src/PasswordInput/story/Sizes.example.tsx
@@ -1,0 +1,57 @@
+import React, { useState } from 'react'
+import { PasswordInput, Container, Typography } from '@toptal/picasso'
+import { SPACING_4 } from '@toptal/picasso/utils'
+
+const Example = () => {
+  const [value, setValue] = useState<string>('')
+
+  const handleChange = (event: React.ChangeEvent<{ value: string }>) => {
+    setValue(event.target.value)
+  }
+
+  return (
+    <Container flex direction='column'>
+      <Container padded={SPACING_4}>
+        <Typography variant='heading' size='small'>
+          Small
+        </Typography>
+        <Container top={SPACING_4} bottom={SPACING_4}>
+          <PasswordInput
+            size='small'
+            value={value}
+            placeholder='Small'
+            onChange={handleChange}
+          />
+        </Container>
+      </Container>
+      <Container padded={SPACING_4}>
+        <Typography variant='heading' size='small'>
+          Medium (default)
+        </Typography>
+        <Container top={SPACING_4} bottom={SPACING_4}>
+          <PasswordInput
+            size='medium'
+            value={value}
+            placeholder='Medium (default)'
+            onChange={handleChange}
+          />
+        </Container>
+      </Container>
+      <Container padded={SPACING_4}>
+        <Typography variant='heading' size='small'>
+          Large
+        </Typography>
+        <Container top={SPACING_4} bottom={SPACING_4}>
+          <PasswordInput
+            size='large'
+            value={value}
+            placeholder='Large'
+            onChange={handleChange}
+          />
+        </Container>
+      </Container>
+    </Container>
+  )
+}
+
+export default Example

--- a/packages/picasso/src/PasswordInput/story/index.jsx
+++ b/packages/picasso/src/PasswordInput/story/index.jsx
@@ -18,3 +18,4 @@ page
   .addExample('PasswordInput/story/Default.example.tsx', 'Default')
   .addExample('PasswordInput/story/Disabled.example.tsx', 'Disabled')
   .addExample('PasswordInput/story/Status.example.tsx', 'Status')
+  .addExample('PasswordInput/story/Sizes.example.tsx', 'Sizes')


### PR DESCRIPTION
[no-jira]

### Description

The `PasswordInput` component accepts the `size` prop, but it was not working properly. The component rendered in default size, regardless of the `size` value.

### How to test

<!-- The temploy link will be automatically updated when the temploy is deployed -->
- [Temploy](https://picasso.toptal.net/taco-fix-passwordinput-size)
- Check the new **Sizes** example in `PasswordInput` storybook

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| ![image](https://github.com/toptal/picasso/assets/597793/d0c67981-a164-4f13-98e9-bf236a6f090d) | ![image](https://github.com/toptal/picasso/assets/597793/314a1870-1060-44cb-be6a-45f23b0053e5) |

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests ([visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md) included)

**Breaking change**

- [-] codemod is created and showcased in the changeset
- [-] test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>
