### PR TITLE
Fix button errors

### DIFF
--- a/.changeset/angry-colts-scream.md
+++ b/.changeset/angry-colts-scream.md
@@ -1,0 +1,5 @@
+---
+'@toptal/picasso-button': patch
+---
+
+- fix "Maximum update depth exceeded" issue

--- a/packages/base/Button/src/ButtonAction/ButtonAction.tsx
+++ b/packages/base/Button/src/ButtonAction/ButtonAction.tsx
@@ -64,10 +64,13 @@ export const ButtonAction: OverridableComponent<Props> = forwardRef<
   Props
 >(function ButtonAction(props, ref) {
   const {
-    className,
+    /* eslint-disable @typescript-eslint/no-unused-vars */
+    // We use these props only to determine styles
     active,
     focused,
     hovered,
+    /* eslint-enable @typescript-eslint/no-unused-vars */
+    className,
     disabled,
     loading,
     icon,
@@ -95,9 +98,6 @@ export const ButtonAction: OverridableComponent<Props> = forwardRef<
       onClick={loading ? undefined : onClick}
       className={finalClassName}
       contentClassName='font-semibold text-blue-500 text-md'
-      active={active}
-      hovered={hovered}
-      focused={focused}
       disabled={disabled}
     />
   )

--- a/packages/base/Button/src/ButtonBase/ButtonBase.tsx
+++ b/packages/base/Button/src/ButtonBase/ButtonBase.tsx
@@ -1,10 +1,4 @@
-import type {
-  ReactNode,
-  ReactElement,
-  MouseEvent,
-  ElementType,
-  FC,
-} from 'react'
+import type { ReactNode, ReactElement, MouseEvent, ElementType } from 'react'
 import React, { forwardRef } from 'react'
 import { twMerge } from 'tailwind-merge'
 import type {
@@ -15,6 +9,7 @@ import type {
 } from '@toptal/picasso-shared'
 import { useTitleCase } from '@toptal/picasso-shared'
 import { Button as MUIButtonBase } from '@mui/base/Button'
+import type { ButtonRootSlotProps } from '@mui/base/Button'
 import { Loader } from '@toptal/picasso-loader'
 import { Container } from '@toptal/picasso-container'
 import { noop, toTitleCase } from '@toptal/picasso-utils'
@@ -48,6 +43,8 @@ export interface Props
   title?: string
   /** HTML type of Button component */
   type?: 'button' | 'reset' | 'submit'
+  /** The HTML element that is ultimately rendered, for example 'button', 'a' or 'label */
+  rootElementName?: keyof HTMLElementTagNameMap
 }
 
 const getClickHandler = (loading?: boolean, handler?: Props['onClick']) =>
@@ -64,14 +61,14 @@ const getIcon = ({ icon }: { icon?: ReactElement }) => {
   })
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const isReactComponent = (component: any) => {
-  return (
-    component &&
-    (component.$$typeof === Symbol.for('react.forward_ref') ||
-      typeof component === 'function')
-  )
-}
+const RootElement = forwardRef(
+  (props: ButtonRootSlotProps & { as: ElementType }, ref) => {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { ownerState, as: Root, ...rest } = props
+
+    return <Root {...rest} ref={ref} />
+  }
+)
 
 export const ButtonBase: OverridableComponent<Props> = forwardRef<
   HTMLButtonElement,
@@ -91,23 +88,10 @@ export const ButtonBase: OverridableComponent<Props> = forwardRef<
     value,
     type,
     as = 'button',
+    rootElementName,
     titleCase: propsTitleCase,
     ...rest
   } = props
-
-  let RootElement: ElementType | FC = as
-
-  if (isReactComponent(RootElement)) {
-    RootElement = forwardRef(
-      // We don't need to pass ownerState to the root component
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      ({ ownerState, ...restProps }: { ownerState: object }, rootRef) => {
-        const Root = as
-
-        return <Root ref={rootRef} {...restProps} />
-      }
-    )
-  }
 
   const titleCase = useTitleCase(propsTitleCase)
   const finalChildren = [titleCase ? toTitleCase(children) : children]
@@ -115,8 +99,9 @@ export const ButtonBase: OverridableComponent<Props> = forwardRef<
    Workaround for the case: <Button as={Link} href='' /> (with empty href!), we have to determine "rootElementName" like below
    Mui/base throws an error when "href" or "to" are empty
    */
-  const rootElementName =
-    as !== 'button' && ('href' in props || 'to' in props) ? 'a' : undefined
+  const finalRootElementName =
+    rootElementName ||
+    (as !== 'button' && ('href' in props || 'to' in props) ? 'a' : undefined)
 
   if (icon) {
     const iconComponent = getIcon({ icon })
@@ -145,8 +130,10 @@ export const ButtonBase: OverridableComponent<Props> = forwardRef<
       data-component-type='button'
       tabIndex={rest.tabIndex ?? disabled ? -1 : 0}
       role={rest.role ?? 'button'}
-      rootElementName={rootElementName}
+      rootElementName={finalRootElementName}
       slots={{ root: RootElement }}
+      // @ts-ignore
+      slotProps={{ root: { as } }}
     >
       <Container
         as='span'

--- a/packages/base/Button/src/ButtonControlLabel/ButtonControlLabel.tsx
+++ b/packages/base/Button/src/ButtonControlLabel/ButtonControlLabel.tsx
@@ -56,6 +56,7 @@ const ButtonControlLabel = ({
       variant='secondary'
       size={size}
       as='label'
+      rootElementName='label'
       htmlFor={id}
       disabled={disabled}
     >


### PR DESCRIPTION
[FX-NNNN]

### Description

When we used 

```jsx
import React from 'react'
import { Button, Link, Tooltip } from '@toptal/picasso'
import { Player16 } from '@toptal/picasso-icons'

const Example = () => {
  return (
    <div>
      <Tooltip content='Watch Pitch' compact>
        <Button.Circular
          as={Link}
          size='small'
          variant='flat'
          disabled={false}
          href={''}
          target='_blank'
          rel='noreferrer'
          icon={<Player16 color='black' />}
        />
      </Tooltip>
    </div>
  )
}
```

It threw error `Error: Maximum update depth exceeded. This can happen when a component repeatedly calls setState inside componentWillUpdate or componentDidUpdate. React limits the number of nested updates to prevent infinite loops.`

### How to test

<!-- The temploy link will be automatically updated when the temploy is deployed -->
- [Temploy](https://picasso.toptal.net/fx-null-fix-button)
- Try ☝️ code snippet in the Picasso storybook, it should not throw an error
### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| ![image](https://github.com/toptal/picasso/assets/6830426/4c3de290-fa04-4a88-a9f8-4e0f53b8cc2f) | ![image](https://github.com/toptal/picasso/assets/6830426/068dff61-1065-446b-80f6-239ac3191121) |

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- Covered with tests ([visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md) included)

**Breaking change**

- codemod is created and showcased in the changeset
- [x] test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>
