### PR TITLE
[FX-5596] Disable days before minDate

### DIFF
--- a/.changeset/chilly-owls-appear.md
+++ b/.changeset/chilly-owls-appear.md
@@ -1,0 +1,5 @@
+---
+'@toptal/picasso-calendar': patch
+---
+
+- disable days before minDate

--- a/packages/base/Calendar/src/Calendar/Calendar.tsx
+++ b/packages/base/Calendar/src/Calendar/Calendar.tsx
@@ -240,7 +240,6 @@ export const Calendar = forwardRef<HTMLDivElement, Props>(function Calendar(
             // @ts-ignore
             onSelect={range ? handleRangeChange : handleSingleDateChange}
             fromDate={minDate}
-            fromYear={minDate?.getFullYear()}
             onMonthChange={month => setNavigationMonth(month)}
             toDate={maxDate}
             numberOfMonths={shouldRenderMultipleMonths ? numberOfMonths : 1}

--- a/packages/base/Calendar/src/Calendar/test.tsx
+++ b/packages/base/Calendar/src/Calendar/test.tsx
@@ -64,4 +64,27 @@ describe('Calendar', () => {
       expect(onChange).not.toHaveBeenCalled()
     })
   })
+
+  describe('when minDate is set', () => {
+    it('will not trigger onChange when we click on disabled button', () => {
+      const minDate = new Date(2024, 6, 10)
+      const maxDate = new Date(2024, 6, 15)
+      const value = new Date(2024, 6, 12)
+      const onChange = jest.fn()
+
+      const { getByTestId } = render(
+        <Calendar
+          minDate={minDate}
+          maxDate={maxDate}
+          value={value}
+          onChange={onChange}
+        />
+      )
+
+      const disabledButton = getByTestId('day-button-6')
+
+      fireEvent.click(disabledButton)
+      expect(onChange).not.toHaveBeenCalled()
+    })
+  })
 })

--- a/packages/base/Calendar/src/Calendar/test.tsx
+++ b/packages/base/Calendar/src/Calendar/test.tsx
@@ -43,48 +43,52 @@ describe('Calendar', () => {
   })
 
   describe('when maxDate is set', () => {
-    it('will not trigger onChange when we click on disabled button', () => {
-      const minDate = new Date(2024, 6, 1)
-      const maxDate = new Date(2024, 6, 10)
-      const value = new Date(2024, 6, 2)
-      const onChange = jest.fn()
+    describe('when we click on disabled button', () => {
+      it('will not trigger onChange', () => {
+        const minDate = new Date(2024, 6, 1)
+        const maxDate = new Date(2024, 6, 10)
+        const value = new Date(2024, 6, 2)
+        const onChange = jest.fn()
 
-      const { getByTestId } = render(
-        <Calendar
-          minDate={minDate}
-          maxDate={maxDate}
-          value={value}
-          onChange={onChange}
-        />
-      )
+        const { getByTestId } = render(
+          <Calendar
+            minDate={minDate}
+            maxDate={maxDate}
+            value={value}
+            onChange={onChange}
+          />
+        )
 
-      const disabledButton = getByTestId('day-button-11')
+        const disabledButton = getByTestId('day-button-11')
 
-      fireEvent.click(disabledButton)
-      expect(onChange).not.toHaveBeenCalled()
+        fireEvent.click(disabledButton)
+        expect(onChange).not.toHaveBeenCalled()
+      })
     })
   })
 
   describe('when minDate is set', () => {
-    it('will not trigger onChange when we click on disabled button', () => {
-      const minDate = new Date(2024, 6, 10)
-      const maxDate = new Date(2024, 6, 15)
-      const value = new Date(2024, 6, 12)
-      const onChange = jest.fn()
+    describe('when we click on disabled button', () => {
+      it('will not trigger onChange', () => {
+        const minDate = new Date(2024, 6, 10)
+        const maxDate = new Date(2024, 6, 15)
+        const value = new Date(2024, 6, 12)
+        const onChange = jest.fn()
 
-      const { getByTestId } = render(
-        <Calendar
-          minDate={minDate}
-          maxDate={maxDate}
-          value={value}
-          onChange={onChange}
-        />
-      )
+        const { getByTestId } = render(
+          <Calendar
+            minDate={minDate}
+            maxDate={maxDate}
+            value={value}
+            onChange={onChange}
+          />
+        )
 
-      const disabledButton = getByTestId('day-button-6')
+        const disabledButton = getByTestId('day-button-6')
 
-      fireEvent.click(disabledButton)
-      expect(onChange).not.toHaveBeenCalled()
+        fireEvent.click(disabledButton)
+        expect(onChange).not.toHaveBeenCalled()
+      })
     })
   })
 })


### PR DESCRIPTION
[FX-5596]

### Description

when we pass `minDate` all days before that date have to be disabled.

### How to test

<!-- The temploy link will be automatically updated when the temploy is deployed -->
- [Temploy](https://picasso.toptal.net/fx-null-fix-day-picker-2)
- FIXME: Add the steps describing how to verify your changes

### Screenshots



### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- Annotate all `props` in component with documentation
- Create `examples` for component
- Ensure that deployed demo has expected results and good examples
- Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests ([visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md) included)

**Breaking change**

- codemod is created and showcased in the changeset
- test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-5596]: https://toptal-core.atlassian.net/browse/FX-5596?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ