### PR TITLE
[FX-4816] Add TableSortableCell

### DIFF
--- a/.changeset/brave-spies-visit.md
+++ b/.changeset/brave-spies-visit.md
@@ -1,0 +1,5 @@
+---
+'@toptal/picasso-table': minor
+---
+
+- added TableSortableCell, enabling the ability to sort table columns

--- a/packages/base/Table/package.json
+++ b/packages/base/Table/package.json
@@ -24,6 +24,8 @@
   "dependencies": {
     "@toptal/picasso-shared": "14.0.1",
     "@toptal/picasso-typography": "1.0.2",
+    "@toptal/picasso-button": "1.0.4",
+    "@toptal/picasso-icons": "1.0.2",
     "@toptal/picasso-utils": "1.0.2",
     "ap-style-title-case": "^1.1.2",
     "classnames": "^2.5.1"

--- a/packages/base/Table/src/Table/story/Sortable.example.tsx
+++ b/packages/base/Table/src/Table/story/Sortable.example.tsx
@@ -1,0 +1,119 @@
+/* eslint-disable id-length */
+import React, { useMemo } from 'react'
+import { Table, TableSortableCell } from '@toptal/picasso'
+
+const data = [
+  {
+    id: 0,
+    name: 'Delia Floyd',
+    talentType: 'Designer',
+    company: 'Airbnb',
+  },
+  {
+    id: 1,
+    name: 'Linnie Sims',
+    talentType: 'Designer',
+    company: 'Facebook',
+  },
+  {
+    id: 2,
+    name: 'Charles Watson',
+    talentType: 'Developer',
+    company: 'Amazon',
+  },
+  {
+    id: 3,
+    name: 'Leila Pena',
+    talentType: 'Developer',
+    company: 'Invision',
+  },
+  {
+    id: 4,
+    name: 'Logan Burton',
+    talentType: 'Developer',
+    company: 'Microsoft',
+  },
+]
+
+const sortAlphabetically = (
+  a: string,
+  b: string,
+  direction: 'asc' | 'desc'
+) => {
+  if (direction === 'asc') {
+    return a.localeCompare(b)
+  }
+
+  return b.localeCompare(a)
+}
+
+const Example = () => {
+  const [sortState, setSortState] = React.useState<{
+    key: 'name' | 'talentType'
+    direction: 'asc' | 'desc'
+  }>({
+    key: 'name',
+    direction: 'asc',
+  })
+
+  const sortedData = useMemo(() => {
+    return data.sort((a, b) => {
+      return sortAlphabetically(
+        a[sortState.key],
+        b[sortState.key],
+        sortState.direction
+      )
+    })
+  }, [sortState])
+
+  const onSort = (key: 'name' | 'talentType') => {
+    setSortState({
+      key,
+      direction:
+        sortState.key === key && sortState.direction === 'asc' ? 'desc' : 'asc',
+    })
+  }
+
+  return (
+    <div>
+      <Table>
+        <Table.Head>
+          <Table.Row>
+            <TableSortableCell
+              onSortClick={() => onSort('name')}
+              sortDirection={
+                sortState.key === 'name' && sortState.direction === 'desc'
+                  ? 'desc'
+                  : 'asc'
+              }
+            >
+              Name
+            </TableSortableCell>
+            <TableSortableCell
+              onSortClick={() => onSort('talentType')}
+              sortDirection={
+                sortState.key === 'talentType' && sortState.direction === 'desc'
+                  ? 'desc'
+                  : 'asc'
+              }
+            >
+              Talent type
+            </TableSortableCell>
+            <Table.Cell>Company</Table.Cell>
+          </Table.Row>
+        </Table.Head>
+        <Table.Body>
+          {sortedData.map(row => (
+            <Table.Row key={row.id}>
+              <Table.Cell>{row.name}</Table.Cell>
+              <Table.Cell>{row.talentType}</Table.Cell>
+              <Table.Cell>{row.company}</Table.Cell>
+            </Table.Row>
+          ))}
+        </Table.Body>
+      </Table>
+    </div>
+  )
+}
+
+export default Example

--- a/packages/base/Table/src/Table/story/index.jsx
+++ b/packages/base/Table/src/Table/story/index.jsx
@@ -5,6 +5,7 @@ import tableHeadStory from '../../TableHead/story'
 import tableSectionHeadStory from '../../TableSectionHead/story'
 import tableRowStory from '../../TableRow/story'
 import tableExpandableRowStory from '../../TableExpandableRow/story'
+import tableSortableCellStory from '../../TableSortableCell/story'
 import { Table } from '../Table'
 import PicassoBook from '~/.storybook/components/PicassoBook'
 
@@ -42,6 +43,7 @@ page
   .addComponentDocs(tableRowStory.componentDocs)
   .addComponentDocs(tableCellStory.componentDocs)
   .addComponentDocs(tableExpandableRowStory.componentDocs)
+  .addComponentDocs(tableSortableCellStory.componentDocs)
 
 page
   .createChapter()
@@ -107,6 +109,16 @@ page
     'Table/story/ExpandableRowsDefaultExpanded.example.tsx',
     {
       title: 'Expandable rows, expanded by default',
+      takeScreenshot: false,
+    },
+    'base/Table'
+  )
+  .addExample(
+    'Table/story/Sortable.example.tsx',
+    {
+      title: 'Sortable table',
+      description:
+        'Use TableSortableCell instead of TableCell in TableHead to sort columns',
       takeScreenshot: false,
     },
     'base/Table'

--- a/packages/base/Table/src/TableCell/TableCell.tsx
+++ b/packages/base/Table/src/TableCell/TableCell.tsx
@@ -1,4 +1,4 @@
-import type { HTMLAttributes } from 'react'
+import type { HTMLAttributes, ReactNode } from 'react'
 import React, { forwardRef, useContext } from 'react'
 import type { Theme } from '@material-ui/core/styles'
 import { makeStyles } from '@material-ui/core/styles'
@@ -29,6 +29,7 @@ export interface Props
   colSpan?: number
   /** Indicates for how many rows the cell extends */
   rowSpan?: number
+  adornment?: ReactNode
 }
 
 const useStyles = makeStyles<Theme>(styles, { name: 'PicassoTableCell' })
@@ -73,6 +74,7 @@ export const TableCell = forwardRef<HTMLTableCellElement, Props>(
       colSpan,
       rowSpan,
       titleCase: propsTitleCase,
+      adornment,
       ...rest
     } = props
 
@@ -89,6 +91,21 @@ export const TableCell = forwardRef<HTMLTableCellElement, Props>(
     const renderChildren = () =>
       isHead && titleCase ? toTitleCase(children) : children
 
+    const CellContent = () => {
+      return adornment ? (
+        <div className='flex items-center'>
+          <Typography as='div' {...getTypographySettings(tableSection)}>
+            {renderChildren()}
+          </Typography>
+          {adornment}
+        </div>
+      ) : (
+        <Typography as='div' {...getTypographySettings(tableSection)}>
+          {renderChildren()}
+        </Typography>
+      )
+    }
+
     return (
       <MUITableCell
         {...rest}
@@ -103,9 +120,7 @@ export const TableCell = forwardRef<HTMLTableCellElement, Props>(
         colSpan={colSpan}
         rowSpan={rowSpan}
       >
-        <Typography as='div' {...getTypographySettings(tableSection)}>
-          {renderChildren()}
-        </Typography>
+        <CellContent />
       </MUITableCell>
     )
   }

--- a/packages/base/Table/src/TableSortableCell/TableSortableCell.tsx
+++ b/packages/base/Table/src/TableSortableCell/TableSortableCell.tsx
@@ -1,0 +1,44 @@
+import React from 'react'
+import { ButtonCircular } from '@toptal/picasso-button'
+import { ArrowLongUp16, ArrowLongDown16 } from '@toptal/picasso-icons'
+
+import type { TableCellProps } from '../TableCell'
+import { TableCell } from '../TableCell'
+
+export type Props = {
+  /** Set the direction of sorting to get the appropriate icon */
+  sortDirection: 'asc' | 'desc'
+  /** Callback called when sort button is clicked */
+  onSortClick: () => void
+} & Exclude<TableCellProps, 'adornment'>
+
+export const TableSortableCell = ({
+  sortDirection,
+  onSortClick,
+  ...rest
+}: Props) => {
+  const Icon = sortDirection === 'desc' ? ArrowLongDown16 : ArrowLongUp16
+
+  return (
+    <TableCell
+      className='group hover:bg-gray-100'
+      adornment={
+        <ButtonCircular
+          variant='flat'
+          icon={<Icon />}
+          onClick={onSortClick}
+          className='ml-2 invisible group-hover:visible'
+        />
+      }
+      {...rest}
+    />
+  )
+}
+
+TableSortableCell.defaultProps = {
+  align: 'inherit',
+}
+
+TableSortableCell.displayName = 'TableSortableCell'
+
+export default TableSortableCell

--- a/packages/base/Table/src/TableSortableCell/TableSortableCell.tsx
+++ b/packages/base/Table/src/TableSortableCell/TableSortableCell.tsx
@@ -15,6 +15,7 @@ export type Props = {
 export const TableSortableCell = ({
   sortDirection,
   onSortClick,
+
   ...rest
 }: Props) => {
   const Icon = sortDirection === 'desc' ? ArrowLongDown16 : ArrowLongUp16

--- a/packages/base/Table/src/TableSortableCell/__snapshots__/test.tsx.snap
+++ b/packages/base/Table/src/TableSortableCell/__snapshots__/test.tsx.snap
@@ -1,0 +1,91 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`TableCell renders 1`] = `
+<div>
+  <div
+    class="Picasso-root"
+  >
+    <table
+      class="MuiTable-root"
+    >
+      <tbody
+        class="MuiTableBody-root"
+      >
+        <tr
+          class="MuiTableRow-root PicassoTableRow-root PicassoTableRow-bordered"
+        >
+          <td
+            class="MuiTableCell-root PicassoTableCell-root MuiTableCell-body"
+          >
+            <div
+              class="MuiTypography-root PicassoTypography-bodySmall PicassoTypography-darkGrey PicassoTypography-inheritWeight MuiTypography-body1"
+            >
+              Cell
+            </div>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</div>
+`;
+
+exports[`TableCell renders compact 1`] = `
+<div>
+  <div
+    class="Picasso-root"
+  >
+    <table
+      class="MuiTable-root"
+    >
+      <tbody
+        class="MuiTableBody-root"
+      >
+        <tr
+          class="MuiTableRow-root PicassoTableRow-root PicassoTableRow-bordered"
+        >
+          <td
+            class="MuiTableCell-root PicassoTableCell-root MuiTableCell-body"
+          >
+            <div
+              class="MuiTypography-root PicassoTypography-bodySmall PicassoTypography-darkGrey PicassoTypography-inheritWeight MuiTypography-body1"
+            >
+              Cell
+            </div>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</div>
+`;
+
+exports[`TableCell renders narrow 1`] = `
+<div>
+  <div
+    class="Picasso-root"
+  >
+    <table
+      class="MuiTable-root"
+    >
+      <tbody
+        class="MuiTableBody-root"
+      >
+        <tr
+          class="MuiTableRow-root PicassoTableRow-root PicassoTableRow-bordered"
+        >
+          <td
+            class="MuiTableCell-root PicassoTableCell-root MuiTableCell-body"
+          >
+            <div
+              class="MuiTypography-root PicassoTypography-bodySmall PicassoTypography-darkGrey PicassoTypography-inheritWeight MuiTypography-body1"
+            >
+              Cell
+            </div>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</div>
+`;

--- a/packages/base/Table/src/TableSortableCell/__snapshots__/test.tsx.snap
+++ b/packages/base/Table/src/TableSortableCell/__snapshots__/test.tsx.snap
@@ -1,91 +1,83 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`TableCell renders 1`] = `
+exports[`TableCell sort direction is asc renders with a sort button in the right direction 1`] = `
 <div>
   <div
     class="Picasso-root"
   >
-    <table
-      class="MuiTable-root"
+    <td
+      class="MuiTableCell-root PicassoTableCell-root group hover:bg-gray"
     >
-      <tbody
-        class="MuiTableBody-root"
+      <div
+        class="flex items-center"
       >
-        <tr
-          class="MuiTableRow-root PicassoTableRow-root PicassoTableRow-bordered"
+        <div
+          class="MuiTypography-root PicassoTypography-bodySmall PicassoTypography-darkGrey PicassoTypography-inheritWeight MuiTypography-body1"
         >
-          <td
-            class="MuiTableCell-root PicassoTableCell-root MuiTableCell-body"
+          Cell
+        </div>
+        <button
+          class="MuiButtonBase-root PicassoButton-small PicassoButton-primary PicassoButton-root PicassoButtonCircular-flat PicassoButtonCircular-root ml-2 invisible group-hover:visible"
+          data-component-type="button"
+          tabindex="0"
+          type="button"
+        >
+          <span
+            class="PicassoContainer-centerAlignItems PicassoContainer-flex PicassoContainer-inline PicassoButton-content"
           >
-            <div
-              class="MuiTypography-root PicassoTypography-bodySmall PicassoTypography-darkGrey PicassoTypography-inheritWeight MuiTypography-body1"
+            <svg
+              class="PicassoSvgArrowLongUp16-root PicassoButton-icon"
+              style="min-width: 16px; min-height: 16px;"
+              viewBox="0 0 16 16"
             >
-              Cell
-            </div>
-          </td>
-        </tr>
-      </tbody>
-    </table>
+              <path
+                d="M7.5 1.793 11.207 5.5l-.707.707-2.5-2.5V14H7V3.707l-2.5 2.5-.707-.707 3-3 .707-.707Z"
+              />
+            </svg>
+          </span>
+        </button>
+      </div>
+    </td>
   </div>
 </div>
 `;
 
-exports[`TableCell renders compact 1`] = `
+exports[`TableCell sort direction is desc renders with a sort button in the right direction 1`] = `
 <div>
   <div
     class="Picasso-root"
   >
-    <table
-      class="MuiTable-root"
+    <td
+      class="MuiTableCell-root PicassoTableCell-root group hover:bg-gray"
     >
-      <tbody
-        class="MuiTableBody-root"
+      <div
+        class="flex items-center"
       >
-        <tr
-          class="MuiTableRow-root PicassoTableRow-root PicassoTableRow-bordered"
+        <div
+          class="MuiTypography-root PicassoTypography-bodySmall PicassoTypography-darkGrey PicassoTypography-inheritWeight MuiTypography-body1"
+        />
+        <button
+          class="MuiButtonBase-root PicassoButton-small PicassoButton-primary PicassoButton-root PicassoButtonCircular-flat PicassoButtonCircular-root ml-2 invisible group-hover:visible"
+          data-component-type="button"
+          tabindex="0"
+          type="button"
         >
-          <td
-            class="MuiTableCell-root PicassoTableCell-root MuiTableCell-body"
+          <span
+            class="PicassoContainer-centerAlignItems PicassoContainer-flex PicassoContainer-inline PicassoButton-content"
           >
-            <div
-              class="MuiTypography-root PicassoTypography-bodySmall PicassoTypography-darkGrey PicassoTypography-inheritWeight MuiTypography-body1"
+            <svg
+              class="PicassoSvgArrowLongDown16-root PicassoButton-icon"
+              style="min-width: 16px; min-height: 16px;"
+              viewBox="0 0 16 16"
             >
-              Cell
-            </div>
-          </td>
-        </tr>
-      </tbody>
-    </table>
-  </div>
-</div>
-`;
-
-exports[`TableCell renders narrow 1`] = `
-<div>
-  <div
-    class="Picasso-root"
-  >
-    <table
-      class="MuiTable-root"
-    >
-      <tbody
-        class="MuiTableBody-root"
-      >
-        <tr
-          class="MuiTableRow-root PicassoTableRow-root PicassoTableRow-bordered"
-        >
-          <td
-            class="MuiTableCell-root PicassoTableCell-root MuiTableCell-body"
-          >
-            <div
-              class="MuiTypography-root PicassoTypography-bodySmall PicassoTypography-darkGrey PicassoTypography-inheritWeight MuiTypography-body1"
-            >
-              Cell
-            </div>
-          </td>
-        </tr>
-      </tbody>
-    </table>
+              <path
+                d="M8 2v10.293l2.5-2.5.707.707L7.5 14.207 3.793 10.5l.707-.707 2.5 2.5V2h1Z"
+              />
+            </svg>
+          </span>
+        </button>
+      </div>
+    </td>
   </div>
 </div>
 `;

--- a/packages/base/Table/src/TableSortableCell/index.ts
+++ b/packages/base/Table/src/TableSortableCell/index.ts
@@ -1,0 +1,6 @@
+import type { OmitInternalProps } from '@toptal/picasso-shared'
+
+import type { Props } from './TableSortableCell'
+
+export { default as TableSortableCell } from './TableSortableCell'
+export type TableSortableCellProps = OmitInternalProps<Props>

--- a/packages/base/Table/src/TableSortableCell/story/index.jsx
+++ b/packages/base/Table/src/TableSortableCell/story/index.jsx
@@ -1,0 +1,12 @@
+import { TableSortableCell } from '../TableSortableCell'
+import PicassoBook from '~/.storybook/components/PicassoBook'
+
+const componentDocs = PicassoBook.createComponentDocs(
+  TableSortableCell,
+  'TableSortableCell',
+  'Sortable cell for table header'
+)
+
+export default {
+  componentDocs,
+}

--- a/packages/base/Table/src/TableSortableCell/test.tsx
+++ b/packages/base/Table/src/TableSortableCell/test.tsx
@@ -1,0 +1,89 @@
+import React from 'react'
+import { render } from '@toptal/picasso-test-utils'
+
+import type { TableConfig } from '../Table'
+import { TableContext } from '../Table'
+import { TableCompound as Table } from '../TableCompound'
+import type { Props } from './TableSortableCell'
+
+const renderTableCell = (
+  { children = 'Cell', ...rest }: Partial<Props> = {},
+  { spacing = 'regular', variant = 'bordered' }: Partial<TableConfig> = {}
+) => {
+  return render(
+    <TableContext.Provider value={{ spacing, variant }}>
+      <Table>
+        <Table.Body>
+          <Table.Row>
+            <Table.Cell {...rest}>{children}</Table.Cell>
+          </Table.Row>
+        </Table.Body>
+      </Table>
+    </TableContext.Provider>
+  )
+}
+
+describe('TableCell', () => {
+  it('renders', () => {
+    const { container } = renderTableCell()
+
+    expect(container).toMatchSnapshot()
+  })
+
+  it('renders compact', () => {
+    const { container } = renderTableCell({}, { spacing: 'compact' })
+
+    expect(container).toMatchSnapshot()
+  })
+
+  it('renders narrow', () => {
+    const { container } = renderTableCell({}, { spacing: 'narrow' })
+
+    expect(container).toMatchSnapshot()
+  })
+
+  it('sets attribuites correctly', () => {
+    const { getByTestId } = renderTableCell({
+      'data-testid': 'cell',
+      rowSpan: 10,
+      colSpan: 2,
+      style: { background: 'red' },
+    })
+
+    const cell = getByTestId('cell')
+
+    expect(cell).toHaveAttribute('rowspan', '10')
+    expect(cell).toHaveAttribute('colspan', '2')
+    expect(cell).toHaveAttribute('style', 'background: red;')
+  })
+
+  it('capitalizes in head if titleCase is truthy', () => {
+    const { getByTestId } = render(
+      <Table>
+        <Table.Head>
+          <Table.Row>
+            <Table.Cell data-testid='head-cell'>head</Table.Cell>
+          </Table.Row>
+        </Table.Head>
+      </Table>,
+      undefined,
+      { titleCase: true }
+    )
+
+    expect(getByTestId('head-cell')).toHaveTextContent('Head')
+  })
+
+  it('does not capitalize in head if titleCase is falsy', () => {
+    const { getByTestId } = render(
+      <Table>
+        <Table.Head>
+          <Table.Row>
+            <Table.Cell data-testid='head-cell'>head</Table.Cell>
+          </Table.Row>
+        </Table.Head>
+      </Table>
+    )
+
+    expect(getByTestId('head-cell')).toHaveTextContent('head')
+  })
+})

--- a/packages/base/Table/src/TableSortableCell/test.tsx
+++ b/packages/base/Table/src/TableSortableCell/test.tsx
@@ -1,89 +1,54 @@
 import React from 'react'
 import { render } from '@toptal/picasso-test-utils'
+import { noop } from '@toptal/picasso-utils'
 
-import type { TableConfig } from '../Table'
-import { TableContext } from '../Table'
-import { TableCompound as Table } from '../TableCompound'
+import { TableSortableCell } from '../TableSortableCell'
 import type { Props } from './TableSortableCell'
 
 const renderTableCell = (
-  { children = 'Cell', ...rest }: Partial<Props> = {},
-  { spacing = 'regular', variant = 'bordered' }: Partial<TableConfig> = {}
+  { children, sortDirection, onSortClick }: Props = {
+    children: 'Cell',
+    sortDirection: 'asc',
+    onSortClick: noop,
+  }
 ) => {
   return render(
-    <TableContext.Provider value={{ spacing, variant }}>
-      <Table>
-        <Table.Body>
-          <Table.Row>
-            <Table.Cell {...rest}>{children}</Table.Cell>
-          </Table.Row>
-        </Table.Body>
-      </Table>
-    </TableContext.Provider>
+    <TableSortableCell sortDirection={sortDirection} onSortClick={onSortClick}>
+      {children}
+    </TableSortableCell>
   )
 }
 
 describe('TableCell', () => {
-  it('renders', () => {
-    const { container } = renderTableCell()
+  describe('sort direction is asc', () => {
+    it('renders with a sort button in the right direction', () => {
+      const { container, getByRole } = renderTableCell()
+      const button = getByRole('button')
 
-    expect(container).toMatchSnapshot()
-  })
-
-  it('renders compact', () => {
-    const { container } = renderTableCell({}, { spacing: 'compact' })
-
-    expect(container).toMatchSnapshot()
-  })
-
-  it('renders narrow', () => {
-    const { container } = renderTableCell({}, { spacing: 'narrow' })
-
-    expect(container).toMatchSnapshot()
-  })
-
-  it('sets attribuites correctly', () => {
-    const { getByTestId } = renderTableCell({
-      'data-testid': 'cell',
-      rowSpan: 10,
-      colSpan: 2,
-      style: { background: 'red' },
+      expect(button).toContainHTML('PicassoSvgArrowLongUp16')
+      expect(container).toMatchSnapshot()
     })
+  })
+  describe('sort direction is desc', () => {
+    it('renders with a sort button in the right direction', () => {
+      const { container, getByRole } = renderTableCell({
+        sortDirection: 'desc',
+      })
+      const button = getByRole('button')
 
-    const cell = getByTestId('cell')
-
-    expect(cell).toHaveAttribute('rowspan', '10')
-    expect(cell).toHaveAttribute('colspan', '2')
-    expect(cell).toHaveAttribute('style', 'background: red;')
+      expect(button).toContainHTML('PicassoSvgArrowLongDown16')
+      expect(container).toMatchSnapshot()
+    })
   })
 
-  it('capitalizes in head if titleCase is truthy', () => {
-    const { getByTestId } = render(
-      <Table>
-        <Table.Head>
-          <Table.Row>
-            <Table.Cell data-testid='head-cell'>head</Table.Cell>
-          </Table.Row>
-        </Table.Head>
-      </Table>,
-      undefined,
-      { titleCase: true }
-    )
+  it('executes the callback when clicked', () => {
+    const mockOnClick = jest.fn()
 
-    expect(getByTestId('head-cell')).toHaveTextContent('Head')
-  })
+    const { getByRole } = renderTableCell({ onSortClick: mockOnClick })
 
-  it('does not capitalize in head if titleCase is falsy', () => {
-    const { getByTestId } = render(
-      <Table>
-        <Table.Head>
-          <Table.Row>
-            <Table.Cell data-testid='head-cell'>head</Table.Cell>
-          </Table.Row>
-        </Table.Head>
-      </Table>
-    )
+    const button = getByRole('button')
 
-    expect(getByTestId('head-cell')).toHaveTextContent('head')
+    button.click()
+    expect(mockOnClick).toHaveBeenCalled()
   })
 })

--- a/packages/base/Table/src/index.ts
+++ b/packages/base/Table/src/index.ts
@@ -1,6 +1,7 @@
 export * from './Table'
 export * from './TableBody'
 export * from './TableCell'
+export * from './TableSortableCell'
 export * from './TableCompound'
 export * from './TableExpandableRow'
 export * from './TableFooter'

--- a/packages/picasso/src/index.ts
+++ b/packages/picasso/src/index.ts
@@ -244,6 +244,7 @@ export {
   TableFooter,
   TableBody,
   TableCell,
+  TableSortableCell,
   TableRow,
   TableExpandableRow,
   TableHead,
@@ -254,6 +255,7 @@ export type {
   TableCellProps,
   TableRowProps,
   TableExpandableRowProps,
+  TableSortableCellProps,
 } from '@toptal/picasso-table'
 export { TabsCompound as Tabs } from '@toptal/picasso-tabs'
 export type { TabsProps, TabProps } from '@toptal/picasso-tabs'


### PR DESCRIPTION
[FX-4816](https://toptal-core.atlassian.net/browse/FX-4816)

### Description

Adds a required functionality to sort table items by exposing a custom table cell with a circular button containing an icon.

An example on how it can be used is also available in the Storybook now.

### How to test

<!-- The temploy link will be automatically updated when the temploy is deployed -->
- [Temploy](https://picasso.toptal.net/fx-4816-add-table-sorting-to-the-header-in-table-component)
- Check out the code for the `TableSortableCell`
- See the new story for `Table` with a sortable example at the end

### Screenshots

![image (26)](https://github.com/toptal/picasso/assets/18409292/2759a821-27d3-435e-8a18-a77156539011)


### Development checks

- [ ] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [ ] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [ ] Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [ ] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [ ] Self reviewed
- [ ] Covered with tests ([visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md) included)

**Breaking change**

- [ ] codemod is created and showcased in the changeset
- [ ] test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-4816]: https://toptal-core.atlassian.net/browse/FX-4816?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ