### PR TITLE
Update Cypress Tailwind setup

### DIFF
--- a/.changeset/loud-baboons-approve.md
+++ b/.changeset/loud-baboons-approve.md
@@ -1,0 +1,5 @@
+---
+'@toptal/picasso-test-utils': minor
+---
+
+- add posibility to pass injectFirst property to TestingPicasso

--- a/.changeset/olive-llamas-retire.md
+++ b/.changeset/olive-llamas-retire.md
@@ -1,0 +1,6 @@
+---
+'@toptal/picasso-page': patch
+---
+
+- fix Paper styles of the Hamburger menu on smaller screens
+  after we changed the order of styles

--- a/.changeset/quiet-cobras-exist.md
+++ b/.changeset/quiet-cobras-exist.md
@@ -1,0 +1,5 @@
+---
+'@toptal/picasso-carousel': patch
+---
+
+- update styles to fix margin issue after we change an order of styles

--- a/cypress/support/commands.jsx
+++ b/cypress/support/commands.jsx
@@ -50,5 +50,10 @@ Cypress.Commands.add(
 Cypress.Commands.add('mount', (component, options, props = {}) => {
   // Wrap any parent components needed
   // ie: return mount(<MyProvider>{component}</MyProvider>, options)
-  return mount(<TestingPicasso {...props}>{component}</TestingPicasso>, options)
+  return mount(
+    <TestingPicasso injectFirst {...props}>
+      {component}
+    </TestingPicasso>,
+    options
+  )
 })

--- a/packages/base/Carousel/src/CarouselNavigation/CarouselNavigation.tsx
+++ b/packages/base/Carousel/src/CarouselNavigation/CarouselNavigation.tsx
@@ -48,6 +48,8 @@ const CarouselNavigation = ({
 }: Props) => {
   const classes = useStyles()
 
+  console.log({ hasArrows, hasDots })
+
   return (
     <Container
       className={classes.navigation}
@@ -56,11 +58,18 @@ const CarouselNavigation = ({
       data-testid={testIds.navigation}
     >
       {hasDots && (
-        <div
-          {...getDotsProps()}
-          data-testid={testIds.dots}
-          className={classes.dots}
-        />
+        /*
+         default slider css ads margin: 0 auto; to the dots container
+         so we need to wrap it in a div to avoid the margin.
+         Could be removed when we migrate all styles to TailwindCSS
+        */
+        <div>
+          <div
+            {...getDotsProps()}
+            data-testid={testIds.dots}
+            className={classes.dots}
+          />
+        </div>
       )}
       {hasArrows && (
         <Container data-testid={testIds.arrows}>

--- a/packages/base/Carousel/src/CarouselNavigation/CarouselNavigation.tsx
+++ b/packages/base/Carousel/src/CarouselNavigation/CarouselNavigation.tsx
@@ -48,8 +48,6 @@ const CarouselNavigation = ({
 }: Props) => {
   const classes = useStyles()
 
-  console.log({ hasArrows, hasDots })
-
   return (
     <Container
       className={classes.navigation}

--- a/packages/base/Carousel/src/CarouselNavigation/styles.ts
+++ b/packages/base/Carousel/src/CarouselNavigation/styles.ts
@@ -8,7 +8,6 @@ export default ({ palette, transitions }: Theme) =>
       transform: 'rotate(180deg)',
     },
     dots: {
-      margin: 0,
       '& .glider-dot': {
         width: 10,
         height: 10,

--- a/packages/base/Page/src/Page/Page.tsx
+++ b/packages/base/Page/src/Page/Page.tsx
@@ -48,7 +48,7 @@ export const Page = forwardRef<HTMLDivElement, Props>(function Page(
       {...rest}
       ref={ref}
       className={cx(classes.root, className)}
-      style={style}
+      style={{ ...style, '--header-height': '3.5rem' } as React.CSSProperties}
     >
       <PageContext.Provider value={{ width, fullWidth }}>
         <PageHamburgerContextProvider hamburgerId={hamburgerId}>

--- a/packages/base/Page/src/Page/__snapshots__/test.tsx.snap
+++ b/packages/base/Page/src/Page/__snapshots__/test.tsx.snap
@@ -7,6 +7,7 @@ exports[`Page renders 1`] = `
   >
     <div
       class="Page-root"
+      style="--header-height: 3.5rem;"
     >
       <div>
         Test

--- a/packages/base/Page/src/Page/styles.ts
+++ b/packages/base/Page/src/Page/styles.ts
@@ -1,8 +1,6 @@
 import type { Theme } from '@material-ui/core/styles'
 import { createStyles } from '@material-ui/core/styles'
 
-import { headerHeight } from '../PageTopBar/constants'
-
 export default ({ layout, palette }: Theme) =>
   createStyles({
     root: {
@@ -16,7 +14,7 @@ export default ({ layout, palette }: Theme) =>
         flex: 0,
       },
       '& > header + *': {
-        marginTop: headerHeight.default,
+        marginTop: 'var(--header-height)',
       },
     },
   })

--- a/packages/base/Page/src/PageHamburger/PageHamburger.tsx
+++ b/packages/base/Page/src/PageHamburger/PageHamburger.tsx
@@ -33,7 +33,7 @@ const PageHamburger = ({ id, 'data-testid': dataTestId }: Props) => {
         [classes.hidden]: !showSidebarMenu,
       })}
       classes={{
-        content: `!shadow-[inset_-1px_0px_0px_0px] !shadow-gray-200 max-h-[calc(100vh-var(--header-height))] !bg-gray-100`,
+        content: `!shadow-[inset_-1px_0px_0px_0px] !shadow-gray-200 max-h-[calc(100vh-var(--header-height, 3.5rem))] !bg-gray-100`,
         popper: classes.popper,
       }}
       // The "disablePortal" is needed for testing the dropdown hamburger menu in Cypress.

--- a/packages/base/Page/src/PageHamburger/PageHamburger.tsx
+++ b/packages/base/Page/src/PageHamburger/PageHamburger.tsx
@@ -7,6 +7,7 @@ import { Dropdown } from '@toptal/picasso-dropdown'
 import { Close24, Overview24 } from '@toptal/picasso-icons'
 
 import { useHamburgerContext } from './PageHamburgerContext'
+import { headerHeight } from '../PageTopBar/constants'
 import styles from './styles'
 
 interface Props {
@@ -33,7 +34,7 @@ const PageHamburger = ({ id, 'data-testid': dataTestId }: Props) => {
         [classes.hidden]: !showSidebarMenu,
       })}
       classes={{
-        content: classes.responsiveWrapperContent,
+        content: `!shadow-[inset_-1px_0px_0px_0px] !shadow-gray-200 max-h-[calc(100vh-${headerHeight.default})] !bg-gray-100`,
         popper: classes.popper,
       }}
       // The "disablePortal" is needed for testing the dropdown hamburger menu in Cypress.

--- a/packages/base/Page/src/PageHamburger/PageHamburger.tsx
+++ b/packages/base/Page/src/PageHamburger/PageHamburger.tsx
@@ -7,7 +7,6 @@ import { Dropdown } from '@toptal/picasso-dropdown'
 import { Close24, Overview24 } from '@toptal/picasso-icons'
 
 import { useHamburgerContext } from './PageHamburgerContext'
-import { headerHeight } from '../PageTopBar/constants'
 import styles from './styles'
 
 interface Props {
@@ -34,7 +33,7 @@ const PageHamburger = ({ id, 'data-testid': dataTestId }: Props) => {
         [classes.hidden]: !showSidebarMenu,
       })}
       classes={{
-        content: `!shadow-[inset_-1px_0px_0px_0px] !shadow-gray-200 max-h-[calc(100vh-${headerHeight.default})] !bg-gray-100`,
+        content: `!shadow-[inset_-1px_0px_0px_0px] !shadow-gray-200 max-h-[calc(100vh-var(--header-height))] !bg-gray-100`,
         popper: classes.popper,
       }}
       // The "disablePortal" is needed for testing the dropdown hamburger menu in Cypress.

--- a/packages/base/Page/src/PageHamburger/PageHamburger.tsx
+++ b/packages/base/Page/src/PageHamburger/PageHamburger.tsx
@@ -33,7 +33,7 @@ const PageHamburger = ({ id, 'data-testid': dataTestId }: Props) => {
         [classes.hidden]: !showSidebarMenu,
       })}
       classes={{
-        content: `!shadow-[inset_-1px_0px_0px_0px] !shadow-gray-200 max-h-[calc(100vh-var(--header-height, 3.5rem))] !bg-gray-100`,
+        content: `!shadow-[inset_-1px_0px_0px_0px] !shadow-gray-200 max-h-[calc(100vh-var(--header-height,3.5rem))] !bg-gray-100`,
         popper: classes.popper,
       }}
       // The "disablePortal" is needed for testing the dropdown hamburger menu in Cypress.

--- a/packages/base/Page/src/PageHamburger/styles.ts
+++ b/packages/base/Page/src/PageHamburger/styles.ts
@@ -1,11 +1,8 @@
-import type { Theme } from '@material-ui/core/styles'
 import { createStyles } from '@material-ui/core/styles'
 
-import { headerHeight, headerBreakingPointXL } from '../PageTopBar/constants'
+import { headerBreakingPointXL } from '../PageTopBar/constants'
 
-export default ({ palette }: Theme) => {
-  const wrapperBoxShadow = `inset -1px 0px 0px 0px ${palette.grey.lighter2}`
-
+export default () => {
   return createStyles({
     root: {
       [headerBreakingPointXL]: {
@@ -20,11 +17,6 @@ export default ({ palette }: Theme) => {
     },
     hidden: {
       display: 'none',
-    },
-    responsiveWrapperContent: {
-      backgroundColor: palette.grey.lighter,
-      boxShadow: wrapperBoxShadow,
-      maxHeight: `calc(100vh - ${headerHeight.default})`, // viewport minus header height: ;
     },
   })
 }

--- a/packages/base/Page/src/PageSidebar/styles.ts
+++ b/packages/base/Page/src/PageSidebar/styles.ts
@@ -41,7 +41,7 @@ export default ({ palette, screens, transitions }: Theme) =>
     wrapper: {
       height: '100%',
       '&$sticky': {
-        maxHeight: `calc(100vh - var(--header-height, 3.5rem))`,
+        maxHeight: `calc(100vh - var(--header-height,3.5rem))`,
         position: 'sticky',
         top: 'var(--header-height, 3.5rem)',
       },

--- a/packages/base/Page/src/PageSidebar/styles.ts
+++ b/packages/base/Page/src/PageSidebar/styles.ts
@@ -41,9 +41,9 @@ export default ({ palette, screens, transitions }: Theme) =>
     wrapper: {
       height: '100%',
       '&$sticky': {
-        maxHeight: `calc(100vh - var(--header-height))`,
+        maxHeight: `calc(100vh - var(--header-height, 3.5rem))`,
         position: 'sticky',
-        top: 'var(--header-height)',
+        top: 'var(--header-height, 3.5rem)',
       },
     },
     scrollableContent: {

--- a/packages/base/Page/src/PageSidebar/styles.ts
+++ b/packages/base/Page/src/PageSidebar/styles.ts
@@ -2,10 +2,7 @@ import type { Theme } from '@material-ui/core/styles'
 import { createStyles } from '@material-ui/core/styles'
 import { rem } from '@toptal/picasso-shared'
 
-import {
-  headerHeight,
-  headerBreakingPointXL,
-} from '../PageTopBar/constants'
+import { headerBreakingPointXL } from '../PageTopBar/constants'
 
 // decided to use a custom shadow for the sidebar's collapse button
 const COLLAPSE_BUTTON_SHADOW =
@@ -44,9 +41,9 @@ export default ({ palette, screens, transitions }: Theme) =>
     wrapper: {
       height: '100%',
       '&$sticky': {
-        maxHeight: `calc(100vh - ${headerHeight.default})`,
+        maxHeight: `calc(100vh - var(--header-height))`,
         position: 'sticky',
-        top: headerHeight.default,
+        top: 'var(--header-height)',
       },
     },
     scrollableContent: {

--- a/packages/base/Page/src/PageTopBar/__snapshots__/test.tsx.snap
+++ b/packages/base/Page/src/PageTopBar/__snapshots__/test.tsx.snap
@@ -54,7 +54,7 @@ exports[`Page.TopBar render with custom logo 1`] = `
                 >
                   <div>
                     <div
-                      class="bg-white shadow-0 transition-shadow duration-300 delay-0 PicassoDropdown-content !shadow-[inset_-1px_0px_0px_0px] !shadow-gray max-h-[calc(100vh !bg-gray"
+                      class="bg-white shadow-0 transition-shadow duration-300 delay-0 PicassoDropdown-content !shadow-[inset_-1px_0px_0px_0px] !shadow-gray max-h-[calc(100vh-var(--header !bg-gray"
                       style="opacity: 0; transform: scale(0.75, 0.5625); visibility: hidden;"
                     >
                       <div>
@@ -151,7 +151,7 @@ exports[`Page.TopBar render with link 1`] = `
                 >
                   <div>
                     <div
-                      class="bg-white shadow-0 transition-shadow duration-300 delay-0 PicassoDropdown-content !shadow-[inset_-1px_0px_0px_0px] !shadow-gray max-h-[calc(100vh !bg-gray"
+                      class="bg-white shadow-0 transition-shadow duration-300 delay-0 PicassoDropdown-content !shadow-[inset_-1px_0px_0px_0px] !shadow-gray max-h-[calc(100vh-var(--header !bg-gray"
                       style="opacity: 0; transform: scale(0.75, 0.5625); visibility: hidden;"
                     >
                       <div>
@@ -274,7 +274,7 @@ exports[`Page.TopBar renders 1`] = `
                 >
                   <div>
                     <div
-                      class="bg-white shadow-0 transition-shadow duration-300 delay-0 PicassoDropdown-content !shadow-[inset_-1px_0px_0px_0px] !shadow-gray max-h-[calc(100vh !bg-gray"
+                      class="bg-white shadow-0 transition-shadow duration-300 delay-0 PicassoDropdown-content !shadow-[inset_-1px_0px_0px_0px] !shadow-gray max-h-[calc(100vh-var(--header !bg-gray"
                       style="opacity: 0; transform: scale(0.75, 0.5625); visibility: hidden;"
                     >
                       <div>

--- a/packages/base/Page/src/PageTopBar/__snapshots__/test.tsx.snap
+++ b/packages/base/Page/src/PageTopBar/__snapshots__/test.tsx.snap
@@ -54,7 +54,7 @@ exports[`Page.TopBar render with custom logo 1`] = `
                 >
                   <div>
                     <div
-                      class="bg-white shadow-0 transition-shadow duration-300 delay-0 PicassoDropdown-content !shadow-[inset_-1px_0px_0px_0px] !shadow-gray max-h-[calc(100vh-var(--header 3.5rem))] !bg-gray"
+                      class="bg-white shadow-0 transition-shadow duration-300 delay-0 PicassoDropdown-content !shadow-[inset_-1px_0px_0px_0px] !shadow-gray max-h-[calc(100vh-var(--header !bg-gray"
                       style="opacity: 0; transform: scale(0.75, 0.5625); visibility: hidden;"
                     >
                       <div>
@@ -151,7 +151,7 @@ exports[`Page.TopBar render with link 1`] = `
                 >
                   <div>
                     <div
-                      class="bg-white shadow-0 transition-shadow duration-300 delay-0 PicassoDropdown-content !shadow-[inset_-1px_0px_0px_0px] !shadow-gray max-h-[calc(100vh-var(--header 3.5rem))] !bg-gray"
+                      class="bg-white shadow-0 transition-shadow duration-300 delay-0 PicassoDropdown-content !shadow-[inset_-1px_0px_0px_0px] !shadow-gray max-h-[calc(100vh-var(--header !bg-gray"
                       style="opacity: 0; transform: scale(0.75, 0.5625); visibility: hidden;"
                     >
                       <div>
@@ -274,7 +274,7 @@ exports[`Page.TopBar renders 1`] = `
                 >
                   <div>
                     <div
-                      class="bg-white shadow-0 transition-shadow duration-300 delay-0 PicassoDropdown-content !shadow-[inset_-1px_0px_0px_0px] !shadow-gray max-h-[calc(100vh-var(--header 3.5rem))] !bg-gray"
+                      class="bg-white shadow-0 transition-shadow duration-300 delay-0 PicassoDropdown-content !shadow-[inset_-1px_0px_0px_0px] !shadow-gray max-h-[calc(100vh-var(--header !bg-gray"
                       style="opacity: 0; transform: scale(0.75, 0.5625); visibility: hidden;"
                     >
                       <div>

--- a/packages/base/Page/src/PageTopBar/__snapshots__/test.tsx.snap
+++ b/packages/base/Page/src/PageTopBar/__snapshots__/test.tsx.snap
@@ -54,7 +54,7 @@ exports[`Page.TopBar render with custom logo 1`] = `
                 >
                   <div>
                     <div
-                      class="bg-white shadow-0 transition-shadow duration-300 delay-0 PicassoDropdown-content !shadow-[inset_-1px_0px_0px_0px] !shadow-gray max-h-[calc(100vh-var(--header !bg-gray"
+                      class="bg-white shadow-0 transition-shadow duration-300 delay-0 PicassoDropdown-content !shadow-[inset_-1px_0px_0px_0px] !shadow-gray max-h-[calc(100vh-var(--header 3.5rem))] !bg-gray"
                       style="opacity: 0; transform: scale(0.75, 0.5625); visibility: hidden;"
                     >
                       <div>
@@ -151,7 +151,7 @@ exports[`Page.TopBar render with link 1`] = `
                 >
                   <div>
                     <div
-                      class="bg-white shadow-0 transition-shadow duration-300 delay-0 PicassoDropdown-content !shadow-[inset_-1px_0px_0px_0px] !shadow-gray max-h-[calc(100vh-var(--header !bg-gray"
+                      class="bg-white shadow-0 transition-shadow duration-300 delay-0 PicassoDropdown-content !shadow-[inset_-1px_0px_0px_0px] !shadow-gray max-h-[calc(100vh-var(--header 3.5rem))] !bg-gray"
                       style="opacity: 0; transform: scale(0.75, 0.5625); visibility: hidden;"
                     >
                       <div>
@@ -274,7 +274,7 @@ exports[`Page.TopBar renders 1`] = `
                 >
                   <div>
                     <div
-                      class="bg-white shadow-0 transition-shadow duration-300 delay-0 PicassoDropdown-content !shadow-[inset_-1px_0px_0px_0px] !shadow-gray max-h-[calc(100vh-var(--header !bg-gray"
+                      class="bg-white shadow-0 transition-shadow duration-300 delay-0 PicassoDropdown-content !shadow-[inset_-1px_0px_0px_0px] !shadow-gray max-h-[calc(100vh-var(--header 3.5rem))] !bg-gray"
                       style="opacity: 0; transform: scale(0.75, 0.5625); visibility: hidden;"
                     >
                       <div>

--- a/packages/base/Page/src/PageTopBar/__snapshots__/test.tsx.snap
+++ b/packages/base/Page/src/PageTopBar/__snapshots__/test.tsx.snap
@@ -54,7 +54,7 @@ exports[`Page.TopBar render with custom logo 1`] = `
                 >
                   <div>
                     <div
-                      class="bg-white shadow-0 transition-shadow duration-300 delay-0 PicassoDropdown-content PageHamburger-responsiveWrapperContent"
+                      class="bg-white shadow-0 transition-shadow duration-300 delay-0 PicassoDropdown-content !shadow-[inset_-1px_0px_0px_0px] !shadow-gray max-h-[calc(100vh !bg-gray"
                       style="opacity: 0; transform: scale(0.75, 0.5625); visibility: hidden;"
                     >
                       <div>
@@ -151,7 +151,7 @@ exports[`Page.TopBar render with link 1`] = `
                 >
                   <div>
                     <div
-                      class="bg-white shadow-0 transition-shadow duration-300 delay-0 PicassoDropdown-content PageHamburger-responsiveWrapperContent"
+                      class="bg-white shadow-0 transition-shadow duration-300 delay-0 PicassoDropdown-content !shadow-[inset_-1px_0px_0px_0px] !shadow-gray max-h-[calc(100vh !bg-gray"
                       style="opacity: 0; transform: scale(0.75, 0.5625); visibility: hidden;"
                     >
                       <div>
@@ -274,7 +274,7 @@ exports[`Page.TopBar renders 1`] = `
                 >
                   <div>
                     <div
-                      class="bg-white shadow-0 transition-shadow duration-300 delay-0 PicassoDropdown-content PageHamburger-responsiveWrapperContent"
+                      class="bg-white shadow-0 transition-shadow duration-300 delay-0 PicassoDropdown-content !shadow-[inset_-1px_0px_0px_0px] !shadow-gray max-h-[calc(100vh !bg-gray"
                       style="opacity: 0; transform: scale(0.75, 0.5625); visibility: hidden;"
                     >
                       <div>

--- a/packages/base/Page/src/PageTopBar/styles.ts
+++ b/packages/base/Page/src/PageTopBar/styles.ts
@@ -32,7 +32,7 @@ export default ({ palette, layout, zIndex, screens }: Theme) =>
       justifyContent: 'space-between',
       maxWidth: layout.contentWidth,
       padding: `0 ${layout.contentMobilePaddingHorizontal}`,
-      height: 'var(--header-height)',
+      height: 'var(--header-height, 3.5rem)',
       [screens('md', 'lg', 'xl')]: {
         padding: `0 ${layout.contentPaddingHorizontal}`,
       },
@@ -44,8 +44,8 @@ export default ({ palette, layout, zIndex, screens }: Theme) =>
     },
     wrapper: {
       position: 'relative',
-      height: 'var(--header-height)',
-      minHeight: 'var(--header-height)',
+      height: 'var(--header-height, 3.5rem)',
+      minHeight: 'var(--header-height, 3.5rem)',
     },
     wide: {
       maxWidth: layout.contentWidthWide,

--- a/packages/base/Page/src/PageTopBar/styles.ts
+++ b/packages/base/Page/src/PageTopBar/styles.ts
@@ -1,7 +1,7 @@
 import type { Theme } from '@material-ui/core/styles'
 import { createStyles } from '@material-ui/core/styles'
 
-import { headerHeight, headerBreakingPointXL } from './constants'
+import { headerBreakingPointXL } from './constants'
 
 export default ({ palette, layout, zIndex, screens }: Theme) =>
   createStyles({
@@ -32,7 +32,7 @@ export default ({ palette, layout, zIndex, screens }: Theme) =>
       justifyContent: 'space-between',
       maxWidth: layout.contentWidth,
       padding: `0 ${layout.contentMobilePaddingHorizontal}`,
-      height: headerHeight.default,
+      height: 'var(--header-height)',
       [screens('md', 'lg', 'xl')]: {
         padding: `0 ${layout.contentPaddingHorizontal}`,
       },
@@ -44,8 +44,8 @@ export default ({ palette, layout, zIndex, screens }: Theme) =>
     },
     wrapper: {
       position: 'relative',
-      height: headerHeight.default,
-      minHeight: headerHeight.default,
+      height: 'var(--header-height)',
+      minHeight: 'var(--header-height)',
     },
     wide: {
       maxWidth: layout.contentWidthWide,

--- a/packages/base/Page/src/PageTopBarMenu/styles.ts
+++ b/packages/base/Page/src/PageTopBarMenu/styles.ts
@@ -1,8 +1,6 @@
 import type { Theme } from '@material-ui/core/styles'
 import { createStyles } from '@material-ui/core/styles'
 
-import { headerHeight } from '../PageTopBar/constants'
-
 export default ({ screens }: Theme) =>
   createStyles({
     avatar: {
@@ -17,7 +15,7 @@ export default ({ screens }: Theme) =>
       },
     },
     content: {
-      maxHeight: `calc(100vh - ${headerHeight.default})`, // viewport minus header height
+      maxHeight: `calc(100vh - var(--header-height))`, // viewport minus header height
       width: '15em',
       [screens('xs', 'sm')]: {
         width: '100vw',

--- a/packages/base/Page/src/PageTopBarMenu/styles.ts
+++ b/packages/base/Page/src/PageTopBarMenu/styles.ts
@@ -15,7 +15,7 @@ export default ({ screens }: Theme) =>
       },
     },
     content: {
-      maxHeight: `calc(100vh - var(--header-height))`, // viewport minus header height
+      maxHeight: `calc(100vh - var(--header-height, 3.5rem))`, // viewport minus header height
       width: '15em',
       [screens('xs', 'sm')]: {
         width: '100vw',

--- a/packages/base/Test-Utils/src/test-utils/TestingPicasso.tsx
+++ b/packages/base/Test-Utils/src/test-utils/TestingPicasso.tsx
@@ -4,9 +4,14 @@ import type { TextLabelProps } from '@toptal/picasso-shared'
 
 export type Props = TextLabelProps & {
   children: React.ReactNode
+  injectFirst?: boolean
 }
 
-export const TestingPicasso = ({ children, titleCase }: Props) => {
+export const TestingPicasso = ({
+  children,
+  titleCase,
+  injectFirst = false,
+}: Props) => {
   return (
     <Picasso
       loadFavicon={false}
@@ -15,6 +20,7 @@ export const TestingPicasso = ({ children, titleCase }: Props) => {
       preventPageWidthChangeOnScrollbar={false}
       titleCase={titleCase}
       disableTransitions
+      injectFirst={injectFirst}
     >
       {children}
     </Picasso>

--- a/yarn.lock
+++ b/yarn.lock
@@ -9290,12 +9290,7 @@ content-disposition@0.5.4:
   dependencies:
     safe-buffer "5.2.1"
 
-content-type@~1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.4.tgz#e138cc75e040c727b1966fe5e5f8c9aee256fe3b"
-  integrity sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==
-
-content-type@~1.0.5:
+content-type@~1.0.4, content-type@~1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.5.tgz#8b773162656d1d1086784c8f23a54ce6d73d7918"
   integrity sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==
@@ -16020,14 +16015,14 @@ json-stringify-safe@^5.0.1, json-stringify-safe@~5.0.1:
   resolved "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
   integrity sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==
 
-json5@1, json5@^1.0.1, json5@^1.0.2, json5@^2.1.1:
+json5@1, json5@^1.0.1, json5@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/json5/-/json5-1.0.2.tgz#63d98d60f21b313b77c4d6da18bfa69d80e1d593"
   integrity sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==
   dependencies:
     minimist "^1.2.0"
 
-json5@2.2.3, json5@^2.1.0, json5@^2.1.2, json5@^2.2.0, json5@^2.2.2, json5@^2.2.3, json5@^2.x:
+json5@2.2.3, json5@^2.1.0, json5@^2.1.1, json5@^2.1.2, json5@^2.2.0, json5@^2.2.2, json5@^2.2.3, json5@^2.x:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.3.tgz#78cd6f1a19bdc12b73db5ad0c61efd66c1e29283"
   integrity sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==


### PR DESCRIPTION
[FX-NNNN]

### Description

We need mui styles to be injected first in cypress to have the same setup as product. After we updated the style order in Cypress, some bugs appeared in PageSidebar and Carousel.

Also some screenshots were updated, but it looks like the old screenshots were wrong

### How to test

<!-- The temploy link will be automatically updated when the temploy is deployed -->
- [Temploy](https://picasso.toptal.net/fx-null-happo-browser-update)
- Check Happo screenshots

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| Insert screenshots or screen recordings | Insert screenshots or screen recordings |

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- Annotate all `props` in component with documentation
- Create `examples` for component
- Ensure that deployed demo has expected results and good examples
- Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests ([visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md) included)

**Breaking change**

- codemod is created and showcased in the changeset
- test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>
