### PR TITLE
Fix TimePicker duplicate clock icons

### DIFF
--- a/.changeset/flat-rats-search.md
+++ b/.changeset/flat-rats-search.md
@@ -1,0 +1,7 @@
+---
+'@toptal/picasso': patch
+---
+
+### TimePicker Icon
+
+- fix `TimePicker` duplicate clock icons

--- a/packages/picasso/src/TimePicker/styles.ts
+++ b/packages/picasso/src/TimePicker/styles.ts
@@ -17,10 +17,15 @@ export default ({ palette }: Theme) =>
     inputBase: {
       marginRight: '-8px', // override default margin for icon position
 
-      // override styles for native 'clock' icon for type='time'
+      // this workaround is needed to show the picker when we click our own clock icon
+      // eventually, we could "display: none" this native icon and use native showPicker()
+      // but currently not all browsers support the picker (e.g. Safari and Firefox), so for now we
+      // hide the native icon (with its functionality available) behind our icon
       '&::-webkit-calendar-picker-indicator': {
-        outline: 'none',
+        position: 'absolute',
+        right: '0.5rem',
         cursor: 'pointer',
+        background: 'none',
       },
     },
     inputMask: {


### PR DESCRIPTION
[TOP-4258](https://toptal-core.atlassian.net/browse/TOP-4258)

### Description

Fix **TimePicker** component duplicate icons.

### How to test

<!-- The temploy link will be automatically updated when the temploy is deployed -->
- [Temploy](https://picasso.toptal.net/fix-timepicker-duplicate-icons)
- Make sure we have one **TimePicker** icon and we can click on it to open the time selector (the time selector is not available on [Firefox and Safari](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/time)).
> To reproduce the bug, you should have the most recent versions of Chrome, as discussed [here](https://toptal-core.slack.com/archives/CERF5NHT3/p1709211732462009?thread_ts=1709210865.916469&cid=CERF5NHT3).

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| ![image](https://github.com/toptal/picasso/assets/82273361/1bcab5e1-6eef-49a4-923f-3e4983250dd5) | ![image](https://github.com/toptal/picasso/assets/82273361/36aabd27-018a-46e1-ac14-88ff595636a5) |

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- Annotate all `props` in component with documentation
- Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- Covered with tests ([visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md) included)

**Breaking change**

- codemod is created and showcased in the changeset
- test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[TOP-4258]: https://toptal-core.atlassian.net/browse/TOP-4258?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ