### PR TITLE
[FX-4622] Migrate TableBody to TailwindCSS

### DIFF
--- a/packages/base/Table/src/Table/__snapshots__/test.tsx.snap
+++ b/packages/base/Table/src/Table/__snapshots__/test.tsx.snap
@@ -25,14 +25,12 @@ exports[`Table renders 1`] = `
           </td>
         </tr>
       </thead>
-      <tbody
-        class="MuiTableBody-root"
-      >
+      <tbody>
         <tr
           class="MuiTableRow-root PicassoTableRow-root PicassoTableRow-bordered"
         >
           <td
-            class="MuiTableCell-root PicassoTableCell-root MuiTableCell-body"
+            class="MuiTableCell-root PicassoTableCell-root"
           >
             <div
               class="MuiTypography-root PicassoTypography-bodySmall PicassoTypography-darkGrey PicassoTypography-inheritWeight MuiTypography-body1"

--- a/packages/base/Table/src/TableBody/TableBody.tsx
+++ b/packages/base/Table/src/TableBody/TableBody.tsx
@@ -1,11 +1,7 @@
 import type { ReactNode, HTMLAttributes } from 'react'
 import React, { forwardRef, useContext } from 'react'
-import type { Theme } from '@material-ui/core/styles'
-import { makeStyles } from '@material-ui/core/styles'
-import { TableBody as MUITableBody } from '@material-ui/core'
 import type { BaseProps } from '@toptal/picasso-shared'
 
-import styles from './styles'
 import { TableSectionContext, TableSection, TableContext } from '../Table'
 
 export interface Props
@@ -32,25 +28,16 @@ const stripeRows = (children: React.ReactNode) => {
   })
 }
 
-const useStyles = makeStyles<Theme>(styles, { name: 'PicassoTableBody' })
-
 export const TableBody = forwardRef<HTMLTableSectionElement, Props>(
   function TableBody(props, ref) {
     const { className, style, children, ...rest } = props
-    const classes = useStyles()
     const { variant } = useContext(TableContext)
 
     return (
       <TableSectionContext.Provider value={TableSection.BODY}>
-        <MUITableBody
-          {...rest}
-          ref={ref}
-          classes={classes}
-          className={className}
-          style={style}
-        >
+        <tbody {...rest} ref={ref} className={className} style={style}>
           {variant === 'striped' ? stripeRows(children) : children}
-        </MUITableBody>
+        </tbody>
       </TableSectionContext.Provider>
     )
   }

--- a/packages/base/Table/src/TableBody/__snapshots__/test.tsx.snap
+++ b/packages/base/Table/src/TableBody/__snapshots__/test.tsx.snap
@@ -8,14 +8,12 @@ exports[`TableCell renders 1`] = `
     <table
       class="MuiTable-root"
     >
-      <tbody
-        class="MuiTableBody-root"
-      >
+      <tbody>
         <tr
           class="MuiTableRow-root PicassoTableRow-root PicassoTableRow-bordered"
         >
           <td
-            class="MuiTableCell-root PicassoTableCell-root MuiTableCell-body"
+            class="MuiTableCell-root PicassoTableCell-root"
           >
             <div
               class="MuiTypography-root PicassoTypography-bodySmall PicassoTypography-darkGrey PicassoTypography-inheritWeight MuiTypography-body1"

--- a/packages/base/Table/src/TableCell/__snapshots__/test.tsx.snap
+++ b/packages/base/Table/src/TableCell/__snapshots__/test.tsx.snap
@@ -8,14 +8,12 @@ exports[`TableCell renders 1`] = `
     <table
       class="MuiTable-root"
     >
-      <tbody
-        class="MuiTableBody-root"
-      >
+      <tbody>
         <tr
           class="MuiTableRow-root PicassoTableRow-root PicassoTableRow-bordered"
         >
           <td
-            class="MuiTableCell-root PicassoTableCell-root MuiTableCell-body"
+            class="MuiTableCell-root PicassoTableCell-root"
           >
             <div
               class="MuiTypography-root PicassoTypography-bodySmall PicassoTypography-darkGrey PicassoTypography-inheritWeight MuiTypography-body1"
@@ -38,14 +36,12 @@ exports[`TableCell renders compact 1`] = `
     <table
       class="MuiTable-root"
     >
-      <tbody
-        class="MuiTableBody-root"
-      >
+      <tbody>
         <tr
           class="MuiTableRow-root PicassoTableRow-root PicassoTableRow-bordered"
         >
           <td
-            class="MuiTableCell-root PicassoTableCell-root MuiTableCell-body"
+            class="MuiTableCell-root PicassoTableCell-root"
           >
             <div
               class="MuiTypography-root PicassoTypography-bodySmall PicassoTypography-darkGrey PicassoTypography-inheritWeight MuiTypography-body1"
@@ -68,14 +64,12 @@ exports[`TableCell renders narrow 1`] = `
     <table
       class="MuiTable-root"
     >
-      <tbody
-        class="MuiTableBody-root"
-      >
+      <tbody>
         <tr
           class="MuiTableRow-root PicassoTableRow-root PicassoTableRow-bordered"
         >
           <td
-            class="MuiTableCell-root PicassoTableCell-root MuiTableCell-body"
+            class="MuiTableCell-root PicassoTableCell-root"
           >
             <div
               class="MuiTypography-root PicassoTypography-bodySmall PicassoTypography-darkGrey PicassoTypography-inheritWeight MuiTypography-body1"

--- a/packages/base/Table/src/TableRow/__snapshots__/test.tsx.snap
+++ b/packages/base/Table/src/TableRow/__snapshots__/test.tsx.snap
@@ -8,14 +8,12 @@ exports[`TableRow renders 1`] = `
     <table
       class="MuiTable-root"
     >
-      <tbody
-        class="MuiTableBody-root"
-      >
+      <tbody>
         <tr
           class="MuiTableRow-root PicassoTableRow-root PicassoTableRow-bordered"
         >
           <td
-            class="MuiTableCell-root PicassoTableCell-root MuiTableCell-body"
+            class="MuiTableCell-root PicassoTableCell-root"
           >
             <div
               class="MuiTypography-root PicassoTypography-bodySmall PicassoTypography-darkGrey PicassoTypography-inheritWeight MuiTypography-body1"

--- a/packages/base/Table/src/TableSectionHead/__snapshots__/test.tsx.snap
+++ b/packages/base/Table/src/TableSectionHead/__snapshots__/test.tsx.snap
@@ -8,14 +8,12 @@ exports[`TableSectionHead renders 1`] = `
     <table
       class="MuiTable-root"
     >
-      <tbody
-        class="MuiTableBody-root"
-      >
+      <tbody>
         <tr
           class="MuiTableRow-root PicassoTableRow-root PicassoTableSectionHead-sectionHeaderRow PicassoTableRow-bordered"
         >
           <td
-            class="MuiTableCell-root PicassoTableCell-root MuiTableCell-body"
+            class="MuiTableCell-root PicassoTableCell-root"
             colspan="100"
           >
             <div


### PR DESCRIPTION
[FX-4622]

### Description

Migration to Tailwind.

### How to test

<!-- The temploy link will be automatically updated when the temploy is deployed -->
- [Temploy](https://picasso.toptal.net/fx-4622-migrate-tablebody)
- Check the [production](https://picasso.toptal.net/?path=/story/components-table--table) and compare it with the temploy.

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| ![Picasso - Table - Google Chrome 2024-04-12 at 11 56 58 AM](https://github.com/toptal/picasso/assets/100089376/b1c028c9-dd2f-4390-b3e9-d904b197ada3) | ![Picasso - Table - Google Chrome 2024-04-12 at 2 49 37 PM](https://github.com/toptal/picasso/assets/100089376/ae72c352-7836-4f64-8f63-b7c5852bb635)
 |

### Development checks

- ~Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)~
- ~Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- ~Annotate all `props` in component with documentation~
- ~Create `examples` for component~
- ~Ensure that deployed demo has expected results and good examples~
- ~Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).~
- [x] Self reviewed
- ~Covered with tests ([visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md) included)~

**Breaking change**

- ~codemod is created and showcased in the changeset~
- ~test alpha package of Picasso in StaffPortal~

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-4622]: https://toptal-core.atlassian.net/browse/FX-4622?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ