### PR TITLE
[TOP-4328] Hide submenu on other menu item focus

### DIFF
--- a/.changeset/chilled-feet-buy.md
+++ b/.changeset/chilled-feet-buy.md
@@ -1,0 +1,7 @@
+---
+'@toptal/picasso-menu': patch
+---
+
+### Menu
+
+- hide submenu on other menu item focus

--- a/packages/base/Menu/src/Menu/hooks/use-drilldown-menu/use-drilldown-menu.ts
+++ b/packages/base/Menu/src/Menu/hooks/use-drilldown-menu/use-drilldown-menu.ts
@@ -1,4 +1,3 @@
-import type { ReactElement } from 'react'
 import { useCallback, useMemo, useState } from 'react'
 
 import type { MenuContextProps } from '../../MenuContext'
@@ -6,14 +5,9 @@ import type { MenuContextProps } from '../../MenuContext'
 const useDrilldownMenu = () => {
   const [activeItemKey, setActiveItemKey] = useState<string>()
 
-  const handleItemMouseEnter = useCallback(
-    (key: string, menu?: ReactElement) => {
-      if (menu) {
-        setActiveItemKey(key)
-      }
-    },
-    []
-  )
+  const handleItemMouseEnter = useCallback((key: string) => {
+    setActiveItemKey(key)
+  }, [])
 
   const handleMenuMouseLeave = useCallback(() => {
     setActiveItemKey(undefined)


### PR DESCRIPTION
[TOP-4328]

Description

Submenu on drilldown menu does not hide if you move mouse to the siblings items

How to test

Add Menu component with 'variant' prop = drilldown and add two children as Menu.Items, one of which with 'menu' prop equal to the Menu Component. Try to hover to item with drilldown submenu, it opens, then try to navigate to other menu.item. you will see that previosly opened submenu still open

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| Insert screenshots or screen recordings | Insert screenshots or screen recordings |

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests ([visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md) included)

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[TOP-4328]: https://toptal-core.atlassian.net/browse/TOP-4328?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ