### PR TITLE
[FX-5762] Completely hide axis when needed

### DIFF
--- a/.changeset/pink-rings-suffer.md
+++ b/.changeset/pink-rings-suffer.md
@@ -1,0 +1,5 @@
+---
+'@toptal/picasso-charts': patch
+---
+
+- hide axis if every tick is skipped

--- a/packages/picasso-charts/src/BarChart/BarChart.tsx
+++ b/packages/picasso-charts/src/BarChart/BarChart.tsx
@@ -19,8 +19,6 @@ import { BarChartIndicators } from '../BarChartIndicators'
 import type { BaseChartProps, BarChartDataItem, BarOptions } from '../types'
 import { defineStackId, findTopDomain } from './utils'
 import CHART_CONSTANTS, { chartMargins } from '../utils/constants'
-// TODO: rename file and align exports
-//import { checkIfLabelsExistInData } from './utils/check-if-labels-exist-in-data'
 
 const {
   TICK_MARGIN,
@@ -170,12 +168,10 @@ const BarChart = <T extends string>({
     tickFormatter: valueAxisTickFormatter,
   }
 
-  //const dataHasLabels = checkIfLabelsExistInData<T>(data, labelKey)
-
   const xAxisProps = horizontal ? categoryAxisProps : valueAxisProps
   const yAxisProps = !horizontal ? categoryAxisProps : valueAxisProps
 
-  // If data labels are empty, the corresponding axis with labels is not rendered to avoid empty space
+  // If ticks are not shown, the corresponding axis is not rendered to avoid empty space
   const renderXAxis = showEveryNthTickOnXAxis !== 0
   const renderYAxis = showEveryNthTickOnYAxis !== 0
 

--- a/packages/picasso-charts/src/BarChart/BarChart.tsx
+++ b/packages/picasso-charts/src/BarChart/BarChart.tsx
@@ -19,6 +19,8 @@ import { BarChartIndicators } from '../BarChartIndicators'
 import type { BaseChartProps, BarChartDataItem, BarOptions } from '../types'
 import { defineStackId, findTopDomain } from './utils'
 import CHART_CONSTANTS, { chartMargins } from '../utils/constants'
+// TODO: rename file and align exports
+//import { checkIfLabelsExistInData } from './utils/check-if-labels-exist-in-data'
 
 const {
   TICK_MARGIN,
@@ -116,7 +118,7 @@ const BarChart = <T extends string>({
   customTooltip,
   allowTooltipEscapeViewBox,
   getBarColor = defaultGetBarColor,
-  labelKey,
+  labelKey = 'name',
   getBarLabelColor = defaultGetBarLabelColor,
   renderBarIndicators,
   testIds,
@@ -156,7 +158,7 @@ const BarChart = <T extends string>({
   const ticks = getD3Ticks(BOTTOM_DOMAIN, topDomain, NUMBER_OF_TICKS)
 
   const categoryAxisProps = {
-    dataKey: labelKey || 'name',
+    dataKey: labelKey,
     height: TICK_HEIGHT,
     interval: 0,
     tick: { width: TICK_WIDTH },
@@ -168,8 +170,14 @@ const BarChart = <T extends string>({
     tickFormatter: valueAxisTickFormatter,
   }
 
+  //const dataHasLabels = checkIfLabelsExistInData<T>(data, labelKey)
+
   const xAxisProps = horizontal ? categoryAxisProps : valueAxisProps
   const yAxisProps = !horizontal ? categoryAxisProps : valueAxisProps
+
+  // If data labels are empty, the corresponding axis with labels is not rendered to avoid empty space
+  const renderXAxis = showEveryNthTickOnXAxis !== 0
+  const renderYAxis = showEveryNthTickOnYAxis !== 0
 
   return (
     <div style={{ height, width }} className={className} {...rest}>
@@ -190,24 +198,31 @@ const BarChart = <T extends string>({
             stroke={palette.grey.lighter2}
             vertical={!horizontal}
           />
-          <XAxis
-            {...xAxisProps}
-            type={horizontal ? 'category' : 'number'}
-            tickLine={TICK_LINE}
-            axisLine={AXIS_LINE}
-            minTickGap={MIN_TICK_GAP}
-            tickMargin={TICK_MARGIN}
-            interval={showEveryNthTickOnXAxis - 1}
-          />
-          <YAxis
-            {...yAxisProps}
-            type={horizontal ? 'number' : 'category'}
-            tickLine={TICK_LINE}
-            axisLine={AXIS_LINE}
-            minTickGap={MIN_TICK_GAP}
-            tickMargin={TICK_MARGIN}
-            interval={showEveryNthTickOnYAxis - 1}
-          />
+
+          {renderXAxis && (
+            <XAxis
+              {...xAxisProps}
+              type={horizontal ? 'category' : 'number'}
+              tickLine={TICK_LINE}
+              axisLine={AXIS_LINE}
+              minTickGap={MIN_TICK_GAP}
+              tickMargin={TICK_MARGIN}
+              interval={showEveryNthTickOnXAxis - 1}
+            />
+          )}
+
+          {renderYAxis && (
+            <YAxis
+              {...yAxisProps}
+              type={horizontal ? 'number' : 'category'}
+              tickLine={TICK_LINE}
+              axisLine={AXIS_LINE}
+              minTickGap={MIN_TICK_GAP}
+              tickMargin={TICK_MARGIN}
+              interval={showEveryNthTickOnYAxis - 1}
+            />
+          )}
+
           {tooltipElement}
           {dataKeys.map(dataKey => (
             <Bar
@@ -254,6 +269,7 @@ BarChart.defaultProps = {
   width: 'auto',
   tooltip: false,
   showBarLabel: true,
+  labelKey: 'name',
   layout: 'horizontal',
 }
 

--- a/packages/picasso-charts/src/BarChart/story/index.jsx
+++ b/packages/picasso-charts/src/BarChart/story/index.jsx
@@ -65,7 +65,8 @@ page
     takeScreenshot: false,
   })
   .addExample('BarChart/story/ShowEveryNthTick.example.tsx', {
-    title: 'Show every Nth tick on X or Y-axis',
+    title:
+      'Show every Nth tick on X or Y-axis (or hide axis labels completely)',
     description: `You can show every Nth tick for X-axis or Y-axis. "0" hides all ticks, "1" shows all ticks (default behavior). The example below has "showEveryNthTickOnXAxis={3}" (every third tick is shown on X-axis) and "showEveryNthTickOnYAxis={0}" (no ticks are shown on Y-axis).`,
     takeScreenshot: false,
   })

--- a/packages/picasso-charts/src/BarChart/utils/check-if-labels-exist-in-data.ts
+++ b/packages/picasso-charts/src/BarChart/utils/check-if-labels-exist-in-data.ts
@@ -1,0 +1,6 @@
+import type { BarChartDataItem } from '../../types'
+
+export const checkIfLabelsExistInData = <K extends string>(
+  data: BarChartDataItem<K>[],
+  labelKey: string
+) => data.filter(entry => !(labelKey in entry)).length > 0

--- a/packages/picasso-charts/src/BarChart/utils/check-if-labels-exist-in-data.ts
+++ b/packages/picasso-charts/src/BarChart/utils/check-if-labels-exist-in-data.ts
@@ -1,6 +1,0 @@
-import type { BarChartDataItem } from '../../types'
-
-export const checkIfLabelsExistInData = <K extends string>(
-  data: BarChartDataItem<K>[],
-  labelKey: string
-) => data.filter(entry => !(labelKey in entry)).length > 0


### PR DESCRIPTION
[FX-5762](https://toptal-core.atlassian.net/browse/FX-5725)

### Description

Describe the changes and motivations for the pull request.

### How to test

<!-- The temploy link will be automatically updated when the temploy is deployed -->
- [Temploy](https://picasso.toptal.net/fx-5725-barchart-shows-extra-space-in-the-bottom/?path=/story/picasso-charts-barchart--barchart)
- Compare with https://picasso.toptal.net/?path=/story/picasso-charts-barchart--barchart

### Screenshots

Comparison with `master`

https://github.com/user-attachments/assets/62a7211a-1768-4c5c-b154-21719287e9c4


### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [N/A] Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [N/A] Annotate all `props` in component with documentation
- [N/A] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [N/A] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests ([visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md) included)

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-5762]: https://toptal-core.atlassian.net/browse/FX-5762?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ