### PR TITLE
Add `dropdownNavigation` to Calendar

### DIFF
--- a/.changeset/real-avocados-work.md
+++ b/.changeset/real-avocados-work.md
@@ -1,0 +1,8 @@
+---
+'@toptal/picasso-date-picker': minor
+'@toptal/picasso-calendar': minor
+---
+
+### DatePicker, Calendar
+
+- add `dropdownNavigation` to enable alternative navigation between months and years

--- a/cypress/component/Calendar.spec.tsx
+++ b/cypress/component/Calendar.spec.tsx
@@ -74,4 +74,21 @@ describe('Calendar', () => {
       })
     })
   })
+  describe('when dropdownNavigation is enabled', () => {
+    it('renders the alternative navigation variant', () => {
+      cy.mount(
+        <TestCalendar
+          onChange={noop}
+          dropdownNavigation
+          minDate={new Date('1990-01-01')}
+          maxDate={new Date('2022-11-30')}
+        />
+      )
+
+      cy.get('body').happoScreenshot({
+        component,
+        variant: 'dropdown-navigation',
+      })
+    })
+  })
 })

--- a/packages/base/Calendar/src/Calendar/Calendar.tsx
+++ b/packages/base/Calendar/src/Calendar/Calendar.tsx
@@ -32,6 +32,7 @@ import type {
 } from './types'
 import type { RenderRoot } from '../CalendarContainer'
 import { CalendarContainer } from '../CalendarContainer'
+import { CalendarDateSelector } from '../CalendarDateSelector'
 
 export type CalendarMonthsAmount = 1 | 2
 
@@ -68,6 +69,8 @@ export interface Props
   hasFooter?: boolean
   /** Number of months to display */
   numberOfMonths?: CalendarMonthsAmount
+  /** Display dropdown navigation between days and months (requires minDate and maxDate to be set) */
+  dropdownNavigation?: boolean
 }
 
 const useStyles = makeStyles<Theme>(styles, { name: 'PicassoCalendar' })
@@ -102,6 +105,7 @@ export const Calendar = forwardRef<HTMLDivElement, Props>(function Calendar(
     hasFooter = false,
     renderRoot,
     numberOfMonths = 1,
+    dropdownNavigation = false,
     ...rest
   } = props
 
@@ -207,6 +211,8 @@ export const Calendar = forwardRef<HTMLDivElement, Props>(function Calendar(
 
   const mobileScreen = useBreakpoint(['xs', 'sm'])
   const shouldRenderMultipleMonths = numberOfMonths > 1 && !mobileScreen
+  const shouldDisplayDropdownNavigation =
+    dropdownNavigation && minDate && maxDate
 
   return (
     <div ref={ref} {...rest} tabIndex={0}>
@@ -234,6 +240,8 @@ export const Calendar = forwardRef<HTMLDivElement, Props>(function Calendar(
             // @ts-ignore
             onSelect={range ? handleRangeChange : handleSingleDateChange}
             fromDate={minDate}
+            fromYear={minDate?.getFullYear()}
+            toYear={maxDate?.getFullYear()}
             onMonthChange={month => setNavigationMonth(month)}
             toDate={maxDate}
             numberOfMonths={shouldRenderMultipleMonths ? numberOfMonths : 1}
@@ -241,12 +249,19 @@ export const Calendar = forwardRef<HTMLDivElement, Props>(function Calendar(
             weekStartsOn={weekStartsOn}
             formatters={{ formatWeekdayName: date => format(date, 'EEE') }}
             modifiers={modifiers}
+            captionLayout={
+              shouldDisplayDropdownNavigation ? 'dropdown' : undefined
+            }
             components={{
-              Caption: CalendarMonthHeader,
+              Caption: shouldDisplayDropdownNavigation
+                ? undefined
+                : CalendarMonthHeader,
               Day: CalendarDay,
+              Dropdown: CalendarDateSelector,
             }}
             classNames={{
               months: shouldRenderMultipleMonths ? classes.months : undefined,
+              caption_dropdowns: classes.caption_dropdowns,
               head: classes.head,
               table: classes.table,
               head_row: classes.head_row,

--- a/packages/base/Calendar/src/Calendar/styles.ts
+++ b/packages/base/Calendar/src/Calendar/styles.ts
@@ -7,6 +7,27 @@ export default ({ palette }: Theme) =>
     head: {
       display: 'block',
     },
+    caption_dropdowns: {
+      display: 'flex',
+      gap: '1rem',
+      paddingBottom: '1rem',
+    },
+    pointer_events: {
+      pointerEvents: 'none',
+    },
+    icon_wrapper: { width: '24px', height: '24px' },
+    select: {
+      opacity: '0',
+      position: 'absolute',
+      fontSize: '0.875rem',
+      fontWeight: 400,
+      cursor: 'pointer',
+    },
+    dropdown_label: {
+      display: 'flex',
+      position: 'relative',
+      alignItems: 'center',
+    },
     head_row: {
       display: 'flex',
       textAlign: 'center',

--- a/packages/base/Calendar/src/CalendarDateSelector/CalendarDateSelector.tsx
+++ b/packages/base/Calendar/src/CalendarDateSelector/CalendarDateSelector.tsx
@@ -1,0 +1,55 @@
+import React from 'react'
+import type { DropdownProps } from 'react-day-picker'
+import { Typography } from '@toptal/picasso-typography'
+import { Container } from '@toptal/picasso-container'
+import { ArrowDropDown16 } from '@toptal/picasso-icons'
+import { makeStyles, type Theme } from '@material-ui/core/styles'
+
+import styles from '../Calendar/styles'
+
+const useStyles = makeStyles<Theme>(styles, { name: 'PicassoCalendar' })
+
+const CalendarDateSelector = ({
+  children,
+  caption,
+  onChange,
+  value,
+  'aria-label': ariaLabel,
+}: DropdownProps) => {
+  const classes = useStyles()
+
+  return (
+    <label
+      aria-label={ariaLabel}
+      htmlFor={`month${caption}`}
+      className={classes.dropdown_label}
+    >
+      <Typography
+        variant='heading'
+        size='medium'
+        color='black'
+        weight='semibold'
+      >
+        {caption}
+      </Typography>
+      <Container
+        className={classes.icon_wrapper}
+        flex
+        justifyContent='center'
+        alignItems='center'
+      >
+        <ArrowDropDown16 className={classes.pointer_events} color='darkGrey' />
+      </Container>
+      <select
+        name={`month${caption}`}
+        className={classes.select}
+        value={value}
+        onChange={onChange}
+      >
+        {children}
+      </select>
+    </label>
+  )
+}
+
+export default CalendarDateSelector

--- a/packages/base/Calendar/src/CalendarDateSelector/index.ts
+++ b/packages/base/Calendar/src/CalendarDateSelector/index.ts
@@ -1,0 +1,1 @@
+export { default as CalendarDateSelector } from './CalendarDateSelector'

--- a/packages/base/DatePicker/src/DatePicker/DatePicker.tsx
+++ b/packages/base/DatePicker/src/DatePicker/DatePicker.tsx
@@ -120,6 +120,8 @@ export interface Props
   highlight?: 'autofill'
   /** Display more than one month at the same time */
   numberOfMonths?: CalendarMonthsAmount
+  /** Display dropdown navigation between days and months (requires minDate and maxDate to be set) */
+  dropdownNavigation?: boolean
 }
 
 export const DatePicker = (props: Props) => {
@@ -153,6 +155,7 @@ export const DatePicker = (props: Props) => {
     footerBackgroundColor,
     highlight,
     numberOfMonths = 1,
+    dropdownNavigation,
     ...rest
   } = props
   const classes = useStyles()
@@ -465,6 +468,7 @@ export const DatePicker = (props: Props) => {
                 hasFooter={Boolean(footer)}
                 weekStartsOn={weekStartsOn}
                 numberOfMonths={numberOfMonths}
+                dropdownNavigation={dropdownNavigation}
               />
               {footer && (
                 <div

--- a/packages/base/DatePicker/src/DatePicker/story/DropdownNav.example.tsx
+++ b/packages/base/DatePicker/src/DatePicker/story/DropdownNav.example.tsx
@@ -1,0 +1,26 @@
+import React, { useState } from 'react'
+import { DatePicker, Typography } from '@toptal/picasso'
+
+const DefaultExample = () => {
+  const [datepickerValue, setDatepickerValue] = useState<Date>()
+
+  return (
+    <div style={{ height: '50vh' }}>
+      <Typography>
+        Requires minDate and maxDate to be set in order to work
+      </Typography>
+      <br />
+      <DatePicker
+        value={datepickerValue}
+        minDate={new Date('1990-01-01')}
+        maxDate={new Date('2022-11-30')}
+        onChange={date => {
+          setDatepickerValue(date as Date)
+        }}
+        dropdownNavigation
+      />
+    </div>
+  )
+}
+
+export default DefaultExample

--- a/packages/base/DatePicker/src/DatePicker/story/index.jsx
+++ b/packages/base/DatePicker/src/DatePicker/story/index.jsx
@@ -173,3 +173,13 @@ page
     },
     'base/DatePicker'
   )
+  .addExample(
+    'DatePicker/story/DropdownNav.example.tsx',
+    {
+      title: 'Dropdown Navigation',
+      description:
+        'Display an alternative navigation for the calendar, using dropdowns for month and year selection',
+      takeScreenshot: false,
+    },
+    'base/DatePicker'
+  )


### PR DESCRIPTION
[FX-5305](https://toptal-core.atlassian.net/browse/FX-5305)

### Description

Adds a `dropdownNavigation` prop to `Calendar` (and propagates it to `DatePicker`) to display an alternative navigation between years and months via a set of dropdowns.

### How to test

<!-- The temploy link will be automatically updated when the temploy is deployed -->
- Temploy
- Code looks good
- New screenshot test is visible in Happo
- New story (available in `DatePicker` section at the bottom) works as expected

### Screenshots

![image](https://github.com/toptal/picasso/assets/18409292/88bf8dd7-3ff4-40b4-bc27-49c9d3b3fc4f)


### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests ([visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md) included)

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>
