### PR TITLE
[FX-5596] Set height to auto after transition is finished

### DIFF
--- a/.changeset/smart-ladybugs-play.md
+++ b/.changeset/smart-ladybugs-play.md
@@ -1,0 +1,5 @@
+---
+'@toptal/picasso-collapse': patch
+---
+
+- set height auto after the open transition is finished

--- a/cypress/component/Table.spec.tsx
+++ b/cypress/component/Table.spec.tsx
@@ -205,7 +205,7 @@ const ExpandableContent = () => (
       </Container>
     </Container>
 
-    <Container top='small'>
+    <Container top='small' data-testid='tag'>
       <Tag>$2k Design Credit</Tag>
     </Container>
   </Container>
@@ -349,6 +349,8 @@ describe('Table', () => {
     ]
 
     cy.mount(<TableExpandableRowsExample localData={localData} />)
+
+    cy.getByTestId('tag')
 
     cy.get('body').happoScreenshot({
       component,

--- a/packages/base/Collapse/src/Collapse/Collapse.tsx
+++ b/packages/base/Collapse/src/Collapse/Collapse.tsx
@@ -73,14 +73,10 @@ export const Collapse = forwardRef<HTMLDivElement, Props>(
       if (transitionState === 'exiting' || transitionState === 'entering') {
         // we need to add small delay as 'exit' and 'exiting'
         // are triggered in the same time and React is batching them
-
-        // flushSync react dom
         setTimeout(() => setHeight(heightByState[transitionState]), 50)
       } else {
         setHeight(heightByState[transitionState])
       }
-
-      console.log('transitionState', transitionState)
     }, [transitionState])
 
     const memoStyles = useMemo(() => {

--- a/packages/base/Collapse/src/Collapse/Collapse.tsx
+++ b/packages/base/Collapse/src/Collapse/Collapse.tsx
@@ -17,8 +17,8 @@ export interface Props extends TransitionProps, BaseProps {
   onEnter?: (node: HTMLElement, isAppearing: boolean) => void
 }
 
-const useCollapseLogic = () => {
-  const [height, setHeight] = useState<string>('0px')
+const useCollapseLogic = (inProps: boolean) => {
+  const [height, setHeight] = useState<string>(inProps ? 'auto' : '0px')
   const wrapperRef = React.useRef<HTMLDivElement>(null)
 
   const getCurrentHeight = () => wrapperRef.current?.clientHeight
@@ -58,7 +58,7 @@ export const Collapse = forwardRef<HTMLDivElement, Props>(
       setHeightToZero,
       setHeightToAuto,
       setHeightToCurrent,
-    } = useCollapseLogic()
+    } = useCollapseLogic(inProps)
 
     // we need to add small delay as 'enter', 'entering' and 'exit', 'exiting'
     // are triggered in the same time and React is batching them

--- a/packages/base/Collapse/src/Collapse/Collapse.tsx
+++ b/packages/base/Collapse/src/Collapse/Collapse.tsx
@@ -14,7 +14,7 @@ export interface Props extends TransitionProps, BaseProps {
   /* Unmount the component on exit */
   unmountOnExit?: boolean
   /* Callback fired when the component has entered */
-  onEnter?: (node: HTMLElement | null, isAppearing: boolean) => void
+  onEnter?: (node: HTMLElement, isAppearing: boolean) => void
 }
 
 const useCollapseLogic = () => {

--- a/packages/base/Collapse/src/Collapse/story/AppearOnRender.example.tsx
+++ b/packages/base/Collapse/src/Collapse/story/AppearOnRender.example.tsx
@@ -1,0 +1,25 @@
+import { Container, Button } from '@toptal/picasso'
+import { Collapse } from '@toptal/picasso-collapse'
+import React, { useState } from 'react'
+
+const Example = () => {
+  const [faded, setFaded] = useState(false)
+
+  const handleOnClick = () => setFaded(prevFaded => !prevFaded)
+
+  return (
+    <Container>
+      <Button onClick={handleOnClick} className='mb-4'>
+        {faded ? 'Unmount Collapse' : 'Render Collapse'}
+      </Button>
+
+      {faded && (
+        <Collapse appear in timeout={400}>
+          <div className='bg-gray-100 p-4 rounded-md'>Collapse content</div>
+        </Collapse>
+      )}
+    </Container>
+  )
+}
+
+export default Example

--- a/packages/base/Collapse/src/Collapse/story/index.jsx
+++ b/packages/base/Collapse/src/Collapse/story/index.jsx
@@ -8,11 +8,21 @@ page.createTabChapter('Props').addComponentDocs({
   name: 'Collapse',
 })
 
-page.createChapter().addExample(
-  'Collapse/story/Default.example.tsx',
-  {
-    title: 'Default',
-    takeScreenshot: false,
-  },
-  'base/Collapse'
-)
+page
+  .createChapter()
+  .addExample(
+    'Collapse/story/Default.example.tsx',
+    {
+      title: 'Default',
+      takeScreenshot: false,
+    },
+    'base/Collapse'
+  )
+  .addExample(
+    'Collapse/story/AppearOnRender.example.tsx',
+    {
+      title: 'Appear on render',
+      takeScreenshot: false,
+    },
+    'base/Collapse'
+  )

--- a/packages/base/Collapse/src/Collapse/test.tsx
+++ b/packages/base/Collapse/src/Collapse/test.tsx
@@ -26,7 +26,7 @@ describe('Collapse', () => {
       </Collapse>
     )
 
-    expect(getByTestId('collapse')).toHaveClass('hidden')
+    expect(getByTestId('collapse')).toHaveClass('invisible')
 
     act(() => {
       rerender(

--- a/packages/base/Section/src/Section/__snapshots__/test.tsx.snap
+++ b/packages/base/Section/src/Section/__snapshots__/test.tsx.snap
@@ -89,7 +89,7 @@ exports[`Section renders collapsible initially expanded 1`] = `
       </div>
       <div
         class="transition-[height] ease-in min-h overflow-visible"
-        style="transition-duration: 350ms;"
+        style="transition-duration: 350ms; height: 0px;"
       >
         <div
           class="flex"
@@ -145,7 +145,7 @@ exports[`Section renders with title, subtitle, actions and content 1`] = `
       </div>
       <div
         class="transition-[height] ease-in min-h overflow-visible"
-        style="transition-duration: 350ms;"
+        style="transition-duration: 350ms; height: 0px;"
       >
         <div
           class="flex"
@@ -178,7 +178,7 @@ exports[`Section renders without header 1`] = `
     >
       <div
         class="transition-[height] ease-in min-h overflow-visible"
-        style="transition-duration: 350ms;"
+        style="transition-duration: 350ms; height: 0px;"
       >
         <div
           class="flex"

--- a/packages/base/Section/src/Section/__snapshots__/test.tsx.snap
+++ b/packages/base/Section/src/Section/__snapshots__/test.tsx.snap
@@ -88,17 +88,22 @@ exports[`Section renders collapsible initially expanded 1`] = `
         </div>
       </div>
       <div
-        class="flex"
+        class="transition-[height] ease-in min-h overflow-visible"
+        style="transition-duration: 350ms;"
       >
         <div
-          class="w-full"
+          class="flex"
         >
           <div
-            class=""
+            class="w-full"
           >
             <div
-              data-testid="content"
-            />
+              class=""
+            >
+              <div
+                data-testid="content"
+              />
+            </div>
           </div>
         </div>
       </div>
@@ -139,17 +144,22 @@ exports[`Section renders with title, subtitle, actions and content 1`] = `
         </div>
       </div>
       <div
-        class="flex"
+        class="transition-[height] ease-in min-h overflow-visible"
+        style="transition-duration: 350ms;"
       >
         <div
-          class="w-full"
+          class="flex"
         >
           <div
-            class=""
+            class="w-full"
           >
             <div
-              data-testid="content"
-            />
+              class=""
+            >
+              <div
+                data-testid="content"
+              />
+            </div>
           </div>
         </div>
       </div>
@@ -167,17 +177,22 @@ exports[`Section renders without header 1`] = `
       class="pt-8 [&>:last-child:not(:first-child)]:mt-6"
     >
       <div
-        class="flex"
+        class="transition-[height] ease-in min-h overflow-visible"
+        style="transition-duration: 350ms;"
       >
         <div
-          class="w-full"
+          class="flex"
         >
           <div
-            class=""
+            class="w-full"
           >
             <div
-              data-testid="content"
-            />
+              class=""
+            >
+              <div
+                data-testid="content"
+              />
+            </div>
           </div>
         </div>
       </div>

--- a/packages/base/Section/src/Section/__snapshots__/test.tsx.snap
+++ b/packages/base/Section/src/Section/__snapshots__/test.tsx.snap
@@ -89,7 +89,7 @@ exports[`Section renders collapsible initially expanded 1`] = `
       </div>
       <div
         class="transition-[height] ease-in min-h overflow-visible"
-        style="transition-duration: 350ms; height: 0px;"
+        style="transition-duration: 350ms; height: auto;"
       >
         <div
           class="flex"
@@ -145,7 +145,7 @@ exports[`Section renders with title, subtitle, actions and content 1`] = `
       </div>
       <div
         class="transition-[height] ease-in min-h overflow-visible"
-        style="transition-duration: 350ms; height: 0px;"
+        style="transition-duration: 350ms; height: auto;"
       >
         <div
           class="flex"
@@ -178,7 +178,7 @@ exports[`Section renders without header 1`] = `
     >
       <div
         class="transition-[height] ease-in min-h overflow-visible"
-        style="transition-duration: 350ms; height: 0px;"
+        style="transition-duration: 350ms; height: auto;"
       >
         <div
           class="flex"

--- a/packages/base/Table/src/Table/story/ExpandableRows.example.tsx
+++ b/packages/base/Table/src/Table/story/ExpandableRows.example.tsx
@@ -23,6 +23,85 @@ const StyledArrowDownMinor16 = styled(
   transform: rotate(${({ expanded }) => (expanded ? '180deg' : '0deg')});
 `
 
+const DynamicContent = () => {
+  const [isLoaded, setLoaded] = React.useState(false)
+
+  React.useEffect(() => {
+    setTimeout(() => {
+      setLoaded(true)
+    }, 1000)
+  })
+
+  return (
+    <Container>
+      {isLoaded ? (
+        <Typography size='small'>
+          Lorem ipsum dolor sit amet consectetur adipisicing elit. Modi placeat
+          dolorem provident, aut aspernatur doloribus eos reiciendis molestiae
+          ab quidem ad facilis animi dolorum quis laborum possimus temporibus
+          debitis maiores ullam neque? Tempora rem eligendi ex consectetur
+          impedit eos optio illum voluptates. Quis expedita, rerum reiciendis
+          hic quae molestiae sit doloribus, beatae assumenda illo non iste
+          itaque deleniti! Expedita ducimus, deleniti accusantium iusto adipisci
+          nesciunt inventore! Laborum, repudiandae temporibus eligendi
+          blanditiis laudantium suscipit. Tempore culpa, consequuntur placeat,
+          inventore cumque vitae recusandae at consequatur praesentium
+          asperiores sunt porro beatae, ipsa dicta laboriosam quae voluptatum.
+          Magnam animi ea sint ex, ipsum explicabo. Lorem ipsum dolor sit amet
+          consectetur adipisicing elit. Modi placeat dolorem provident, aut
+          aspernatur doloribus eos reiciendis molestiae ab quidem ad facilis
+          animi dolorum quis laborum possimus temporibus debitis maiores ullam
+          neque? Tempora rem eligendi ex consectetur impedit eos optio illum
+          voluptates. Quis expedita, rerum reiciendis hic quae molestiae sit
+          doloribus, beatae assumenda illo non iste itaque deleniti! Expedita
+          ducimus, deleniti accusantium iusto adipisci nesciunt inventore!
+          Laborum, repudiandae temporibus eligendi blanditiis laudantium
+          suscipit. Tempore culpa, consequuntur placeat, inventore cumque vitae
+          recusandae at consequatur praesentium asperiores sunt porro beatae,
+          ipsa dicta laboriosam quae voluptatum. Magnam animi ea sint ex, ipsum
+          explicabo. Lorem ipsum dolor sit amet consectetur adipisicing elit.
+          Modi placeat dolorem provident, aut aspernatur doloribus eos
+          reiciendis molestiae ab quidem ad facilis animi dolorum quis laborum
+          possimus temporibus debitis maiores ullam neque? Tempora rem eligendi
+          ex consectetur impedit eos optio illum voluptates. Quis expedita,
+          rerum reiciendis hic quae molestiae sit doloribus, beatae assumenda
+          illo non iste itaque deleniti! Expedita ducimus, deleniti accusantium
+          iusto adipisci nesciunt inventore! Laborum, repudiandae temporibus
+          eligendi blanditiis laudantium suscipit. Tempore culpa, consequuntur
+          placeat, inventore cumque vitae recusandae at consequatur praesentium
+          asperiores sunt porro beatae, ipsa dicta laboriosam quae voluptatum.
+          Magnam animi ea sint ex, ipsum explicabo. Lorem ipsum dolor sit amet
+          consectetur adipisicing elit. Modi placeat dolorem provident, aut
+          aspernatur doloribus eos reiciendis molestiae ab quidem ad facilis
+          animi dolorum quis laborum possimus temporibus debitis maiores ullam
+          neque? Tempora rem eligendi ex consectetur impedit eos optio illum
+          voluptates. Quis expedita, rerum reiciendis hic quae molestiae sit
+          doloribus, beatae assumenda illo non iste itaque deleniti! Expedita
+          ducimus, deleniti accusantium iusto adipisci nesciunt inventore!
+          Laborum, repudiandae temporibus eligendi blanditiis laudantium
+          suscipit. Tempore culpa, consequuntur placeat, inventore cumque vitae
+          recusandae at consequatur praesentium asperiores sunt porro beatae,
+          ipsa dicta laboriosam quae voluptatum. Magnam animi ea sint ex, ipsum
+          explicabo. Lorem ipsum dolor sit amet consectetur adipisicing elit.
+          Modi placeat dolorem provident, aut aspernatur doloribus eos
+          reiciendis molestiae ab quidem ad facilis animi dolorum quis laborum
+          possimus temporibus debitis maiores ullam neque? Tempora rem eligendi
+          ex consectetur impedit eos optio illum voluptates. Quis expedita,
+          rerum reiciendis hic quae molestiae sit doloribus, beatae assumenda
+          illo non iste itaque deleniti! Expedita ducimus, deleniti accusantium
+          iusto adipisci nesciunt inventore! Laborum, repudiandae temporibus
+          eligendi blanditiis laudantium suscipit. Tempore culpa, consequuntur
+          placeat, inventore cumque vitae recusandae at consequatur praesentium
+          asperiores sunt porro beatae, ipsa dicta laboriosam quae voluptatum.
+          Magnam animi ea sint ex, ipsum explicabo.
+        </Typography>
+      ) : (
+        <Typography size='small'>Loading dynamic content...</Typography>
+      )}
+    </Container>
+  )
+}
+
 const ExpandableContent = () => (
   <Container padded={SPACING_4}>
     <Tabs value={1}>
@@ -61,6 +140,7 @@ const ExpandableContent = () => (
     <Container top={SPACING_4}>
       <Tag>$2k Design Credit</Tag>
     </Container>
+    <DynamicContent />
   </Container>
 )
 

--- a/packages/base/Table/src/Table/story/ExpandableRows.example.tsx
+++ b/packages/base/Table/src/Table/story/ExpandableRows.example.tsx
@@ -33,7 +33,7 @@ const DynamicContent = () => {
   })
 
   return (
-    <Container>
+    <Container className='max-w-[500px]'>
       {isLoaded ? (
         <Typography size='small'>
           Lorem ipsum dolor sit amet consectetur adipisicing elit. Modi placeat
@@ -60,40 +60,6 @@ const DynamicContent = () => {
           recusandae at consequatur praesentium asperiores sunt porro beatae,
           ipsa dicta laboriosam quae voluptatum. Magnam animi ea sint ex, ipsum
           explicabo. Lorem ipsum dolor sit amet consectetur adipisicing elit.
-          Modi placeat dolorem provident, aut aspernatur doloribus eos
-          reiciendis molestiae ab quidem ad facilis animi dolorum quis laborum
-          possimus temporibus debitis maiores ullam neque? Tempora rem eligendi
-          ex consectetur impedit eos optio illum voluptates. Quis expedita,
-          rerum reiciendis hic quae molestiae sit doloribus, beatae assumenda
-          illo non iste itaque deleniti! Expedita ducimus, deleniti accusantium
-          iusto adipisci nesciunt inventore! Laborum, repudiandae temporibus
-          eligendi blanditiis laudantium suscipit. Tempore culpa, consequuntur
-          placeat, inventore cumque vitae recusandae at consequatur praesentium
-          asperiores sunt porro beatae, ipsa dicta laboriosam quae voluptatum.
-          Magnam animi ea sint ex, ipsum explicabo. Lorem ipsum dolor sit amet
-          consectetur adipisicing elit. Modi placeat dolorem provident, aut
-          aspernatur doloribus eos reiciendis molestiae ab quidem ad facilis
-          animi dolorum quis laborum possimus temporibus debitis maiores ullam
-          neque? Tempora rem eligendi ex consectetur impedit eos optio illum
-          voluptates. Quis expedita, rerum reiciendis hic quae molestiae sit
-          doloribus, beatae assumenda illo non iste itaque deleniti! Expedita
-          ducimus, deleniti accusantium iusto adipisci nesciunt inventore!
-          Laborum, repudiandae temporibus eligendi blanditiis laudantium
-          suscipit. Tempore culpa, consequuntur placeat, inventore cumque vitae
-          recusandae at consequatur praesentium asperiores sunt porro beatae,
-          ipsa dicta laboriosam quae voluptatum. Magnam animi ea sint ex, ipsum
-          explicabo. Lorem ipsum dolor sit amet consectetur adipisicing elit.
-          Modi placeat dolorem provident, aut aspernatur doloribus eos
-          reiciendis molestiae ab quidem ad facilis animi dolorum quis laborum
-          possimus temporibus debitis maiores ullam neque? Tempora rem eligendi
-          ex consectetur impedit eos optio illum voluptates. Quis expedita,
-          rerum reiciendis hic quae molestiae sit doloribus, beatae assumenda
-          illo non iste itaque deleniti! Expedita ducimus, deleniti accusantium
-          iusto adipisci nesciunt inventore! Laborum, repudiandae temporibus
-          eligendi blanditiis laudantium suscipit. Tempore culpa, consequuntur
-          placeat, inventore cumque vitae recusandae at consequatur praesentium
-          asperiores sunt porro beatae, ipsa dicta laboriosam quae voluptatum.
-          Magnam animi ea sint ex, ipsum explicabo.
         </Typography>
       ) : (
         <Typography size='small'>Loading dynamic content...</Typography>

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -87,7 +87,7 @@ export type ColorType =
 
 export interface TransitionProps {
   /* Callback fired when the component has exited */
-  onExited?: (node: HTMLElement | null) => void
+  onExited?: (node: HTMLElement) => void
   /* The duration for the transition, in milliseconds */
   timeout?: number | { enter?: number; exit?: number; appear?: number }
 }

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -87,7 +87,7 @@ export type ColorType =
 
 export interface TransitionProps {
   /* Callback fired when the component has exited */
-  onExited?: (node: HTMLElement) => void
+  onExited?: (node: HTMLElement | null) => void
   /* The duration for the transition, in milliseconds */
   timeout?: number | { enter?: number; exit?: number; appear?: number }
 }


### PR DESCRIPTION
[FX-5596]

### Description

After migrating from MUI@4, we encountered an issue with dynamic content inside the Collapse component. The primary problem was that the height property was not set to auto after the transition ended, which caused issues when the component was closing. Specifically, the browser was batching style changes and transitioning directly from auto to 0, skipping the intermediate height value (node.clientHeight). This behavior breaks the expected transition as the browser cannot animate from auto to a numeric value.

To resolve this, we introduced a mechanism to delay the update to the 0. This ensures that the transition updates the height from auto to the actual height (node.clientHeight), and then to 0, thereby making the transitions smooth.


### How to test

<!-- The temploy link will be automatically updated when the temploy is deployed -->
- [Temploy](https://picasso.toptal.net/fx-extandable-row)
- Check Collapse in the Storybook
- [Check Table and its extendable row example where I added dynamic content](https://picasso.toptal.net/fx-extandable-row/?path=/story/components-table--table#expandable-rows)

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- Covered with tests ([visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md) included)

**Breaking change**

- codemod is created and showcased in the changeset
- test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-5596]: https://toptal-core.atlassian.net/browse/FX-5596?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ