### PR TITLE
[FX-4718] Remove deprecated props

### DIFF
--- a/.changeset/tough-ties-hear.md
+++ b/.changeset/tough-ties-hear.md
@@ -1,0 +1,7 @@
+---
+'@toptal/picasso-tree-view': major
+---
+
+### TreeView
+
+- removed deprecated props: `centerTranslation` and `transitionDuration`

--- a/packages/base/TreeView/src/TreeView/TreeView.tsx
+++ b/packages/base/TreeView/src/TreeView/TreeView.tsx
@@ -15,6 +15,7 @@ import styles from './styles'
 import { useZoom } from './use-zoom'
 import {
   DEFAULT_SCALE_EXTENT,
+  DEFAULT_TRANSITION_DURATION,
   ZERO_VECTOR2,
   TreeViewPropsDefaults,
 } from './variables'
@@ -91,7 +92,7 @@ export const TreeView = (props: Props) => {
       x: center.x + ZERO_VECTOR2.x,
       y: center.y + ZERO_VECTOR2.y,
     },
-    transitionDuration: 750,
+    transitionDuration: DEFAULT_TRANSITION_DURATION,
     initialScale,
   })
   const [initialized, setInitialized] = useState(false)

--- a/packages/base/TreeView/src/TreeView/TreeView.tsx
+++ b/packages/base/TreeView/src/TreeView/TreeView.tsx
@@ -7,7 +7,6 @@ import React, {
 } from 'react'
 import type { Theme } from '@material-ui/core/styles'
 import { makeStyles } from '@material-ui/core/styles'
-import { usePropDeprecationWarning } from '@toptal/picasso-utils'
 
 import { TreeViewContext } from './TreeViewContainer'
 import { useTree } from './use-tree'
@@ -32,39 +31,11 @@ export interface Props extends TreeViewPropsBase {
   showZoom?: boolean
   /** Scales the current zoom transform by coefficient */
   scaleCoefficient?: number
-  /**
-   * Custom center translation vector (happens after zoom center translation on selected node is applied)
-   * @deprecated [FX-4718] If you happen to rely on it, you are likely would want to migrate to StaticTreeView component instead of TreeView
-   */
-  centerTranslation?: Vector2
-  /**
-   * Transition duration for centering animation in ms
-   * @deprecated [FX-4718] If you happen to rely on it, you are likely would want to migrate to StaticTreeView component instead of TreeView
-   */
-  transitionDuration?: number
 }
 
 const useStyles = makeStyles<Theme>(styles, { name: 'PicassoTreeView' })
 
 export const TreeView = (props: Props) => {
-  // TODO: [FX-4718]
-  usePropDeprecationWarning({
-    props,
-    name: 'centerTranslation',
-    componentName: 'TreeView',
-    description:
-      'If you happen to rely on it, you are likely would want to migrate to StaticTreeView component instead of TreeView',
-  })
-
-  // TODO: [FX-4718]
-  usePropDeprecationWarning({
-    props,
-    name: 'transitionDuration',
-    componentName: 'TreeView',
-    description:
-      'If you happen to rely on it, you are likely would want to migrate to StaticTreeView component instead of TreeView',
-  })
-
   const {
     data,
     renderNode,
@@ -74,10 +45,6 @@ export const TreeView = (props: Props) => {
     initialScale = TreeView.defaultProps.initialScale,
     scaleCoefficient = TreeView.defaultProps.scaleCoefficient,
     showZoom = TreeView.defaultProps.showZoom,
-    // NOTE: these two are intentionally removed from defaultProps in order
-    // to make usePropDeprecationWarning hook correctly detect their usage
-    centerTranslation = ZERO_VECTOR2,
-    transitionDuration = 750,
   } = props
 
   const {
@@ -121,10 +88,10 @@ export const TreeView = (props: Props) => {
     rootRef,
     scaleExtent,
     center: {
-      x: center.x + centerTranslation.x,
-      y: center.y + centerTranslation.y,
+      x: center.x + ZERO_VECTOR2.x,
+      y: center.y + ZERO_VECTOR2.y,
     },
-    transitionDuration,
+    transitionDuration: 750,
     initialScale,
   })
   const [initialized, setInitialized] = useState(false)

--- a/packages/base/TreeView/src/TreeView/variables.ts
+++ b/packages/base/TreeView/src/TreeView/variables.ts
@@ -8,6 +8,7 @@ export const DEFAULT_WIDTH = 236
 export const DEFAULT_HEIGHT = 59
 export const DEFAULT_SCALE_EXTENT: [number, number] = [0.1, 5]
 export const ZERO_VECTOR2: Vector2 = { x: 0, y: 0 }
+export const DEFAULT_TRANSITION_DURATION = 750
 
 export const TreeViewPropsDefaults = {
   nodeWidth: DEFAULT_WIDTH,


### PR DESCRIPTION
[FX-4718](https://toptal-core.atlassian.net/browse/FX-4718)

### Description

Removes deprecated props from `TreeView`.
There are no usages of the prop across the entire org.

### How to test

<!-- The temploy link will be automatically updated when the temploy is deployed -->
- [Temploy](https://picasso.toptal.net/fx-4718-remove-deprecated-treeview-props)
- CI should pass, no other changes

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests ([visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md) included)

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-4718]: https://toptal-core.atlassian.net/browse/FX-4718?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ