### PR TITLE
Wait for image to be fully loaded

### DIFF
--- a/packages/base/TreeView/src/StaticTreeView/story/index.jsx
+++ b/packages/base/TreeView/src/StaticTreeView/story/index.jsx
@@ -9,47 +9,6 @@ const page = PicassoBook.section('Components').createPage(
   `
 )
 
-const waitForImageToLoad = url => {
-  return new Promise((resolve, reject) => {
-    const img = new Image()
-
-    img.onerror = () =>
-      reject(new Error(`Failed to load image with url ${url}`))
-    img.onload = resolve
-    img.src = url
-  })
-}
-
-const waitForSvgImagesToRender = () => {
-  return new Promise((resolve, reject) => {
-    const svgImages = document.querySelectorAll('svg image')
-    const promises = [...svgImages]
-      .map(image => image.href)
-      .filter(Boolean)
-      .map(waitForImageToLoad)
-
-    if (promises.length === 0) {
-      // There are no images to wait for, so we can just resolve right away.
-      resolve()
-    }
-
-    Promise.all(promises)
-      .then(() => {
-        // Now that the images have loaded, we need to wait for a couple of
-        // animation frames to go by before we think they will have finished
-        // rendering.
-        return requestAnimationFrame(() => {
-          // Start render
-          requestAnimationFrame(() => {
-            // Finish rendering
-            resolve()
-          })
-        })
-      })
-      .catch(reject)
-  })
-}
-
 page.createTabChapter('Props').addComponentDocs({
   component: StaticTreeView,
   name: 'StaticTreeView',
@@ -62,8 +21,12 @@ page
     {
       title: 'Default',
       takeScreenshot: {
-        beforeScreenshot: async () => {
-          await waitForSvgImagesToRender()
+        // https://docs.happo.io/docs/storybook#waiting-for-a-condition-to-be-truthy
+        waitFor: () => {
+          const imageElement: HTMLImageElement | undefined =
+            document.querySelector('svg image')
+
+          return imageElement && imageElement.complete
         },
       },
     },


### PR DESCRIPTION
[FX-NNNN]

### Description

The screenshot for StaticTreeView has been flaky for a long time, the function that we were currently using for waiting for images to load is not working. 

According to [the documentation](https://docs.happo.io/docs/storybook#waiting-for-a-condition-to-be-truthy) we can use `waitFor` function. The screenshot will be taken after the condition is true.

### How to test

<!-- The temploy link will be automatically updated when the temploy is deployed -->
- [Temploy](https://picasso.toptal.net/fix-cypress-flaky-test)
- The CI should be green

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| Insert screenshots or screen recordings | Insert screenshots or screen recordings |

### Development checks

- Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- Annotate all `props` in component with documentation
- Create `examples` for component
- Ensure that deployed demo has expected results and good examples
- Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- Covered with tests ([visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md) included)

**Breaking change**

- codemod is created and showcased in the changeset
- test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>
