### PR TITLE
[CPT-2187] Allow qb controls customization from consumers

### DIFF
--- a/.changeset/clean-kiwis-try.md
+++ b/.changeset/clean-kiwis-try.md
@@ -1,0 +1,9 @@
+---
+'@toptal/picasso-query-builder': major
+---
+
+- remove `totalCount` and `totalCountLoading` props from Query Builder. Add `runQueryChildren` prop to Query Builder.
+  In order for users to add the desired functionality for the Run Query button, we added `runQueryChildren` prop.
+  `totalCount` and `totalCountLoading` are properties that should not be defined at the library level.
+  Instead they will be implemented in the consumer.
+- remove deprecation of `hideControls` propery.

--- a/.changeset/clean-kiwis-try.md
+++ b/.changeset/clean-kiwis-try.md
@@ -2,8 +2,8 @@
 '@toptal/picasso-query-builder': major
 ---
 
-- remove `totalCount` and `totalCountLoading` props from Query Builder. Add `runQueryChildren` prop to Query Builder.
-  In order to allow consumers to add the desired functionality for the Run Query button, we added `runQueryChildren` prop.
+- remove `totalCount` and `totalCountLoading` props from Query Builder. Add `runQueryButtonContent` prop to Query Builder.
+  In order to allow consumers to add the desired functionality for the Run Query button, we added `runQueryButtonContent` prop.
   `totalCount` and `totalCountLoading` are properties that should not be defined at the library level.
   Instead they will be implemented in the consumer.
 - remove deprecation of `hideControls` propery.

--- a/.changeset/clean-kiwis-try.md
+++ b/.changeset/clean-kiwis-try.md
@@ -3,7 +3,7 @@
 ---
 
 - remove `totalCount` and `totalCountLoading` props from Query Builder. Add `runQueryChildren` prop to Query Builder.
-  In order for users to add the desired functionality for the Run Query button, we added `runQueryChildren` prop.
+  In order to allow consumers to add the desired functionality for the Run Query button, we added `runQueryChildren` prop.
   `totalCount` and `totalCountLoading` are properties that should not be defined at the library level.
   Instead they will be implemented in the consumer.
 - remove deprecation of `hideControls` propery.

--- a/packages/picasso-query-builder/src/QueryBuilder/QueryBuilder.tsx
+++ b/packages/picasso-query-builder/src/QueryBuilder/QueryBuilder.tsx
@@ -63,8 +63,8 @@ type Props = {
   hideControls?: boolean
   /** Defines the possibility to enable, or not, drag-and-drop functionality. This possibility applies to rules and groups to rearrange it within QB. */
   enableDragAndDrop?: boolean
-  /** Defines custom Run Query button children that allows to change button text or display custom logic. */
-  runQueryChildren?: ReactNode
+  /** Defines custom Run Query button content that allows to change button text or display custom logic. */
+  runQueryButtonContent?: ReactNode
   /** Adds a customized footer at the bottom of the query builder. */
   footer?: React.ReactNode
   /** Adds a customized header at the top of the query builder. */
@@ -94,7 +94,7 @@ const QueryBuilder = ({
   enableDragAndDrop = false,
   resetOnFieldChange = true,
   padded = SPACING_6,
-  runQueryChildren,
+  runQueryButtonContent,
   onQueryReset,
   testIds,
 }: Props) => {
@@ -237,7 +237,7 @@ const QueryBuilder = ({
             <RunQueryButton
               onClick={handleSubmit}
               loading={loading}
-              children={runQueryChildren}
+              children={runQueryButtonContent}
               runQueryTestId={testIds?.runQueryButton}
             />
           </Container>

--- a/packages/picasso-query-builder/src/QueryBuilder/QueryBuilder.tsx
+++ b/packages/picasso-query-builder/src/QueryBuilder/QueryBuilder.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useState } from 'react'
-import type { ComponentType } from 'react'
+import type { ComponentType, ReactNode } from 'react'
 import { Container } from '@toptal/picasso-container'
 import { useNotifications } from '@toptal/picasso-notification'
 import type {
@@ -59,23 +59,18 @@ type Props = {
   loading?: boolean
   /** Defines padded layout. */
   padded?: SpacingType
-  /**
-   * @deprecated [CPT-2188] Controls will be defined at the consumer level
-   * Defines the possibility to display, or not, any of the controls. For example "Clear query" or "Run query" control.
-   */
+  /** Defines the possibility to display, or not, any of the controls. For example "Clear query" or "Run query" control. */
   hideControls?: boolean
   /** Defines the possibility to enable, or not, drag-and-drop functionality. This possibility applies to rules and groups to rearrange it within QB. */
   enableDragAndDrop?: boolean
+  /** Defines custom Run Query button children that allows to change button text or display custom logic. */
+  runQueryChildren?: ReactNode
   /** Adds a customized footer at the bottom of the query builder. */
   footer?: React.ReactNode
   /** Adds a customized header at the top of the query builder. */
   header?: React.ReactNode
   /** Defines the possibility to reset, or not, operator and value fields when the user changes the field selection for a rule. */
   resetOnFieldChange?: boolean
-  /** Defines the total number of results, usually used by other components that may need to know the total number of results. */
-  totalCount?: number
-  /** Defines the possibility to display a loading indicator or message to the user while the total count is being fetched. */
-  totalCountLoading?: boolean
   testIds?: TestId
 }
 
@@ -99,8 +94,7 @@ const QueryBuilder = ({
   enableDragAndDrop = false,
   resetOnFieldChange = true,
   padded = SPACING_6,
-  totalCount,
-  totalCountLoading,
+  runQueryChildren,
   onQueryReset,
   testIds,
 }: Props) => {
@@ -243,8 +237,7 @@ const QueryBuilder = ({
             <RunQueryButton
               onClick={handleSubmit}
               loading={loading}
-              totalCount={totalCount}
-              totalCountLoading={totalCountLoading}
+              children={runQueryChildren}
               runQueryTestId={testIds?.runQueryButton}
             />
           </Container>

--- a/packages/picasso-query-builder/src/QueryBuilder/story/CustomRunQueryButton.example.tsx
+++ b/packages/picasso-query-builder/src/QueryBuilder/story/CustomRunQueryButton.example.tsx
@@ -67,7 +67,7 @@ const Example = () => {
       fields={fields}
       query={query}
       onQueryChange={handleQueryChange}
-      runQueryChildren={
+      runQueryButtonContent={
         <>
           Custom Text{' '}
           {renderTotalCount({ totalCount: 15, totalCountLoading: false })}

--- a/packages/picasso-query-builder/src/QueryBuilder/story/CustomRunQueryButton.example.tsx
+++ b/packages/picasso-query-builder/src/QueryBuilder/story/CustomRunQueryButton.example.tsx
@@ -3,6 +3,8 @@ import {
   QueryBuilder,
   type RuleGroupTypeAny,
 } from '@toptal/picasso-query-builder'
+import { Container } from '@toptal/picasso-container'
+import { Loader } from '@toptal/picasso-loader'
 
 const initialQuery: RuleGroupTypeAny = {
   rules: [
@@ -42,12 +44,35 @@ const Example = () => {
     setQuery(newQuery)
   }
 
+  const renderTotalCount = ({
+    totalCountLoading,
+    totalCount,
+  }: {
+    totalCountLoading: boolean
+    totalCount: number
+  }) => {
+    if (totalCountLoading) {
+      return (
+        <Container left='small'>
+          <Loader size='small' variant='inherit' />
+        </Container>
+      )
+    }
+
+    return totalCount !== undefined && `(${totalCount})`
+  }
+
   return (
     <QueryBuilder
       fields={fields}
       query={query}
       onQueryChange={handleQueryChange}
-      totalCount={15}
+      runQueryChildren={
+        <>
+          Custom Text{' '}
+          {renderTotalCount({ totalCount: 15, totalCountLoading: false })}
+        </>
+      }
     />
   )
 }

--- a/packages/picasso-query-builder/src/QueryBuilder/story/index.jsx
+++ b/packages/picasso-query-builder/src/QueryBuilder/story/index.jsx
@@ -47,6 +47,11 @@ page
     title: 'Custom Padding',
   })
 
+  .addExample('QueryBuilder/story/CustomRunQueryButton.example.tsx', {
+    title: 'Custom Run Query Button',
+    description: 'Example of Customized children for Run query button',
+  })
+
   .addExample('QueryBuilder/story/FieldDescription.example.tsx', {
     title: 'Field Description',
     description: `Hover over 'First  name' field in the field selector dropdown to display field description in a tooltip`,
@@ -69,12 +74,6 @@ page
 
   .addExample('QueryBuilder/story/CustomOperators.example.tsx', {
     title: 'Custom Operators',
-    takeScreenshot: false,
-  })
-
-  .addExample('QueryBuilder/story/TotalCount.example.tsx', {
-    title: 'Total Count',
-    description: 'Total count is set to 15',
     takeScreenshot: false,
   })
 

--- a/packages/picasso-query-builder/src/RunQueryButton/RunQueryButton.tsx
+++ b/packages/picasso-query-builder/src/RunQueryButton/RunQueryButton.tsx
@@ -1,7 +1,6 @@
+import type { ReactNode } from 'react'
 import React from 'react'
 import { Button } from '@toptal/picasso-button'
-import { Container } from '@toptal/picasso-container'
-import { Loader } from '@toptal/picasso-loader'
 import { makeStyles } from '@material-ui/core/styles'
 
 import styles from './styles'
@@ -10,8 +9,7 @@ import type { TestId } from '../types/query-builder'
 type Props = {
   loading?: boolean
   onClick?: () => void
-  totalCount?: number
-  totalCountLoading?: boolean
+  children?: ReactNode
   runQueryTestId: TestId['runQueryButton']
 }
 
@@ -20,23 +18,10 @@ const useStyles = makeStyles(styles)
 export const RunQueryButton = ({
   loading,
   onClick,
-  totalCount,
-  totalCountLoading,
+  children = 'Run Query',
   runQueryTestId,
 }: Props) => {
   const classes = useStyles()
-
-  const renderTotalCount = () => {
-    if (totalCountLoading) {
-      return (
-        <Container left='small'>
-          <Loader size='small' variant='inherit' />
-        </Container>
-      )
-    }
-
-    return totalCount !== undefined && `(${totalCount})`
-  }
 
   return (
     <Button
@@ -46,7 +31,7 @@ export const RunQueryButton = ({
       onClick={onClick}
       data-testid={runQueryTestId}
     >
-      Run Query {renderTotalCount()}
+      {children}
     </Button>
   )
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6239,17 +6239,17 @@
     "@types/node" "*"
     form-data "^3.0.0"
 
-"@types/node@*", "@types/node@20.4.7":
-  version "20.4.7"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.4.7.tgz#74d323a93f1391a63477b27b9aec56669c98b2ab"
-  integrity sha512-bUBrPjEry2QUTsnuEjzjbS7voGWCc30W0qzgMf90GPeDGFRakvrz47ju+oqDAKCXLUCe39u57/ORMl/O/04/9g==
-
-"@types/node@>=20.12.5":
+"@types/node@*", "@types/node@>=20.12.5":
   version "20.12.7"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-20.12.7.tgz#04080362fa3dd6c5822061aa3124f5c152cff384"
   integrity sha512-wq0cICSkRLVaf3UGLMGItu/PtdY7oaXaI/RVU+xliKVOtRna3PRY57ZDfztpDL0n11vfymMUnXv8QwYCO7L1wg==
   dependencies:
     undici-types "~5.26.4"
+
+"@types/node@20.4.7":
+  version "20.4.7"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-20.4.7.tgz#74d323a93f1391a63477b27b9aec56669c98b2ab"
+  integrity sha512-bUBrPjEry2QUTsnuEjzjbS7voGWCc30W0qzgMf90GPeDGFRakvrz47ju+oqDAKCXLUCe39u57/ORMl/O/04/9g==
 
 "@types/node@^12.7.1":
   version "12.20.37"

--- a/yarn.lock
+++ b/yarn.lock
@@ -15967,14 +15967,14 @@ json-stringify-safe@^5.0.1, json-stringify-safe@~5.0.1:
   resolved "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
   integrity sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==
 
-json5@1, json5@^1.0.1, json5@^1.0.2, json5@^2.1.1:
+json5@1, json5@^1.0.1, json5@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/json5/-/json5-1.0.2.tgz#63d98d60f21b313b77c4d6da18bfa69d80e1d593"
   integrity sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==
   dependencies:
     minimist "^1.2.0"
 
-json5@2.2.3, json5@^2.1.0, json5@^2.1.2, json5@^2.2.0, json5@^2.2.2, json5@^2.2.3, json5@^2.x:
+json5@2.2.3, json5@^2.1.0, json5@^2.1.1, json5@^2.1.2, json5@^2.2.0, json5@^2.2.2, json5@^2.2.3, json5@^2.x:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.3.tgz#78cd6f1a19bdc12b73db5ad0c61efd66c1e29283"
   integrity sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==


### PR DESCRIPTION
[CPT-2187](https://toptal-core.atlassian.net/browse/CPT-2187)

### Description

In this PR we added new property in order to provide desired text/functionality to Run Query button. Considering that `totalCount` and `totalCountLoading` props are something custom that should not be defined on the level of library we removed these props from Query Builder.
Also we removed deprecation of `hideControls` property that was introduced before. There was a misalignment and at the moment we are not planning to move controls to consumers because Run Query and Clear Query it is something common. Instead not showing these controls it is an edge case which is handled by `hideControls`.
 
### How to test

<!-- The temploy link will be automatically updated when the temploy is deployed -->
- [Temploy](https://picasso.toptal.net/CPT-2187-allow-qb-controls-customization-from-consumers)
- Check Custom Run Query Button story
### Screenshots

| After.                                  |
 | --------------------------------------- |
 | ![Screenshot from 2024-04-25 10-53-34](https://github.com/toptal/picasso/assets/112090359/a8df6c2b-9b9b-4f5b-88f1-3741e8d2f80e) |

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests ([visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md) included)

**Breaking change**

- n/a codemod is created and showcased in the changeset
- [x] test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[CPT-2187]: https://toptal-core.atlassian.net/browse/CPT-2187?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ