### PR TITLE
[FX-5554] Remove picasso-tailwind dependency on picasso-tailwind-merge

### DIFF
--- a/.changeset/healthy-buckets-accept.md
+++ b/.changeset/healthy-buckets-accept.md
@@ -1,0 +1,5 @@
+---
+'@toptal/picasso-tailwind-merge': minor
+---
+
+- remove peer dependency on picasso-tailwind

--- a/.changeset/orange-horses-end.md
+++ b/.changeset/orange-horses-end.md
@@ -1,0 +1,5 @@
+---
+'@toptal/picasso-tailwind': patch
+---
+
+- remove `module` entry from `package.json`

--- a/packages/picasso-tailwind-merge/package.json
+++ b/packages/picasso-tailwind-merge/package.json
@@ -28,13 +28,13 @@
   },
   "sideEffects": false,
   "peerDependencies": {
-    "@toptal/picasso-tailwind": ">=2.5.1",
     "react": ">=16.12.0 < 19.0.0"
   },
   "exports": {
     ".": "./dist-package/src/index.js"
   },
   "devDependencies": {
+    "@toptal/picasso-tailwind": "2.6.0",
     "@toptal/picasso-test-utils": "1.1.1"
   },
   "files": [

--- a/packages/picasso-tailwind-merge/src/test.ts
+++ b/packages/picasso-tailwind-merge/src/test.ts
@@ -1,9 +1,21 @@
-import { twMerge } from './twMerge'
+import * as picassoTailwindConfig from '@toptal/picasso-tailwind'
+
+import { PICASSO_TW_FONT_SIZES, twMerge } from './twMerge'
 
 describe('twMerge', () => {
   it('merges font size classes correctly', () => {
     expect(twMerge('font-inherit-size text-button-large text-2xs')).toBe(
       'text-2xs'
     )
+  })
+
+  describe('PICASSO_TW_FONT_SIZES', () => {
+    it('contains all font sizes from picasso-tailwind', () => {
+      expect(PICASSO_TW_FONT_SIZES).toStrictEqual(
+        Object.keys(picassoTailwindConfig.theme.fontSize).map(
+          key => `text-${key}`
+        )
+      )
+    })
   })
 })

--- a/packages/picasso-tailwind-merge/src/twMerge.ts
+++ b/packages/picasso-tailwind-merge/src/twMerge.ts
@@ -1,13 +1,23 @@
 import { extendTailwindMerge, twJoin } from 'tailwind-merge'
-import { theme } from '@toptal/picasso-tailwind'
+
+export const PICASSO_TW_FONT_SIZES = [
+  'text-2xs',
+  'text-xxs',
+  'text-sm',
+  'text-md',
+  'text-lg',
+  'text-xl',
+  'text-2xl',
+  'text-xxl',
+  'text-button-small',
+  'text-button-medium',
+  'text-button-large',
+]
 
 export const twMerge = extendTailwindMerge({
   extend: {
     classGroups: {
-      'font-size': [
-        ...Object.keys(theme.fontSize).map(key => `text-${key}`),
-        'font-inherit-size',
-      ],
+      'font-size': [...PICASSO_TW_FONT_SIZES, 'font-inherit-size'],
     },
   },
 })

--- a/packages/picasso-tailwind-merge/tsconfig.json
+++ b/packages/picasso-tailwind-merge/tsconfig.json
@@ -2,5 +2,5 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": { "outDir": "dist-package" },
   "include": ["src"],
-  "references": [{ "path": "../base/Utils" }, { "path": "../picasso-tailwind" }]
+  "references": [{ "path": "../base/Utils" }]
 }

--- a/packages/picasso-tailwind/package.json
+++ b/packages/picasso-tailwind/package.json
@@ -30,7 +30,6 @@
     "tailwindcss": "^3.3.5"
   },
   "sideEffects": false,
-  "module": "./src/index.js",
   "files": [
     "dist-package/**",
     "!dist-package/tsconfig.tsbuildinfo",

--- a/packages/picasso-tailwind/src/index.js
+++ b/packages/picasso-tailwind/src/index.js
@@ -61,6 +61,7 @@ module.exports = {
       regular: '400',
       semibold: '600',
     },
+    // NOTE: If adding new font sizes, make sure to update @toptal/picasso-tailwind-merge
     fontSize: {
       '2xs': ['0.688rem', { lineHeight: '1rem' }],
       xxs: ['0.75rem', { lineHeight: '1.125rem' }],


### PR DESCRIPTION
[FX-5554]

### Description

Because picasso-tailwind is a pure CJS module, it caused a few problems with the expected webpack setup, which would try to transpile it to an ESM module. Besides, this dependency brought the whole `tailwind` package to the runtime bundle, which is unnecessary for such a simple case.

I also added a unit test to guarantee that the 2 packages are in sync, while also adding a not to `picasso-tailwind` to remind developers that the two need to have the same value

### How to test

<!-- The temploy link will be automatically updated when the temploy is deployed -->
- [Temploy](https://picasso.toptal.net/fix/picasso-tailwind-dep-on-merge)
- CI should be green

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| Insert screenshots or screen recordings | Insert screenshots or screen recordings |

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests ([visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md) included)

**Breaking change**

- [x] codemod is created and showcased in the changeset
- [x] test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-5554]: https://toptal-core.atlassian.net/browse/FX-5554?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ