### PR TITLE
[CRT-7024] Introduce 'labelEndAdornment' prop for Label component

### DIFF
--- a/.changeset/small-trainers-hug.md
+++ b/.changeset/small-trainers-hug.md
@@ -1,0 +1,7 @@
+---
+'@toptal/picasso-forms': minor
+'@toptal/picasso-form': minor
+'@toptal/picasso': minor
+---
+
+- introduce `labelEndAdornment` prop for `FormLabel` component.

--- a/packages/base/Checkbox/src/Checkbox/Checkbox.tsx
+++ b/packages/base/Checkbox/src/Checkbox/Checkbox.tsx
@@ -7,7 +7,7 @@ import type {
   TextLabelProps,
 } from '@toptal/picasso-shared'
 import cx from 'classnames'
-import type { ComponentProps, ReactNode } from 'react'
+import type { ComponentProps, CSSProperties, ReactNode } from 'react'
 import React, { forwardRef } from 'react'
 import { Container } from '@toptal/picasso-container'
 import { FormControlLabel } from '@toptal/picasso-form'
@@ -31,6 +31,8 @@ export interface Props
   label?: ReactNode
   /** The id of the input element */
   id?: string
+  /** Label's style */
+  labelStyle?: CSSProperties
   /** Whether to show asterisk or (optional) postfix for the label as a 'required' decoration */
   requiredDecoration?: RequiredDecoration
   /** Callback invoked when `Checkbox` changed its value */
@@ -49,6 +51,7 @@ export const Checkbox = forwardRef<HTMLButtonElement | HTMLLabelElement, Props>(
       id,
       className,
       style,
+      labelStyle,
       disabled,
       requiredDecoration,
       onChange,
@@ -105,6 +108,7 @@ export const Checkbox = forwardRef<HTMLButtonElement | HTMLLabelElement, Props>(
     return (
       <FormControlLabel
         {...externalEventListeners}
+        style={labelStyle}
         ref={ref as React.ForwardedRef<HTMLLabelElement>}
         classes={{
           ...rootClasses,

--- a/packages/base/Form/src/FormLabel/FormLabel.tsx
+++ b/packages/base/Form/src/FormLabel/FormLabel.tsx
@@ -37,6 +37,8 @@ export interface Props
   size?: SizeType<'medium' | 'large'>
   /** Whether label should be aligned to top of the container or not */
   alignment?: 'top' | 'middle'
+  /** Label's end adornment */
+  labelEndAdornment?: ReactNode
 }
 
 const useStyles = makeStyles<Theme, Props>(styles, { name: 'PicassoFormLabel' })
@@ -57,6 +59,7 @@ export const FormLabel = forwardRef<HTMLLabelElement, Props>(function FormLabel(
     requiredDecoration,
     size = 'medium',
     alignment = 'middle',
+    labelEndAdornment,
     ...rest
   } = props
 
@@ -90,7 +93,10 @@ export const FormLabel = forwardRef<HTMLLabelElement, Props>(function FormLabel(
         )}
 
         {titleCase ? toTitleCase(children) : children}
+
         {requiredDecoration === 'optional' && ' (optional)'}
+
+        {labelEndAdornment}
       </span>
     </Component>
   )

--- a/packages/base/Form/src/FormLabel/__snapshots__/test.tsx.snap
+++ b/packages/base/Form/src/FormLabel/__snapshots__/test.tsx.snap
@@ -82,6 +82,37 @@ exports[`FormLabel required with (optional) 1`] = `
 </div>
 `;
 
+exports[`FormLabel required with (optional) and with \`labelEndAdornment\` 1`] = `
+<div>
+  <div
+    class="Picasso-root"
+  >
+    <form
+      class=""
+    >
+      <div
+        class="PicassoFormField-root"
+        data-field-has-error="false"
+      >
+        <label
+          class="PicassoFormLabel-root"
+        >
+          <span
+            class="PicassoFormLabel-medium"
+          >
+            Label
+             (optional)
+            <span>
+              label end adornment
+            </span>
+          </span>
+        </label>
+      </div>
+    </form>
+  </div>
+</div>
+`;
+
 exports[`FormLabel required with asterisk 1`] = `
 <div>
   <div

--- a/packages/base/Form/src/FormLabel/test.tsx
+++ b/packages/base/Form/src/FormLabel/test.tsx
@@ -16,6 +16,7 @@ const TestFormLabel = ({
   titleCase,
   htmlFor,
   inline,
+  labelEndAdornment,
 }: OmitInternalProps<Props>) => {
   return (
     <Form>
@@ -26,6 +27,7 @@ const TestFormLabel = ({
           titleCase={titleCase}
           htmlFor={htmlFor}
           inline={inline}
+          labelEndAdornment={labelEndAdornment}
         >
           {children}
         </FormLabel>
@@ -59,6 +61,19 @@ describe('FormLabel', () => {
   it('required with (optional)', () => {
     const { container } = render(
       <TestFormLabel requiredDecoration='optional'>Label</TestFormLabel>
+    )
+
+    expect(container).toMatchSnapshot()
+  })
+
+  it('required with (optional) and with `labelEndAdornment`', () => {
+    const { container } = render(
+      <TestFormLabel
+        labelEndAdornment={<span>label end adornment</span>}
+        requiredDecoration='optional'
+      >
+        Label
+      </TestFormLabel>
     )
 
     expect(container).toMatchSnapshot()

--- a/packages/picasso-forms/src/Autocomplete/Autocomplete.tsx
+++ b/packages/picasso-forms/src/Autocomplete/Autocomplete.tsx
@@ -3,13 +3,16 @@ import type { AutocompleteProps } from '@toptal/picasso'
 import { Autocomplete as PicassoAutocomplete } from '@toptal/picasso'
 
 import type { FieldProps } from '../Field'
+import type { Props as FieldLabelProps } from '../FieldLabel'
 import FieldLabel from '../FieldLabel'
 import InputField from '../InputField'
 
-export type Props = AutocompleteProps & FieldProps<AutocompleteProps['value']>
+export type Props = AutocompleteProps &
+  FieldProps<AutocompleteProps['value']> &
+  FieldLabelProps
 
 export const Autocomplete = (props: Props) => {
-  const { label, titleCase, ...rest } = props
+  const { label, labelEndAdornment, titleCase, ...rest } = props
 
   return (
     <InputField<AutocompleteProps>
@@ -20,6 +23,7 @@ export const Autocomplete = (props: Props) => {
             name={props.name}
             required={props.required}
             label={label}
+            labelEndAdornment={labelEndAdornment}
             titleCase={titleCase}
           />
         ) : null

--- a/packages/picasso-forms/src/AvatarUpload/AvatarUpload.tsx
+++ b/packages/picasso-forms/src/AvatarUpload/AvatarUpload.tsx
@@ -4,10 +4,13 @@ import { AvatarUpload as PicassoAvatarUpload } from '@toptal/picasso'
 import type { FieldInputProps as FinalFieldInputProps } from 'react-final-form'
 
 import type { FieldProps } from '../Field'
+import type { Props as FieldLabelProps } from '../FieldLabel'
 import FieldLabel from '../FieldLabel'
 import InputField from '../InputField'
 
-type Props = AvatarUploadProps & FieldProps<AvatarUploadProps['value']>
+type Props = AvatarUploadProps &
+  FieldProps<AvatarUploadProps['value']> &
+  FieldLabelProps
 
 type FinalFormOnChangeType = FinalFieldInputProps<
   AvatarUploadProps['value']
@@ -16,6 +19,7 @@ type FinalFormOnChangeType = FinalFieldInputProps<
 const AvatarUpload = (props: Props) => {
   const {
     label,
+    labelEndAdornment,
     titleCase,
     size = 'small',
     // dropping 'src' value here out from 'rest'. 'src' value should be provided via form context
@@ -58,6 +62,7 @@ const AvatarUpload = (props: Props) => {
             name={props.name}
             required={props.required}
             label={label}
+            labelEndAdornment={labelEndAdornment}
             titleCase={titleCase}
             alignment={alignment}
           />

--- a/packages/picasso-forms/src/Checkbox/Checkbox.tsx
+++ b/packages/picasso-forms/src/Checkbox/Checkbox.tsx
@@ -1,6 +1,9 @@
 import React, { useContext } from 'react'
 import type { CheckboxProps } from '@toptal/picasso'
-import { Checkbox as PicassoCheckbox } from '@toptal/picasso'
+import {
+  useFieldsLayoutContext,
+  Checkbox as PicassoCheckbox,
+} from '@toptal/picasso'
 import type { FieldRenderProps as FinalFormFieldProps } from 'react-final-form'
 import { Field } from 'react-final-form'
 
@@ -28,6 +31,7 @@ export const Checkbox = ({
   defaultValue,
   ...restProps
 }: Props) => {
+  const { layout } = useFieldsLayoutContext()
   const formConfig = useFormConfig()
   const groupName = useContext(CheckboxGroupContext)
   const isCheckboxInGroup = Boolean(groupName)
@@ -63,12 +67,18 @@ export const Checkbox = ({
         highlight,
         ...input
       }: CheckboxProps & { highlight?: 'autofill' }) => (
-        <PicassoCheckbox
-          {...input}
-          label={label}
-          titleCase={restProps.titleCase}
-          requiredDecoration={requiredDecoration}
-        />
+        <>
+          {layout === 'horizontal' && <div />}
+          <PicassoCheckbox
+            {...input}
+            labelStyle={
+              layout === 'horizontal' ? { gridArea: 'input' } : undefined
+            }
+            label={label}
+            titleCase={restProps.titleCase}
+            requiredDecoration={requiredDecoration}
+          />
+        </>
       )}
     </PicassoField>
   )

--- a/packages/picasso-forms/src/CheckboxGroup/CheckboxGroup.tsx
+++ b/packages/picasso-forms/src/CheckboxGroup/CheckboxGroup.tsx
@@ -5,14 +5,22 @@ import { Checkbox as PicassoCheckbox } from '@toptal/picasso'
 
 import type { FieldProps } from '../Field'
 import PicassoField from '../Field'
+import type { Props as FieldLabelProps } from '../FieldLabel'
 import FieldLabel from '../FieldLabel'
 import CheckboxGroupContext from './CheckboxGroupContext'
 
 type ValueType = string[] | undefined
-export type Props = CheckboxGroupProps & FieldProps<ValueType>
+export type Props = CheckboxGroupProps & FieldProps<ValueType> & FieldLabelProps
 
 export const CheckboxGroup = (props: Props) => {
-  const { children, titleCase, label, initialValue, ...rest } = props
+  const {
+    children,
+    titleCase,
+    label,
+    labelEndAdornment,
+    initialValue,
+    ...rest
+  } = props
 
   const alignment = Children.count(children) > 2 ? 'top' : 'middle'
 
@@ -28,6 +36,7 @@ export const CheckboxGroup = (props: Props) => {
               name={props.name}
               required={props.required}
               label={label}
+              labelEndAdornment={labelEndAdornment}
               titleCase={titleCase}
               alignment={alignment}
             />

--- a/packages/picasso-forms/src/DatePicker/DatePicker.tsx
+++ b/packages/picasso-forms/src/DatePicker/DatePicker.tsx
@@ -4,15 +4,18 @@ import { DatePicker as PicassoDatePicker } from '@toptal/picasso'
 
 import type { FieldProps } from '../Field'
 import InputField from '../InputField'
+import type { Props as FieldLabelProps } from '../FieldLabel'
 import FieldLabel from '../FieldLabel'
 
 export type FormDatePickerProps = Omit<DatePickerProps, 'onChange'> & {
   onChange?: DatePickerProps['onChange']
 }
-export type Props = FormDatePickerProps & FieldProps<DatePickerProps['value']>
+export type Props = FormDatePickerProps &
+  FieldProps<DatePickerProps['value']> &
+  FieldLabelProps
 
 export const DatePicker = (props: Props) => {
-  const { label, titleCase, ...rest } = props
+  const { label, labelEndAdornment, titleCase, ...rest } = props
 
   return (
     <InputField<FormDatePickerProps>
@@ -22,6 +25,7 @@ export const DatePicker = (props: Props) => {
           name={props.name}
           required={props.required}
           label={label}
+          labelEndAdornment={labelEndAdornment}
           titleCase={titleCase}
         />
       }

--- a/packages/picasso-forms/src/Dropzone/Dropzone.tsx
+++ b/packages/picasso-forms/src/Dropzone/Dropzone.tsx
@@ -5,12 +5,13 @@ import type { FieldInputProps as FinalFieldInputProps } from 'react-final-form'
 
 import type { FieldProps } from '../Field'
 import PicassoField from '../Field'
+import type { Props as FieldLabelProps } from '../FieldLabel'
 import FieldLabel from '../FieldLabel'
 
 export type Props = DropzoneProps &
   FieldProps<DropzoneProps['value']> & {
     dropzoneHint?: string
-  }
+  } & FieldLabelProps
 
 type FinalFormOnChangeType = FinalFieldInputProps<
   DropzoneProps['value']
@@ -61,6 +62,7 @@ const Dropzone = ({ dropzoneHint, ...props }: Props) => {
           name={props.name}
           required={props.required}
           label={props.label}
+          labelEndAdornment={props.labelEndAdornment}
           titleCase={props.titleCase}
           alignment='top'
         />

--- a/packages/picasso-forms/src/FieldLabel/FieldLabel.tsx
+++ b/packages/picasso-forms/src/FieldLabel/FieldLabel.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from 'react'
 import React from 'react'
 import type { RequiredDecoration } from '@toptal/picasso'
 import { Form as PicassoForm } from '@toptal/picasso'
@@ -8,10 +9,16 @@ import { useFormConfig } from '../FormConfig'
 
 export type Props = {
   name?: string
-  label?: React.ReactNode
+  label?: ReactNode
+  /** Label's end adornment */
+  labelEndAdornment?: ReactNode
   required?: boolean
-  alignment?: 'top' | 'middle'
 } & TextLabelProps
+
+type InternalProps = {
+  /** Whether label should be aligned to top of the container or not */
+  alignment?: 'top' | 'middle'
+}
 
 const getRequiredDecoration = (
   required?: boolean,
@@ -31,9 +38,14 @@ const getRequiredDecoration = (
   }
 }
 
-const FieldLabel = (props: Props) => {
-  const { label, required, titleCase, name, alignment } = props
-
+const FieldLabel = ({
+  label,
+  required,
+  titleCase,
+  name,
+  alignment,
+  labelEndAdornment,
+}: Props & InternalProps) => {
   const formConfig = useFormConfig()
 
   if (!label) {
@@ -51,6 +63,7 @@ const FieldLabel = (props: Props) => {
       htmlFor={name}
       titleCase={titleCase}
       alignment={alignment}
+      labelEndAdornment={labelEndAdornment}
     >
       {label}
     </PicassoForm.Label>

--- a/packages/picasso-forms/src/FieldWrapper/FieldWrapper.tsx
+++ b/packages/picasso-forms/src/FieldWrapper/FieldWrapper.tsx
@@ -1,17 +1,16 @@
-import type { ReactNode } from 'react'
 import React from 'react'
 
 import type { Props as FieldProps } from '../Field'
 import type { ValueType, IFormComponentProps } from '../FieldBase'
+import type { Props as FieldLabelProps } from '../FieldLabel'
 import FieldLabel from '../FieldLabel'
 import InputField from '../InputField'
 
 export type Props<TWrappedComponentProps, TInputValue> = Omit<
   FieldProps<TWrappedComponentProps, TInputValue>,
   'label'
-> & {
-  label?: ReactNode
-}
+> &
+  Omit<FieldLabelProps, 'name'>
 
 const FieldWrapper = <
   TWrappedComponentProps extends IFormComponentProps,
@@ -19,7 +18,7 @@ const FieldWrapper = <
 >(
   props: Props<TWrappedComponentProps, TInputValue>
 ) => {
-  const { label, name, titleCase, children, ...rest } = props
+  const { label, labelEndAdornment, name, titleCase, children, ...rest } = props
 
   return (
     <InputField<IFormComponentProps, TInputValue>
@@ -28,9 +27,10 @@ const FieldWrapper = <
       label={
         label ? (
           <FieldLabel
-            name={props.name}
+            name={name}
             required={props.required}
             label={label}
+            labelEndAdornment={labelEndAdornment}
             titleCase={titleCase}
           />
         ) : null

--- a/packages/picasso-forms/src/FieldWrapper/story/index.jsx
+++ b/packages/picasso-forms/src/FieldWrapper/story/index.jsx
@@ -14,8 +14,13 @@ const componentDocs = PicassoBook.createComponentDocs(
     },
     label: {
       name: 'label',
-      type: 'string',
+      type: 'ReactNode',
       description: 'The field label text',
+    },
+    labelEndAdornment: {
+      name: 'labelEndAdornment',
+      type: 'ReactNode',
+      description: "The label's end adornment",
     },
     hint: {
       name: 'hint',

--- a/packages/picasso-forms/src/FileInput/FileInput.tsx
+++ b/packages/picasso-forms/src/FileInput/FileInput.tsx
@@ -6,12 +6,15 @@ import type { FieldInputProps as FinalFieldInputProps } from 'react-final-form'
 import type { FieldProps } from '../Field'
 import PicassoField from '../Field'
 import FieldLabel from '../FieldLabel'
+import type { Props as FieldLabelProps } from '../FieldLabel'
 
 type FinalFormOnChangeType = FinalFieldInputProps<
   FileInputProps['value']
 >['onChange']
 
-export type Props = FileInputProps & FieldProps<FileInputProps['value']>
+export type Props = FileInputProps &
+  FieldProps<FileInputProps['value']> &
+  FieldLabelProps
 
 export const FileInput = (props: Props) => {
   const handleChange = (
@@ -53,6 +56,7 @@ export const FileInput = (props: Props) => {
             name={props.name}
             required={props.required}
             label={props.label}
+            labelEndAdornment={props.labelEndAdornment}
             titleCase={props.titleCase}
           />
         ) : null

--- a/packages/picasso-forms/src/Form/Form.tsx
+++ b/packages/picasso-forms/src/Form/Form.tsx
@@ -21,6 +21,7 @@ export type Props<T = AnyObject> = FinalFormProps<T> & {
   scrollOffsetTop?: number
   layout?: 'horizontal' | 'vertical'
   labelWidth?: FormProps['labelWidth']
+  className?: string
   'data-testid'?: string
 }
 
@@ -63,6 +64,7 @@ export const Form = <T extends AnyObject = AnyObject>(props: Props<T>) => {
     'data-testid': dataTestId,
     layout,
     labelWidth,
+    className,
     ...rest
   } = props
   const { showSuccess, showError } = useNotifications()
@@ -136,6 +138,7 @@ export const Form = <T extends AnyObject = AnyObject>(props: Props<T>) => {
             setActiveFieldTouched={form.mutators.setActiveFieldTouched}
             labelWidth={labelWidth}
             layout={layout}
+            className={className}
           >
             {children}
           </FormRenderer>

--- a/packages/picasso-forms/src/Form/story/Horizontal.example.tsx
+++ b/packages/picasso-forms/src/Form/story/Horizontal.example.tsx
@@ -1,6 +1,12 @@
 import React, { useState } from 'react'
-import { FormActionsContainer } from '@toptal/picasso'
-import { SPACING_4, isSubstring } from '@toptal/picasso-utils'
+import {
+  Button,
+  Container,
+  FormActionsContainer,
+  Info16,
+  Tooltip,
+} from '@toptal/picasso'
+import { SPACING_4, isSubstring, SPACING_1 } from '@toptal/picasso/utils'
 import type { Item } from '@toptal/picasso/Autocomplete'
 import {
   FormNonCompound as Form,
@@ -60,7 +66,7 @@ const filterOptions = (str = '', options: Item[] = []): Item[] | null => {
 }
 
 const initialValues = {
-  'default-gender': 'female',
+  'horizontal-gender': 'female',
 }
 
 // eslint-disable-next-line max-lines-per-function
@@ -88,97 +94,124 @@ const Example = () => {
           set('')
         }}
         required
-        name='default-firstName'
+        name='horizontal-firstName'
         label='First name'
         placeholder='e.g. Bruce'
       />
       <Input
         required
-        name='default-lastName'
+        name='horizontal-lastName'
         label='Last name'
         placeholder='e.g. Wayne'
         size='small'
       />
       <Input
         required
-        name='default-nickName'
+        name='horizontal-nickName'
         label='Nick name'
         placeholder='e.g. Batman'
       />
       <Input
         required
-        name='default-website'
+        name='horizontal-website'
         label='Website'
         placeholder='e.g. google.com'
         size='large'
       />
-      <Input name='default-multiline' label='Description' multiline rows={4} />
+      <Input
+        name='horizontal-multiline'
+        label='Description'
+        multiline
+        rows={4}
+      />
       <RichTextEditor
-        name='default-richTextEditorName'
-        id='default-richTextEditorName'
+        name='horizontal-richTextEditorName'
+        id='horizontal-richTextEditorName'
         label='Rich text editor'
       />
-      <Dropzone label='Attachments' required name='default-attachments' />
+      <Dropzone label='Attachments' required name='horizontal-attachments' />
       <AvatarUpload
         label='Profile photo xxsmall'
         required
-        name='default-avatarUpload-xxsmall'
+        name='horizontal-avatarUpload-xxsmall'
         size='xxsmall'
       />
       <AvatarUpload
         label='Profile photo xsmall'
         required
-        name='default-avatarUpload-xsmall'
+        name='horizontal-avatarUpload-xsmall'
         size='xsmall'
       />
       <AvatarUpload
         label='Profile photo'
         required
-        name='default-avatarUpload-small'
+        name='horizontal-avatarUpload-small'
       />
       <AvatarUpload
         label='Profile photo medium'
         required
-        name='default-avatarUpload-medium'
+        name='horizontal-avatarUpload-medium'
         size='medium'
       />
       <AvatarUpload
         label='Profile photo large'
         required
-        name='default-avatarUpload-large'
+        name='horizontal-avatarUpload-large'
         size='large'
       />
       <NumberInput
         enableReset
-        required
-        name='default-age'
+        name='horizontal-age'
         label="What's your age?"
         placeholder='e.g. 25'
+        labelEndAdornment={
+          <Container inline left={SPACING_1}>
+            <Tooltip content='Content goes here...' placement='right'>
+              <Button.Circular variant='flat' icon={<Info16 />} />
+            </Tooltip>
+          </Container>
+        }
       />
-      <RadioGroup name='default-gender' label='Gender'>
+      <RadioGroup
+        name='horizontal-gender'
+        label='Gender'
+        required
+        labelEndAdornment={
+          <Container inline left={SPACING_1}>
+            <Tooltip content='Content goes here...' placement='right'>
+              <Button.Circular variant='flat' icon={<Info16 />} />
+            </Tooltip>
+          </Container>
+        }
+      >
         <Radio label='Male' value='male' />
         <Radio label='Female' value='female' />
       </RadioGroup>
-      <RadioGroup name='default-language-radio' label='Languages'>
+      <RadioGroup name='horizontal-language-radio' label='Languages'>
         <Radio label='English' value='english' />
         <Radio label='French' value='french' />
         <Radio label='German' value='german' />
       </RadioGroup>
-      <RadioGroup name='default-gender' label='Gender' horizontal spacing={8}>
+      <RadioGroup
+        name='horizontal-gender'
+        label='Gender'
+        horizontal
+        spacing={8}
+      >
         <ButtonRadio value='male'>Male</ButtonRadio>
         <ButtonRadio value='female'>Female</ButtonRadio>
       </RadioGroup>
-      <CheckboxGroup name='default-hobbies' label='Hobbies'>
+      <CheckboxGroup name='horizontal-hobbies' label='Hobbies'>
         <Checkbox label='Skiing' value='skiing' />
         <Checkbox label='Free diving' value='freeDiving' />
         <Checkbox label='Dancing' value='dancing' />
       </CheckboxGroup>
-      <CheckboxGroup name='default-language' label='Languages'>
+      <CheckboxGroup name='horizontal-language' label='Languages'>
         <Checkbox label='English' value='english' />
         <Checkbox label='French' value='french' />
       </CheckboxGroup>
       <CheckboxGroup
-        name='default-hobbies-buttons'
+        name='horizontal-hobbies-buttons'
         label='Hobbies'
         horizontal
         spacing={8}
@@ -187,10 +220,10 @@ const Example = () => {
         <ButtonCheckbox value='freeDiving'>Free diving</ButtonCheckbox>
         <ButtonCheckbox value='dancing'>Dancing</ButtonCheckbox>
       </CheckboxGroup>
-      <DatePicker name='default-dateOfBirth' label='Date of birth' />
-      <TimePicker name='default-timeOfBirth' label='Time of birth' />
+      <DatePicker name='horizontal-dateOfBirth' label='Date of birth' />
+      <TimePicker name='horizontal-timeOfBirth' label='Time of birth' />
       <TagSelector
-        name='default-skills'
+        name='horizontal-skills'
         label='Skills'
         inputValue={skillInputValue}
         options={skillOptions}
@@ -206,7 +239,7 @@ const Example = () => {
       <Select
         enableReset
         required
-        name='default-businessType'
+        name='horizontal-businessType'
         label='Business type'
         width='auto'
         options={[
@@ -215,13 +248,13 @@ const Example = () => {
         ]}
       />
       <Select
-        name='default-origin_country'
+        name='horizontal-origin_country'
         label='Origin country'
         width='auto'
         options={countries}
       />
       <Autocomplete
-        name='default-current_country'
+        name='horizontal-current_country'
         label='Current country'
         placeholder='Start typing country...'
         width='auto'
@@ -245,28 +278,28 @@ const Example = () => {
         getDisplayValue={getAutocompleteDisplayValue}
       />
       <Rating.Stars
-        name='default-rating'
+        name='horizontal-rating'
         label='How much do you love Picasso?'
         required
       />
       <Rating.Thumbs
-        name='default-thumbs'
+        name='horizontal-thumbs'
         label='Would you recommend Picasso?'
         required
       />
       <FileInput
         required
-        name='default-resume'
+        name='horizontal-resume'
         label='Resume'
         status='No file selected.'
       />
       <Checkbox
         required
-        name='default-legal'
+        name='horizontal-legal'
         label='I confirm that I have legal permission from the client to feature this project.'
       />
       <Switch
-        name='default-publicProfile'
+        name='horizontal-publicProfile'
         label='Public Profile'
         width='auto'
       />

--- a/packages/picasso-forms/src/Form/story/Horizontal.example.tsx
+++ b/packages/picasso-forms/src/Form/story/Horizontal.example.tsx
@@ -193,7 +193,7 @@ const Example = () => {
         <Radio label='German' value='german' />
       </RadioGroup>
       <RadioGroup
-        name='horizontal-gender'
+        name='horizontal-gender-2'
         label='Gender'
         horizontal
         spacing={8}

--- a/packages/picasso-forms/src/Input/Input.tsx
+++ b/packages/picasso-forms/src/Input/Input.tsx
@@ -4,6 +4,7 @@ import { Input as PicassoInput } from '@toptal/picasso'
 import { useForm } from 'react-final-form'
 
 import type { FieldProps } from '../Field'
+import type { Props as FieldLabelProps } from '../FieldLabel'
 import FieldLabel from '../FieldLabel'
 import InputField from '../InputField'
 
@@ -11,7 +12,9 @@ export type FormInputProps = Omit<InputProps, 'onResetClick'> & {
   /** Callback invoked when reset button was clicked */
   onResetClick?: (set: (value: string) => void) => void
 }
-export type Props = FormInputProps & FieldProps<InputProps['value']>
+export type Props = FormInputProps &
+  FieldProps<InputProps['value']> &
+  FieldLabelProps
 
 const warnAutocompleteDisabledInput = (name?: string) => {
   const autocompleteDisabled =
@@ -37,7 +40,7 @@ export const Input = React.forwardRef<HTMLInputElement, Props>((props, ref) => {
     mutators: { setHasMultilineCounter },
   } = useForm()
 
-  const { label, titleCase, ...rest } = props
+  const { label, labelEndAdornment, titleCase, ...rest } = props
   const { multiline, rows, rowsMax } = props
 
   const alignment = useMemo(() => {
@@ -62,6 +65,7 @@ export const Input = React.forwardRef<HTMLInputElement, Props>((props, ref) => {
             name={props.name}
             required={props.required}
             label={label}
+            labelEndAdornment={labelEndAdornment}
             titleCase={titleCase}
             alignment={alignment}
           />

--- a/packages/picasso-forms/src/NumberInput/NumberInput.tsx
+++ b/packages/picasso-forms/src/NumberInput/NumberInput.tsx
@@ -5,10 +5,13 @@ import type { FieldValidator } from 'final-form'
 
 import { validators } from '../utils'
 import type { FieldProps } from '../Field'
+import type { Props as FieldLabelProps } from '../FieldLabel'
 import FieldLabel from '../FieldLabel'
 import InputField from '../InputField'
 
-export type Props = NumberInputProps & FieldProps<NumberInputProps['value']>
+export type Props = NumberInputProps &
+  FieldProps<NumberInputProps['value']> &
+  FieldLabelProps
 
 const MIN = -2147483648
 const MAX = 2147483647
@@ -16,7 +19,15 @@ const MAX = 2147483647
 const { composeValidators } = validators
 
 export const NumberInput = (props: Props) => {
-  const { min = MIN, max = MAX, validate, label, titleCase, ...rest } = props
+  const {
+    min = MIN,
+    max = MAX,
+    validate,
+    label,
+    labelEndAdornment,
+    titleCase,
+    ...rest
+  } = props
 
   const validateNumberLimits: FieldValidator<
     NumberInputProps['value']
@@ -39,6 +50,7 @@ export const NumberInput = (props: Props) => {
             name={props.name}
             required={props.required}
             label={label}
+            labelEndAdornment={labelEndAdornment}
             titleCase={titleCase}
           />
         ) : null

--- a/packages/picasso-forms/src/PasswordInput/PasswordInput.tsx
+++ b/packages/picasso-forms/src/PasswordInput/PasswordInput.tsx
@@ -6,13 +6,16 @@ import type { FieldValidator } from 'final-form'
 
 import { validators } from '../utils'
 import type { FieldProps } from '../Field'
+import type { Props as FieldLabelProps } from '../FieldLabel'
 import FieldLabel from '../FieldLabel'
 import passwordValidators from './validators'
 import InputField from '../InputField'
 import FieldRenderer from './FieldRenderer'
 
 export type Props = PasswordInputProps &
-  FieldProps<PasswordInputProps['value']> & { hideRequirements?: boolean }
+  FieldProps<PasswordInputProps['value']> & {
+    hideRequirements?: boolean
+  } & FieldLabelProps
 
 const { composeValidators } = validators
 
@@ -121,6 +124,7 @@ export const PasswordInput = ({
             name={rest.name}
             required={rest.required}
             label={rest.label}
+            labelEndAdornment={rest.labelEndAdornment}
             titleCase={rest.titleCase}
           />
         ) : null

--- a/packages/picasso-forms/src/RadioGroup/RadioGroup.tsx
+++ b/packages/picasso-forms/src/RadioGroup/RadioGroup.tsx
@@ -5,12 +5,15 @@ import { Radio as PicassoRadio } from '@toptal/picasso'
 import type { FieldProps } from '../Field'
 import PicassoField from '../Field'
 import FieldLabel from '../FieldLabel'
+import type { Props as FieldLabelProps } from '../FieldLabel'
 import RadioGroupContext from './RadioGroupContext'
 
-export type Props = RadioGroupProps & FieldProps<RadioProps['value']>
+export type Props = RadioGroupProps &
+  FieldProps<RadioProps['value']> &
+  FieldLabelProps
 
 export const RadioGroup = (props: Props) => {
-  const { children, label, titleCase, ...rest } = props
+  const { children, label, labelEndAdornment, titleCase, ...rest } = props
 
   const alignment = Children.count(children) > 2 ? 'top' : 'middle'
 
@@ -25,6 +28,7 @@ export const RadioGroup = (props: Props) => {
               name={props.name}
               required={props.required}
               label={label}
+              labelEndAdornment={labelEndAdornment}
               titleCase={titleCase}
               alignment={alignment}
             />

--- a/packages/picasso-forms/src/Rating/Rating.tsx
+++ b/packages/picasso-forms/src/Rating/Rating.tsx
@@ -8,13 +8,15 @@ import { Rating as PicassoRating } from '@toptal/picasso'
 import type { FieldProps } from '../Field'
 import PicassoField from '../Field'
 import FieldLabel from '../FieldLabel'
+import type { Props as FieldLabelProps } from '../FieldLabel'
 import { validators } from '../utils'
 
 export type RatingStarsProps = PicassoRatingStarsProps &
-  FieldProps<PicassoRatingStarsProps['value']>
+  FieldProps<PicassoRatingStarsProps['value']> &
+  FieldLabelProps
 
 const Stars = (props: RatingStarsProps) => {
-  const { label, titleCase, ...rest } = props
+  const { label, labelEndAdornment, titleCase, ...rest } = props
 
   return (
     <PicassoField<PicassoRatingStarsProps>
@@ -26,6 +28,7 @@ const Stars = (props: RatingStarsProps) => {
             name={props.name}
             required={props.required}
             label={label}
+            labelEndAdornment={labelEndAdornment}
             titleCase={titleCase}
           />
         ) : null
@@ -58,8 +61,15 @@ const thumbsRequired = (value: boolean | undefined) =>
   value == null ? validators.required(null) : undefined
 
 const Thumbs = (props: RatingThumbsProps) => {
-  const { required, validate, requirePositive, label, titleCase, ...rest } =
-    props
+  const {
+    required,
+    validate,
+    requirePositive,
+    label,
+    labelEndAdornment,
+    titleCase,
+    ...rest
+  } = props
 
   const validateOverride = validators.composeValidators([
     required && !requirePositive ? thumbsRequired : undefined,
@@ -77,6 +87,7 @@ const Thumbs = (props: RatingThumbsProps) => {
             name={props.name}
             required={props.required}
             label={label}
+            labelEndAdornment={labelEndAdornment}
             titleCase={titleCase}
           />
         ) : null

--- a/packages/picasso-forms/src/RichTextEditor/RichTextEditor.tsx
+++ b/packages/picasso-forms/src/RichTextEditor/RichTextEditor.tsx
@@ -10,6 +10,7 @@ import { useForm } from 'react-final-form'
 import type { FieldProps } from '../FieldWrapper'
 import InputField from '../InputField'
 import FieldLabel from '../FieldLabel'
+import type { Props as FieldLabelProps } from '../FieldLabel'
 import { useEnforceHighlightAutofill } from './hooks'
 
 type OverriddenProps = {
@@ -20,12 +21,21 @@ type OverriddenProps = {
 
 export type Props = RichTextEditorProps &
   Except<FieldProps<string>, keyof OverriddenProps> &
-  OverriddenProps
+  OverriddenProps &
+  FieldLabelProps
 
 type InternalProps = RichTextEditorProps & { value: string }
 
 export const RichTextEditor = (props: Props) => {
-  const { onChange, onFocus, defaultValue, label, titleCase, ...rest } = props
+  const {
+    onChange,
+    onFocus,
+    defaultValue,
+    label,
+    labelEndAdornment,
+    titleCase,
+    ...rest
+  } = props
 
   const { enforceHighlightAutofill, registerChangeOrFocus } =
     useEnforceHighlightAutofill()
@@ -64,6 +74,7 @@ export const RichTextEditor = (props: Props) => {
             name={hiddenInputId}
             required={props.required}
             label={label}
+            labelEndAdornment={labelEndAdornment}
             titleCase={titleCase}
             alignment='top'
           />

--- a/packages/picasso-forms/src/Select/Select.tsx
+++ b/packages/picasso-forms/src/Select/Select.tsx
@@ -6,16 +6,24 @@ import { generateRandomStringOrGetEmptyInTest } from '@toptal/picasso-utils'
 import type { FieldProps } from '../Field'
 import InputField from '../InputField'
 import FieldLabel from '../FieldLabel'
+import type { Props as FieldLabelProps } from '../FieldLabel'
 
 export type Props<
   T extends SelectValueType,
   M extends boolean = false
-> = SelectProps<T, M> & FieldProps<SelectProps<T, M>['value']>
+> = SelectProps<T, M> & FieldProps<SelectProps<T, M>['value']> & FieldLabelProps
 
 export const Select = <T extends SelectValueType, M extends boolean = false>(
   props: Props<T, M>
 ) => {
-  const { name, id = name, label, titleCase, ...rest } = props
+  const {
+    name,
+    id = name,
+    label,
+    labelEndAdornment,
+    titleCase,
+    ...rest
+  } = props
   const randomizedId = id ? generateRandomStringOrGetEmptyInTest(id) : undefined
 
   return (
@@ -29,6 +37,7 @@ export const Select = <T extends SelectValueType, M extends boolean = false>(
             name={randomizedId}
             required={rest.required}
             label={label}
+            labelEndAdornment={labelEndAdornment}
             titleCase={titleCase}
           />
         ) : null

--- a/packages/picasso-forms/src/Switch/Switch.tsx
+++ b/packages/picasso-forms/src/Switch/Switch.tsx
@@ -4,11 +4,14 @@ import { Switch as PicassoSwitch, Form as PicassoForm } from '@toptal/picasso'
 
 import type { FieldProps } from '../Field'
 import PicassoField from '../Field'
+import type { Props as FieldLabelProps } from '../FieldLabel'
 
 export type FormSwitchProps = Omit<SwitchProps, 'onChange'> & {
   onChange?: SwitchProps['onChange']
 }
-export type Props = FormSwitchProps & FieldProps<SwitchProps['value']>
+export type Props = FormSwitchProps &
+  FieldProps<SwitchProps['value']> &
+  Omit<FieldLabelProps, 'name' | 'required'>
 
 export const Switch = (props: Props) => (
   <PicassoField<FormSwitchProps>
@@ -16,7 +19,11 @@ export const Switch = (props: Props) => (
     type='checkbox'
     label={
       props.label ? (
-        <PicassoForm.Label htmlFor={props.id} titleCase={props.titleCase}>
+        <PicassoForm.Label
+          htmlFor={props.id}
+          titleCase={props.titleCase}
+          labelEndAdornment={props.labelEndAdornment}
+        >
           {props.label}
         </PicassoForm.Label>
       ) : null

--- a/packages/picasso-forms/src/TagSelector/TagSelector.tsx
+++ b/packages/picasso-forms/src/TagSelector/TagSelector.tsx
@@ -3,13 +3,16 @@ import type { TagSelectorProps } from '@toptal/picasso'
 import { TagSelector as PicassoTagSelector } from '@toptal/picasso'
 
 import type { FieldProps } from '../Field'
+import type { Props as FieldLabelProps } from '../FieldLabel'
 import FieldLabel from '../FieldLabel'
 import InputField from '../InputField'
 
-export type Props = TagSelectorProps & FieldProps<TagSelectorProps['value']>
+export type Props = TagSelectorProps &
+  FieldProps<TagSelectorProps['value']> &
+  FieldLabelProps
 
 export const TagSelector = (props: Props) => {
-  const { label, titleCase, ...rest } = props
+  const { label, labelEndAdornment, titleCase, ...rest } = props
 
   return (
     <InputField<TagSelectorProps>
@@ -20,6 +23,7 @@ export const TagSelector = (props: Props) => {
             name={props.name}
             required={props.required}
             label={label}
+            labelEndAdornment={labelEndAdornment}
             titleCase={titleCase}
           />
         ) : null

--- a/packages/picasso-forms/src/TimePicker/TimePicker.tsx
+++ b/packages/picasso-forms/src/TimePicker/TimePicker.tsx
@@ -5,14 +5,17 @@ import { TimePicker as PicassoTimePicker } from '@toptal/picasso'
 import type { FieldProps } from '../Field'
 import InputField from '../InputField'
 import FieldLabel from '../FieldLabel'
+import type { Props as FieldLabelProps } from '../FieldLabel'
 
 export type FormTimePickerProps = Omit<TimePickerProps, 'onChange'> & {
   onChange?: TimePickerProps['onChange']
 }
-export type Props = FormTimePickerProps & FieldProps<TimePickerProps['value']>
+export type Props = FormTimePickerProps &
+  FieldProps<TimePickerProps['value']> &
+  FieldLabelProps
 
 export const TimePicker = (props: Props) => {
-  const { label, titleCase, ...rest } = props
+  const { label, labelEndAdornment, titleCase, ...rest } = props
 
   return (
     <InputField<FormTimePickerProps>
@@ -23,6 +26,7 @@ export const TimePicker = (props: Props) => {
             name={props.name}
             required={props.required}
             label={label}
+            labelEndAdornment={labelEndAdornment}
             titleCase={titleCase}
           />
         ) : null


### PR DESCRIPTION
[CRT-7024]

### Description

As discussed in https://toptal-core.slack.com/archives/CERF5NHT3/p1709118058674239 and https://toptal-core.slack.com/archives/CCC3GP6CC/p1709110403440549 the `endAdornment` prop needs to be introduced in Picasso's Label component to be able to cover all cases needed in CP.

### How to test
- review code and Happo screenshots

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests ([visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md) included)

**Breaking change**
- n/a codemod is created and showcased in the changeset
- n/a test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[CRT-7024]: https://toptal-core.atlassian.net/browse/CRT-7024?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ