### PR TITLE
Update link line-height

### DIFF
--- a/.changeset/smooth-frogs-stare.md
+++ b/.changeset/smooth-frogs-stare.md
@@ -1,0 +1,7 @@
+---
+'@toptal/picasso-link': patch
+---
+
+### Link
+
+- update line-height to match the previous MUI implementation

--- a/packages/base/AccountSelect/src/AccountSelect/__snapshots__/test.tsx.snap
+++ b/packages/base/AccountSelect/src/AccountSelect/__snapshots__/test.tsx.snap
@@ -26,7 +26,7 @@ exports[`AccountSelect renders 1`] = `
               class="PicassoContainer-centerAlignItems PicassoContainer-flex"
             >
               <a
-                class="m-0 font-inherit leading-[1.5em] font-inherit focus:outline-none hover:underline text-blue visited:text-purple no-underline !no-underline PicassoAccountSelect-accountLink"
+                class="m-0 font-inherit font-inherit focus:outline-none hover:underline leading-[inherit] text-blue visited:text-purple no-underline !no-underline PicassoAccountSelect-accountLink"
               >
                 <div
                   class="PicassoContainer-mediumPadding PicassoContainer-centerAlignItems PicassoContainer-spaceBetweenJustifyContent PicassoContainer-flex"
@@ -97,7 +97,7 @@ exports[`AccountSelect renders 1`] = `
               class="PicassoContainer-centerAlignItems PicassoContainer-flex"
             >
               <a
-                class="m-0 font-inherit leading-[1.5em] font-inherit focus:outline-none hover:underline text-blue visited:text-purple no-underline !no-underline PicassoAccountSelect-accountLink"
+                class="m-0 font-inherit font-inherit focus:outline-none hover:underline leading-[inherit] text-blue visited:text-purple no-underline !no-underline PicassoAccountSelect-accountLink"
                 href="#"
               >
                 <div
@@ -169,7 +169,7 @@ exports[`AccountSelect renders 1`] = `
               class="PicassoContainer-centerAlignItems PicassoContainer-flex"
             >
               <a
-                class="m-0 font-inherit leading-[1.5em] font-inherit focus:outline-none hover:underline text-blue visited:text-purple no-underline !no-underline PicassoAccountSelect-accountLink"
+                class="m-0 font-inherit font-inherit focus:outline-none hover:underline leading-[inherit] text-blue visited:text-purple no-underline !no-underline PicassoAccountSelect-accountLink"
                 href="#"
               >
                 <div

--- a/packages/base/Link/src/Link/Link.tsx
+++ b/packages/base/Link/src/Link/Link.tsx
@@ -115,7 +115,7 @@ export const Link: OverridableComponent<Props> = forwardRef<
       color='inherit'
       weight={variant === 'action' ? 'semibold' : 'inherit'}
       className={twMerge(
-        'focus:outline-none hover:underline',
+        'focus:outline-none hover:underline leading-[inherit]',
         COLOR_DISABLED_MAP[color][variant][disabled ? 'disabled' : 'normal'],
         disabled ? 'cursor-not-allowed' : '',
         noUnderline ? '!no-underline' : '',

--- a/packages/base/Link/src/Link/__snapshots__/test.tsx.snap
+++ b/packages/base/Link/src/Link/__snapshots__/test.tsx.snap
@@ -6,7 +6,7 @@ exports[`Link renders 1`] = `
     class="Picasso-root"
   >
     <a
-      class="m-0 font-inherit leading-[1.5em] font-inherit focus:outline-none hover:underline text-blue visited:text-purple no-underline"
+      class="m-0 font-inherit font-inherit focus:outline-none hover:underline leading-[inherit] text-blue visited:text-purple no-underline"
     >
       Please verify your email
     </a>
@@ -21,7 +21,7 @@ exports[`Link renders a Link from react-router 1`] = `
   >
     <div>
       <a
-        class="m-0 font-inherit leading-[1.5em] font-inherit focus:outline-none hover:underline text-blue visited:text-purple no-underline"
+        class="m-0 font-inherit font-inherit focus:outline-none hover:underline leading-[inherit] text-blue visited:text-purple no-underline"
         href="/"
       >
         Please verify your email
@@ -38,7 +38,7 @@ exports[`Link renders disabled link 1`] = `
   >
     <a
       aria-disabled="true"
-      class="m-0 font-inherit leading-[1.5em] font-inherit focus:outline-none hover:underline text-gray underline cursor-not"
+      class="m-0 font-inherit font-inherit focus:outline-none hover:underline leading-[inherit] text-gray underline cursor-not"
       download="filename"
       rel="noopener"
     >
@@ -54,7 +54,7 @@ exports[`Link renders native attributes 1`] = `
     class="Picasso-root"
   >
     <a
-      class="m-0 font-inherit leading-[1.5em] font-inherit focus:outline-none hover:underline text-blue visited:text-purple no-underline"
+      class="m-0 font-inherit font-inherit focus:outline-none hover:underline leading-[inherit] text-blue visited:text-purple no-underline"
       download="filename"
       href="https://toptal.com/filename.txt"
       rel="noopener"

--- a/packages/base/Page/src/PageTopBar/__snapshots__/test.tsx.snap
+++ b/packages/base/Page/src/PageTopBar/__snapshots__/test.tsx.snap
@@ -168,7 +168,7 @@ exports[`Page.TopBar render with link 1`] = `
                 </div>
               </div>
               <a
-                class="m-0 font-inherit leading-[1.5em] font-inherit focus:outline-none hover:underline text-blue visited:text-purple no-underline"
+                class="m-0 font-inherit font-inherit focus:outline-none hover:underline leading-[inherit] text-blue visited:text-purple no-underline"
                 href="https://www.toptal.com"
               >
                 <svg


### PR DESCRIPTION
[FX-NNNN]

### Description

Fixes the line-height difference with MUI Link

### How to test

<!-- The temploy link will be automatically updated when the temploy is deployed -->
- [Temploy](https://picasso.toptal.net/fx-xxx-fix-link-line-height)
- The screenshot tests should no longer differ from master on smaller screens


### Screenshots

![image](https://github.com/toptal/picasso/assets/18409292/5dc10c42-8742-4ab5-988e-86c0a0a6718b)

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests ([visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md) included)

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>
