### PR TITLE
[FX-5568] Fix Picasso docs build

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -74,7 +74,7 @@ jobs:
           echo 'EOF' >> $GITHUB_ENV
           echo "TOPTAL_DEVBOT_TOKEN=${{ steps.parse_secrets.outputs.TOPTAL_DEVBOT_TOKEN }}" >> $GITHUB_ENV
 
-      - uses: toptal/davinci-github-actions/build-push-image@v15.0.0
+      - uses: toptal/davinci-github-actions/build-push-image@v15.3.0
         with:
           sha: ${{ github.event.pull_request.head.sha }}
           image-name: picasso

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -169,7 +169,7 @@ jobs:
           sed -i 's|toptal/actions/trigger-jenkins-job@main|./.github/actions/trigger-jenkins-job|' ./.github/actions/create-jira-deployment/action.yml
 
       - name: Build and push picasso image
-        uses: toptal/davinci-github-actions/build-push-image@v15.0.0
+        uses: toptal/davinci-github-actions/build-push-image@v15.3.0
         with:
           image-name: picasso
           registry-name: ${{ steps.parse_secrets.outputs.TOPTAL_DEFAULT_REGISTRY }}

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "tsc:all": "tsc --build tsconfig.pkgsrc.json --verbose",
     "build:package": "lerna run build:package",
     "build:package:watch": "lerna watch -- lerna run --scope=\\$LERNA_PACKAGE_NAME build:package --include-dependents",
-    "build:storybook": "yarn build:package && build-storybook -c .storybook -o build/storybook --quiet",
+    "build:storybook": "yarn nx reset && yarn build:package && build-storybook -c .storybook -o build/storybook --quiet",
     "check:icon-sizes": "node ./bin/check-icon-sizes",
     "circularity": "madge --circular packages/*/src",
     "clean": "yarn cache clean && nx reset && find . -type d -name \"node_modules\" -exec rm -rf '{}' +",


### PR DESCRIPTION
[FX-5568]

### Description

This pull request adds the `nx reset` command before building the Storybook to unblock the Picasso releases (right now package releases work, but https://picasso.toptal.net/ is not updated).

The reason is still unknown, the issue happens randomly based on https://jenkins-build.toptal.net/job/picasso-docs/ logs. It seems like https://github.com/toptal/davinci-github-actions/tree/master/build-push-image sometimes adds the `.nx/cache` folder to the image (created on some **runner A**) and then this image is used to run `"yarn build:storybook"` command on some **runner B**, so the `nx` throws error below as the cache was generated on **runner A**. 

```
17:02:31  The local cache artifact in "/app/.nx/cache/8544709143843587005" was not generated on this machine.
17:02:31  As a result, the cache's content integrity cannot be confirmed, which may make cache restoration potentially unsafe.
17:02:31  If your machine ID has changed since the artifact was cached, run "nx reset" to fix this issue.
17:02:31  Read about the error and how to address it here: https://nx.dev/troubleshooting/unknown-local-cache
```

The question **why** https://github.com/toptal/davinci-github-actions/tree/master/build-push-image adds `.nx/cache` to the image is still not clear, this could be researched later (the https://toptal-core.atlassian.net/browse/FX-5571 was added to research it further).

### How to test

<!-- The temploy link will be automatically updated when the temploy is deployed -->
- [Temploy](https://picasso.toptal.net/FX-NULL-fix-picasso-docs-djd7202)
- The https://github.com/toptal/picasso/actions/runs/9661880432/job/26650552292 was manually triggered for this branched and it worked

### Development checks

- [N/A] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Ensure that deployed demo has expected results and good examples
- [x] Self reviewed

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-5568]: https://toptal-core.atlassian.net/browse/FX-5568?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ