### PR TITLE
Add refresh tsconfig dependencies to lint-staged

### DIFF
--- a/cypress/component/DatePicker.spec.tsx
+++ b/cypress/component/DatePicker.spec.tsx
@@ -176,7 +176,7 @@ describe('DatePicker', () => {
     const DATEPICKER_INPUT_TESTID = 'datepicker-input'
 
     const DrawerExample = () => {
-      const [val, setVal] = useState<Date>()
+      const [val, setVal] = useState<Date>(new Date(1712068105523))
 
       return (
         <Drawer open>

--- a/package.json
+++ b/package.json
@@ -63,6 +63,9 @@
     "{**/*.{js,jsx,ts,tsx},.changeset/*.md}": [
       "davinci-syntax lint code",
       "prettier --write"
+    ],
+    "**/package.json": [
+      "yarn refresh:tsconfig-references --addToGit"
     ]
   },
   "nyc": {

--- a/packages/base/Backdrop/tsconfig.json
+++ b/packages/base/Backdrop/tsconfig.json
@@ -2,5 +2,9 @@
   "extends": "../../../tsconfig.base.json",
   "compilerOptions": { "outDir": "dist-package" },
   "include": ["src"],
-  "references": [{ "path": "../Fade" }, { "path": "../Utils" }]
+  "references": [
+    { "path": "../../picasso-tailwind" },
+    { "path": "../Fade" },
+    { "path": "../Utils" }
+  ]
 }

--- a/packages/base/Fade/tsconfig.json
+++ b/packages/base/Fade/tsconfig.json
@@ -2,5 +2,5 @@
   "extends": "../../../tsconfig.base.json",
   "compilerOptions": { "outDir": "dist-package" },
   "include": ["src"],
-  "references": [{ "path": "../Utils" }]
+  "references": [{ "path": "../../picasso-tailwind" }, { "path": "../Utils" }]
 }

--- a/packages/base/Paper/tsconfig.json
+++ b/packages/base/Paper/tsconfig.json
@@ -2,5 +2,9 @@
   "extends": "../../../tsconfig.base.json",
   "compilerOptions": { "outDir": "dist-package" },
   "include": ["src"],
-  "references": [{ "path": "../../picasso-provider" }, { "path": "../Utils" }]
+  "references": [
+    { "path": "../../picasso-provider" },
+    { "path": "../../picasso-tailwind" },
+    { "path": "../Utils" }
+  ]
 }

--- a/packages/base/Table/tsconfig.json
+++ b/packages/base/Table/tsconfig.json
@@ -5,6 +5,8 @@
   "references": [
     { "path": "../../picasso-provider" },
     { "path": "../../shared" },
+    { "path": "../Button" },
+    { "path": "../Icons" },
     { "path": "../Typography" },
     { "path": "../Utils" }
   ]


### PR DESCRIPTION
### Description

Because tsconfig references can become outdated, I'm setting up running the refresh script on every `package.json` change for lint-staged

### How to test

<!-- The temploy link will be automatically updated when the temploy is deployed -->
- [Temploy](https://picasso.toptal.net/feature/update-tsc-references-on-lint)
- Modifying a `package.json` should trigger tsconfig project references refresh for that project

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| Insert screenshots or screen recordings | Insert screenshots or screen recordings |

### Development checks

- [NA] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [NA] Annotate all `props` in component with documentation
- [NA] Create `examples` for component
- [NA] Ensure that deployed demo has expected results and good examples
- [NA] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [NA] Covered with tests ([visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md) included)

**Breaking change**

- [NA] codemod is created and showcased in the changeset
- [NA] test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>
