### PR TITLE
[FX-5185] Use twMerge in Typography

### DIFF
--- a/.changeset/thin-jeans-mix.md
+++ b/.changeset/thin-jeans-mix.md
@@ -1,0 +1,5 @@
+---
+'@toptal/picasso-typography': patch
+---
+
+- replace `classnames` with `twMerge`

--- a/packages/base/FileInput/src/FileList/__snapshots__/test.tsx.snap
+++ b/packages/base/FileInput/src/FileList/__snapshots__/test.tsx.snap
@@ -38,7 +38,7 @@ exports[`FileList renders 1`] = `
             </p>
           </div>
           <p
-            class="m-0 text-xxs text-red font-regular !leading-4"
+            class="m-0 text-xxs text-red font-regular leading-4"
           />
         </div>
       </div>

--- a/packages/base/FileInput/src/FileListItem/FileListItem.tsx
+++ b/packages/base/FileInput/src/FileListItem/FileListItem.tsx
@@ -83,7 +83,7 @@ const FileListItem = ({ file, index, disabled, onRemove, testIds }: Props) => {
           </TypographyOverflow>
         </Container>
         <Typography
-          className='!leading-4'
+          className='leading-4'
           variant='body'
           size='xsmall'
           color='red'

--- a/packages/base/FileInput/src/FileListItem/__snapshots__/test.tsx.snap
+++ b/packages/base/FileInput/src/FileListItem/__snapshots__/test.tsx.snap
@@ -35,7 +35,7 @@ exports[`FileListItem renders 1`] = `
           </p>
         </div>
         <p
-          class="m-0 text-xxs text-red font-regular !leading-4"
+          class="m-0 text-xxs text-red font-regular leading-4"
         />
       </div>
       <button

--- a/packages/base/Form/src/FieldRequirements/FieldRequirementItem.tsx
+++ b/packages/base/Form/src/FieldRequirements/FieldRequirementItem.tsx
@@ -49,7 +49,7 @@ const FieldRequirementItem = ({ children, status, testIds }: Props) => {
       data-testid={testIds?.root}
     >
       <IconComponent color={colorMap[status]} data-testid={iconTestId} />
-      <Typography color={colorMap[status]} className='!ml-[8px]' size='xxsmall'>
+      <Typography color={colorMap[status]} className='ml-[8px]' size='xxsmall'>
         {children}
       </Typography>
     </Grid.Item>

--- a/packages/base/Form/src/FieldRequirements/FieldRequirements.tsx
+++ b/packages/base/Form/src/FieldRequirements/FieldRequirements.tsx
@@ -54,7 +54,7 @@ export const FieldRequirements = <TValueType,>({
           data-testid={testIds?.description}
           variant='body'
           size='xxsmall'
-          className='!mt-[0.4rem]'
+          className='mt-[0.4rem]'
         >
           {description}
         </Typography>

--- a/packages/base/Section/src/Section/Section.tsx
+++ b/packages/base/Section/src/Section/Section.tsx
@@ -73,7 +73,7 @@ export const Section = forwardRef<HTMLDivElement, Props>(function Section(
     title ? (
       <Typography
         as={isString(title) ? undefined : 'div'}
-        className='!mr-4 min-w-0'
+        className='mr-4 min-w-0'
         data-testid={testIds?.title}
         variant='heading'
         size={titleSize}

--- a/packages/base/Section/src/Section/__snapshots__/test.tsx.snap
+++ b/packages/base/Section/src/Section/__snapshots__/test.tsx.snap
@@ -125,7 +125,7 @@ exports[`Section renders with title, subtitle, actions and content 1`] = `
         data-testid="header"
       >
         <h3
-          class="m-0 text-lg text-black font-semibold !mr-4 min-w"
+          class="m-0 text-lg text-black font-semibold mr-4 min-w"
           data-testid="title"
         >
           Title

--- a/packages/base/Tabs/src/TabDescription/TabDescription.tsx
+++ b/packages/base/Tabs/src/TabDescription/TabDescription.tsx
@@ -11,7 +11,7 @@ const TabDescription = ({ children, disabled }: Props) => {
 
   return (
     <TypographyOverflow
-      className='!mt-[2px]'
+      className='mt-[2px]'
       size='xxsmall'
       inline
       color={color}

--- a/packages/base/Tag/src/Tag/__snapshots__/test.tsx.snap
+++ b/packages/base/Tag/src/Tag/__snapshots__/test.tsx.snap
@@ -104,7 +104,7 @@ exports[`Tag renders with adornment 1`] = `
           foobar
         </span>
         <span
-          class="m-0 text-xxs text-inherit font-regular inline-flex items-center gap-[5px] text-gray group-aria-disabled:text-gray"
+          class="m-0 text-xxs font-regular inline-flex items-center gap-[5px] text-gray group-aria-disabled:text-gray"
         >
           <svg
             class="PicassoSvgLink16-root"
@@ -150,7 +150,7 @@ exports[`Tag renders with connection and icon 1`] = `
           foobar
         </span>
         <span
-          class="m-0 text-xxs text-inherit font-regular inline-flex items-center gap-[5px] text-gray group-aria-disabled:text-gray"
+          class="m-0 text-xxs font-regular inline-flex items-center gap-[5px] text-gray group-aria-disabled:text-gray"
         >
           <svg
             class="PicassoSvgLink16-root"

--- a/packages/base/Tag/src/TagRectangular/__snapshots__/test.tsx.snap
+++ b/packages/base/Tag/src/TagRectangular/__snapshots__/test.tsx.snap
@@ -9,7 +9,7 @@ exports[`TagRectangular renders rectangular Tag 1`] = `
       class="text-lg transition-none rounded-sm font-semibold h-4 inline-flex content-center justify-center align-middle bg-gray"
     >
       <p
-        class="m-0 text-2xs text-graphite font-semibold whitespace-nowrap overflow-ellipsis overflow-hidden mx-1 w-max text-graphite"
+        class="m-0 text-2xs font-semibold whitespace-nowrap overflow-ellipsis overflow-hidden mx-1 w-max text-graphite"
       >
         Reactangular Tag
       </p>

--- a/packages/base/Timeline/src/Timeline/__snapshots__/test.tsx.snap
+++ b/packages/base/Timeline/src/Timeline/__snapshots__/test.tsx.snap
@@ -137,7 +137,7 @@ exports[`Timeline renders with dates 1`] = `
               class="PicassoContainer-rightlargeMargin PicassoTimelineRow-date"
             >
               <p
-                class="m-0 text-md text-graphite font-semibold !leading-6"
+                class="m-0 text-md text-graphite font-semibold leading-6"
               >
                 25.06.2021
               </p>
@@ -178,7 +178,7 @@ exports[`Timeline renders with dates 1`] = `
               class="PicassoContainer-rightlargeMargin PicassoTimelineRow-date"
             >
               <p
-                class="m-0 text-md text-graphite font-semibold !leading-6"
+                class="m-0 text-md text-graphite font-semibold leading-6"
               >
                 25.06.2022
               </p>
@@ -219,7 +219,7 @@ exports[`Timeline renders with dates 1`] = `
               class="PicassoContainer-rightlargeMargin PicassoTimelineRow-date"
             >
               <p
-                class="m-0 text-md text-graphite font-semibold !leading-6"
+                class="m-0 text-md text-graphite font-semibold leading-6"
               >
                 25.06.2023
               </p>

--- a/packages/base/Timeline/src/TimelineRow/TimelineRow.tsx
+++ b/packages/base/Timeline/src/TimelineRow/TimelineRow.tsx
@@ -75,7 +75,7 @@ const TimelineRow = ({
           style={{ whiteSpace: 'nowrap' }}
         >
           <Container className={classes.date} right='large'>
-            <Typography className='!leading-6' weight='semibold' size='medium'>
+            <Typography className='leading-6' weight='semibold' size='medium'>
               {date}
             </Typography>
           </Container>

--- a/packages/base/Typography/package.json
+++ b/packages/base/Typography/package.json
@@ -33,6 +33,7 @@
   "peerDependencies": {
     "@material-ui/core": "4.12.4",
     "@toptal/picasso-provider": "*",
+    "@toptal/picasso-tailwind-merge": "^1.0.0",
     "tailwindcss": ">=3",
     "react": ">=16.12.0 < 19.0.0"
   },

--- a/packages/base/Typography/src/Typography/Typography.tsx
+++ b/packages/base/Typography/src/Typography/Typography.tsx
@@ -1,6 +1,5 @@
 import type { ReactNode, HTMLAttributes, ElementType } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
 import type {
   StandardProps,
   ColorType,
@@ -8,6 +7,7 @@ import type {
   SizeType,
 } from '@toptal/picasso-shared'
 import { toTitleCase } from '@toptal/picasso-utils'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 
 import variantToElement from './utils/variant-to-element'
 
@@ -191,7 +191,7 @@ export const Typography = forwardRef<HTMLElement, Props>(function Typography(
   return (
     <Component
       ref={ref}
-      className={cx(
+      className={twMerge(
         'm-0',
         VARIANT_SIZE[variant][size],
         getColor(),

--- a/packages/base/Typography/tsconfig.json
+++ b/packages/base/Typography/tsconfig.json
@@ -2,5 +2,9 @@
   "extends": "../../../tsconfig.base.json",
   "compilerOptions": { "outDir": "dist-package" },
   "include": ["src"],
-  "references": [{ "path": "../../picasso-provider" }, { "path": "../Utils" }]
+  "references": [
+    { "path": "../../picasso-provider" },
+    { "path": "../../picasso-tailwind-merge" },
+    { "path": "../Utils" }
+  ]
 }

--- a/packages/base/UserBadge/src/UserBadge/UserBadge.tsx
+++ b/packages/base/UserBadge/src/UserBadge/UserBadge.tsx
@@ -86,7 +86,7 @@ export const UserBadge = forwardRef<HTMLDivElement, Props>(function UserBadge(
     userTitle = renderTitle ? (
       renderTitle(title, invert)
     ) : (
-      <Typography inline invert={invert} className='!ml-[7px]' size='medium'>
+      <Typography inline invert={invert} className='ml-[7px]' size='medium'>
         {title}
       </Typography>
     )


### PR DESCRIPTION
[FX-5185]

### Description

Replace `classnames` with `twMerge` in `Typography`.

### How to test

<!-- The temploy link will be automatically updated when the temploy is deployed -->
- [Temploy](https://picasso.toptal.net/fx-5185-use-twmerge-in-typography)
- FIXME: Add the steps describing how to verify your changes

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests ([visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md) included)

**Breaking change**

- [x] ~codemod is created and showcased in the changeset~
- [x] ~test alpha package of Picasso in StaffPortal~

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-5185]: https://toptal-core.atlassian.net/browse/FX-5185?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ