### PR TITLE
[FX-5115] Update types of compound components

### DIFF
--- a/.changeset/green-keys-nail.md
+++ b/.changeset/green-keys-nail.md
@@ -1,0 +1,26 @@
+---
+'@toptal/picasso-application-update-notification': patch
+'@toptal/picasso-overview-block': patch
+'@toptal/picasso-notification': patch
+'@toptal/picasso-breadcrumbs': patch
+'@toptal/picasso-tagselector': patch
+'@toptal/picasso-accordion': patch
+'@toptal/picasso-forms': patch
+'@toptal/picasso-helpbox': patch
+'@toptal/picasso-avatar': patch
+'@toptal/picasso-button': patch
+'@toptal/picasso-alert': patch
+'@toptal/picasso-modal': patch
+'@toptal/picasso-radio': patch
+'@toptal/picasso-table': patch
+'@toptal/picasso-form': patch
+'@toptal/picasso-grid': patch
+'@toptal/picasso-menu': patch
+'@toptal/picasso-note': patch
+'@toptal/picasso-page': patch
+'@toptal/picasso-step': patch
+'@toptal/picasso-tabs': patch
+'@toptal/picasso-tag': patch
+---
+
+- update types for the compound component

--- a/packages/base/Accordion/src/AccordionCompound/index.ts
+++ b/packages/base/Accordion/src/AccordionCompound/index.ts
@@ -1,8 +1,16 @@
 import { Accordion, Details, Summary } from '../Accordion'
 
-export const AccordionCompound = Object.assign(Accordion, {
-  Summary,
-  Details,
-})
+type AccordionCompoundType = typeof Accordion & {
+  Summary: typeof Summary
+  Details: typeof Details
+}
+
+export const AccordionCompound: AccordionCompoundType = Object.assign(
+  Accordion,
+  {
+    Summary,
+    Details,
+  }
+)
 
 export default AccordionCompound

--- a/packages/base/Alert/src/AlertCompound/index.ts
+++ b/packages/base/Alert/src/AlertCompound/index.ts
@@ -1,6 +1,10 @@
 import { Alert } from '../Alert'
 import { AlertInline } from '../AlertInline'
 
-export const AlertCompound = Object.assign(Alert, {
+type AlertCompoundType = typeof Alert & {
+  Inline: typeof AlertInline
+}
+
+export const AlertCompound: AlertCompoundType = Object.assign(Alert, {
   Inline: AlertInline,
 })

--- a/packages/base/ApplicationUpdateNotification/src/ApplicationUpdateNotificationCompound/index.ts
+++ b/packages/base/ApplicationUpdateNotification/src/ApplicationUpdateNotificationCompound/index.ts
@@ -1,9 +1,12 @@
 import { ApplicationUpdateNotification } from '../ApplicationUpdateNotification'
 import { ApplicationUpdateNotificationActions } from '../ApplicationUpdateNotificationActions'
 
-export const ApplicationUpdateNotificationCompound = Object.assign(
-  ApplicationUpdateNotification,
-  {
-    Actions: ApplicationUpdateNotificationActions,
+type ApplicationUpdateNotificationCompoundType =
+  typeof ApplicationUpdateNotification & {
+    Actions: typeof ApplicationUpdateNotificationActions
   }
-)
+
+export const ApplicationUpdateNotificationCompound: ApplicationUpdateNotificationCompoundType =
+  Object.assign(ApplicationUpdateNotification, {
+    Actions: ApplicationUpdateNotificationActions,
+  })

--- a/packages/base/Avatar/src/AvatarCompound/index.ts
+++ b/packages/base/Avatar/src/AvatarCompound/index.ts
@@ -1,6 +1,10 @@
 import { Avatar } from '../Avatar'
 import { AvatarGroup } from '../AvatarGroup'
 
-export const AvatarCompound = Object.assign(Avatar, {
+type AvatarCompoundType = typeof Avatar & {
+  Group: typeof AvatarGroup
+}
+
+export const AvatarCompound: AvatarCompoundType = Object.assign(Avatar, {
   Group: AvatarGroup,
 })

--- a/packages/base/Breadcrumbs/src/BreadcrumbsCompound/index.ts
+++ b/packages/base/Breadcrumbs/src/BreadcrumbsCompound/index.ts
@@ -1,6 +1,13 @@
 import { Breadcrumbs } from '../Breadcrumbs'
 import { BreadcrumbsItem } from '../BreadcrumbsItem'
 
-export const BreadcrumbsCompound = Object.assign(Breadcrumbs, {
-  Item: BreadcrumbsItem,
-})
+type BreadcrumbsCompoundType = typeof Breadcrumbs & {
+  Item: typeof BreadcrumbsItem
+}
+
+export const BreadcrumbsCompound: BreadcrumbsCompoundType = Object.assign(
+  Breadcrumbs,
+  {
+    Item: BreadcrumbsItem,
+  }
+)

--- a/packages/base/Button/src/ButtonCompound/index.ts
+++ b/packages/base/Button/src/ButtonCompound/index.ts
@@ -6,7 +6,16 @@ import { ButtonSplit } from '../ButtonSplit'
 import { ButtonCheckbox } from '../ButtonCheckbox'
 import { ButtonRadio } from '../ButtonRadio'
 
-export const ButtonCompound = Object.assign(Button, {
+type ButtonCompoundType = typeof Button & {
+  Group: typeof ButtonGroup
+  Circular: typeof ButtonCircular
+  Action: typeof ButtonAction
+  Split: typeof ButtonSplit
+  Checkbox: typeof ButtonCheckbox
+  Radio: typeof ButtonRadio
+}
+
+export const ButtonCompound: ButtonCompoundType = Object.assign(Button, {
   Group: ButtonGroup,
   Circular: ButtonCircular,
   Action: ButtonAction,

--- a/packages/base/Form/src/FormCompound/index.ts
+++ b/packages/base/Form/src/FormCompound/index.ts
@@ -4,7 +4,14 @@ import { FormField } from '../FormField'
 import { FormHint } from '../FormHint'
 import { FormLabel } from '../FormLabel'
 
-export const FormCompound = Object.assign(Form, {
+type FormCompoundType = typeof Form & {
+  Field: typeof FormField
+  Hint: typeof FormHint
+  Error: typeof FormError
+  Label: typeof FormLabel
+}
+
+export const FormCompound: FormCompoundType = Object.assign(Form, {
   Field: FormField,
   Hint: FormHint,
   Error: FormError,

--- a/packages/base/Grid/src/GridCompound/index.ts
+++ b/packages/base/Grid/src/GridCompound/index.ts
@@ -1,4 +1,10 @@
 import { Grid } from '../Grid'
 import { GridItem } from '../GridItem'
 
-export const GridCompound = Object.assign(Grid, { Item: GridItem })
+type GridCompoundType = typeof Grid & {
+  Item: typeof GridItem
+}
+
+export const GridCompound: GridCompoundType = Object.assign(Grid, {
+  Item: GridItem,
+})

--- a/packages/base/Helpbox/src/HelpboxCompound/index.ts
+++ b/packages/base/Helpbox/src/HelpboxCompound/index.ts
@@ -3,7 +3,13 @@ import { HelpboxActions } from '../HelpboxActions'
 import { HelpboxContent } from '../HelpboxContent'
 import { HelpboxTitle } from '../HelpboxTitle'
 
-export const HelpboxCompound = Object.assign(Helpbox, {
+type HelpboxCompoundType = typeof Helpbox & {
+  Title: typeof HelpboxTitle
+  Content: typeof HelpboxContent
+  Actions: typeof HelpboxActions
+}
+
+export const HelpboxCompound: HelpboxCompoundType = Object.assign(Helpbox, {
   Title: HelpboxTitle,
   Content: HelpboxContent,
   Actions: HelpboxActions,

--- a/packages/base/Menu/src/MenuCompound/index.ts
+++ b/packages/base/Menu/src/MenuCompound/index.ts
@@ -1,4 +1,10 @@
 import { Menu } from '../Menu'
 import { MenuItem } from '../MenuItem'
 
-export const MenuCompound = Object.assign(Menu, { Item: MenuItem })
+type MenuCompoundType = typeof Menu & {
+  Item: typeof MenuItem
+}
+
+export const MenuCompound: MenuCompoundType = Object.assign(Menu, {
+  Item: MenuItem,
+})

--- a/packages/base/Modal/src/ModalCompound/index.ts
+++ b/packages/base/Modal/src/ModalCompound/index.ts
@@ -3,7 +3,13 @@ import { ModalActions } from '../ModalActions'
 import { ModalContent } from '../ModalContent'
 import { ModalTitle } from '../ModalTitle'
 
-export const ModalCompound = Object.assign(Modal, {
+type ModalCompoundType = typeof Modal & {
+  Content: typeof ModalContent
+  Actions: typeof ModalActions
+  Title: typeof ModalTitle
+}
+
+export const ModalCompound: ModalCompoundType = Object.assign(Modal, {
   Content: ModalContent,
   Actions: ModalActions,
   Title: ModalTitle,

--- a/packages/base/Note/src/NoteCompound/index.ts
+++ b/packages/base/Note/src/NoteCompound/index.ts
@@ -3,7 +3,13 @@ import { NoteContent } from '../NoteContent'
 import { NoteSubtitle } from '../NoteSubtitle'
 import { NoteTitle } from '../NoteTitle'
 
-export const NoteCompound = Object.assign(Note, {
+type NoteCompoundType = typeof Note & {
+  Title: typeof NoteTitle
+  Subtitle: typeof NoteSubtitle
+  Content: typeof NoteContent
+}
+
+export const NoteCompound: NoteCompoundType = Object.assign(Note, {
   Title: NoteTitle,
   Subtitle: NoteSubtitle,
   Content: NoteContent,

--- a/packages/base/Notification/src/NotificationCompound/index.ts
+++ b/packages/base/Notification/src/NotificationCompound/index.ts
@@ -1,6 +1,13 @@
 import { Notification } from '../Notification'
 import { NotificationActions } from '../NotificationActions'
 
-export const NotificationCompound = Object.assign(Notification, {
-  Actions: NotificationActions,
-})
+type NotificationCompoundType = typeof Notification & {
+  Actions: typeof NotificationActions
+}
+
+export const NotificationCompound: NotificationCompoundType = Object.assign(
+  Notification,
+  {
+    Actions: NotificationActions,
+  }
+)

--- a/packages/base/OverviewBlock/src/OverviewBlockCompound/index.ts
+++ b/packages/base/OverviewBlock/src/OverviewBlockCompound/index.ts
@@ -2,7 +2,15 @@ import { OverviewBlock } from '../OverviewBlock'
 import { OverviewBlockGroup } from '../OverviewBlockGroup'
 import { OverviewBlockRow } from '../OverviewBlockRow'
 
-export const OverviewBlockCompound = Object.assign(OverviewBlock, {
-  Group: OverviewBlockGroup,
-  Row: OverviewBlockRow,
-})
+type OverviewBlockCompoundType = typeof OverviewBlock & {
+  Group: typeof OverviewBlockGroup
+  Row: typeof OverviewBlockRow
+}
+
+export const OverviewBlockCompound: OverviewBlockCompoundType = Object.assign(
+  OverviewBlock,
+  {
+    Group: OverviewBlockGroup,
+    Row: OverviewBlockRow,
+  }
+)

--- a/packages/base/Page/src/PageCompound/index.ts
+++ b/packages/base/Page/src/PageCompound/index.ts
@@ -9,7 +9,19 @@ import { PageBanner } from '../PageBanner'
 import { PageAutocomplete } from '../PageAutocomplete'
 import { PageArticle } from '../PageArticle'
 
-export const PageCompound = Object.assign(Page, {
+type PageCompoundType = typeof Page & {
+  TopBar: typeof PageTopBar
+  TopBarMenu: typeof PageTopBarMenu
+  Content: typeof PageContent
+  Footer: typeof PageFooter
+  Sidebar: typeof PageSidebar
+  Banner: typeof PageBanner
+  Helmet: typeof PageHelmet
+  Autocomplete: typeof PageAutocomplete
+  Article: typeof PageArticle
+}
+
+export const PageCompound: PageCompoundType = Object.assign(Page, {
   TopBar: PageTopBar,
   TopBarMenu: PageTopBarMenu,
   Content: PageContent,

--- a/packages/base/Page/src/PageTopBarCompound/index.ts
+++ b/packages/base/Page/src/PageTopBarCompound/index.ts
@@ -2,7 +2,15 @@ import { PageTopBar } from '../PageTopBar'
 import { TopBarMenu } from '../TopBarMenu'
 import { TopBarItem } from '../TopBarItem'
 
-export const PageTopBarCompound = Object.assign(PageTopBar, {
-  Menu: TopBarMenu,
-  Item: TopBarItem,
-})
+type PageTopBarCompoundType = typeof PageTopBar & {
+  Menu: typeof TopBarMenu
+  Item: typeof TopBarItem
+}
+
+export const PageTopBarCompound: PageTopBarCompoundType = Object.assign(
+  PageTopBar,
+  {
+    Menu: TopBarMenu,
+    Item: TopBarItem,
+  }
+)

--- a/packages/base/Radio/src/RadioCompound/index.ts
+++ b/packages/base/Radio/src/RadioCompound/index.ts
@@ -1,6 +1,10 @@
 import { Radio } from '../Radio'
 import { RadioGroup } from '../RadioGroup'
 
-export const RadioCompound = Object.assign(Radio, {
+type RadioCompoundType = typeof Radio & {
+  Group: typeof RadioGroup
+}
+
+export const RadioCompound: RadioCompoundType = Object.assign(Radio, {
   Group: RadioGroup,
 })

--- a/packages/base/Step/src/StepperCompound/index.ts
+++ b/packages/base/Step/src/StepperCompound/index.ts
@@ -1,6 +1,10 @@
 import { Stepper } from '../Stepper'
 import { StepperVertical } from '../StepperVertical'
 
-export const StepperCompound = Object.assign(Stepper, {
+type StepperCompoundType = typeof Stepper & {
+  Vertical: typeof StepperVertical
+}
+
+export const StepperCompound: StepperCompoundType = Object.assign(Stepper, {
   Vertical: StepperVertical,
 })

--- a/packages/base/Table/src/TableCompound/index.ts
+++ b/packages/base/Table/src/TableCompound/index.ts
@@ -7,7 +7,17 @@ import { TableSectionHead } from '../TableSectionHead'
 import { TableFooter } from '../TableFooter'
 import { TableExpandableRow } from '../TableExpandableRow'
 
-export const TableCompound = Object.assign(Table, {
+type TableCompoundType = typeof Table & {
+  Cell: typeof TableCell
+  Body: typeof TableBody
+  Row: typeof TableRow
+  Head: typeof TableHead
+  SectionHead: typeof TableSectionHead
+  Footer: typeof TableFooter
+  ExpandableRow: typeof TableExpandableRow
+}
+
+export const TableCompound: TableCompoundType = Object.assign(Table, {
   Cell: TableCell,
   Body: TableBody,
   Head: TableHead,

--- a/packages/base/Tabs/src/TabsCompound/index.ts
+++ b/packages/base/Tabs/src/TabsCompound/index.ts
@@ -1,6 +1,10 @@
 import { Tab } from '../Tab'
 import { Tabs } from '../Tabs'
 
-export const TabsCompound = Object.assign(Tabs, {
+type TabsCompoundType = typeof Tabs & {
+  Tab: typeof Tab
+}
+
+export const TabsCompound: TabsCompoundType = Object.assign(Tabs, {
   Tab,
 })

--- a/packages/base/Tag/src/TagCompound/index.ts
+++ b/packages/base/Tag/src/TagCompound/index.ts
@@ -4,7 +4,14 @@ import { TagRectangular } from '../TagRectangular'
 import { TagConnection } from '../TagConnection'
 import { TagCheckable } from '../TagCheckable'
 
-export const TagCompound = Object.assign(Tag, {
+type TagCompoundType = typeof Tag & {
+  Group: typeof TagGroup
+  Rectangular: typeof TagRectangular
+  Connection: typeof TagConnection
+  Checkable: typeof TagCheckable
+}
+
+export const TagCompound: TagCompoundType = Object.assign(Tag, {
   Group: TagGroup,
   Rectangular: TagRectangular,
   Connection: TagConnection,

--- a/packages/base/Tagselector/src/TagSelectorCompound/index.ts
+++ b/packages/base/Tagselector/src/TagSelectorCompound/index.ts
@@ -1,6 +1,13 @@
 import { TagSelector } from '../TagSelector'
 import { TagSelectorLabel } from '../TagSelectorLabel'
 
-export const TagSelectorCompound = Object.assign(TagSelector, {
-  Label: TagSelectorLabel,
-})
+type TagSelectorCompoundType = typeof TagSelector & {
+  Label: typeof TagSelectorLabel
+}
+
+export const TagSelectorCompound: TagSelectorCompoundType = Object.assign(
+  TagSelector,
+  {
+    Label: TagSelectorLabel,
+  }
+)

--- a/packages/picasso-forms/src/FormCompound/index.ts
+++ b/packages/picasso-forms/src/FormCompound/index.ts
@@ -24,7 +24,33 @@ import PasswordInput from '../PasswordInput'
 import { FormConfigContext } from '../FormConfig'
 import AvatarUpload from '../AvatarUpload'
 
-export const FormCompound = Object.assign(Form, {
+type FormCompoundType = typeof Form & {
+  Autocomplete: typeof Autocomplete
+  Input: typeof Input
+  Select: typeof Select
+  Radio: typeof Radio
+  ButtonRadio: typeof ButtonRadio
+  RadioGroup: typeof RadioGroup
+  Checkbox: typeof Checkbox
+  ButtonCheckbox: typeof ButtonCheckbox
+  CheckboxGroup: typeof CheckboxGroup
+  NumberInput: typeof NumberInput
+  FileInput: typeof FileInput
+  DatePicker: typeof DatePicker
+  TimePicker: typeof TimePicker
+  TagSelector: typeof TagSelector
+  SubmitButton: typeof SubmitButton
+  ConfigProvider: typeof FormConfigContext.Provider
+  Switch: typeof Switch
+  Rating: typeof Rating
+  Dropzone: typeof Dropzone
+  PasswordInput: typeof PasswordInput
+  FieldRequirements: typeof FieldRequirements
+  RichTextEditor: typeof RichTextEditor
+  AvatarUpload: typeof AvatarUpload
+}
+
+export const FormCompound: FormCompoundType = Object.assign(Form, {
   Autocomplete: Autocomplete,
   Input: Input,
   Select: Select,


### PR DESCRIPTION
[FX-5115]

### Description

When we leave on Typescript to set types for compound components, it is resolving wrongly paths to other packages.
We can't have `packages/shared/dist-package/src` in generated files as they do not exist and it needs to be resolved to `@toptal/picasso-shared`. It seems like a bug in Typescript itself.

When we explicitly type the compound component, the types are generated correctly.

### How to test

<!-- The temploy link will be automatically updated when the temploy is deployed -->
- [Temploy](https://picasso.toptal.net/fx-5115-types)
- check screenshot bellow, or
- you can check locally the branch and open story of Page and try to read types of `Page.Article`
  - on current commit it should show proper types
  - if you remove the types from the Page compound component, it will not work again

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| ![image](https://github.com/toptal/picasso/assets/6830426/5bf951ef-7e35-4517-aa19-0c84c45d76bd) | ![image](https://github.com/toptal/picasso/assets/6830426/3e8bd9d9-941e-47dd-8de1-3635da119c3e) |

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- Annotate all `props` in component with documentation
- Create `examples` for component
- Ensure that deployed demo has expected results and good examples
- Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- Covered with tests ([visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md) included)

**Breaking change**

- codemod is created and showcased in the changeset
- test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-5115]: https://toptal-core.atlassian.net/browse/FX-5115?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ