### PR TITLE
[FX-5607] Allow to customize the color of icon

### DIFF
--- a/.changeset/modern-sheep-help.md
+++ b/.changeset/modern-sheep-help.md
@@ -1,0 +1,8 @@
+---
+'@toptal/picasso-tag': patch
+'@toptal/picasso': patch
+---
+
+### Tag
+
+- allow to customize the color of an icon

--- a/packages/base/Tag/src/Tag/Tag.tsx
+++ b/packages/base/Tag/src/Tag/Tag.tsx
@@ -56,8 +56,8 @@ const DeleteIcon = ({ onClick }: { onClick: (event: MouseEvent) => void }) => (
   </span>
 )
 
-const cloneIcon = (icon: ReactElement<IconProps>, disabled?: boolean) => {
-  if (!icon || !React.isValidElement(icon)) {
+const cloneIcon = (icon: ReactNode, disabled?: boolean) => {
+  if (!icon || !React.isValidElement<IconProps>(icon)) {
     return null
   }
 
@@ -101,7 +101,7 @@ export const Tag = forwardRef<HTMLDivElement, Props>(function Tag(props, ref) {
     }
   }
 
-  const clonedIcon = cloneIcon(icon as ReactElement<IconProps>, disabled)
+  const clonedIcon = cloneIcon(icon, disabled)
 
   return (
     <Root

--- a/packages/base/Tag/src/Tag/__snapshots__/test.tsx.snap
+++ b/packages/base/Tag/src/Tag/__snapshots__/test.tsx.snap
@@ -133,7 +133,7 @@ exports[`Tag renders with connection and icon 1`] = `
       data-testid="tag"
     >
       <svg
-        class="PicassoSvgSettings16-root flex items-center -mr ml-3 text-graphite"
+        class="PicassoSvgSettings16-root flex items-center -mr ml-3 PicassoSvgSettings16-darkGrey"
         style="min-width: 16px; min-height: 16px;"
         viewBox="0 0 16 16"
       >


### PR DESCRIPTION
[FX-5607]

### Description

```jsx
<Tag icon={<Settings16 color='blue' />} variant='light-grey'>
  Light grey
</Tag>
```

Previously, the icon always had the `text-graphite-700` color or `text-gray-500` when disabled. When user tries to customize, it is ignored. I checked the BASE design and there are cases where icon needs to be colored.

### How to test

<!-- The temploy link will be automatically updated when the temploy is deployed -->
- [Temploy](https://picasso.toptal.net/fx-5607-tag-bug)
- Try to change color of Tag in the storybook ☝️ 

### Screenshots

![image](https://github.com/toptal/picasso/assets/6830426/f30ce6f8-8f6e-47d8-8ca5-f8ca54b1a508)

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- Annotate all `props` in component with documentation
- Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [ ] Self reviewed
- Covered with tests ([visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md) included)

**Breaking change**

- codemod is created and showcased in the changeset
- test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-5607]: https://toptal-core.atlassian.net/browse/FX-5607?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ