### PR TITLE
[FX-NULL] Add guide on running visual tests locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,39 @@ Changes in dev dependencies, component HTML structure, or visual changes are not
 
 In order to run storybook you need to execute `yarn start` which will spin up storybook server on <http://localhost:9001>.
 
+## Running visual tests locally
+
+### Run Happo locally for Storybook
+
+1. Go to https://happo.io/a/675/account (`toptal-picasso` account)
+2. Set environment variable `HAPPO_API_KEY` same as API key (`export HAPPO_API_KEY=...` in Unix)
+3. Set environment variable `HAPPO_API_SECRET` same as API secret (`export HAPPO_API_SECRET=...` in Unix)
+4. Run `yarn happo (run|debug|compare|…)` depending on you goals
+
+
+For example, in order to compare two commits (`abc123` and `def456`), follow the steps below
+1. Generate report for `abc123` commit via `yarn happo run abc123` and get link to the report (something like https://happo.io/a/675/p/1189/report/abc123)
+2. Generate report for `def456` commit via `yarn happo run def456` and get link to the report (something like https://happo.io/a/675/p/1189/report/def456)
+3. Compare commits via `yarn happo compare abc123 def456` and get link to the comparison result (something like https://happo.io/a/675/p/1189/compare/abc123/def456)
+
+
+### Run Happo locally for Cypress
+1. Go to https://happo.io/a/675/account (`toptal-picasso` account)
+2. Set environment variable `HAPPO_API_KEY` same as API key (export HAPPO_API_KEY=... in Unix)
+3. Set environment variable `HAPPO_API_SECRET` same as API secret (`export HAPPO_API_SECRET=...` in Unix)
+4. Set environment variable `HAPPO_PROJECT` to match Cypress project (`export HAPPO_PROJECT=Picasso/Cypress` in Unix)
+5. Set environment variable `HAPPO_PREVIOUS_SHA`, it should be the sha of the last `master` commit that passed Happo (Picasso/Cypress) check ([documentation for environment variable](https://docs.happo.io/docs/cypress#continuous-integration))
+6. Set environment variable `HAPPO_CURRENT_SHA`, it should be [the sha of the commit](https://github.com/toptal/picasso/commits/master/) that is compared to `master` ([documentation for environment variable](https://docs.happo.io/docs/cypress#continuous-integration))
+7. Run `yarn test:integration:ci` and get link to the comparison result, something like
+
+
+```bash
+yarn test:integration:ci
+...
+[HAPPO] https://happo.io/a/675/jobs/1104613
+✨  Done in 378.45s.
+```
+
 ## Project commands
 
 | Command                     | Description                                                                         |
@@ -52,6 +85,7 @@ In order to run storybook you need to execute `yarn start` which will spin up st
 | **test**                    | Run jest and cypress tests                                                          |
 | **test:integration**        | Run cypress tests                                                                   |
 | **test:integration:open**   | Run cypress in development mode                                                     |
+| **test:integration:ci**     | Run cypress in CI mode and run cypress visual tests                                 |
 | **test:unit**               | Run unit tests                                                                      |
 | **test:unit -u**            | Update jest snapshots                                                               |
 | **test:unit:watch**         | Run unit tests in watch mode                                                        |


### PR DESCRIPTION
No Jira ticket.

### Description

This pull request adds guide on running visual tests locally (in fact moves it from https://toptal-core.slack.com/archives/GG3F4AS4T/p1712657917104799 to Picasso `README` file).

### How to test

<!-- The temploy link will be automatically updated when the temploy is deployed -->
- Check out the https://github.com/toptal/picasso/tree/FX-NULL-update-readme-dsfdksf0?tab=readme-ov-file#running-visual-tests-locally

### Development checks

- [N/A] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [N/A] Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [N/A] Annotate all `props` in component with documentation
- [N/A] Create `examples` for component
- [N/A] Ensure that deployed demo has expected results and good examples
- [N/A] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [N/A] Covered with tests ([visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md) included)
- [ ] ⚠️ Update pinned message

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>
