### PR TITLE
[FX-5534] Migrate FormField and FormActionsContainer to TailwindCSS

### DIFF
--- a/.changeset/late-kids-unite.md
+++ b/.changeset/late-kids-unite.md
@@ -1,0 +1,5 @@
+---
+'@toptal/picasso-form': patch
+---
+
+- migrate FormField and FormActionContainer to TailwindCSS

--- a/packages/base/Form/src/FormActionsContainer/FormActionsContainer.tsx
+++ b/packages/base/Form/src/FormActionsContainer/FormActionsContainer.tsx
@@ -1,27 +1,21 @@
 import React from 'react'
 import type { ReactNode } from 'react'
-import cx from 'classnames'
-import type { Theme } from '@material-ui/core/styles'
-import { makeStyles } from '@material-ui/core/styles'
 import type { ContainerProps } from '@toptal/picasso-container'
 import { Container } from '@toptal/picasso-container'
 
-import styles from './styles'
 import { useFieldsLayoutContext } from '../FieldsLayout'
-import { createLabelWidthStyles } from '../FormField/styles'
+import {
+  createLabelWidthStyles,
+  horizontalLayoutClasses,
+} from '../FormField/styles'
 
 export interface Props extends Omit<ContainerProps, 'children'> {
   /** Content */
   children: ReactNode
 }
 
-const useStyles = makeStyles<Theme>(styles, {
-  name: 'PicassoFormActionsContainer',
-})
-
 const FormActionsContainer = ({ children, style, ...rest }: Props) => {
   const { layout, labelWidth } = useFieldsLayoutContext()
-  const classes = useStyles()
 
   if (layout === 'vertical') {
     return <Container {...rest}>{children}</Container>
@@ -31,7 +25,7 @@ const FormActionsContainer = ({ children, style, ...rest }: Props) => {
 
   return (
     <Container
-      className={cx(classes.horizontalLayout)}
+      className={horizontalLayoutClasses}
       {...rest}
       style={{ ...style, ...labelWidthStyles }}
     >

--- a/packages/base/Form/src/FormActionsContainer/styles.ts
+++ b/packages/base/Form/src/FormActionsContainer/styles.ts
@@ -1,9 +1,0 @@
-import { createStyles } from '@material-ui/core/styles'
-import type { Theme } from '@material-ui/core'
-
-import { createStylesForHorizontalLayout } from '../FormField/styles'
-
-export default (theme: Theme) =>
-  createStyles({
-    horizontalLayout: createStylesForHorizontalLayout(theme),
-  })

--- a/packages/base/Form/src/FormError/__snapshots__/test.tsx.snap
+++ b/packages/base/Form/src/FormError/__snapshots__/test.tsx.snap
@@ -9,7 +9,7 @@ exports[`FormError renders 1`] = `
       class=""
     >
       <div
-        class="PicassoFormField-root"
+        class="text-[1rem] [&+&]:mt-4"
         data-field-has-error="false"
       >
         <label

--- a/packages/base/Form/src/FormField/FormField.tsx
+++ b/packages/base/Form/src/FormField/FormField.tsx
@@ -35,6 +35,7 @@ const FormFieldAdornments = ({
   hasMultilineCounter,
 }: FormFieldAdornmentsProps) => {
   const { layout } = useFieldsLayoutContext()
+  const isHorizontal = layout === 'horizontal'
 
   if (Children.toArray(children).length === 0) {
     return null
@@ -42,7 +43,7 @@ const FormFieldAdornments = ({
 
   if (!autoSaveIndicator) {
     return (
-      <div className={twJoin(layout === 'horizontal' && '[grid-area:error]')}>
+      <div className={twJoin(isHorizontal && '[grid-area:error]')}>
         {children}
       </div>
     )
@@ -52,10 +53,7 @@ const FormFieldAdornments = ({
     <Container
       flex
       direction='column'
-      className={twJoin(
-        'relative pr-8',
-        layout === 'horizontal' && '[grid-area:error]'
-      )}
+      className={twJoin('relative pr-8', isHorizontal && '[grid-area:error]')}
     >
       {children}
       <Container
@@ -87,8 +85,10 @@ export const FormField = forwardRef<HTMLDivElement, Props>(function FormField(
   } = props
 
   const { layout, labelWidth } = useFieldsLayoutContext()
-  const labelWidthStyles =
-    layout === 'horizontal' ? createLabelWidthStyles(labelWidth) : {}
+  const isHorizontal = layout === 'horizontal'
+  const labelWidthStyles = isHorizontal
+    ? createLabelWidthStyles(labelWidth)
+    : {}
 
   return (
     <div
@@ -96,7 +96,7 @@ export const FormField = forwardRef<HTMLDivElement, Props>(function FormField(
       ref={ref}
       className={twMerge(
         'text-[1rem] [&+&]:mt-4',
-        layout === 'horizontal' && horizontalLayoutClasses,
+        isHorizontal && horizontalLayoutClasses,
         className
       )}
       style={{ ...style, ...labelWidthStyles }}

--- a/packages/base/Form/src/FormField/FormField.tsx
+++ b/packages/base/Form/src/FormField/FormField.tsx
@@ -1,14 +1,12 @@
 import type { ReactNode, HTMLAttributes } from 'react'
 import React, { forwardRef, Children } from 'react'
-import type { Theme } from '@material-ui/core/styles'
-import { makeStyles } from '@material-ui/core/styles'
-import cx from 'classnames'
 import type { BaseProps } from '@toptal/picasso-shared'
 import { Container } from '@toptal/picasso-container'
+import { twJoin, twMerge } from '@toptal/picasso-tailwind-merge'
 
 import { FormHint } from '../FormHint'
 import { FormError } from '../FormError'
-import styles, { createLabelWidthStyles } from './styles'
+import { createLabelWidthStyles, horizontalLayoutClasses } from './styles'
 import { useFieldsLayoutContext } from '../FieldsLayout'
 
 export interface Props extends BaseProps, HTMLAttributes<HTMLDivElement> {
@@ -26,8 +24,6 @@ export interface Props extends BaseProps, HTMLAttributes<HTMLDivElement> {
   hasMultilineCounter?: boolean
 }
 
-const useStyles = makeStyles<Theme>(styles, { name: 'PicassoFormField' })
-
 type FormFieldAdornmentsProps = Pick<
   Props,
   'autoSaveIndicator' | 'hasMultilineCounter' | 'children'
@@ -38,7 +34,6 @@ const FormFieldAdornments = ({
   children,
   hasMultilineCounter,
 }: FormFieldAdornmentsProps) => {
-  const classes = useStyles()
   const { layout } = useFieldsLayoutContext()
 
   if (Children.toArray(children).length === 0) {
@@ -47,11 +42,7 @@ const FormFieldAdornments = ({
 
   if (!autoSaveIndicator) {
     return (
-      <div
-        className={cx({
-          [classes.horizontalLayoutAdornment]: layout === 'horizontal',
-        })}
-      >
+      <div className={twJoin(layout === 'horizontal' && '[grid-area:error]')}>
         {children}
       </div>
     )
@@ -61,15 +52,17 @@ const FormFieldAdornments = ({
     <Container
       flex
       direction='column'
-      className={cx(classes.adornment, {
-        [classes.horizontalLayoutAdornment]: layout === 'horizontal',
-      })}
+      className={twJoin(
+        'relative pr-8',
+        layout === 'horizontal' && '[grid-area:error]'
+      )}
     >
       {children}
       <Container
-        className={cx(classes.autoSaveIndicator, {
-          [classes.hasMultilineCounter]: hasMultilineCounter,
-        })}
+        className={twJoin(
+          'absolute right-0',
+          hasMultilineCounter ? '-top-[0.875rem]' : 'top-0'
+        )}
       >
         {autoSaveIndicator}
       </Container>
@@ -93,7 +86,6 @@ export const FormField = forwardRef<HTMLDivElement, Props>(function FormField(
     ...rest
   } = props
 
-  const classes = useStyles()
   const { layout, labelWidth } = useFieldsLayoutContext()
   const labelWidthStyles =
     layout === 'horizontal' ? createLabelWidthStyles(labelWidth) : {}
@@ -102,9 +94,9 @@ export const FormField = forwardRef<HTMLDivElement, Props>(function FormField(
     <div
       {...rest}
       ref={ref}
-      className={cx(
-        classes.root,
-        { [classes.horizontalLayout]: layout === 'horizontal' },
+      className={twMerge(
+        'text-[1rem] [&+&]:mt-4',
+        layout === 'horizontal' && horizontalLayoutClasses,
         className
       )}
       style={{ ...style, ...labelWidthStyles }}
@@ -115,8 +107,12 @@ export const FormField = forwardRef<HTMLDivElement, Props>(function FormField(
         autoSaveIndicator={autoSaveIndicator}
         hasMultilineCounter={hasMultilineCounter}
       >
-        {error && <FormError className={classes.error}>{error}</FormError>}
-        {hint && <FormHint className={classes.hint}>{hint}</FormHint>}
+        {error && <FormError>{error}</FormError>}
+        {hint && (
+          <FormHint className={twJoin(error && hint && 'mt-0')}>
+            {hint}
+          </FormHint>
+        )}
         {fieldRequirements}
       </FormFieldAdornments>
     </div>

--- a/packages/base/Form/src/FormField/__snapshots__/test.tsx.snap
+++ b/packages/base/Form/src/FormField/__snapshots__/test.tsx.snap
@@ -6,7 +6,7 @@ exports[`FormField when layout is horizontal renders FormField with appropriate 
     class="Picasso-root"
   >
     <div
-      class="text-[1rem] [&+&]:mt-4 grid w-full gap-x gap-y grid-rows grid-cols-[calc((17rem/4)*var(--form-label [grid-template xs:[--form-label-width:var(--form-label-width- sm:[--form-label-width:var(--form-label-width- md:[--form-label-width:var(--form-label-width- lg:[--form-label-width:var(--form-label-width- xl:[--form-label-width:var(--form-label-width-"
+      class="text-[1rem] [&+&]:mt-4 grid w-full gap-x gap-y grid-rows grid-cols-[calc(4.25rem*var(--form-label [grid-template xs:[--form-label-width:var(--form-label-width- sm:[--form-label-width:var(--form-label-width- md:[--form-label-width:var(--form-label-width- lg:[--form-label-width:var(--form-label-width- xl:[--form-label-width:var(--form-label-width-"
       data-field-has-error="false"
       style="--form-label-width: 3;"
     >
@@ -22,7 +22,7 @@ exports[`FormField when layout is horizontal when labelWidth is 4 renders FormFi
     class="Picasso-root"
   >
     <div
-      class="text-[1rem] [&+&]:mt-4 grid w-full gap-x gap-y grid-rows grid-cols-[calc((17rem/4)*var(--form-label [grid-template xs:[--form-label-width:var(--form-label-width- sm:[--form-label-width:var(--form-label-width- md:[--form-label-width:var(--form-label-width- lg:[--form-label-width:var(--form-label-width- xl:[--form-label-width:var(--form-label-width-"
+      class="text-[1rem] [&+&]:mt-4 grid w-full gap-x gap-y grid-rows grid-cols-[calc(4.25rem*var(--form-label [grid-template xs:[--form-label-width:var(--form-label-width- sm:[--form-label-width:var(--form-label-width- md:[--form-label-width:var(--form-label-width- lg:[--form-label-width:var(--form-label-width- xl:[--form-label-width:var(--form-label-width-"
       data-field-has-error="false"
       style="--form-label-width: 4;"
     >

--- a/packages/base/Form/src/FormField/__snapshots__/test.tsx.snap
+++ b/packages/base/Form/src/FormField/__snapshots__/test.tsx.snap
@@ -6,7 +6,7 @@ exports[`FormField when layout is horizontal renders FormField with appropriate 
     class="Picasso-root"
   >
     <div
-      class="PicassoFormField-root PicassoFormField-horizontalLayout"
+      class="text-[1rem] [&+&]:mt-4 grid w-full gap-x gap-y grid-rows grid-cols-[calc((17rem/4)*var(--form-label [grid-template xs:[--form-label-width:var(--form-label-width- sm:[--form-label-width:var(--form-label-width- md:[--form-label-width:var(--form-label-width- lg:[--form-label-width:var(--form-label-width- xl:[--form-label-width:var(--form-label-width-"
       data-field-has-error="false"
       style="--form-label-width: 3;"
     >
@@ -22,7 +22,7 @@ exports[`FormField when layout is horizontal when labelWidth is 4 renders FormFi
     class="Picasso-root"
   >
     <div
-      class="PicassoFormField-root PicassoFormField-horizontalLayout"
+      class="text-[1rem] [&+&]:mt-4 grid w-full gap-x gap-y grid-rows grid-cols-[calc((17rem/4)*var(--form-label [grid-template xs:[--form-label-width:var(--form-label-width- sm:[--form-label-width:var(--form-label-width- md:[--form-label-width:var(--form-label-width- lg:[--form-label-width:var(--form-label-width- xl:[--form-label-width:var(--form-label-width-"
       data-field-has-error="false"
       style="--form-label-width: 4;"
     >
@@ -38,7 +38,7 @@ exports[`FormField when layout is vertical renders FormField with appropriate fo
     class="Picasso-root"
   >
     <div
-      class="PicassoFormField-root"
+      class="text-[1rem] [&+&]:mt-4"
       data-field-has-error="false"
     >
       <input />

--- a/packages/base/Form/src/FormField/styles.ts
+++ b/packages/base/Form/src/FormField/styles.ts
@@ -1,6 +1,4 @@
-import { createStyles } from '@material-ui/core/styles'
 import type { BreakpointKeys } from '@toptal/picasso-provider'
-import type { Theme } from '@material-ui/core'
 
 import { DEFAULT_LABEL_WIDTH_SIZE } from '../FieldsLayout'
 import type {
@@ -12,22 +10,7 @@ export const getLabelWithName = (breakpoint: BreakpointKeys) => {
   return `--form-label-width--${breakpoint}`
 }
 
-export const HORISONTAL_LABEL_COLUMN_WIDTH = '17rem'
 export const FORM_LABEL_WIDTH_CSS_VARIABLE = '--form-label-width'
-
-/**
- * Generates CSS variables for each breakpoint to set --form-label-width
- */
-export const createBreakpointsForLabelWidth = (theme: Theme) =>
-  [...theme.breakpoints.keys].reduce(
-    (acc, breakpoint) => ({
-      ...acc,
-      [theme.breakpoints.up(breakpoint)]: {
-        [FORM_LABEL_WIDTH_CSS_VARIABLE]: `var(${getLabelWithName(breakpoint)})`,
-      },
-    }),
-    {}
-  )
 
 const isLabelColumnSize = (
   labelWidth: LabelColumnSize | ResponsiveLabelColumnSize
@@ -64,60 +47,14 @@ export const createLabelWidthStyles = (
   )
 }
 
-export const createStylesForHorizontalLayout = (theme: Theme) => {
-  return {
-    display: 'grid',
-    // --form-label-width is passed down from cascading style, in this case from Form
-    '--label-width': `calc(${HORISONTAL_LABEL_COLUMN_WIDTH} / 4 * var(${FORM_LABEL_WIDTH_CSS_VARIABLE}, ${DEFAULT_LABEL_WIDTH_SIZE}))`,
-    gridTemplateColumns: `var(--label-width) 1fr`,
-    gap: '0 32px', // 0 and lg, respectively
-    gridTemplateRows: 'auto auto',
-    gridTemplateAreas: `
-        "label input"
-        "hint error"
-      `,
-    width: '100%',
+export const horizontalLayoutClasses = `
+  grid w-full gap-x-[32px] gap-y-0 grid-rows-[auto_auto] 
+  grid-cols-[calc((17rem/4)*var(--form-label-width,3))_1fr]
+  [grid-template-areas:"label_input"_"hint_error"]
 
-    // create media queries for each breakpoint to set --form-label-width
-    ...createBreakpointsForLabelWidth(theme),
-  }
-}
-
-export default (theme: Theme) =>
-  createStyles({
-    root: {
-      fontSize: '1rem',
-
-      '& + &': {
-        marginTop: '1em',
-      },
-      '& $error + $hint': {
-        marginTop: 0,
-      },
-    },
-
-    adornment: {
-      position: 'relative',
-      paddingRight: '2rem',
-    },
-    autoSaveIndicator: {
-      position: 'absolute',
-      top: 0,
-      right: 0,
-
-      '&$hasMultilineCounter': {
-        top: '-0.875rem',
-      },
-    },
-
-    horizontalLayout: createStylesForHorizontalLayout(theme),
-
-    horizontalLayoutAdornment: {
-      gridArea: 'error',
-    },
-
-    // These classes might still be used in selectors
-    hasMultilineCounter: {},
-    hint: {},
-    error: {},
-  })
+  xs:[--form-label-width:var(--form-label-width--xs)]
+  sm:[--form-label-width:var(--form-label-width--sm)]
+  md:[--form-label-width:var(--form-label-width--md)]
+  lg:[--form-label-width:var(--form-label-width--lg)]
+  xl:[--form-label-width:var(--form-label-width--xl)]
+  `

--- a/packages/base/Form/src/FormField/styles.ts
+++ b/packages/base/Form/src/FormField/styles.ts
@@ -49,7 +49,7 @@ export const createLabelWidthStyles = (
 
 export const horizontalLayoutClasses = `
   grid w-full gap-x-[32px] gap-y-0 grid-rows-[auto_auto] 
-  grid-cols-[calc((17rem/4)*var(--form-label-width,3))_1fr]
+  grid-cols-[calc(4.25rem*var(--form-label-width,3))_1fr]
   [grid-template-areas:"label_input"_"hint_error"]
 
   xs:[--form-label-width:var(--form-label-width--xs)]

--- a/packages/base/Form/src/FormLabel/__snapshots__/test.tsx.snap
+++ b/packages/base/Form/src/FormLabel/__snapshots__/test.tsx.snap
@@ -9,7 +9,7 @@ exports[`FormLabel disabled 1`] = `
       class=""
     >
       <div
-        class="PicassoFormField-root"
+        class="text-[1rem] [&+&]:mt-4"
         data-field-has-error="false"
       >
         <label
@@ -36,7 +36,7 @@ exports[`FormLabel renders 1`] = `
       class=""
     >
       <div
-        class="PicassoFormField-root"
+        class="text-[1rem] [&+&]:mt-4"
         data-field-has-error="false"
       >
         <label
@@ -63,7 +63,7 @@ exports[`FormLabel required with (optional) 1`] = `
       class=""
     >
       <div
-        class="PicassoFormField-root"
+        class="text-[1rem] [&+&]:mt-4"
         data-field-has-error="false"
       >
         <label
@@ -91,7 +91,7 @@ exports[`FormLabel required with (optional) and with \`labelEndAdornment\` 1`] =
       class=""
     >
       <div
-        class="PicassoFormField-root"
+        class="text-[1rem] [&+&]:mt-4"
         data-field-has-error="false"
       >
         <label
@@ -122,7 +122,7 @@ exports[`FormLabel required with asterisk 1`] = `
       class=""
     >
       <div
-        class="PicassoFormField-root"
+        class="text-[1rem] [&+&]:mt-4"
         data-field-has-error="false"
       >
         <label

--- a/packages/picasso-forms/src/Checkbox/__snapshots__/test.tsx.snap
+++ b/packages/picasso-forms/src/Checkbox/__snapshots__/test.tsx.snap
@@ -12,7 +12,7 @@ exports[`Form.Checkbox default render for checkboxes in a group 1`] = `
         class=""
       >
         <div
-          class="PicassoFormField-root"
+          class="text-[1rem] [&+&]:mt-4"
           data-field-has-error="false"
         >
           <label
@@ -134,7 +134,7 @@ exports[`Form.Checkbox default render for single checkbox 1`] = `
         class=""
       >
         <div
-          class="PicassoFormField-root"
+          class="text-[1rem] [&+&]:mt-4"
           data-field-has-error="false"
           data-testid="single-checkbox"
         >
@@ -194,7 +194,7 @@ exports[`Form.Checkbox required with asterisk single checkbox 1`] = `
         class=""
       >
         <div
-          class="PicassoFormField-root"
+          class="text-[1rem] [&+&]:mt-4"
           data-field-has-error="false"
           data-testid="single-checkbox"
         >

--- a/packages/picasso-forms/src/Form/__snapshots__/test.tsx.snap
+++ b/packages/picasso-forms/src/Form/__snapshots__/test.tsx.snap
@@ -13,7 +13,7 @@ exports[`Form renders 1`] = `
         data-testid="form"
       >
         <div
-          class="PicassoFormField-root"
+          class="text-[1rem] [&+&]:mt-4"
           data-field-has-error="false"
         >
           <div
@@ -64,7 +64,7 @@ exports[`Form renders with an error 1`] = `
         data-testid="form"
       >
         <div
-          class="PicassoFormField-root"
+          class="text-[1rem] [&+&]:mt-4"
           data-field-has-error="true"
         >
           <div
@@ -85,7 +85,7 @@ exports[`Form renders with an error 1`] = `
             class=""
           >
             <div
-              class="mt-1 PicassoFormField-error"
+              class="mt-1"
             >
               <p
                 class="m-0 text-2xs text-red font-regular cursor-default"

--- a/packages/picasso-forms/src/Radio/__snapshots__/test.tsx.snap
+++ b/packages/picasso-forms/src/Radio/__snapshots__/test.tsx.snap
@@ -12,7 +12,7 @@ exports[`FormRadio renders 1`] = `
         class=""
       >
         <div
-          class="PicassoFormField-root"
+          class="text-[1rem] [&+&]:mt-4"
           data-field-has-error="false"
         >
           <label
@@ -127,7 +127,7 @@ exports[`FormRadio required with asterisk 1`] = `
         class=""
       >
         <div
-          class="PicassoFormField-root"
+          class="text-[1rem] [&+&]:mt-4"
           data-field-has-error="false"
         >
           <label

--- a/packages/picasso-forms/src/Rating/__snapshots__/test.tsx.snap
+++ b/packages/picasso-forms/src/Rating/__snapshots__/test.tsx.snap
@@ -12,7 +12,7 @@ exports[`Rating Thumbs renders default Stars 1`] = `
         class=""
       >
         <div
-          class="PicassoFormField-root"
+          class="text-[1rem] [&+&]:mt-4"
           data-field-has-error="false"
         >
           <div
@@ -167,7 +167,7 @@ exports[`Rating Thumbs renders default Thumbs 1`] = `
         class=""
       >
         <div
-          class="PicassoFormField-root"
+          class="text-[1rem] [&+&]:mt-4"
           data-field-has-error="false"
         >
           <div


### PR DESCRIPTION
[FX-5534]

### Description

Migrate FormField and FormAction to TailwindCSS.

### How to test

<!-- The temploy link will be automatically updated when the temploy is deployed -->
- [Temploy](https://picasso.toptal.net/fx-5534-formfield-and-formaction-to-tailwind)
- Check PR checks and storybook

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- ~Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core~
- ~Annotate all `props` in component with documentation~
- ~Create `examples` for component~
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- ~Covered with tests ([visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md) included)~

**Breaking change**

- ~codemod is created and showcased in the changeset~
- ~test alpha package of Picasso in StaffPortal~

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-5534]: https://toptal-core.atlassian.net/browse/FX-5534?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ