### PR TITLE
Add TailwindCSS as a peer dependency

### DIFF
--- a/.changeset/polite-files-shake.md
+++ b/.changeset/polite-files-shake.md
@@ -3,3 +3,5 @@
 ---
 
 - add TailwindCSS as a peer dependency
+- users of Picasso are expected to have TailwindCSS setup in their project
+- [adoption guide](https://toptal-core.atlassian.net/wiki/spaces/FE/pages/3558866965/Adopting+Tailwind+CSS+in+current+project)

--- a/.changeset/polite-files-shake.md
+++ b/.changeset/polite-files-shake.md
@@ -1,0 +1,5 @@
+---
+'@toptal/picasso': major
+---
+
+- add TailwindCSS as a peer dependency

--- a/packages/picasso/package.json
+++ b/packages/picasso/package.json
@@ -32,7 +32,8 @@
     "notistack": "3.0.1",
     "react": ">=16.12.0 < 19.0.0",
     "react-dom": ">=16.12.0 < 19.0.0",
-    "typescript": "~4.7.0"
+    "typescript": "~4.7.0",
+    "tailwindcss": ">=3"
   },
   "dependencies": {
     "@toptal/picasso-accordion": "1.0.2",


### PR DESCRIPTION
[FX-NNNN]

### Description

We already have TailwindCSS setup and we are ready to migrate first components. Before that, we need to release a semantic breaking change, so users are notified that we expect them to have Tailwind setup in their projects from now on.

### How to test

<!-- The temploy link will be automatically updated when the temploy is deployed -->
- [Temploy](https://picasso.toptal.net/fx-null-tailwind-peer-dependency)
- FIXME: Add the steps describing how to verify your changes

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| Insert screenshots or screen recordings | Insert screenshots or screen recordings |

### Development checks

- [ ] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [ ] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [ ] Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [ ] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [ ] Self reviewed
- [ ] Covered with tests ([visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md) included)

**Breaking change**

- [ ] codemod is created and showcased in the changeset
- [ ] test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>
