### PR TITLE
[FX-5267] Add strokes to Container, Alert and Helpbox components

### DIFF
--- a/.changeset/rotten-knives-doubt.md
+++ b/.changeset/rotten-knives-doubt.md
@@ -1,0 +1,14 @@
+---
+'@toptal/picasso-container': minor
+'@toptal/picasso-alert': minor
+'@toptal/picasso-helpbox': minor
+'@toptal/picasso-tailwind': minor
+---
+
+### Alert, Helpwbox, Container
+
+- all variants except white (in Container only) and transparent now have a 1px border by default.
+
+### Picasso-Tailwind
+
+- add new colors to tailwindCss configuration

--- a/.changeset/rotten-knives-doubt.md
+++ b/.changeset/rotten-knives-doubt.md
@@ -2,13 +2,9 @@
 '@toptal/picasso-container': minor
 '@toptal/picasso-alert': minor
 '@toptal/picasso-helpbox': minor
-'@toptal/picasso-tailwind': minor
+'@toptal/picasso': patch
 ---
 
-### Alert, Helpwbox, Container
+### Alert, Helpbox, Container
 
 - all variants except white (in Container only) and transparent now have a 1px border by default.
-
-### Picasso-Tailwind
-
-- add new colors to tailwindCss configuration

--- a/.changeset/tidy-donkeys-drive.md
+++ b/.changeset/tidy-donkeys-drive.md
@@ -1,15 +1,45 @@
 ---
 '@toptal/picasso-container': major
 '@toptal/picasso': major
+'@toptal/picasso-account-select': major
 '@toptal/picasso-alert': major
+'@toptal/picasso-application-update-notification': major
+'@toptal/picasso-autocomplete': major
+'@toptal/picasso-avatar': major
 '@toptal/picasso-button': major
+'@toptal/picasso-calendar': major
+'@toptal/picasso-carousel': major
 '@toptal/picasso-checkbox': major
+'@toptal/picasso-date-picker': major
+'@toptal/picasso-drawer': major
+'@toptal/picasso-dropzone': major
+'@toptal/picasso-empty-state': major
+'@toptal/picasso-file-input': major
 '@toptal/picasso-form': major
 '@toptal/picasso-helpbox': major
+'@toptal/picasso-input': major
+'@toptal/picasso-input-adornment': major
+'@toptal/picasso-list': major
+'@toptal/picasso-menu': major
+'@toptal/picasso-note': major
+'@toptal/picasso-notification': major
+'@toptal/picasso-number-input': major
+'@toptal/picasso-overview-block': major
 '@toptal/picasso-page': major
 '@toptal/picasso-pagination': major
+'@toptal/picasso-prompt-modal': major
+'@toptal/picasso-quote': major
+'@toptal/picasso-rating': major
 '@toptal/picasso-section': major
+'@toptal/picasso-select': major
+'@toptal/picasso-tabs': major
+'@toptal/picasso-timeline': major
+'@toptal/picasso-tree-view': major
+'@toptal/picasso-user-badge': major
+'@toptal/picasso-forms': major
+'@toptal/picasso-query-builder': major
 '@toptal/picasso-rich-text-editor': major
+'@topkit/analytics-charts': major
 ---
 
 ### Container
@@ -18,6 +48,6 @@
 - make "@toptal/picasso-tailwind-merge": "^1.1.1" a peer dependency
 - the "@toptal/picasso-tailwind" package has been updated to the latest version in peerDependencies
 
-### Picasso, Alert, Button, Checkbox, Form, Helpbox, Page, Pagination, Section, RichTextEditor
+### Picasso, AccountSelect, Alert, ApplicationUpdateNotification, Autocomplete, Avatar, Button, Calendar, Carousel, Checkbox, DatePicker, Drawer, Dropzone, EmptyState, FileInput, Form, Helpbox, Input, InputAdornment, List, Menu, Note, Notification, NumberInput, OverviewBlock, Page, Pagination, PromptModal, Quote, Rating, Section, Select, Tabs, Timeline, TreeView, Forms, QueryBuilder, RichTextEditor, AnalyticsCharts
 
 - the "@toptal/picasso-tailwind" package has been updated to the latest version in peerDependencies

--- a/.changeset/tidy-donkeys-drive.md
+++ b/.changeset/tidy-donkeys-drive.md
@@ -1,6 +1,23 @@
 ---
 '@toptal/picasso-container': major
+'@toptal/picasso': major
+'@toptal/picasso-alert': major
+'@toptal/picasso-button': major
+'@toptal/picasso-checkbox': major
+'@toptal/picasso-form': major
+'@toptal/picasso-helpbox': major
+'@toptal/picasso-page': major
+'@toptal/picasso-pagination': major
+'@toptal/picasso-section': major
+'@toptal/picasso-rich-text-editor': major
 ---
+
+### Container
 
 - migrate to TailwindCSS, material-ui@4 is no longer required for this package
 - make "@toptal/picasso-tailwind-merge": "^1.1.1" a peer dependency
+- the "@toptal/picasso-tailwind" package has been updated to the latest version in peerDependencies
+
+### Picasso, Alert, Button, Checkbox, Form, Helpbox, Page, Pagination, Section, RichTextEditor
+
+- the "@toptal/picasso-tailwind" package has been updated to the latest version in peerDependencies

--- a/.changeset/unlucky-games-relate.md
+++ b/.changeset/unlucky-games-relate.md
@@ -1,0 +1,8 @@
+---
+'@toptal/picasso-tailwind': minor
+'@toptal/picasso': patch
+---
+
+### picasso-tailwind
+
+- add new colors to tailwindCss configuration

--- a/packages/base/AccountSelect/package.json
+++ b/packages/base/AccountSelect/package.json
@@ -37,6 +37,7 @@
   ],
   "peerDependencies": {
     "@material-ui/core": "4.12.4",
+    "@toptal/picasso-tailwind": ">=2.7",
     "react": ">=16.12.0 < 19.0.0"
   },
   "exports": {

--- a/packages/base/AccountSelect/tsconfig.json
+++ b/packages/base/AccountSelect/tsconfig.json
@@ -3,6 +3,7 @@
   "compilerOptions": { "outDir": "dist-package" },
   "include": ["src"],
   "references": [
+    { "path": "../../picasso-tailwind" },
     { "path": "../Container" },
     { "path": "../Icons" },
     { "path": "../Link" },

--- a/packages/base/Alert/package.json
+++ b/packages/base/Alert/package.json
@@ -34,7 +34,7 @@
   ],
   "peerDependencies": {
     "@toptal/picasso-provider": "*",
-    "@toptal/picasso-tailwind": ">=2.6",
+    "@toptal/picasso-tailwind": ">=2.7",
     "react": ">=16.12.0 < 19.0.0"
   },
   "exports": {

--- a/packages/base/Alert/src/Alert/__snapshots__/test.tsx.snap
+++ b/packages/base/Alert/src/Alert/__snapshots__/test.tsx.snap
@@ -6,7 +6,7 @@ exports[`Alert renders 1`] = `
     class="Picasso-root"
   >
     <div
-      class="bg-yellow p-4 justify-between rounded-md flex"
+      class="bg-yellow border border-solid border-yellow p-4 justify-between rounded-md flex"
       role="alert"
     >
       <div

--- a/packages/base/ApplicationUpdateNotification/package.json
+++ b/packages/base/ApplicationUpdateNotification/package.json
@@ -35,6 +35,7 @@
   ],
   "peerDependencies": {
     "@material-ui/core": "4.12.4",
+    "@toptal/picasso-tailwind": ">=2.7",
     "react": ">=16.12.0 < 19.0.0"
   },
   "exports": {

--- a/packages/base/ApplicationUpdateNotification/tsconfig.json
+++ b/packages/base/ApplicationUpdateNotification/tsconfig.json
@@ -3,6 +3,7 @@
   "compilerOptions": { "outDir": "dist-package" },
   "include": ["src"],
   "references": [
+    { "path": "../../picasso-tailwind" },
     { "path": "../Button" },
     { "path": "../Container" },
     { "path": "../Icons" },

--- a/packages/base/Autocomplete/package.json
+++ b/packages/base/Autocomplete/package.json
@@ -44,6 +44,7 @@
   ],
   "peerDependencies": {
     "@material-ui/core": "4.12.4",
+    "@toptal/picasso-tailwind": ">=2.7",
     "@toptal/picasso-provider": "*",
     "react": ">=16.12.0 < 19.0.0"
   },

--- a/packages/base/Autocomplete/tsconfig.json
+++ b/packages/base/Autocomplete/tsconfig.json
@@ -4,6 +4,7 @@
   "include": ["src"],
   "references": [
     { "path": "../../picasso-provider" },
+    { "path": "../../picasso-tailwind" },
     { "path": "../../shared" },
     { "path": "../Container" },
     { "path": "../Form" },

--- a/packages/base/Avatar/package.json
+++ b/packages/base/Avatar/package.json
@@ -35,7 +35,7 @@
     "**/styles.js"
   ],
   "peerDependencies": {
-    "tailwindcss": ">=3",
+    "@toptal/picasso-tailwind": ">=2.7",
     "react": ">=16.12.0 < 19.0.0",
     "@toptal/picasso-tailwind-merge": "^1.1.1"
   },

--- a/packages/base/Avatar/tsconfig.json
+++ b/packages/base/Avatar/tsconfig.json
@@ -3,6 +3,7 @@
   "compilerOptions": { "outDir": "dist-package" },
   "include": ["src"],
   "references": [
+    { "path": "../../picasso-tailwind" },
     { "path": "../../picasso-tailwind-merge" },
     { "path": "../../shared" },
     { "path": "../Container" },

--- a/packages/base/Button/package.json
+++ b/packages/base/Button/package.json
@@ -41,7 +41,7 @@
     "**/styles.js"
   ],
   "peerDependencies": {
-    "@toptal/picasso-tailwind": ">=2.5.0",
+    "@toptal/picasso-tailwind": ">=2.7",
     "@toptal/picasso-provider": "*",
     "react": ">=16.12.0 < 19.0.0"
   },

--- a/packages/base/Calendar/package.json
+++ b/packages/base/Calendar/package.json
@@ -38,6 +38,7 @@
   ],
   "peerDependencies": {
     "@material-ui/core": "4.12.4",
+    "@toptal/picasso-tailwind": ">=2.7",
     "@toptal/picasso-provider": "*",
     "react": ">=16.12.0 < 19.0.0"
   },

--- a/packages/base/Calendar/tsconfig.json
+++ b/packages/base/Calendar/tsconfig.json
@@ -4,6 +4,7 @@
   "include": ["src"],
   "references": [
     { "path": "../../picasso-provider" },
+    { "path": "../../picasso-tailwind" },
     { "path": "../../shared" },
     { "path": "../Button" },
     { "path": "../Container" },

--- a/packages/base/Carousel/package.json
+++ b/packages/base/Carousel/package.json
@@ -36,6 +36,7 @@
   ],
   "peerDependencies": {
     "@material-ui/core": "4.12.4",
+    "@toptal/picasso-tailwind": ">=2.7",
     "react": ">=16.12.0 < 19.0.0"
   },
   "exports": {

--- a/packages/base/Carousel/tsconfig.json
+++ b/packages/base/Carousel/tsconfig.json
@@ -3,6 +3,7 @@
   "compilerOptions": { "outDir": "dist-package" },
   "include": ["src"],
   "references": [
+    { "path": "../../picasso-tailwind" },
     { "path": "../../shared" },
     { "path": "../Button" },
     { "path": "../Container" },

--- a/packages/base/Checkbox/package.json
+++ b/packages/base/Checkbox/package.json
@@ -39,7 +39,7 @@
     "@material-ui/core": "4.12.4",
     "@toptal/picasso-provider": "*",
     "react": ">=16.12.0 < 19.0.0",
-    "@toptal/picasso-tailwind": ">=2.4.0"
+    "@toptal/picasso-tailwind": ">=2.7"
   },
   "devDependencies": {
     "@toptal/picasso-provider": "4.2.1",

--- a/packages/base/Container/package.json
+++ b/packages/base/Container/package.json
@@ -29,7 +29,6 @@
     "@toptal/picasso-utils": "1.0.3"
   },
   "peerDependencies": {
-    "@material-ui/core": "4.12.4",
     "@toptal/picasso-provider": "*",
     "@toptal/picasso-tailwind": ">=2.6",
     "@toptal/picasso-tailwind-merge": "^1.1.1",

--- a/packages/base/Container/package.json
+++ b/packages/base/Container/package.json
@@ -30,7 +30,7 @@
   },
   "peerDependencies": {
     "@toptal/picasso-provider": "*",
-    "@toptal/picasso-tailwind": ">=2.6",
+    "@toptal/picasso-tailwind": ">=2.7",
     "@toptal/picasso-tailwind-merge": "^1.1.1",
     "react": ">=16.12.0 < 19.0.0"
   },

--- a/packages/base/Container/src/Container/Container.tsx
+++ b/packages/base/Container/src/Container/Container.tsx
@@ -101,7 +101,8 @@ export const Container: ContainerProps = documentable(
       } = props
 
       const spacingProps = { gap, padded, top, bottom, right, left }
-      const isBorderedVariant = !variant || variant === 'white'
+      const isBorderedVariant =
+        !variant || variant === 'white' || variant === 'transparent'
 
       const getDisplayValue = (
         isInline: boolean | undefined,

--- a/packages/base/Container/src/Container/Container.tsx
+++ b/packages/base/Container/src/Container/Container.tsx
@@ -101,6 +101,7 @@ export const Container: ContainerProps = documentable(
       } = props
 
       const spacingProps = { gap, padded, top, bottom, right, left }
+      const isBorderedVariant = !variant || variant === 'white'
 
       const getDisplayValue = (
         isInline: boolean | undefined,
@@ -121,6 +122,7 @@ export const Container: ContainerProps = documentable(
           ref={ref}
           className={twMerge(
             variant && variantClassesByColor[variant],
+
             getSpacingClasses(spacingProps),
 
             typeof align === 'string' && alignmentClasses.textAlign[align],
@@ -129,12 +131,17 @@ export const Container: ContainerProps = documentable(
 
             justifyContent && alignmentClasses.justifyContent[justifyContent],
 
-            bordered && 'border border-solid border-gray-200',
+            bordered &&
+              isBorderedVariant &&
+              'border border-solid border-gray-200',
             rounded && 'rounded-md',
+
             getDisplayValue(inline, flex),
+
             direction &&
               direction !== 'row' &&
               alignmentClasses.direction[direction],
+
             className
           )}
           style={{

--- a/packages/base/Container/src/Container/story/Variant.example.tsx
+++ b/packages/base/Container/src/Container/story/Variant.example.tsx
@@ -18,16 +18,6 @@ const Example = () => (
       >
         White
       </Container>
-    </Container>
-
-    <Container>
-      <Typography variant='heading' size='medium'>
-        Non-bordered
-      </Typography>
-
-      <Container rounded padded={SPACING_6} bottom={SPACING_4} top={SPACING_4}>
-        White
-      </Container>
       <Container rounded variant='red' padded={SPACING_6} bottom={SPACING_4}>
         Red
       </Container>
@@ -42,6 +32,16 @@ const Example = () => (
       </Container>
       <Container rounded variant='grey' padded={SPACING_6}>
         Grey
+      </Container>
+    </Container>
+
+    <Container>
+      <Typography variant='heading' size='medium'>
+        Non-bordered
+      </Typography>
+
+      <Container rounded padded={SPACING_6} bottom={SPACING_4} top={SPACING_4}>
+        White
       </Container>
     </Container>
   </Container>

--- a/packages/base/Container/src/Container/styles.ts
+++ b/packages/base/Container/src/Container/styles.ts
@@ -61,10 +61,10 @@ export const alignmentClasses = {
 
 export const variantClassesByColor: Record<VariantType, string> = {
   white: 'bg-white',
-  red: 'bg-red-100',
-  green: 'bg-green-100',
-  yellow: 'bg-yellow-100',
-  blue: 'bg-blue-100',
-  grey: 'bg-gray-200',
+  red: 'bg-red-100 border border-solid border-red-150',
+  green: 'bg-green-100 border border-solid border-green-150',
+  yellow: 'bg-yellow-100 border border-solid border-yellow-150',
+  blue: 'bg-blue-100 border border-solid border-blue-150',
+  grey: 'bg-gray-200 border border-solid border-gray-400',
   transparent: '',
 }

--- a/packages/base/DatePicker/package.json
+++ b/packages/base/DatePicker/package.json
@@ -39,6 +39,7 @@
   ],
   "peerDependencies": {
     "@material-ui/core": "4.12.4",
+    "@toptal/picasso-tailwind": ">=2.7",
     "react": ">=16.12.0 < 19.0.0"
   },
   "devDependencies": {

--- a/packages/base/DatePicker/tsconfig.json
+++ b/packages/base/DatePicker/tsconfig.json
@@ -3,6 +3,7 @@
   "compilerOptions": { "outDir": "dist-package" },
   "include": ["src"],
   "references": [
+    { "path": "../../picasso-tailwind" },
     { "path": "../Calendar" },
     { "path": "../Container" },
     { "path": "../Icons" },

--- a/packages/base/Drawer/package.json
+++ b/packages/base/Drawer/package.json
@@ -37,7 +37,7 @@
   "peerDependencies": {
     "@material-ui/core": "4.12.4",
     "@toptal/picasso-provider": "*",
-    "tailwindcss": ">=3",
+    "@toptal/picasso-tailwind": ">=2.7",
     "react": ">=16.12.0 < 19.0.0"
   },
   "exports": {

--- a/packages/base/Drawer/tsconfig.json
+++ b/packages/base/Drawer/tsconfig.json
@@ -4,6 +4,7 @@
   "include": ["src"],
   "references": [
     { "path": "../../picasso-provider" },
+    { "path": "../../picasso-tailwind" },
     { "path": "../Backdrop" },
     { "path": "../Button" },
     { "path": "../Container" },

--- a/packages/base/Dropzone/package.json
+++ b/packages/base/Dropzone/package.json
@@ -37,6 +37,7 @@
   ],
   "peerDependencies": {
     "@material-ui/core": "4.12.4",
+    "@toptal/picasso-tailwind": ">=2.7",
     "react": ">=16.12.0 < 19.0.0"
   },
   "exports": {

--- a/packages/base/Dropzone/tsconfig.json
+++ b/packages/base/Dropzone/tsconfig.json
@@ -3,6 +3,7 @@
   "compilerOptions": { "outDir": "dist-package" },
   "include": ["src"],
   "references": [
+    { "path": "../../picasso-tailwind" },
     { "path": "../Container" },
     { "path": "../FileInput" },
     { "path": "../Form" },

--- a/packages/base/EmptyState/package.json
+++ b/packages/base/EmptyState/package.json
@@ -32,6 +32,7 @@
   ],
   "peerDependencies": {
     "@material-ui/core": "4.12.4",
+    "@toptal/picasso-tailwind": ">=2.7",
     "react": ">=16.12.0 < 19.0.0"
   },
   "exports": {

--- a/packages/base/EmptyState/tsconfig.json
+++ b/packages/base/EmptyState/tsconfig.json
@@ -3,6 +3,7 @@
   "compilerOptions": { "outDir": "dist-package" },
   "include": ["src"],
   "references": [
+    { "path": "../../picasso-tailwind" },
     { "path": "../Container" },
     { "path": "../Icons" },
     { "path": "../Typography" }

--- a/packages/base/FileInput/package.json
+++ b/packages/base/FileInput/package.json
@@ -40,6 +40,7 @@
   ],
   "peerDependencies": {
     "@material-ui/core": "4.12.4",
+    "@toptal/picasso-tailwind": ">=2.7",
     "react": ">=16.12.0 < 19.0.0"
   },
   "exports": {

--- a/packages/base/FileInput/tsconfig.json
+++ b/packages/base/FileInput/tsconfig.json
@@ -3,6 +3,7 @@
   "compilerOptions": { "outDir": "dist-package" },
   "include": ["src"],
   "references": [
+    { "path": "../../picasso-tailwind" },
     { "path": "../../shared" },
     { "path": "../Button" },
     { "path": "../Container" },

--- a/packages/base/Form/package.json
+++ b/packages/base/Form/package.json
@@ -39,7 +39,7 @@
   "peerDependencies": {
     "@material-ui/core": "4.12.4",
     "@toptal/picasso-provider": "*",
-    "@toptal/picasso-tailwind": ">=2.4.0",
+    "@toptal/picasso-tailwind": ">=2.7",
     "react": ">=16.12.0 < 19.0.0"
   },
   "exports": {

--- a/packages/base/Helpbox/package.json
+++ b/packages/base/Helpbox/package.json
@@ -34,7 +34,7 @@
   ],
   "peerDependencies": {
     "react": ">=16.12.0 < 19.0.0",
-    "@toptal/picasso-tailwind": ">=2.5.0",
+    "@toptal/picasso-tailwind": ">=2.7",
     "@toptal/picasso-tailwind-merge": "^1.1.1"
   },
   "exports": {

--- a/packages/base/Input/package.json
+++ b/packages/base/Input/package.json
@@ -37,6 +37,7 @@
   ],
   "peerDependencies": {
     "@material-ui/core": "4.12.4",
+    "@toptal/picasso-tailwind": ">=2.7",
     "@toptal/picasso-provider": "*",
     "react": ">=16.12.0 < 19.0.0"
   },

--- a/packages/base/Input/tsconfig.json
+++ b/packages/base/Input/tsconfig.json
@@ -4,6 +4,7 @@
   "include": ["src"],
   "references": [
     { "path": "../../picasso-provider" },
+    { "path": "../../picasso-tailwind" },
     { "path": "../../shared" },
     { "path": "../Container" },
     { "path": "../Form" },

--- a/packages/base/InputAdornment/package.json
+++ b/packages/base/InputAdornment/package.json
@@ -34,6 +34,7 @@
   ],
   "peerDependencies": {
     "@material-ui/core": "4.12.4",
+    "@toptal/picasso-tailwind": ">=2.7",
     "@toptal/picasso-provider": "*",
     "react": ">=16.12.0 < 19.0.0"
   },

--- a/packages/base/InputAdornment/tsconfig.json
+++ b/packages/base/InputAdornment/tsconfig.json
@@ -4,6 +4,7 @@
   "include": ["src"],
   "references": [
     { "path": "../../picasso-provider" },
+    { "path": "../../picasso-tailwind" },
     { "path": "../../shared" },
     { "path": "../Container" },
     { "path": "../Icons" },

--- a/packages/base/List/package.json
+++ b/packages/base/List/package.json
@@ -36,7 +36,7 @@
   "peerDependencies": {
     "@material-ui/core": "4.12.4",
     "@toptal/picasso-provider": "*",
-    "tailwindcss": ">=3",
+    "@toptal/picasso-tailwind": ">=2.7",
     "react": ">=16.12.0 < 19.0.0"
   },
   "exports": {

--- a/packages/base/List/tsconfig.json
+++ b/packages/base/List/tsconfig.json
@@ -4,6 +4,7 @@
   "include": ["src"],
   "references": [
     { "path": "../../picasso-provider" },
+    { "path": "../../picasso-tailwind" },
     { "path": "../../shared" },
     { "path": "../Container" },
     { "path": "../Icons" },

--- a/packages/base/Menu/package.json
+++ b/packages/base/Menu/package.json
@@ -39,6 +39,7 @@
   ],
   "peerDependencies": {
     "@material-ui/core": "4.12.4",
+    "@toptal/picasso-tailwind": ">=2.7",
     "@toptal/picasso-provider": "*",
     "react": ">=16.12.0 < 19.0.0"
   },

--- a/packages/base/Menu/tsconfig.json
+++ b/packages/base/Menu/tsconfig.json
@@ -4,6 +4,7 @@
   "include": ["src"],
   "references": [
     { "path": "../../picasso-provider" },
+    { "path": "../../picasso-tailwind" },
     { "path": "../../shared" },
     { "path": "../Avatar" },
     { "path": "../Container" },

--- a/packages/base/Note/package.json
+++ b/packages/base/Note/package.json
@@ -32,6 +32,7 @@
   ],
   "peerDependencies": {
     "@material-ui/core": "4.12.4",
+    "@toptal/picasso-tailwind": ">=2.7",
     "react": ">=16.12.0 < 19.0.0"
   },
   "exports": {

--- a/packages/base/Note/tsconfig.json
+++ b/packages/base/Note/tsconfig.json
@@ -2,5 +2,9 @@
   "extends": "../../../tsconfig.base.json",
   "compilerOptions": { "outDir": "dist-package" },
   "include": ["src"],
-  "references": [{ "path": "../Container" }, { "path": "../Typography" }]
+  "references": [
+    { "path": "../../picasso-tailwind" },
+    { "path": "../Container" },
+    { "path": "../Typography" }
+  ]
 }

--- a/packages/base/Notification/package.json
+++ b/packages/base/Notification/package.json
@@ -38,7 +38,7 @@
   "peerDependencies": {
     "@material-ui/core": "4.12.4",
     "@toptal/picasso-provider": "*",
-    "tailwindcss": ">=3",
+    "@toptal/picasso-tailwind": ">=2.7",
     "react": ">=16.12.0 < 19.0.0"
   },
   "exports": {

--- a/packages/base/Notification/tsconfig.json
+++ b/packages/base/Notification/tsconfig.json
@@ -4,6 +4,7 @@
   "include": ["src"],
   "references": [
     { "path": "../../picasso-provider" },
+    { "path": "../../picasso-tailwind" },
     { "path": "../../shared" },
     { "path": "../Button" },
     { "path": "../Container" },

--- a/packages/base/NumberInput/package.json
+++ b/packages/base/NumberInput/package.json
@@ -37,6 +37,7 @@
   ],
   "peerDependencies": {
     "@material-ui/core": "4.12.4",
+    "@toptal/picasso-tailwind": ">=2.7",
     "react": ">=16.12.0 < 19.0.0"
   },
   "exports": {

--- a/packages/base/NumberInput/tsconfig.json
+++ b/packages/base/NumberInput/tsconfig.json
@@ -3,6 +3,7 @@
   "compilerOptions": { "outDir": "dist-package" },
   "include": ["src"],
   "references": [
+    { "path": "../../picasso-tailwind" },
     { "path": "../../shared" },
     { "path": "../Container" },
     { "path": "../Form" },

--- a/packages/base/OverviewBlock/package.json
+++ b/packages/base/OverviewBlock/package.json
@@ -35,6 +35,7 @@
   ],
   "peerDependencies": {
     "@material-ui/core": "4.12.4",
+    "@toptal/picasso-tailwind": ">=2.7",
     "react": ">=16.12.0 < 19.0.0"
   },
   "exports": {

--- a/packages/base/OverviewBlock/tsconfig.json
+++ b/packages/base/OverviewBlock/tsconfig.json
@@ -3,6 +3,7 @@
   "compilerOptions": { "outDir": "dist-package" },
   "include": ["src"],
   "references": [
+    { "path": "../../picasso-tailwind" },
     { "path": "../../shared" },
     { "path": "../Container" },
     { "path": "../Typography" },

--- a/packages/base/Page/package.json
+++ b/packages/base/Page/package.json
@@ -50,7 +50,7 @@
     "@material-ui/core": "4.12.4",
     "@toptal/picasso-provider": "*",
     "react-dom": "^18.2.0",
-    "@toptal/picasso-tailwind": ">=2.5.0",
+    "@toptal/picasso-tailwind": ">=2.7",
     "react": ">=16.12.0 < 19.0.0"
   },
   "devDependencies": {

--- a/packages/base/Pagination/package.json
+++ b/packages/base/Pagination/package.json
@@ -36,7 +36,7 @@
   "peerDependencies": {
     "@material-ui/core": "4.12.4",
     "react": ">=16.12.0 < 19.0.0",
-    "@toptal/picasso-tailwind": ">=2.5.0"
+    "@toptal/picasso-tailwind": ">=2.7"
   },
   "exports": {
     ".": "./dist-package/src/index.js"

--- a/packages/base/PromptModal/package.json
+++ b/packages/base/PromptModal/package.json
@@ -34,6 +34,7 @@
   ],
   "peerDependencies": {
     "@material-ui/core": "4.12.4",
+    "@toptal/picasso-tailwind": ">=2.7",
     "react": ">=16.12.0 < 19.0.0"
   },
   "exports": {

--- a/packages/base/PromptModal/tsconfig.json
+++ b/packages/base/PromptModal/tsconfig.json
@@ -3,6 +3,7 @@
   "compilerOptions": { "outDir": "dist-package" },
   "include": ["src"],
   "references": [
+    { "path": "../../picasso-tailwind" },
     { "path": "../Button" },
     { "path": "../Container" },
     { "path": "../Modal" },

--- a/packages/base/Quote/package.json
+++ b/packages/base/Quote/package.json
@@ -31,6 +31,7 @@
   ],
   "peerDependencies": {
     "@material-ui/core": "4.12.4",
+    "@toptal/picasso-tailwind": ">=2.7",
     "react": ">=16.12.0 < 19.0.0"
   },
   "exports": {

--- a/packages/base/Quote/tsconfig.json
+++ b/packages/base/Quote/tsconfig.json
@@ -2,5 +2,9 @@
   "extends": "../../../tsconfig.base.json",
   "compilerOptions": { "outDir": "dist-package" },
   "include": ["src"],
-  "references": [{ "path": "../Container" }, { "path": "../Typography" }]
+  "references": [
+    { "path": "../../picasso-tailwind" },
+    { "path": "../Container" },
+    { "path": "../Typography" }
+  ]
 }

--- a/packages/base/Rating/package.json
+++ b/packages/base/Rating/package.json
@@ -33,6 +33,7 @@
   ],
   "peerDependencies": {
     "@material-ui/core": "4.12.4",
+    "@toptal/picasso-tailwind": ">=2.7",
     "react": ">=16.12.0 < 19.0.0"
   },
   "exports": {

--- a/packages/base/Rating/tsconfig.json
+++ b/packages/base/Rating/tsconfig.json
@@ -3,6 +3,7 @@
   "compilerOptions": { "outDir": "dist-package" },
   "include": ["src"],
   "references": [
+    { "path": "../../picasso-tailwind" },
     { "path": "../Container" },
     { "path": "../Icons" },
     { "path": "../Utils" }

--- a/packages/base/Section/package.json
+++ b/packages/base/Section/package.json
@@ -35,7 +35,7 @@
     "**/styles.js"
   ],
   "peerDependencies": {
-    "@toptal/picasso-tailwind": ">=2.5.0",
+    "@toptal/picasso-tailwind": ">=2.7",
     "react": ">=16.12.0 < 19.0.0"
   },
   "exports": {

--- a/packages/base/Select/package.json
+++ b/packages/base/Select/package.json
@@ -43,6 +43,7 @@
   ],
   "peerDependencies": {
     "@material-ui/core": "4.12.4",
+    "@toptal/picasso-tailwind": ">=2.7",
     "react": ">=16.12.0 < 19.0.0"
   },
   "devDependencies": {

--- a/packages/base/Select/tsconfig.json
+++ b/packages/base/Select/tsconfig.json
@@ -3,6 +3,7 @@
   "compilerOptions": { "outDir": "dist-package" },
   "include": ["src"],
   "references": [
+    { "path": "../../picasso-tailwind" },
     { "path": "../../shared" },
     { "path": "../Container" },
     { "path": "../Form" },

--- a/packages/base/Tabs/package.json
+++ b/packages/base/Tabs/package.json
@@ -39,7 +39,7 @@
   "peerDependencies": {
     "@material-ui/core": "4.12.4",
     "@toptal/picasso-provider": "*",
-    "tailwindcss": ">=3",
+    "@toptal/picasso-tailwind": ">=2.7",
     "react": ">=16.12.0 < 19.0.0"
   },
   "exports": {

--- a/packages/base/Tabs/tsconfig.json
+++ b/packages/base/Tabs/tsconfig.json
@@ -4,6 +4,7 @@
   "include": ["src"],
   "references": [
     { "path": "../../picasso-provider" },
+    { "path": "../../picasso-tailwind" },
     { "path": "../../shared" },
     { "path": "../Container" },
     { "path": "../Icons" },

--- a/packages/base/Timeline/package.json
+++ b/packages/base/Timeline/package.json
@@ -34,7 +34,7 @@
   ],
   "peerDependencies": {
     "@material-ui/core": "4.12.4",
-    "tailwindcss": ">=3",
+    "@toptal/picasso-tailwind": ">=2.7",
     "react": ">=16.12.0 < 19.0.0"
   },
   "exports": {

--- a/packages/base/Timeline/tsconfig.json
+++ b/packages/base/Timeline/tsconfig.json
@@ -3,6 +3,7 @@
   "compilerOptions": { "outDir": "dist-package" },
   "include": ["src"],
   "references": [
+    { "path": "../../picasso-tailwind" },
     { "path": "../../shared" },
     { "path": "../Container" },
     { "path": "../Typography" },

--- a/packages/base/TreeView/package.json
+++ b/packages/base/TreeView/package.json
@@ -33,6 +33,7 @@
   ],
   "peerDependencies": {
     "@material-ui/core": "4.12.4",
+    "@toptal/picasso-tailwind": ">=2.7",
     "react": ">=16.12.0 < 19.0.0"
   },
   "devDependencies": {

--- a/packages/base/TreeView/tsconfig.json
+++ b/packages/base/TreeView/tsconfig.json
@@ -3,6 +3,7 @@
   "compilerOptions": { "outDir": "dist-package" },
   "include": ["src"],
   "references": [
+    { "path": "../../picasso-tailwind" },
     { "path": "../Button" },
     { "path": "../Container" },
     { "path": "../Utils" }

--- a/packages/base/UserBadge/package.json
+++ b/packages/base/UserBadge/package.json
@@ -34,7 +34,7 @@
   ],
   "peerDependencies": {
     "@material-ui/core": "4.12.4",
-    "tailwindcss": ">=3",
+    "@toptal/picasso-tailwind": ">=2.7",
     "react": ">=16.12.0 < 19.0.0"
   },
   "exports": {

--- a/packages/base/UserBadge/tsconfig.json
+++ b/packages/base/UserBadge/tsconfig.json
@@ -3,6 +3,7 @@
   "compilerOptions": { "outDir": "dist-package" },
   "include": ["src"],
   "references": [
+    { "path": "../../picasso-tailwind" },
     { "path": "../Avatar" },
     { "path": "../Container" },
     { "path": "../Typography" },

--- a/packages/picasso-forms/package.json
+++ b/packages/picasso-forms/package.json
@@ -23,6 +23,7 @@
   },
   "peerDependencies": {
     "@toptal/picasso-shared": "^15.0.0",
+    "@toptal/picasso-tailwind": ">=2.7",
     "react": ">=16.12.0 < 19.0.0",
     "react-dom": ">=16.12.0 < 19.0.0",
     "typescript": "~4.7.0"

--- a/packages/picasso-forms/tsconfig.json
+++ b/packages/picasso-forms/tsconfig.json
@@ -26,6 +26,7 @@
     { "path": "../base/Timepicker" },
     { "path": "../base/Utils" },
     { "path": "../picasso-rich-text-editor" },
+    { "path": "../picasso-tailwind" },
     { "path": "../shared" }
   ]
 }

--- a/packages/picasso-query-builder/package.json
+++ b/packages/picasso-query-builder/package.json
@@ -24,7 +24,7 @@
   "peerDependencies": {
     "@toptal/picasso-provider": "*",
     "react": ">=16.12.0 < 19.0.0",
-    "tailwindcss": ">=3",
+    "@toptal/picasso-tailwind": ">=2.7",
     "react-dom": ">=16.12.0 < 19.0.0",
     "typescript": "~4.7.0"
   },

--- a/packages/picasso-query-builder/tsconfig.json
+++ b/packages/picasso-query-builder/tsconfig.json
@@ -18,6 +18,7 @@
     { "path": "../base/Tooltip" },
     { "path": "../base/Typography" },
     { "path": "../base/Utils" },
-    { "path": "../picasso-provider" }
+    { "path": "../picasso-provider" },
+    { "path": "../picasso-tailwind" }
   ]
 }

--- a/packages/picasso-rich-text-editor/package.json
+++ b/packages/picasso-rich-text-editor/package.json
@@ -33,7 +33,7 @@
     "react": ">=16.12.0 < 19.0.0",
     "react-dom": ">=16.12.0 < 19.0.0",
     "typescript": "~4.7.0",
-    "@toptal/picasso-tailwind": ">=2.5.0"
+    "@toptal/picasso-tailwind": ">=2.7"
   },
   "dependencies": {
     "@emoji-mart/data": "^1.2.1",

--- a/packages/picasso-tailwind/src/index.js
+++ b/packages/picasso-tailwind/src/index.js
@@ -122,6 +122,7 @@ module.exports = {
       current: 'currentColor',
       blue: {
         100: '#EDF1FD',
+        150: '#D5DEFA',
         400: '#25A9EF',
         500: '#204ECF',
         600: '#183A9E',
@@ -129,6 +130,7 @@ module.exports = {
       },
       green: {
         100: '#EAFBF5',
+        150: '#D7F3E9',
         500: '#00CC83',
         600: '#03B080',
         700: '#05947C',
@@ -149,10 +151,12 @@ module.exports = {
       },
       red: {
         100: '#FBEDF1',
+        150: '#F5D8E0',
         500: '#D42551',
       },
       yellow: {
         100: '#FFF5E3',
+        150: '#F8E7C8',
         500: '#E59C01',
       },
       purple: {

--- a/packages/picasso/package.json
+++ b/packages/picasso/package.json
@@ -29,7 +29,7 @@
   "peerDependencies": {
     "@material-ui/core": "4.12.4",
     "@toptal/picasso-provider": "*",
-    "@toptal/picasso-tailwind": "^2.5.0",
+    "@toptal/picasso-tailwind": ">=2.7",
     "notistack": "3.0.1",
     "react": ">=16.12.0 < 19.0.0",
     "react-dom": ">=16.12.0 < 19.0.0",

--- a/packages/topkit-analytics-charts/package.json
+++ b/packages/topkit-analytics-charts/package.json
@@ -22,6 +22,7 @@
   },
   "peerDependencies": {
     "react": ">=16.12.0 < 19.0.0",
+    "@toptal/picasso-tailwind": ">=2.7",
     "typescript": "~4.7.0"
   },
   "devDependencies": {

--- a/packages/topkit-analytics-charts/tsconfig.json
+++ b/packages/topkit-analytics-charts/tsconfig.json
@@ -7,6 +7,7 @@
     { "path": "../base/Paper" },
     { "path": "../base/Typography" },
     { "path": "../base/Utils" },
-    { "path": "../picasso-charts" }
+    { "path": "../picasso-charts" },
+    { "path": "../picasso-tailwind" }
   ]
 }


### PR DESCRIPTION
[FX-5267]

### Description

This PR updates the strokes for the Container to have an outline color according to the [Figma designs](https://www.figma.com/design/5SCTOPrCDcHuk5We091GBn/Product-Library?node-id=83-0&t=XVpS6TCUUoS71Wpk-0). The only variants that could be bordered/non-bordered will be the `white` and the `transparent` ones.

### How to test

<!-- The temploy link will be automatically updated when the temploy is deployed -->
- [Temploy](https://picasso.toptal.net/fx-5267-add-strokes-to-alert-container-and-helpbox)
- Check the [production](https://picasso.toptal.net/?path=/story/layout-container--container) and compare it with the temploy.

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| ![image](https://github.com/user-attachments/assets/66d0774a-1f34-4d37-8e67-2b00677e74df) | ![image](https://github.com/user-attachments/assets/c707028b-20a7-461f-9d37-5577f860538e) |

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- ~Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)~
- [x] Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- ~Annotate all `props` in component with documentation~
- ~Create `examples` for component~
- ~Ensure that deployed demo has expected results and good examples~
- ~Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).~
- [x] Self reviewed
- ~Covered with tests ([visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md) included)~

**Breaking change**

- ~codemod is created and showcased in the changeset~
- ~test alpha package of Picasso in StaffPortal~

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-5267]: https://toptal-core.atlassian.net/browse/FX-5267?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ