### PR TITLE
[FX-5533] Refactor FormHint and FormError to TailwindCSS

### DIFF
--- a/.changeset/good-horses-brake.md
+++ b/.changeset/good-horses-brake.md
@@ -3,4 +3,4 @@
 '@toptal/picasso': minor
 ---
 
-- refactor FormHind and FormError to TailwindCSS
+- refactor FormHint and FormError to TailwindCSS

--- a/.changeset/good-horses-brake.md
+++ b/.changeset/good-horses-brake.md
@@ -1,0 +1,6 @@
+---
+'@toptal/picasso-form': minor
+'@toptal/picasso': minor
+---
+
+- refactor FormHind and FormError to TailwindCSS

--- a/packages/base/Form/package.json
+++ b/packages/base/Form/package.json
@@ -41,12 +41,14 @@
     "@material-ui/core": "4.12.4",
     "@toptal/picasso-provider": "*",
     "@toptal/picasso-tailwind": ">=2.7",
+    "@toptal/picasso-tailwind-merge": "^1.2.0",
     "react": ">=16.12.0 < 19.0.0"
   },
   "exports": {
     ".": "./dist-package/src/index.js"
   },
   "devDependencies": {
+    "@toptal/picasso-tailwind-merge": "1.2.0",
     "@toptal/picasso-provider": "5.0.0",
     "@toptal/picasso-test-utils": "1.1.1"
   },

--- a/packages/base/Form/src/FormError/FormError.tsx
+++ b/packages/base/Form/src/FormError/FormError.tsx
@@ -1,19 +1,13 @@
 import type { ReactNode, HTMLAttributes } from 'react'
 import React, { forwardRef } from 'react'
-import type { Theme } from '@material-ui/core/styles'
-import { makeStyles } from '@material-ui/core/styles'
-import cx from 'classnames'
 import type { BaseProps } from '@toptal/picasso-shared'
 import { Typography } from '@toptal/picasso-typography'
-
-import styles from './styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 
 export interface Props extends BaseProps, HTMLAttributes<HTMLDivElement> {
   /** The text of the error */
   children: ReactNode
 }
-
-const useStyles = makeStyles<Theme>(styles, { name: 'PicassoFormError' })
 
 export const FormError = forwardRef<HTMLDivElement, Props>(function FormError(
   props,
@@ -21,13 +15,11 @@ export const FormError = forwardRef<HTMLDivElement, Props>(function FormError(
 ) {
   const { children, className, style, ...rest } = props
 
-  const classes = useStyles()
-
   return (
     <div
       {...rest}
       ref={ref}
-      className={cx(classes.root, className)}
+      className={twMerge('mt-1', className)}
       style={style}
     >
       <Typography color='red' size='xxsmall' className='cursor-default'>

--- a/packages/base/Form/src/FormError/__snapshots__/test.tsx.snap
+++ b/packages/base/Form/src/FormError/__snapshots__/test.tsx.snap
@@ -33,7 +33,7 @@ exports[`FormError renders 1`] = `
           />
         </div>
         <div
-          class="PicassoFormError-root"
+          class="mt-1"
         >
           <p
             class="m-0 text-2xs text-red font-regular cursor-default"
@@ -42,7 +42,7 @@ exports[`FormError renders 1`] = `
           </p>
         </div>
         <div
-          class="FormHint-root"
+          class="mt-1"
         >
           <p
             class="m-0 text-2xs text-graphite font-regular"

--- a/packages/base/Form/src/FormError/styles.ts
+++ b/packages/base/Form/src/FormError/styles.ts
@@ -1,8 +1,0 @@
-import { createStyles } from '@material-ui/core/styles'
-
-export default () =>
-  createStyles({
-    root: {
-      marginTop: '0.25em',
-    },
-  })

--- a/packages/base/Form/src/FormHint/FormHint.tsx
+++ b/packages/base/Form/src/FormHint/FormHint.tsx
@@ -1,19 +1,13 @@
 import type { ReactNode, HTMLAttributes } from 'react'
 import React, { forwardRef } from 'react'
-import type { Theme } from '@material-ui/core/styles'
-import { makeStyles } from '@material-ui/core/styles'
-import cx from 'classnames'
 import type { BaseProps } from '@toptal/picasso-shared'
 import { Typography } from '@toptal/picasso-typography'
-
-import styles from './styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 
 export interface Props extends BaseProps, HTMLAttributes<HTMLDivElement> {
   /** The text of the hint */
   children: ReactNode
 }
-
-const useStyles = makeStyles<Theme>(styles, { name: 'FormHint' })
 
 export const FormHint = forwardRef<HTMLDivElement, Props>(function FormHint(
   props,
@@ -21,13 +15,11 @@ export const FormHint = forwardRef<HTMLDivElement, Props>(function FormHint(
 ) {
   const { children, className, style, ...rest } = props
 
-  const classes = useStyles()
-
   return (
     <div
       {...rest}
       ref={ref}
-      className={cx(classes.root, className)}
+      className={twMerge('mt-1', className)}
       style={style}
     >
       <Typography size='xxsmall'>{children}</Typography>

--- a/packages/base/Form/src/FormHint/__snapshots__/test.tsx.snap
+++ b/packages/base/Form/src/FormHint/__snapshots__/test.tsx.snap
@@ -6,7 +6,7 @@ exports[`FormHint renders 1`] = `
     class="Picasso-root"
   >
     <div
-      class="FormHint-root"
+      class="mt-1"
     >
       <p
         class="m-0 text-2xs text-graphite font-regular"

--- a/packages/base/Form/src/FormHint/styles.ts
+++ b/packages/base/Form/src/FormHint/styles.ts
@@ -1,8 +1,0 @@
-import { createStyles } from '@material-ui/core/styles'
-
-export default () =>
-  createStyles({
-    root: {
-      marginTop: '0.25em',
-    },
-  })

--- a/packages/base/Form/tsconfig.json
+++ b/packages/base/Form/tsconfig.json
@@ -5,6 +5,7 @@
   "references": [
     { "path": "../../picasso-provider" },
     { "path": "../../picasso-tailwind" },
+    { "path": "../../picasso-tailwind-merge" },
     { "path": "../../shared" },
     { "path": "../Collapse" },
     { "path": "../Container" },

--- a/packages/picasso-forms/src/Form/__snapshots__/test.tsx.snap
+++ b/packages/picasso-forms/src/Form/__snapshots__/test.tsx.snap
@@ -85,7 +85,7 @@ exports[`Form renders with an error 1`] = `
             class=""
           >
             <div
-              class="PicassoFormError-root PicassoFormField-error"
+              class="mt-1 PicassoFormField-error"
             >
               <p
                 class="m-0 text-2xs text-red font-regular cursor-default"


### PR DESCRIPTION
[FX-5533]

### Description

Refactor FormHint and FormError to TailwindCSS

### How to test

<!-- The temploy link will be automatically updated when the temploy is deployed -->
- [Temploy](https://picasso.toptal.net/fx-5533-formhint)
- Check storybook and Happo screenshots

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| Insert screenshots or screen recordings | Insert screenshots or screen recordings |

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests ([visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md) included)

**Breaking change**

- [x] codemod is created and showcased in the changeset
- [x] test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-5533]: https://toptal-core.atlassian.net/browse/FX-5533?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ