### PR TITLE
[FX-5306] Configure twMerge

### DIFF
--- a/.changeset/brown-starfishes-sneeze.md
+++ b/.changeset/brown-starfishes-sneeze.md
@@ -1,0 +1,5 @@
+---
+'@toptal/picasso-tailwind-merge': patch
+---
+
+- initial release

--- a/.changeset/odd-ads-give.md
+++ b/.changeset/odd-ads-give.md
@@ -1,0 +1,5 @@
+---
+'@toptal/picasso-tailwind': patch
+---
+
+- add index.d.ts

--- a/.changeset/red-brooms-rush.md
+++ b/.changeset/red-brooms-rush.md
@@ -1,0 +1,5 @@
+---
+'@toptal/picasso': patch
+---
+
+- mention `Merging classes` tutorial in README.md

--- a/.storybook/components/CodeExample/CodeExample.tsx
+++ b/.storybook/components/CodeExample/CodeExample.tsx
@@ -134,6 +134,8 @@ const imports: Record<string, object> = {
   '@toptal/picasso-typography-overflow': require('@toptal/picasso-typography-overflow'),
   '@toptal/picasso-user-badge': require('@toptal/picasso-user-badge'),
   '@toptal/picasso-utils': require('@toptal/picasso-utils'),
+  '@toptal/picasso-tailwind': require('@toptal/picasso-tailwind'),
+  '@toptal/picasso-tailwind-merge': require('@toptal/picasso-tailwind-merge'),
 }
 
 const resolver = (path: string) => imports[path]

--- a/.storybook/stories/tutorials/merging-classes/story/index.jsx
+++ b/.storybook/stories/tutorials/merging-classes/story/index.jsx
@@ -9,7 +9,7 @@ mergingClassesPage.createChapter().addTextSection(
   // prettier-ignore
   '## picasso-tailwind-merge\n' +
 
-    '`picasso-tailwind-merge` is a package with tools that should be used for merging and joining classes.\n' +
+    '`@toptal/picasso-tailwind-merge` is a package with tools that should be used for merging and joining classes.\n' +
     
     '\n' +
 
@@ -20,15 +20,19 @@ mergingClassesPage.createChapter().addTextSection(
   '## twMerge\n' +
 
     '`twMerge` can correctly merge classes from TailwindCSS default theme. ' +
-    'However Picasso is using extended theme. That is why `twMerge` from `picasso-tailwind-merge`' +
+    'However Picasso is using extended theme. That is why `twMerge` from `@toptal/picasso-tailwind-merge`' +
     'should be used instead of `twMerge` from `tailwind-merge` package.\n' + 
 
     '\n'+
   
-    'Just import `twMerge` from `picasso-tailwind-merge` and use it as regular `twMerge`.' + 
+    'Just import `twMerge` from `@toptal/picasso-tailwind-merge` and use it as regular `twMerge`.' + 
     'No additional configurations required.\n' + 
+
+    `\n` +
+
+    'Documentation for original `twMerge` placed [here](https://github.com/dcastil/tailwind-merge/blob/v2.3.0/docs/README.md).\n' +
 
   '## twJoin\n' +
 
-    '`twJoin` is also included in `picasso-tailwind-merge`.'
+    '`twJoin` is also included in `@toptal/picasso-tailwind-merge`.'
 )

--- a/.storybook/stories/tutorials/merging-classes/story/index.jsx
+++ b/.storybook/stories/tutorials/merging-classes/story/index.jsx
@@ -1,0 +1,34 @@
+import PicassoBook from '~/.storybook/components/PicassoBook'
+
+const mergingClassesPage = PicassoBook.section('Tutorials').createPage(
+  'Merging classes',
+  'How to merge classes with respect of Picasso TailwindCSS theme'
+)
+
+mergingClassesPage.createChapter().addTextSection(
+  // prettier-ignore
+  '## picasso-tailwind-merge\n' +
+
+    '`picasso-tailwind-merge` is a package with tools that should be used for merging and joining classes.\n' +
+    
+    '\n' +
+
+    'It contains:\n' +  
+      '* `twMerge`\n' +
+      '* `twJoin`\n' + 
+
+  '## twMerge\n' +
+
+    '`twMerge` can correctly merge classes from TailwindCSS default theme. ' +
+    'However Picasso is using extended theme. That is why `twMerge` from `picasso-tailwind-merge`' +
+    'should be used instead of `twMerge` from `tailwind-merge` package.\n' + 
+
+    '\n'+
+  
+    'Just import `twMerge` from `picasso-tailwind-merge` and use it as regular `twMerge`.' + 
+    'No additional configurations required.\n' + 
+
+  '## twJoin\n' +
+
+    '`twJoin` is also included in `picasso-tailwind-merge`.'
+)

--- a/.storybook/stories/tutorials/merging-classes/story/index.jsx
+++ b/.storybook/stories/tutorials/merging-classes/story/index.jsx
@@ -5,34 +5,25 @@ const mergingClassesPage = PicassoBook.section('Tutorials').createPage(
   'How to merge classes with respect of Picasso TailwindCSS theme'
 )
 
-mergingClassesPage.createChapter().addTextSection(
-  // prettier-ignore
-  '## picasso-tailwind-merge\n' +
+mergingClassesPage.createChapter().addTextSection(`
+## picasso-tailwind-merge
 
-    '`@toptal/picasso-tailwind-merge` is a package with tools that should be used for merging and joining classes.\n' +
-    
-    '\n' +
+\`@toptal/picasso-tailwind-merge\` is a package with tools that should be used for merging and joining classes
 
-    'It contains:\n' +  
-      '* `twMerge`\n' +
-      '* `twJoin`\n' + 
+It contains:  
+* \`twMerge\`
+* \`twJoin\` 
+## twMerge
 
-  '## twMerge\n' +
+\`twMerge\` can correctly merge classes from TailwindCSS default theme. 
+However Picasso is using extended theme. That is why \`twMerge\` from \`@toptal/picasso-tailwind-merge\`
+should be used instead of \`twMerge\` from \`tailwind-merge\` package
+Just import \`twMerge\` from \`@toptal/picasso-tailwind-merge\` and use it as regular \`twMerge\`. 
+No additional configurations required.
 
-    '`twMerge` can correctly merge classes from TailwindCSS default theme. ' +
-    'However Picasso is using extended theme. That is why `twMerge` from `@toptal/picasso-tailwind-merge`' +
-    'should be used instead of `twMerge` from `tailwind-merge` package.\n' + 
+Documentation for original \`twMerge\` placed [here](https://github.com/dcastil/tailwind-merge/blob/v2.3.0/docs/README.md).
 
-    '\n'+
-  
-    'Just import `twMerge` from `@toptal/picasso-tailwind-merge` and use it as regular `twMerge`.' + 
-    'No additional configurations required.\n' + 
+## twJoin
 
-    `\n` +
-
-    'Documentation for original `twMerge` placed [here](https://github.com/dcastil/tailwind-merge/blob/v2.3.0/docs/README.md).\n' +
-
-  '## twJoin\n' +
-
-    '`twJoin` is also included in `@toptal/picasso-tailwind-merge`.'
-)
+\`twJoin\` is also included in \`@toptal/picasso-tailwind-merge\`.
+`)

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,7 @@ COPY --chown=node:node packages/picasso-pictograms/package.json ./packages/picas
 COPY --chown=node:node packages/picasso-rich-text-editor/package.json ./packages/picasso-rich-text-editor/package.json
 COPY --chown=node:node packages/picasso-query-builder/package.json ./packages/picasso-query-builder/package.json
 COPY --chown=node:node packages/picasso-tailwind/package.json ./packages/picasso-tailwind/package.json
+COPY --chown=node:node packages/picasso-tailwind-merge/package.json ./packages/picasso-tailwind-merge/package.json
 COPY --chown=node:node packages/base/Accordion/package.json ./packages/base/Accordion/package.json
 COPY --chown=node:node packages/base/AccountSelect/package.json ./packages/base/AccountSelect/package.json
 COPY --chown=node:node packages/base/Alert/package.json ./packages/base/Alert/package.json

--- a/packages/picasso-tailwind-merge/package.json
+++ b/packages/picasso-tailwind-merge/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "@toptal/picasso-tailwind-merge",
+  "version": "1.0.0",
+  "description": "Tailwind merge configured for Picasso theme",
+  "publishConfig": {
+    "access": "public"
+  },
+  "main": "./dist-package/src/index.js",
+  "module": "./dist-package/src/index.js",
+  "scripts": {
+    "build:package": "tsc -b tsconfig.json",
+    "prepublishOnly": "yarn build:package"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/toptal/picasso.git"
+  },
+  "author": "Toptal",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/toptal/picasso/issues"
+  },
+  "homepage": "https://github.com/toptal/picasso/tree/master/packages/picasso#readme",
+  "dependencies": {
+    "@toptal/picasso-utils": "1.0.3",
+    "tailwind-merge": "^2.2.2",
+    "react-transition-group": "^4.4.5"
+  },
+  "sideEffects": false,
+  "peerDependencies": {
+    "@toptal/picasso-tailwind": ">=2.6.0",
+    "react": ">=16.12.0 < 19.0.0"
+  },
+  "exports": {
+    ".": "./dist-package/src/index.js"
+  },
+  "devDependencies": {
+    "@toptal/picasso-test-utils": "1.1.1"
+  },
+  "files": [
+    "dist-package/**",
+    "!dist-package/tsconfig.tsbuildinfo",
+    "src"
+  ]
+}

--- a/packages/picasso-tailwind-merge/src/index.ts
+++ b/packages/picasso-tailwind-merge/src/index.ts
@@ -1,0 +1,1 @@
+export * from './twMerge'

--- a/packages/picasso-tailwind-merge/src/test.ts
+++ b/packages/picasso-tailwind-merge/src/test.ts
@@ -1,0 +1,9 @@
+import { twMerge } from './twMerge'
+
+describe('twMerge', () => {
+  it('merges font size classes correctly', () => {
+    expect(twMerge('font-inherit-size text-button-large text-2xs')).toBe(
+      'text-2xs'
+    )
+  })
+})

--- a/packages/picasso-tailwind-merge/src/twMerge.ts
+++ b/packages/picasso-tailwind-merge/src/twMerge.ts
@@ -1,0 +1,15 @@
+import { extendTailwindMerge, twJoin } from 'tailwind-merge'
+import { theme } from '@toptal/picasso-tailwind'
+
+export const twMerge = extendTailwindMerge({
+  extend: {
+    classGroups: {
+      'font-size': [
+        ...Object.keys(theme.fontSize).map(key => `text-${key}`),
+        'font-inherit-size',
+      ],
+    },
+  },
+})
+
+export { twJoin }

--- a/packages/picasso-tailwind-merge/tsconfig.json
+++ b/packages/picasso-tailwind-merge/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": { "outDir": "dist-package" },
+  "include": ["src"],
+  "references": [{ "path": "../base/Utils" }, { "path": "../picasso-tailwind" }]
+}

--- a/packages/picasso-tailwind/src/index.d.ts
+++ b/packages/picasso-tailwind/src/index.d.ts
@@ -1,1 +1,5 @@
-export const theme: Record<string, string | string[]>
+export const theme: Partial<
+  CustomThemeConfig & {
+    extend: Partial<CustomThemeConfig>
+  }
+>

--- a/packages/picasso-tailwind/src/index.d.ts
+++ b/packages/picasso-tailwind/src/index.d.ts
@@ -1,0 +1,1 @@
+export const theme: Record<string, string | string[]>

--- a/packages/picasso/README.md
+++ b/packages/picasso/README.md
@@ -110,6 +110,10 @@ render () {
 
 **_A [`Picasso`](/?path=/story/components-picasso--picasso) component rendered at root level is required for the library theme configuration and theme to work properly._**
 
+## Merging classes
+
+When working with TailwindCSS merging classes is vital. Read our [Merging classes](?path=/story/tutorials-merging-classes--merging-classes) tutorial to make it right.
+
 ## Documentation
 
 Documentation and demos are available at [picasso.toptal.net](https://picasso.toptal.net/).

--- a/tsconfig.pkgsrc.json
+++ b/tsconfig.pkgsrc.json
@@ -11,6 +11,7 @@
     { "path": "packages/picasso-query-builder" },
     { "path": "packages/picasso-rich-text-editor" },
     { "path": "packages/picasso-tailwind" },
+    { "path": "packages/picasso-tailwind-merge" },
     { "path": "packages/shared" },
     { "path": "packages/topkit-analytics-charts" },
     { "path": "packages/base/Accordion" },


### PR DESCRIPTION
[FX-5306]

### Description

Add new package `picasso-tailwind-merge` that exports configured `twMerge` that works correctly with the Picasso TailwindCSS theme.

The basic configurations were done. In the future, we should extend the theme when we add new custom classes or discover that some classes are not merged correctly. 

### How to test

1. Go to `packages/base/Typography/src/Typography/Typography.tsx`.
2. Import `twMerge` from `@toptal/picasso-tailwind-merge`.
3. On line 194 replace `cx` with `twMerge`.
4. Run Storybook.
5. Check if example normal text example has `font-inherit-size` class. If it is, then it works. 

check the [new documentation](https://picasso.toptal.net/fx-5306-configure-twmerge/?path=/story/tutorials-merging-classes--merging-classes)

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests ([visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md) included)

**Breaking change**

- [x] ~codemod is created and showcased in the changeset~
- [x] ~test alpha package of Picasso in StaffPortal~

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
7. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-5306]: https://toptal-core.atlassian.net/browse/FX-5306?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ