### PR TITLE
[FX-5195] Fix button css precedence

### DIFF
--- a/.changeset/brave-mirrors-obey.md
+++ b/.changeset/brave-mirrors-obey.md
@@ -1,0 +1,7 @@
+---
+'@toptal/picasso-button': patch
+---
+
+### Button
+
+- fix dependency on picasso-link being elicited or tree-shaken

--- a/packages/base/Button/src/Button/Button.tsx
+++ b/packages/base/Button/src/Button/Button.tsx
@@ -17,9 +17,12 @@ import { Container } from '@toptal/picasso-container'
 import { noop, toTitleCase } from '@toptal/picasso-utils'
 // we need to ensure the correct order of styles import
 // @TODO: to be removed when the component is migrated in FX-4614
-import '@toptal/picasso-link'
+import { Link } from '@toptal/picasso-link'
 
 import styles from './styles'
+
+// HACK: This statement is only used to prevent webpack from tree shaking the import
+void Link
 
 const useStyles = makeStyles<Theme, Props>(styles, {
   name: 'PicassoButton',

--- a/packages/base/Button/src/Button/Button.tsx
+++ b/packages/base/Button/src/Button/Button.tsx
@@ -16,7 +16,7 @@ import { Loader } from '@toptal/picasso-loader'
 import { Container } from '@toptal/picasso-container'
 import { noop, toTitleCase } from '@toptal/picasso-utils'
 // we need to ensure the correct order of styles import
-// @TODO: to be removed when the component is migrated in FX-4614
+// TODO: [FX-4614] To be removed when Link component is migrated to tailwind
 import { Link } from '@toptal/picasso-link'
 
 import styles from './styles'


### PR DESCRIPTION
[FX-5195]

### Description

Drop `index` of `Button` styles, to force it to the end of `<head>` (higher precedence), button variants still need a even lower index, to have priority over base `Button`

### How to test

<!-- The temploy link will be automatically updated when the temploy is deployed -->
- [Temploy](https://picasso.toptal.net/FX-5195-fix-button-css-precedence)
- [PR on SP](https://github.com/toptal/staff-portal/pull/12641) should have buttons as before (without [blue coloring](https://github.com/toptal/staff-portal/pull/12540#pullrequestreview-2032922124))

### Screenshots

No screenshots

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests ([visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md) included)

**Breaking change**

- [x] codemod is created and showcased in the changeset
- [x] test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-5195]: https://toptal-core.atlassian.net/browse/FX-5195?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ