### PR TITLE
Prevent Form onSubmit rejections from being swallowed

### DIFF
--- a/.changeset/tiny-games-remain.md
+++ b/.changeset/tiny-games-remain.md
@@ -1,0 +1,5 @@
+---
+'@toptal/picasso-forms': patch
+---
+
+- prevent Form onSubmit rejections from being swallowed

--- a/packages/picasso-forms/src/utils/scroll-to-error-decorator.ts
+++ b/packages/picasso-forms/src/utils/scroll-to-error-decorator.ts
@@ -64,7 +64,12 @@ export default ({ disableScrollOnError }: ScrollToErrorProps = {}) =>
       }
 
       if (result && typeof result.then === 'function') {
-        result.then(scrollOnErrors).catch(() => {})
+        // Catching the rejection on the `result` strips us from
+        // the unhandled promise rejection error.
+        // On the other hand we don't want the scroll to be blocking
+        // for the form submission so we avoid promise chaining here.
+        // eslint-disable-next-line promise/catch-or-return
+        result.then(scrollOnErrors)
       } else {
         scrollOnErrors()
       }


### PR DESCRIPTION
[FX-NNNN]

### Description

The errors from the onSubmit callback of the Form  component are swallowed. It’s pretty dangerous as it prevents our error monitoring tool from reporting such error and it’s challenging to debug it.

I tried to create a sandbox but I’m way over the limit of 10 drafts of the free tier. I was able to reproduce the problem on the picasso website though: https://picasso.toptal.net/?path=/story/picasso-forms-form--form

```jsx
import React from 'react'
import {
  FormNonCompound as Form,
  SubmitButton

} from '@toptal/picasso-forms'


const Example = () => {
  const handleSubmit = () => {
    throw new Error('Some error')
  }
  
  return (
    <Form
      autoComplete='off'
      onSubmit={values => handleSubmit(values)}
    >
        <SubmitButton>Submit</SubmitButton>
    </Form>
  )
}

export default Example
```

Use this snippet and click the Submit  button. No error is reported to dev tools.
Add `disableScrollOnError`  to the form component like

```
<Form
  autoComplete='off'
  onSubmit={values => handleSubmit(values)}
  disableScrollOnError
>
```

### Problem

The problem is that error reporting of the handler rejection is based on unhandled promise callback. 

<img width="448" alt="Screenshot 2024-02-26 at 11 40 33 copy" src="https://github.com/toptal/picasso/assets/2437969/1f4e4b73-2d10-40b0-a4ce-c9f2dbdfac8f">

The unhandled promise rejection wasn't called though because of a dummy `.catch` call in the lifetime of the result promise. Because of that browser assumed the rejection was gracefully handled and didn't raise it as a problem.

### Solution

The solution implemented here is to stop calling `.catch` on the promise if there is no intention to process the `result` promise rejection.  What we get:

 - in case there is a rejection, it will trigger the uncaught promise rejection handler
 - in case there is no rejection but the scroll to error code fails; the form submission will proceed without the scroll and the scroll issue itself will trigger the uncaught promise rejection handler

### How to test

<!-- The temploy link will be automatically updated when the temploy is deployed -->
- [Temploy](https://picasso.toptal.net/dont-swallow-form-on-submit-rejections)
- FIXME: Add the steps describing how to verify your changes

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| <img width="1728" alt="Screenshot 2024-02-26 at 11 40 43" src="https://github.com/toptal/picasso/assets/2437969/7fbd715c-21d6-4e0d-a5c5-ea117d6cba29">  |  <img width="1718" alt="Screenshot 2024-02-26 at 11 40 33" src="https://github.com/toptal/picasso/assets/2437969/0bb4d6ac-190a-4de4-89c6-60ce319ffe75"> |

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- n/a Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- n/a Annotate all `props` in component with documentation
- n/a Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [ ] Covered with tests ([visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md) included)

**Breaking change**

- n/a codemod is created and showcased in the changeset
- n/a test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>
