### PR TITLE
[CPT-2029] Add support to optional tooltip for query builder fields 

### DIFF
--- a/.changeset/polite-boxes-burn.md
+++ b/.changeset/polite-boxes-burn.md
@@ -3,5 +3,5 @@
 '@toptal/picasso-tooltip': minor
 ---
 
-- add `tooltipPopperClassName` to override the material UI tooltip popper styles.
+- add Tooltip `offset` property to shift tooltip position from the left and the top.
 - add tooltip support to the query builder fields using the `tooltip` property in the fields' configuration.

--- a/.changeset/polite-boxes-burn.md
+++ b/.changeset/polite-boxes-burn.md
@@ -1,7 +1,5 @@
 ---
-'@toptal/picasso-query-builder': minor
 '@toptal/picasso-tooltip': minor
 ---
 
 - add Tooltip `offset` property to shift tooltip position from the left and the top.
-- add tooltip support to the query builder fields using the `tooltip` property in the fields' configuration.

--- a/.changeset/polite-boxes-burn.md
+++ b/.changeset/polite-boxes-burn.md
@@ -1,0 +1,7 @@
+---
+'@toptal/picasso-query-builder': minor
+'@toptal/picasso-tooltip': minor
+---
+
+- add `tooltipPopperClassName` to override the material UI tooltip popper styles.
+- add tooltip support to the query builder fields using the `tooltip` property in the fields' configuration.

--- a/.changeset/unlucky-zebras-do.md
+++ b/.changeset/unlucky-zebras-do.md
@@ -1,0 +1,5 @@
+---
+'@toptal/picasso-query-builder': minor
+---
+
+- add tooltip support to the query builder fields using the `tooltip` property in the fields' configuration.

--- a/packages/base/Tooltip/src/Tooltip/Tooltip.tsx
+++ b/packages/base/Tooltip/src/Tooltip/Tooltip.tsx
@@ -70,6 +70,8 @@ export interface Props extends BaseProps, HTMLAttributes<HTMLDivElement> {
   tooltipRef?: React.Ref<HTMLDivElement>
   /** A node, or a function that returns node. The container will have the portal children appended to it. */
   container?: ContainerValue
+  /** Allows customizing the tooltip popper style */
+  popperClassName?: string
 }
 
 const useStyles = makeStyles<Theme>(styles, { name: 'PicassoTooltip' })
@@ -81,6 +83,7 @@ export const Tooltip = forwardRef<unknown, Props>((props, ref) => {
     placement,
     interactive,
     className,
+    popperClassName,
     style,
     open,
     onOpen,
@@ -168,6 +171,7 @@ export const Tooltip = forwardRef<unknown, Props>((props, ref) => {
           [classes.compact]: compact,
           [classes.noMaxWidth]: maxWidth === 'none',
         }),
+        popper: popperClassName,
       }}
       className={className}
       style={style}

--- a/packages/base/Tooltip/src/Tooltip/Tooltip.tsx
+++ b/packages/base/Tooltip/src/Tooltip/Tooltip.tsx
@@ -53,7 +53,7 @@ const getOffset = (
   const isVertical =
     placement.startsWith('top') || placement.startsWith('bottom')
 
-  return !isVertical ? result.reverse().join(',') : result.join(',')
+  return (isVertical ? result : result.reverse()).join(',')
 }
 
 export interface Props extends BaseProps, HTMLAttributes<HTMLDivElement> {

--- a/packages/base/Tooltip/src/Tooltip/Tooltip.tsx
+++ b/packages/base/Tooltip/src/Tooltip/Tooltip.tsx
@@ -11,7 +11,7 @@ import type { TooltipProps } from '@material-ui/core'
 import { Tooltip as MUITooltip } from '@material-ui/core'
 import cx from 'classnames'
 import type { BaseProps } from '@toptal/picasso-shared'
-import { remToNumber, spacingToRem } from '@toptal/picasso-shared'
+import { pxFromRem, spacingToRem } from '@toptal/picasso-shared'
 import type { PicassoSpacing } from '@toptal/picasso-provider'
 import { SPACING_0, usePicassoRoot } from '@toptal/picasso-provider'
 import { Typography } from '@toptal/picasso-typography'
@@ -42,20 +42,13 @@ const getDelayDuration = (delay: DelayType, isTouchDevice: boolean) => {
   return isTouchDevice ? 0 : delayDurations[delay]
 }
 
-const convertRemToPixels = (rem: number) => {
-  return rem * parseFloat(getComputedStyle(document.documentElement).fontSize)
-}
-
 const getOffset = (
   placement: PlacementType = 'top',
   offset: OffsetType
 ): string => {
   const { left = SPACING_0, top = SPACING_0 } = offset
 
-  const result = [
-    convertRemToPixels(remToNumber(spacingToRem(left))),
-    convertRemToPixels(remToNumber(spacingToRem(top))),
-  ]
+  const result = [pxFromRem(spacingToRem(left)), pxFromRem(spacingToRem(top))]
 
   const isVertical =
     placement.startsWith('top') || placement.startsWith('bottom')

--- a/packages/base/Tooltip/src/Tooltip/story/Offset.example.tsx
+++ b/packages/base/Tooltip/src/Tooltip/story/Offset.example.tsx
@@ -1,0 +1,90 @@
+import React from 'react'
+import { Button, Container, Tooltip } from '@toptal/picasso'
+import { SPACING_4, SPACING_6 } from '@toptal/picasso-utils'
+
+const Example = () => (
+  <Container top={SPACING_6} left={SPACING_6}>
+    <Tooltip
+      interactive
+      placement='right'
+      offset={{
+        left: SPACING_4,
+      }}
+      content='Right tooltip with left offset'
+    >
+      <Button>Right/Left</Button>
+    </Tooltip>
+    <Tooltip
+      interactive
+      placement='right'
+      offset={{
+        top: SPACING_4,
+      }}
+      content='Right tooltip with top offset'
+    >
+      <Button>Right/Top</Button>
+    </Tooltip>
+    <Tooltip
+      interactive
+      placement='left'
+      offset={{
+        left: SPACING_4,
+      }}
+      content='Left tooltip with left offset'
+    >
+      <Button>Left/Left</Button>
+    </Tooltip>
+    <Tooltip
+      interactive
+      placement='left'
+      offset={{
+        top: SPACING_4,
+      }}
+      content='Left tooltip with top offset'
+    >
+      <Button>Left/Top</Button>
+    </Tooltip>
+    <Tooltip
+      interactive
+      placement='bottom'
+      offset={{
+        top: SPACING_4,
+      }}
+      content='Bottom tooltip with top offset'
+    >
+      <Button>Bottom/Top</Button>
+    </Tooltip>
+    <Tooltip
+      interactive
+      placement='bottom'
+      offset={{
+        left: SPACING_4,
+      }}
+      content='Bottom tooltip with left offset'
+    >
+      <Button>Bottom/Left</Button>
+    </Tooltip>
+    <Tooltip
+      interactive
+      placement='top'
+      offset={{
+        top: SPACING_4,
+      }}
+      content='Top tooltip with top offset'
+    >
+      <Button>Top/Top</Button>
+    </Tooltip>
+    <Tooltip
+      interactive
+      placement='top'
+      offset={{
+        left: SPACING_4,
+      }}
+      content='Top tooltip with left offset'
+    >
+      <Button>Top/Left</Button>
+    </Tooltip>
+  </Container>
+)
+
+export default Example

--- a/packages/base/Tooltip/src/Tooltip/story/index.jsx
+++ b/packages/base/Tooltip/src/Tooltip/story/index.jsx
@@ -122,3 +122,11 @@ page
     },
     'base/Tooltip'
   )
+  .addExample(
+    'Tooltip/story/Offset.example.tsx',
+    {
+      title: 'Tooltip with offset modifier',
+      takeScreenshot: false,
+    },
+    'base/Tooltip'
+  )

--- a/packages/picasso-query-builder/src/FieldSelector/FieldSelector.tsx
+++ b/packages/picasso-query-builder/src/FieldSelector/FieldSelector.tsx
@@ -33,7 +33,6 @@ export const FieldSelector = ({
         if (option.tooltip) {
           return (
             <Tooltip
-              open
               popperClassName={classes.tooltip}
               compact
               interactive

--- a/packages/picasso-query-builder/src/FieldSelector/FieldSelector.tsx
+++ b/packages/picasso-query-builder/src/FieldSelector/FieldSelector.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import type { ComponentProps } from 'react'
 import { Tooltip, Typography } from '@toptal/picasso'
 import { makeStyles } from '@material-ui/core/styles'
+import { SPACING_4 } from '@toptal/picasso-provider'
 
 import { Select } from '../Select'
 import styles from './styles'
@@ -33,11 +34,13 @@ export const FieldSelector = ({
         if (option.tooltip) {
           return (
             <Tooltip
-              popperClassName={classes.tooltip}
               compact
               interactive
               content={option.tooltip}
               placement='right'
+              offset={{
+                left: SPACING_4,
+              }}
             >
               <Typography
                 className={classes.tooltipOptionText}

--- a/packages/picasso-query-builder/src/FieldSelector/FieldSelector.tsx
+++ b/packages/picasso-query-builder/src/FieldSelector/FieldSelector.tsx
@@ -1,7 +1,12 @@
 import React from 'react'
 import type { ComponentProps } from 'react'
+import { Tooltip, Typography } from '@toptal/picasso'
+import { makeStyles } from '@material-ui/core/styles'
 
 import { Select } from '../Select'
+import styles from './styles'
+
+const useStyles = makeStyles(styles)
 
 export const FieldSelector = ({
   context: { resetSubmitButtonClicked, getDisabledFields, testIds },
@@ -10,6 +15,7 @@ export const FieldSelector = ({
 }: ComponentProps<typeof Select>) => {
   // TODO: https://toptal-core.atlassian.net/browse/CPT-947
   const disabledFields = getDisabledFields()
+  const classes = useStyles()
 
   return (
     <Select
@@ -23,6 +29,31 @@ export const FieldSelector = ({
       }}
       disabled={disabled || disabledFields.includes(props.value)}
       valueEditorTestId={testIds?.fieldSelector}
+      renderOption={option => {
+        if (option.tooltip) {
+          return (
+            <Tooltip
+              open
+              popperClassName={classes.tooltip}
+              compact
+              interactive
+              content={option.tooltip}
+              placement='right'
+            >
+              <Typography
+                className={classes.tooltipOptionText}
+                variant='body'
+                size='medium'
+                color='inherit'
+              >
+                {option.text}
+              </Typography>
+            </Tooltip>
+          )
+        }
+
+        return option.text
+      }}
     />
   )
 }

--- a/packages/picasso-query-builder/src/FieldSelector/styles.ts
+++ b/packages/picasso-query-builder/src/FieldSelector/styles.ts
@@ -5,8 +5,4 @@ export default () =>
     tooltipOptionText: {
       width: '100%',
     },
-    tooltip: {
-      // Style to push the tooltip to the right outside the select option text
-      left: '0.5rem!important',
-    },
   })

--- a/packages/picasso-query-builder/src/FieldSelector/styles.ts
+++ b/packages/picasso-query-builder/src/FieldSelector/styles.ts
@@ -1,0 +1,12 @@
+import { createStyles } from '@material-ui/core/styles'
+
+export default () =>
+  createStyles({
+    tooltipOptionText: {
+      width: '100%',
+    },
+    tooltip: {
+      // Style to push the tooltip to the right outside the select option text
+      left: '0.5rem!important',
+    },
+  })

--- a/packages/picasso-query-builder/src/QueryBuilder/story/FieldDescription.example.tsx
+++ b/packages/picasso-query-builder/src/QueryBuilder/story/FieldDescription.example.tsx
@@ -32,40 +32,6 @@ const fields = [
     name: 'field2',
     label: 'Last name',
   },
-  {
-    name: 'field3',
-    label: 'City',
-  },
-  {
-    name: 'field4',
-    label: 'Country',
-    tooltip: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
-  },
-  {
-    name: 'field5',
-    label: 'Zip code',
-    tooltip: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
-  },
-  {
-    name: 'field6',
-    label: 'Region',
-  },
-  {
-    name: 'field7',
-    label: 'Social security number',
-  },
-  {
-    name: 'field8',
-    label: 'Registration date',
-  },
-  {
-    name: 'field9',
-    label: 'Last login date',
-  },
-  {
-    name: 'field10',
-    label: 'Role',
-  },
 ]
 
 const Example = () => {

--- a/packages/picasso-query-builder/src/QueryBuilder/story/FieldDescription.example.tsx
+++ b/packages/picasso-query-builder/src/QueryBuilder/story/FieldDescription.example.tsx
@@ -1,0 +1,87 @@
+import React, { useState } from 'react'
+import {
+  QueryBuilder,
+  type RuleGroupTypeAny,
+} from '@toptal/picasso-query-builder'
+
+const initialQuery: RuleGroupTypeAny = {
+  rules: [
+    {
+      field: 'name',
+      operator: '=',
+      valueSource: 'value',
+      value: 'John',
+    },
+    {
+      field: 'age',
+      operator: '=',
+      valueSource: 'value',
+      value: '21',
+    },
+  ],
+  combinator: 'and',
+}
+
+const fields = [
+  {
+    name: 'field1',
+    label: 'First name',
+    tooltip: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
+  },
+  {
+    name: 'field2',
+    label: 'Last name',
+  },
+  {
+    name: 'field3',
+    label: 'City',
+  },
+  {
+    name: 'field4',
+    label: 'Country',
+    tooltip: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
+  },
+  {
+    name: 'field5',
+    label: 'Zip code',
+    tooltip: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
+  },
+  {
+    name: 'field6',
+    label: 'Region',
+  },
+  {
+    name: 'field7',
+    label: 'Social security number',
+  },
+  {
+    name: 'field8',
+    label: 'Registration date',
+  },
+  {
+    name: 'field9',
+    label: 'Last login date',
+  },
+  {
+    name: 'field10',
+    label: 'Role',
+  },
+]
+
+const Example = () => {
+  const [query, setQuery] = useState<RuleGroupTypeAny>(initialQuery)
+
+  const handleQueryChange = (newQuery: RuleGroupTypeAny) => {
+    setQuery(newQuery)
+  }
+
+  return (
+    <QueryBuilder
+      fields={fields}
+      query={query}
+      onQueryChange={handleQueryChange}
+    />
+  )
+}
+
+export default Example

--- a/packages/picasso-query-builder/src/QueryBuilder/story/FieldDescription.example.tsx
+++ b/packages/picasso-query-builder/src/QueryBuilder/story/FieldDescription.example.tsx
@@ -7,16 +7,16 @@ import {
 const initialQuery: RuleGroupTypeAny = {
   rules: [
     {
-      field: 'name',
+      field: 'field1',
       operator: '=',
       valueSource: 'value',
       value: 'John',
     },
     {
-      field: 'age',
+      field: 'field2',
       operator: '=',
       valueSource: 'value',
-      value: '21',
+      value: 'John',
     },
   ],
   combinator: 'and',

--- a/packages/picasso-query-builder/src/QueryBuilder/story/index.jsx
+++ b/packages/picasso-query-builder/src/QueryBuilder/story/index.jsx
@@ -38,6 +38,11 @@ page
     description: 'Customized header',
   })
 
+  .addExample('QueryBuilder/story/FieldDescription.example.tsx', {
+    title: 'Field Description',
+    description: 'Display field description in a tooltip',
+  })
+
   .addExample('QueryBuilder/story/Loading.example.tsx', {
     title: 'Loading',
   })

--- a/packages/picasso-query-builder/src/QueryBuilder/story/index.jsx
+++ b/packages/picasso-query-builder/src/QueryBuilder/story/index.jsx
@@ -40,7 +40,7 @@ page
 
   .addExample('QueryBuilder/story/FieldDescription.example.tsx', {
     title: 'Field Description',
-    description: 'Display field description in a tooltip',
+    description: `Hover over 'specificFieldName' to display field description in a tooltip`,
   })
 
   .addExample('QueryBuilder/story/Loading.example.tsx', {

--- a/packages/picasso-query-builder/src/QueryBuilder/story/index.jsx
+++ b/packages/picasso-query-builder/src/QueryBuilder/story/index.jsx
@@ -40,7 +40,7 @@ page
 
   .addExample('QueryBuilder/story/FieldDescription.example.tsx', {
     title: 'Field Description',
-    description: `Hover over 'specificFieldName' to display field description in a tooltip`,
+    description: `Hover over 'First  name' field in the field selector dropdown to display field description in a tooltip`,
   })
 
   .addExample('QueryBuilder/story/Loading.example.tsx', {

--- a/packages/picasso-query-builder/src/Select/Select.tsx
+++ b/packages/picasso-query-builder/src/Select/Select.tsx
@@ -1,4 +1,5 @@
-import React from 'react'
+import type { ComponentProps } from 'react'
+import React, { useMemo } from 'react'
 import { Container, Select as PicassoSelect } from '@toptal/picasso'
 import type { VersatileSelectorProps } from 'react-querybuilder'
 import { makeStyles } from '@material-ui/core/styles'
@@ -10,6 +11,7 @@ import styles from './styles'
 
 interface Props
   extends Omit<VersatileSelectorProps, 'path' | 'level' | 'schema'>,
+    Pick<ComponentProps<typeof PicassoSelect>, 'renderOption'>,
     ValueEditorValidationProps {
   valueEditorTestId?: string
 }
@@ -27,10 +29,15 @@ export const Select = ({
   className,
   fieldData,
   valueEditorTestId,
+  renderOption,
 }: Props) => {
   const classes = useStyles()
 
-  const formattedOptions = generateSelectOptions(options)
+  const formattedOptions = useMemo(
+    () => generateSelectOptions(options),
+    [options]
+  )
+
   const hasError = validateValueEditor({
     validation,
     touched,
@@ -49,6 +56,7 @@ export const Select = ({
         status={hasError ? 'error' : undefined}
         onBlur={() => handleTouched?.(true)}
         data-testid={valueEditorTestId}
+        renderOption={renderOption}
       />
     </Container>
   )

--- a/packages/picasso-query-builder/src/utils/generate-select-options.ts
+++ b/packages/picasso-query-builder/src/utils/generate-select-options.ts
@@ -19,6 +19,7 @@ export const generateSelectOptions = (options?: OptionList) => {
     return options.map(option => ({
       value: option.name,
       text: option.label,
+      tooltip: option.tooltip,
     }))
   }
 


### PR DESCRIPTION
[CPT-2029]

### Description

- We want to improve the query builder so that its users can provide a tooltip to help their end-users understand what a field is for.
- To achieve this functionality, we added an optional property to override the styles of the tooltip popover

**Note:**
For the clause: **Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core**
The implementation was issued from a Toptal design; please reach out to me to receive the link if you want to.

### How to test

<!-- The temploy link will be automatically updated when the temploy is deployed -->
- [Temploy](https://picasso.toptal.net/CPT-2029-fe-add-optional-tooltip-for-a-menu-item-in-the-picasso-select)
- Open the query builder storybook
- Scroll to field description
- Open the fields selector
- Move the mouse over the first name property and notice the popover
- The other select input should not regress

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| - |![image](https://github.com/toptal/picasso/assets/108020813/a5793465-cc14-4fdd-9e34-5d1d6babeb8d) |

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests ([visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md) included)

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[CPT-2029]: https://toptal-core.atlassian.net/browse/CPT-2029?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ