### PR TITLE
Fix TableSortableCell DOM nesting in test

### DIFF
--- a/packages/base/Table/src/TableSortableCell/__snapshots__/test.tsx.snap
+++ b/packages/base/Table/src/TableSortableCell/__snapshots__/test.tsx.snap
@@ -15,7 +15,7 @@ exports[`TableCell sort direction is asc renders with a sort button in the right
               class="flex items-center"
             >
               <div
-                class="m-0 font-regular text-sm text-graphite font-inherit"
+                class="MuiTypography-root PicassoTypography-bodySmall PicassoTypography-darkGrey PicassoTypography-inheritWeight MuiTypography-body1"
               >
                 Cell
               </div>
@@ -63,7 +63,7 @@ exports[`TableCell sort direction is desc renders with a sort button in the righ
               class="flex items-center"
             >
               <div
-                class="m-0 font-regular text-sm text-graphite font-inherit"
+                class="MuiTypography-root PicassoTypography-bodySmall PicassoTypography-darkGrey PicassoTypography-inheritWeight MuiTypography-body1"
               />
               <button
                 class="MuiButtonBase-root PicassoButton-small PicassoButton-primary PicassoButton-root PicassoButtonCircular-flat PicassoButtonCircular-root ml-2 invisible group-hover:visible"

--- a/packages/base/Table/src/TableSortableCell/__snapshots__/test.tsx.snap
+++ b/packages/base/Table/src/TableSortableCell/__snapshots__/test.tsx.snap
@@ -5,39 +5,45 @@ exports[`TableCell sort direction is asc renders with a sort button in the right
   <div
     class="Picasso-root"
   >
-    <td
-      class="MuiTableCell-root PicassoTableCell-root group hover:bg-gray"
-    >
-      <div
-        class="flex items-center"
-      >
-        <div
-          class="MuiTypography-root PicassoTypography-bodySmall PicassoTypography-darkGrey PicassoTypography-inheritWeight MuiTypography-body1"
-        >
-          Cell
-        </div>
-        <button
-          class="MuiButtonBase-root PicassoButton-small PicassoButton-primary PicassoButton-root PicassoButtonCircular-flat PicassoButtonCircular-root ml-2 invisible group-hover:visible"
-          data-component-type="button"
-          tabindex="0"
-          type="button"
-        >
-          <span
-            class="PicassoContainer-centerAlignItems PicassoContainer-flex PicassoContainer-inline PicassoButton-content"
+    <table>
+      <tbody>
+        <tr>
+          <td
+            class="MuiTableCell-root PicassoTableCell-root group hover:bg-gray"
           >
-            <svg
-              class="PicassoSvgArrowLongUp16-root PicassoButton-icon"
-              style="min-width: 16px; min-height: 16px;"
-              viewBox="0 0 16 16"
+            <div
+              class="flex items-center"
             >
-              <path
-                d="M7.5 1.793 11.207 5.5l-.707.707-2.5-2.5V14H7V3.707l-2.5 2.5-.707-.707 3-3 .707-.707Z"
-              />
-            </svg>
-          </span>
-        </button>
-      </div>
-    </td>
+              <div
+                class="m-0 font-regular text-sm text-graphite font-inherit"
+              >
+                Cell
+              </div>
+              <button
+                class="MuiButtonBase-root PicassoButton-small PicassoButton-primary PicassoButton-root PicassoButtonCircular-flat PicassoButtonCircular-root ml-2 invisible group-hover:visible"
+                data-component-type="button"
+                tabindex="0"
+                type="button"
+              >
+                <span
+                  class="PicassoContainer-centerAlignItems PicassoContainer-flex PicassoContainer-inline PicassoButton-content"
+                >
+                  <svg
+                    class="PicassoSvgArrowLongUp16-root PicassoButton-icon"
+                    style="min-width: 16px; min-height: 16px;"
+                    viewBox="0 0 16 16"
+                  >
+                    <path
+                      d="M7.5 1.793 11.207 5.5l-.707.707-2.5-2.5V14H7V3.707l-2.5 2.5-.707-.707 3-3 .707-.707Z"
+                    />
+                  </svg>
+                </span>
+              </button>
+            </div>
+          </td>
+        </tr>
+      </tbody>
+    </table>
   </div>
 </div>
 `;
@@ -47,37 +53,43 @@ exports[`TableCell sort direction is desc renders with a sort button in the righ
   <div
     class="Picasso-root"
   >
-    <td
-      class="MuiTableCell-root PicassoTableCell-root group hover:bg-gray"
-    >
-      <div
-        class="flex items-center"
-      >
-        <div
-          class="MuiTypography-root PicassoTypography-bodySmall PicassoTypography-darkGrey PicassoTypography-inheritWeight MuiTypography-body1"
-        />
-        <button
-          class="MuiButtonBase-root PicassoButton-small PicassoButton-primary PicassoButton-root PicassoButtonCircular-flat PicassoButtonCircular-root ml-2 invisible group-hover:visible"
-          data-component-type="button"
-          tabindex="0"
-          type="button"
-        >
-          <span
-            class="PicassoContainer-centerAlignItems PicassoContainer-flex PicassoContainer-inline PicassoButton-content"
+    <table>
+      <tbody>
+        <tr>
+          <td
+            class="MuiTableCell-root PicassoTableCell-root group hover:bg-gray"
           >
-            <svg
-              class="PicassoSvgArrowLongDown16-root PicassoButton-icon"
-              style="min-width: 16px; min-height: 16px;"
-              viewBox="0 0 16 16"
+            <div
+              class="flex items-center"
             >
-              <path
-                d="M8 2v10.293l2.5-2.5.707.707L7.5 14.207 3.793 10.5l.707-.707 2.5 2.5V2h1Z"
+              <div
+                class="m-0 font-regular text-sm text-graphite font-inherit"
               />
-            </svg>
-          </span>
-        </button>
-      </div>
-    </td>
+              <button
+                class="MuiButtonBase-root PicassoButton-small PicassoButton-primary PicassoButton-root PicassoButtonCircular-flat PicassoButtonCircular-root ml-2 invisible group-hover:visible"
+                data-component-type="button"
+                tabindex="0"
+                type="button"
+              >
+                <span
+                  class="PicassoContainer-centerAlignItems PicassoContainer-flex PicassoContainer-inline PicassoButton-content"
+                >
+                  <svg
+                    class="PicassoSvgArrowLongDown16-root PicassoButton-icon"
+                    style="min-width: 16px; min-height: 16px;"
+                    viewBox="0 0 16 16"
+                  >
+                    <path
+                      d="M8 2v10.293l2.5-2.5.707.707L7.5 14.207 3.793 10.5l.707-.707 2.5 2.5V2h1Z"
+                    />
+                  </svg>
+                </span>
+              </button>
+            </div>
+          </td>
+        </tr>
+      </tbody>
+    </table>
   </div>
 </div>
 `;

--- a/packages/base/Table/src/TableSortableCell/test.tsx
+++ b/packages/base/Table/src/TableSortableCell/test.tsx
@@ -13,9 +13,18 @@ const renderTableCell = (
   }
 ) => {
   return render(
-    <TableSortableCell sortDirection={sortDirection} onSortClick={onSortClick}>
-      {children}
-    </TableSortableCell>
+    <table>
+      <tbody>
+        <tr>
+          <TableSortableCell
+            sortDirection={sortDirection}
+            onSortClick={onSortClick}
+          >
+            {children}
+          </TableSortableCell>
+        </tr>
+      </tbody>
+    </table>
   )
 }
 


### PR DESCRIPTION
[FX-NNNN]

### Description

Removes the warning/error on DOM nesting from the `TableSortableCell` test file

### How to test

<!-- The temploy link will be automatically updated when the temploy is deployed -->
- [Temploy](https://picasso.toptal.net/fx-xxx-fix-sortable-test)
-Tests should pass

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| Insert screenshots or screen recordings | Insert screenshots or screen recordings |

### Development checks

- [n/a] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests ([visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md) included)

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>
