### PR TITLE
Move `color` types to regular dependencies

### DIFF
--- a/.changeset/twenty-islands-love.md
+++ b/.changeset/twenty-islands-love.md
@@ -1,0 +1,5 @@
+---
+'@toptal/picasso-shared': patch
+---
+
+- move `@types/color` from `devDependencies` to `dependencies`

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -33,11 +33,11 @@
   },
   "dependencies": {
     "classnames": "^2.5.1",
-    "color": "^4.2.3"
+    "color": "^4.2.3",
+    "@types/color": "^3.0.3"
   },
   "devDependencies": {
     "@types/classnames": "^2.3.1",
-    "@types/color": "^3.0.3",
     "@toptal/picasso-provider": "4.1.0",
     "notistack": "3.0.1"
   },


### PR DESCRIPTION
[FX-NNNN]

### Description

When using `shared` without the main Picasso package, the consumers are unable to build because `@types/color` is only present in `devDependencies`. Since we intend on all packages working separately, this should be fixed

### How to test

<!-- The temploy link will be automatically updated when the temploy is deployed -->
- [Temploy](https://picasso.toptal.net/fx-xxx-move-color-types-to-deps)
- When installing `@toptal/picasso-shared` directly, `@types/color` should be installed


### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests ([visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md) included)

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>
