### PR TITLE
[FX-5517] Add `disableBackdrop` to Drawer

### DIFF
--- a/.changeset/fast-ligers-exercise.md
+++ b/.changeset/fast-ligers-exercise.md
@@ -1,0 +1,7 @@
+---
+'@toptal/picasso-drawer': minor
+---
+
+### Drawer
+
+- add `disableBackdrop` prop to `Drawer` to preserve interactivity when `Drawer` is open

--- a/packages/base/Drawer/src/Drawer/Drawer.tsx
+++ b/packages/base/Drawer/src/Drawer/Drawer.tsx
@@ -42,6 +42,8 @@ export interface Props extends BaseProps {
   maintainBodyScrollLock?: boolean
   /** Specify the backdrop transparency  */
   transparentBackdrop?: boolean
+  /** Remove the backdrop and leave elements behind interactive  */
+  disableBackdrop?: boolean
 }
 
 const useStyles = makeStyles<Theme>(styles, { name: 'PicassoDrawer' })
@@ -57,6 +59,7 @@ export const Drawer = (props: Props) => {
     transitionProps,
     maintainBodyScrollLock = true,
     transparentBackdrop,
+    disableBackdrop,
     ...rest
   } = props
   const classes = useStyles()
@@ -87,11 +90,17 @@ export const Drawer = (props: Props) => {
       {...rest}
       open={open}
       onClose={handleOnClose}
+      BackdropComponent={disableBackdrop ? () => null : undefined}
       BackdropProps={{ invisible: transparentBackdrop }}
       disablePortal={disablePortal}
       container={container}
       disableScrollLock
-      ModalProps={{ style: { zIndex: theme.zIndex.drawer } }}
+      ModalProps={{
+        style: {
+          zIndex: theme.zIndex.drawer,
+          position: disableBackdrop ? 'unset' : 'fixed',
+        },
+      }}
       SlideProps={transitionProps}
     >
       <Container

--- a/packages/base/Drawer/src/Drawer/story/WithDisabledBackdrop.example.tsx
+++ b/packages/base/Drawer/src/Drawer/story/WithDisabledBackdrop.example.tsx
@@ -1,0 +1,29 @@
+import { Button, Typography, Container, Drawer } from '@toptal/picasso'
+import { SPACING_4 } from '@toptal/picasso-utils'
+import React, { useState } from 'react'
+
+const Example = () => {
+  const [open, setOpen] = useState(false)
+
+  return (
+    <div>
+      <Button data-testid='trigger' onClick={() => setOpen(!open)}>
+        Show drawer
+      </Button>
+      <Drawer
+        open={open}
+        disableBackdrop
+        onClose={() => setOpen(false)}
+        maintainBodyScrollLock={false}
+      >
+        <Container data-testid='content' padded={SPACING_4}>
+          <Typography>
+            The backdrop does not block the interaction with page content.
+          </Typography>
+        </Container>
+      </Drawer>
+    </div>
+  )
+}
+
+export default Example

--- a/packages/base/Drawer/src/Drawer/story/index.jsx
+++ b/packages/base/Drawer/src/Drawer/story/index.jsx
@@ -77,3 +77,11 @@ page
     },
     'base/Drawer'
   )
+  .addExample(
+    'Drawer/story/WithDisabledBackdrop.example.tsx',
+    {
+      title: 'With disabled backdrop',
+      takeScreenshot: false,
+    },
+    'base/Drawer'
+  )


### PR DESCRIPTION
[FX-5517](https://toptal-core.atlassian.net/browse/FX-5517)

### Description

Adds `disableBackdrop` prop to `Drawer`. This enables page interaction when Drawer is engaged.

### How to test

<!-- The temploy link will be automatically updated when the temploy is deployed -->
- [Temploy](https://picasso.toptal.net/fx-5517-disable-backdrop-for-drawer)
- See if the code looks good
- Check the `WithDisabledBackdrop` [story](https://picasso.toptal.net/fx-5517-disable-backdrop-for-drawer/?path=/story/components-drawer--drawer#with-disabled-backdrop) for Drawer at the very bottom

### Screenshots


https://github.com/toptal/picasso/assets/18409292/9360f9ab-acbd-4119-98db-540360d8c718



### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests ([visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md) included)

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-5517]: https://toptal-core.atlassian.net/browse/FX-5517?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ