### PR TITLE
[FX-5541] Refactor Icons to Tailwind

### DIFF
--- a/.changeset/cold-days-flow.md
+++ b/.changeset/cold-days-flow.md
@@ -1,0 +1,6 @@
+---
+'@toptal/picasso-icons': minor
+'@toptal/picasso': minor
+---
+
+- refactor Icons to TailwindCSS

--- a/packages/base/Accordion/src/Accordion/__snapshots__/test.tsx.snap
+++ b/packages/base/Accordion/src/Accordion/__snapshots__/test.tsx.snap
@@ -39,7 +39,7 @@ exports[`Accordion renders collapsed by default 1`] = `
                 class="items-center inline-flex font-semibold text-blue text-md"
               >
                 <svg
-                  class="PicassoSvgArrowDownMinor16-root text-[1.2em] flex-1 w-4 h-4 text-graphite PicassoAccordion-expandIcon"
+                  class="PicassoSvgArrowDownMinor16 fill-current inline-block align-[-.125em] text-[1.2em] flex-1 w-4 h-4 text-graphite PicassoAccordion-expandIcon"
                   style="min-width: 16px; min-height: 16px;"
                   viewBox="0 0 16 16"
                 >
@@ -185,7 +185,7 @@ exports[`Accordion renders disabled 1`] = `
                 class="items-center inline-flex font-semibold text-blue text-md"
               >
                 <svg
-                  class="PicassoSvgArrowDownMinor16-root text-[1.2em] flex-1 w-4 h-4 text-graphite PicassoAccordion-expandIcon"
+                  class="PicassoSvgArrowDownMinor16 fill-current inline-block align-[-.125em] text-[1.2em] flex-1 w-4 h-4 text-graphite PicassoAccordion-expandIcon"
                   style="min-width: 16px; min-height: 16px;"
                   viewBox="0 0 16 16"
                 >

--- a/packages/base/AccountSelect/src/AccountSelect/__snapshots__/test.tsx.snap
+++ b/packages/base/AccountSelect/src/AccountSelect/__snapshots__/test.tsx.snap
@@ -71,7 +71,7 @@ exports[`AccountSelect renders 1`] = `
                     </div>
                   </div>
                   <svg
-                    class="PicassoSvgChevronRight16-root PicassoSvgChevronRight16-darkGrey"
+                    class="PicassoSvgChevronRight16 fill-current inline-block font-inherit h-[1em] align-[-.125em] text-graphite"
                     style="min-width: 16px; min-height: 16px;"
                     viewBox="0 0 16 16"
                   >
@@ -147,7 +147,7 @@ exports[`AccountSelect renders 1`] = `
                     </div>
                   </div>
                   <svg
-                    class="PicassoSvgChevronRight16-root PicassoSvgChevronRight16-darkGrey"
+                    class="PicassoSvgChevronRight16 fill-current inline-block font-inherit h-[1em] align-[-.125em] text-graphite"
                     style="min-width: 16px; min-height: 16px;"
                     viewBox="0 0 16 16"
                   >
@@ -219,7 +219,7 @@ exports[`AccountSelect renders 1`] = `
                     </div>
                   </div>
                   <svg
-                    class="PicassoSvgChevronRight16-root PicassoSvgChevronRight16-darkGrey"
+                    class="PicassoSvgChevronRight16 fill-current inline-block font-inherit h-[1em] align-[-.125em] text-graphite"
                     style="min-width: 16px; min-height: 16px;"
                     viewBox="0 0 16 16"
                   >

--- a/packages/base/Alert/src/Alert/__snapshots__/test.tsx.snap
+++ b/packages/base/Alert/src/Alert/__snapshots__/test.tsx.snap
@@ -16,7 +16,7 @@ exports[`Alert renders 1`] = `
           class="mr-4 items-center flex h-[1.375em]"
         >
           <svg
-            class="PicassoSvgExclamation16-root PicassoSvgExclamation16-yellow"
+            class="PicassoSvgExclamation16 fill-current inline-block font-inherit h-[1em] align-[-.125em] text-yellow"
             style="min-width: 16px; min-height: 16px;"
             viewBox="0 0 16 16"
           >

--- a/packages/base/Alert/src/AlertInline/__snapshots__/test.tsx.snap
+++ b/packages/base/Alert/src/AlertInline/__snapshots__/test.tsx.snap
@@ -12,7 +12,7 @@ exports[`Alert renders 1`] = `
         class="mr-2 items-center flex h-[1.25em]"
       >
         <svg
-          class="PicassoSvgExclamationSolid16-root PicassoSvgExclamationSolid16-yellow"
+          class="PicassoSvgExclamationSolid16 fill-current inline-block font-inherit h-[1em] align-[-.125em] text-yellow"
           style="min-width: 16px; min-height: 16px;"
           viewBox="0 0 16 16"
         >

--- a/packages/base/Autocomplete/src/Autocomplete/__snapshots__/test.tsx.snap
+++ b/packages/base/Autocomplete/src/Autocomplete/__snapshots__/test.tsx.snap
@@ -266,7 +266,7 @@ exports[`Autocomplete static behavior renders 1`] = `
                 class="items-center inline-flex font-semibold whitespace-nowrap text-button"
               >
                 <svg
-                  class="PicassoSvgCloseMinor16-root text-[1.2em] flex-1"
+                  class="PicassoSvgCloseMinor16 fill-current inline-block h-[1em] align-[-.125em] text-[1.2em] flex-1"
                   style="min-width: 16px; min-height: 16px;"
                   viewBox="0 0 16 16"
                 >

--- a/packages/base/AvatarUpload/src/AvatarUpload/__snapshots__/test.tsx.snap
+++ b/packages/base/AvatarUpload/src/AvatarUpload/__snapshots__/test.tsx.snap
@@ -67,7 +67,7 @@ exports[`AvatarUpload renders 1`] = `
         </svg>
       </div>
       <svg
-        class="PicassoSvgUpload24-root absolute pointer-events"
+        class="PicassoSvgUpload24 fill-current inline-block font-inherit h-[1em] align-[-.125em] absolute pointer-events"
         style="min-width: 24px; min-height: 24px;"
         viewBox="0 0 24 24"
       >

--- a/packages/base/Button/src/ButtonSplit/__snapshots__/test.tsx.snap
+++ b/packages/base/Button/src/ButtonSplit/__snapshots__/test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`ButtonSplit closes menu on click to the item 1`] = `
 <svg
-  class="PicassoSvgArrowDownMinor24-root-29"
+  class="PicassoSvgArrowDownMinor24 fill-current inline-block font-inherit-size h-[1em] align-[-.125em]"
   style="min-width: 24px; min-height: 24px;"
   viewBox="0 0 24 24"
 >
@@ -52,7 +52,7 @@ exports[`ButtonSplit default render 1`] = `
               class="items-center inline-flex font-semibold whitespace-nowrap text-button"
             >
               <svg
-                class="PicassoSvgArrowDownMinor16-root"
+                class="PicassoSvgArrowDownMinor16 fill-current inline-block font-inherit h-[1em] align-[-.125em]"
                 style="min-width: 16px; min-height: 16px;"
                 viewBox="0 0 16 16"
               >
@@ -71,7 +71,7 @@ exports[`ButtonSplit default render 1`] = `
 
 exports[`ButtonSplit renders arrow down icon for a closed menu 1`] = `
 <svg
-  class="PicassoSvgArrowDownMinor16-root-29"
+  class="PicassoSvgArrowDownMinor16 fill-current inline-block font-inherit-size h-[1em] align-[-.125em]"
   style="min-width: 16px; min-height: 16px;"
   viewBox="0 0 16 16"
 >
@@ -83,7 +83,7 @@ exports[`ButtonSplit renders arrow down icon for a closed menu 1`] = `
 
 exports[`ButtonSplit renders arrow up icon for an opened menu 1`] = `
 <svg
-  class="PicassoSvgArrowDownMinor16-root-29 rotate-180"
+  class="PicassoSvgArrowDownMinor16 fill-current inline-block font-inherit-size h-[1em] align-[-.125em] rotate-180"
   style="min-width: 16px; min-height: 16px;"
   viewBox="0 0 16 16"
 >

--- a/packages/base/Calendar/src/Calendar/__snapshots__/test.tsx.snap
+++ b/packages/base/Calendar/src/Calendar/__snapshots__/test.tsx.snap
@@ -35,7 +35,7 @@ exports[`Calendar renders 1`] = `
                     class="items-center inline-flex font-semibold whitespace-nowrap text-button"
                   >
                     <svg
-                      class="PicassoSvgBackMinor24-root text-[1.2em] flex-1"
+                      class="PicassoSvgBackMinor24 fill-current inline-block h-[1em] align-[-.125em] text-[1.2em] flex-1"
                       style="min-width: 24px; min-height: 24px;"
                       viewBox="0 0 24 24"
                     >
@@ -66,7 +66,7 @@ exports[`Calendar renders 1`] = `
                     class="items-center inline-flex font-semibold whitespace-nowrap text-button"
                   >
                     <svg
-                      class="PicassoSvgChevronMinor24-root text-[1.2em] flex-1"
+                      class="PicassoSvgChevronMinor24 fill-current inline-block h-[1em] align-[-.125em] text-[1.2em] flex-1"
                       style="min-width: 24px; min-height: 24px;"
                       viewBox="0 0 24 24"
                     >

--- a/packages/base/DatePicker/src/DatePicker/__snapshots__/test.tsx.snap
+++ b/packages/base/DatePicker/src/DatePicker/__snapshots__/test.tsx.snap
@@ -15,7 +15,7 @@ exports[`DatePicker renders 1`] = `
           class="text-graphite h-auto flex items-center whitespace-nowrap max-h pointer-events"
         >
           <svg
-            class="PicassoSvgCalendar16-root"
+            class="PicassoSvgCalendar16 fill-current inline-block font-inherit h-[1em] align-[-.125em]"
             style="min-width: 16px; min-height: 16px;"
             viewBox="0 0 16 16"
           >

--- a/packages/base/DateSelect/src/MonthSelect/__snapshots__/test.tsx.snap
+++ b/packages/base/DateSelect/src/MonthSelect/__snapshots__/test.tsx.snap
@@ -26,7 +26,7 @@ exports[`MonthSelect renders 1`] = `
           />
         </div>
         <svg
-          class="PicassoSvgDropdownArrows16-root absolute top-[calc(50%-0.5rem)] right-[0.3125rem] text-graphite text-[1rem] cursor-inherit pointer-events"
+          class="PicassoSvgDropdownArrows16 fill-current inline-block h-[1em] align-[-.125em] absolute top-[calc(50%-0.5rem)] right-[0.3125rem] text-graphite text-[1rem] cursor-inherit pointer-events"
           style="min-width: 16px; min-height: 16px;"
           viewBox="0 0 16 16"
         >

--- a/packages/base/DateSelect/src/YearSelect/__snapshots__/test.tsx.snap
+++ b/packages/base/DateSelect/src/YearSelect/__snapshots__/test.tsx.snap
@@ -193,7 +193,7 @@ exports[`YearSelect renders 1`] = `
           />
         </div>
         <svg
-          class="PicassoSvgDropdownArrows16-root absolute top-[calc(50%-0.5rem)] right-[0.3125rem] text-graphite text-[1rem] cursor-inherit pointer-events"
+          class="PicassoSvgDropdownArrows16 fill-current inline-block h-[1em] align-[-.125em] absolute top-[calc(50%-0.5rem)] right-[0.3125rem] text-graphite text-[1rem] cursor-inherit pointer-events"
           style="min-width: 16px; min-height: 16px;"
           viewBox="0 0 16 16"
         >

--- a/packages/base/Dropzone/src/Dropzone/__snapshots__/test.tsx.snap
+++ b/packages/base/Dropzone/src/Dropzone/__snapshots__/test.tsx.snap
@@ -21,7 +21,7 @@ exports[`Dropzone renders 1`] = `
           type="file"
         />
         <svg
-          class="PicassoSvgUpload24-root PicassoSvgUpload24-darkGrey"
+          class="PicassoSvgUpload24 fill-current inline-block font-inherit h-[1em] align-[-.125em] text-graphite"
           style="min-width: 24px; min-height: 24px;"
           viewBox="0 0 24 24"
         >

--- a/packages/base/FileInput/src/FileList/__snapshots__/test.tsx.snap
+++ b/packages/base/FileInput/src/FileList/__snapshots__/test.tsx.snap
@@ -21,7 +21,7 @@ exports[`FileList renders 1`] = `
               class="mr-2"
             >
               <svg
-                class="PicassoSvgAttachment16-root PicassoSvgAttachment16-darkGrey"
+                class="PicassoSvgAttachment16 fill-current inline-block font-inherit h-[1em] align-[-.125em] text-graphite"
                 fill="none"
                 style="min-width: 16px; min-height: 16px;"
                 viewBox="0 0 16 16"

--- a/packages/base/FileInput/src/FileListItem/__snapshots__/test.tsx.snap
+++ b/packages/base/FileInput/src/FileListItem/__snapshots__/test.tsx.snap
@@ -18,7 +18,7 @@ exports[`FileListItem renders 1`] = `
             class="mr-2"
           >
             <svg
-              class="PicassoSvgAttachment16-root PicassoSvgAttachment16-darkGrey"
+              class="PicassoSvgAttachment16 fill-current inline-block font-inherit h-[1em] align-[-.125em] text-graphite"
               fill="none"
               style="min-width: 16px; min-height: 16px;"
               viewBox="0 0 16 16"
@@ -50,7 +50,7 @@ exports[`FileListItem renders 1`] = `
           class="items-center inline-flex font-semibold whitespace-nowrap text-button"
         >
           <svg
-            class="PicassoSvgTrash16-root PicassoSvgTrash16-red"
+            class="PicassoSvgTrash16 fill-current inline-block font-inherit h-[1em] align-[-.125em] text-red"
             style="min-width: 16px; min-height: 16px;"
             viewBox="0 0 16 16"
           >

--- a/packages/base/Icons/package.json
+++ b/packages/base/Icons/package.json
@@ -32,6 +32,8 @@
   "peerDependencies": {
     "@material-ui/core": "4.12.4",
     "@toptal/picasso-provider": "*",
+    "@toptal/picasso-tailwind": ">=2.7",
+    "@toptal/picasso-tailwind-merge": "^1.0.1",
     "react": ">=16.12.0 < 19.0.0"
   },
   "exports": {
@@ -39,6 +41,8 @@
   },
   "devDependencies": {
     "@toptal/picasso-provider": "5.0.0",
+    "@toptal/picasso-tailwind": "2.8.0",
+    "@toptal/picasso-tailwind-merge": "1.2.0",
     "@babel/types": "^7.20.7"
   },
   "files": [

--- a/packages/base/Icons/package.json
+++ b/packages/base/Icons/package.json
@@ -22,15 +22,13 @@
   },
   "homepage": "https://github.com/toptal/picasso/tree/master/packages/picasso#readme",
   "dependencies": {
-    "@toptal/picasso-utils": "1.0.3",
-    "classnames": "^2.5.1"
+    "@toptal/picasso-utils": "1.0.3"
   },
   "sideEffects": [
     "**/styles.ts",
     "**/styles.js"
   ],
   "peerDependencies": {
-    "@material-ui/core": "4.12.4",
     "@toptal/picasso-provider": "*",
     "@toptal/picasso-tailwind": ">=2.7",
     "@toptal/picasso-tailwind-merge": "^1.0.1",

--- a/packages/base/Icons/src/Icon/Abstract16.tsx
+++ b/packages/base/Icons/src/Icon/Abstract16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgAbstract16',
-})
 const SvgAbstract16 = forwardRef(function SvgAbstract16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgAbstract16 = forwardRef(function SvgAbstract16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgAbstract16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgAbstract16 = forwardRef(function SvgAbstract16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Abstract24.tsx
+++ b/packages/base/Icons/src/Icon/Abstract24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgAbstract24',
-})
 const SvgAbstract24 = forwardRef(function SvgAbstract24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgAbstract24 = forwardRef(function SvgAbstract24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgAbstract24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgAbstract24 = forwardRef(function SvgAbstract24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Ach16.tsx
+++ b/packages/base/Icons/src/Icon/Ach16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgAch16',
-})
 const SvgAch16 = forwardRef(function SvgAch16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgAch16 = forwardRef(function SvgAch16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgAch16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgAch16 = forwardRef(function SvgAch16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Ach24.tsx
+++ b/packages/base/Icons/src/Icon/Ach24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgAch24',
-})
 const SvgAch24 = forwardRef(function SvgAch24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgAch24 = forwardRef(function SvgAch24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgAch24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -48,7 +46,7 @@ const SvgAch24 = forwardRef(function SvgAch24(
     <svg
       fill='none'
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Ach32.tsx
+++ b/packages/base/Icons/src/Icon/Ach32.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 32
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgAch32',
-})
 const SvgAch32 = forwardRef(function SvgAch32(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgAch32 = forwardRef(function SvgAch32(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgAch32', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgAch32 = forwardRef(function SvgAch32(
   return (
     <svg
       viewBox='0 0 32 32'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Add16.tsx
+++ b/packages/base/Icons/src/Icon/Add16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgAdd16',
-})
 const SvgAdd16 = forwardRef(function SvgAdd16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgAdd16 = forwardRef(function SvgAdd16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgAdd16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -48,7 +46,7 @@ const SvgAdd16 = forwardRef(function SvgAdd16(
     <svg
       fill='none'
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Add24.tsx
+++ b/packages/base/Icons/src/Icon/Add24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgAdd24',
-})
 const SvgAdd24 = forwardRef(function SvgAdd24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgAdd24 = forwardRef(function SvgAdd24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgAdd24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -48,7 +46,7 @@ const SvgAdd24 = forwardRef(function SvgAdd24(
     <svg
       fill='none'
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/AddDocument16.tsx
+++ b/packages/base/Icons/src/Icon/AddDocument16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgAddDocument16',
-})
 const SvgAddDocument16 = forwardRef(function SvgAddDocument16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgAddDocument16 = forwardRef(function SvgAddDocument16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgAddDocument16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgAddDocument16 = forwardRef(function SvgAddDocument16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/AddDocument24.tsx
+++ b/packages/base/Icons/src/Icon/AddDocument24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgAddDocument24',
-})
 const SvgAddDocument24 = forwardRef(function SvgAddDocument24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgAddDocument24 = forwardRef(function SvgAddDocument24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgAddDocument24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgAddDocument24 = forwardRef(function SvgAddDocument24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Afternoon16.tsx
+++ b/packages/base/Icons/src/Icon/Afternoon16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgAfternoon16',
-})
 const SvgAfternoon16 = forwardRef(function SvgAfternoon16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgAfternoon16 = forwardRef(function SvgAfternoon16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgAfternoon16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgAfternoon16 = forwardRef(function SvgAfternoon16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Afternoon24.tsx
+++ b/packages/base/Icons/src/Icon/Afternoon24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgAfternoon24',
-})
 const SvgAfternoon24 = forwardRef(function SvgAfternoon24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgAfternoon24 = forwardRef(function SvgAfternoon24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgAfternoon24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgAfternoon24 = forwardRef(function SvgAfternoon24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Archive16.tsx
+++ b/packages/base/Icons/src/Icon/Archive16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgArchive16',
-})
 const SvgArchive16 = forwardRef(function SvgArchive16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgArchive16 = forwardRef(function SvgArchive16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgArchive16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgArchive16 = forwardRef(function SvgArchive16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Archive24.tsx
+++ b/packages/base/Icons/src/Icon/Archive24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgArchive24',
-})
 const SvgArchive24 = forwardRef(function SvgArchive24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgArchive24 = forwardRef(function SvgArchive24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgArchive24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgArchive24 = forwardRef(function SvgArchive24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/ArrowDownMinor16.tsx
+++ b/packages/base/Icons/src/Icon/ArrowDownMinor16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgArrowDownMinor16',
-})
 const SvgArrowDownMinor16 = forwardRef(function SvgArrowDownMinor16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgArrowDownMinor16 = forwardRef(function SvgArrowDownMinor16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgArrowDownMinor16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgArrowDownMinor16 = forwardRef(function SvgArrowDownMinor16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/ArrowDownMinor24.tsx
+++ b/packages/base/Icons/src/Icon/ArrowDownMinor24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgArrowDownMinor24',
-})
 const SvgArrowDownMinor24 = forwardRef(function SvgArrowDownMinor24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgArrowDownMinor24 = forwardRef(function SvgArrowDownMinor24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgArrowDownMinor24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgArrowDownMinor24 = forwardRef(function SvgArrowDownMinor24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/ArrowDropDown16.tsx
+++ b/packages/base/Icons/src/Icon/ArrowDropDown16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgArrowDropDown16',
-})
 const SvgArrowDropDown16 = forwardRef(function SvgArrowDropDown16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgArrowDropDown16 = forwardRef(function SvgArrowDropDown16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgArrowDropDown16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgArrowDropDown16 = forwardRef(function SvgArrowDropDown16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/ArrowDropDown24.tsx
+++ b/packages/base/Icons/src/Icon/ArrowDropDown24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgArrowDropDown24',
-})
 const SvgArrowDropDown24 = forwardRef(function SvgArrowDropDown24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgArrowDropDown24 = forwardRef(function SvgArrowDropDown24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgArrowDropDown24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgArrowDropDown24 = forwardRef(function SvgArrowDropDown24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/ArrowDropUp16.tsx
+++ b/packages/base/Icons/src/Icon/ArrowDropUp16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgArrowDropUp16',
-})
 const SvgArrowDropUp16 = forwardRef(function SvgArrowDropUp16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgArrowDropUp16 = forwardRef(function SvgArrowDropUp16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgArrowDropUp16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgArrowDropUp16 = forwardRef(function SvgArrowDropUp16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/ArrowDropUp24.tsx
+++ b/packages/base/Icons/src/Icon/ArrowDropUp24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgArrowDropUp24',
-})
 const SvgArrowDropUp24 = forwardRef(function SvgArrowDropUp24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgArrowDropUp24 = forwardRef(function SvgArrowDropUp24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgArrowDropUp24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgArrowDropUp24 = forwardRef(function SvgArrowDropUp24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/ArrowLongDown16.tsx
+++ b/packages/base/Icons/src/Icon/ArrowLongDown16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgArrowLongDown16',
-})
 const SvgArrowLongDown16 = forwardRef(function SvgArrowLongDown16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgArrowLongDown16 = forwardRef(function SvgArrowLongDown16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgArrowLongDown16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgArrowLongDown16 = forwardRef(function SvgArrowLongDown16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/ArrowLongDown24.tsx
+++ b/packages/base/Icons/src/Icon/ArrowLongDown24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgArrowLongDown24',
-})
 const SvgArrowLongDown24 = forwardRef(function SvgArrowLongDown24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgArrowLongDown24 = forwardRef(function SvgArrowLongDown24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgArrowLongDown24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgArrowLongDown24 = forwardRef(function SvgArrowLongDown24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/ArrowLongLeft16.tsx
+++ b/packages/base/Icons/src/Icon/ArrowLongLeft16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgArrowLongLeft16',
-})
 const SvgArrowLongLeft16 = forwardRef(function SvgArrowLongLeft16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgArrowLongLeft16 = forwardRef(function SvgArrowLongLeft16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgArrowLongLeft16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgArrowLongLeft16 = forwardRef(function SvgArrowLongLeft16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/ArrowLongLeft24.tsx
+++ b/packages/base/Icons/src/Icon/ArrowLongLeft24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgArrowLongLeft24',
-})
 const SvgArrowLongLeft24 = forwardRef(function SvgArrowLongLeft24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgArrowLongLeft24 = forwardRef(function SvgArrowLongLeft24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgArrowLongLeft24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgArrowLongLeft24 = forwardRef(function SvgArrowLongLeft24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/ArrowLongRight16.tsx
+++ b/packages/base/Icons/src/Icon/ArrowLongRight16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgArrowLongRight16',
-})
 const SvgArrowLongRight16 = forwardRef(function SvgArrowLongRight16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgArrowLongRight16 = forwardRef(function SvgArrowLongRight16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgArrowLongRight16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgArrowLongRight16 = forwardRef(function SvgArrowLongRight16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/ArrowLongRight24.tsx
+++ b/packages/base/Icons/src/Icon/ArrowLongRight24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgArrowLongRight24',
-})
 const SvgArrowLongRight24 = forwardRef(function SvgArrowLongRight24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgArrowLongRight24 = forwardRef(function SvgArrowLongRight24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgArrowLongRight24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgArrowLongRight24 = forwardRef(function SvgArrowLongRight24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/ArrowLongUp16.tsx
+++ b/packages/base/Icons/src/Icon/ArrowLongUp16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgArrowLongUp16',
-})
 const SvgArrowLongUp16 = forwardRef(function SvgArrowLongUp16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgArrowLongUp16 = forwardRef(function SvgArrowLongUp16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgArrowLongUp16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgArrowLongUp16 = forwardRef(function SvgArrowLongUp16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/ArrowLongUp24.tsx
+++ b/packages/base/Icons/src/Icon/ArrowLongUp24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgArrowLongUp24',
-})
 const SvgArrowLongUp24 = forwardRef(function SvgArrowLongUp24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgArrowLongUp24 = forwardRef(function SvgArrowLongUp24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgArrowLongUp24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgArrowLongUp24 = forwardRef(function SvgArrowLongUp24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/ArrowSubdirectory16.tsx
+++ b/packages/base/Icons/src/Icon/ArrowSubdirectory16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgArrowSubdirectory16',
-})
 const SvgArrowSubdirectory16 = forwardRef(function SvgArrowSubdirectory16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgArrowSubdirectory16 = forwardRef(function SvgArrowSubdirectory16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgArrowSubdirectory16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgArrowSubdirectory16 = forwardRef(function SvgArrowSubdirectory16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/ArrowSubdirectory24.tsx
+++ b/packages/base/Icons/src/Icon/ArrowSubdirectory24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgArrowSubdirectory24',
-})
 const SvgArrowSubdirectory24 = forwardRef(function SvgArrowSubdirectory24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgArrowSubdirectory24 = forwardRef(function SvgArrowSubdirectory24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgArrowSubdirectory24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgArrowSubdirectory24 = forwardRef(function SvgArrowSubdirectory24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/ArrowUpMinor16.tsx
+++ b/packages/base/Icons/src/Icon/ArrowUpMinor16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgArrowUpMinor16',
-})
 const SvgArrowUpMinor16 = forwardRef(function SvgArrowUpMinor16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgArrowUpMinor16 = forwardRef(function SvgArrowUpMinor16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgArrowUpMinor16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgArrowUpMinor16 = forwardRef(function SvgArrowUpMinor16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/ArrowUpMinor24.tsx
+++ b/packages/base/Icons/src/Icon/ArrowUpMinor24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgArrowUpMinor24',
-})
 const SvgArrowUpMinor24 = forwardRef(function SvgArrowUpMinor24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgArrowUpMinor24 = forwardRef(function SvgArrowUpMinor24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgArrowUpMinor24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgArrowUpMinor24 = forwardRef(function SvgArrowUpMinor24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Ask16.tsx
+++ b/packages/base/Icons/src/Icon/Ask16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgAsk16',
-})
 const SvgAsk16 = forwardRef(function SvgAsk16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgAsk16 = forwardRef(function SvgAsk16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgAsk16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -48,7 +46,7 @@ const SvgAsk16 = forwardRef(function SvgAsk16(
     <svg
       fill='none'
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Ask24.tsx
+++ b/packages/base/Icons/src/Icon/Ask24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgAsk24',
-})
 const SvgAsk24 = forwardRef(function SvgAsk24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgAsk24 = forwardRef(function SvgAsk24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgAsk24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -48,7 +46,7 @@ const SvgAsk24 = forwardRef(function SvgAsk24(
     <svg
       fill='none'
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/AsteriskSolid16.tsx
+++ b/packages/base/Icons/src/Icon/AsteriskSolid16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgAsteriskSolid16',
-})
 const SvgAsteriskSolid16 = forwardRef(function SvgAsteriskSolid16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgAsteriskSolid16 = forwardRef(function SvgAsteriskSolid16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgAsteriskSolid16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgAsteriskSolid16 = forwardRef(function SvgAsteriskSolid16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/AsteriskSolid24.tsx
+++ b/packages/base/Icons/src/Icon/AsteriskSolid24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgAsteriskSolid24',
-})
 const SvgAsteriskSolid24 = forwardRef(function SvgAsteriskSolid24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgAsteriskSolid24 = forwardRef(function SvgAsteriskSolid24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgAsteriskSolid24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgAsteriskSolid24 = forwardRef(function SvgAsteriskSolid24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Attachment16.tsx
+++ b/packages/base/Icons/src/Icon/Attachment16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgAttachment16',
-})
 const SvgAttachment16 = forwardRef(function SvgAttachment16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgAttachment16 = forwardRef(function SvgAttachment16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgAttachment16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -48,7 +46,7 @@ const SvgAttachment16 = forwardRef(function SvgAttachment16(
     <svg
       fill='none'
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Attachment24.tsx
+++ b/packages/base/Icons/src/Icon/Attachment24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgAttachment24',
-})
 const SvgAttachment24 = forwardRef(function SvgAttachment24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgAttachment24 = forwardRef(function SvgAttachment24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgAttachment24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -48,7 +46,7 @@ const SvgAttachment24 = forwardRef(function SvgAttachment24(
     <svg
       fill='none'
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Avatar16.tsx
+++ b/packages/base/Icons/src/Icon/Avatar16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgAvatar16',
-})
 const SvgAvatar16 = forwardRef(function SvgAvatar16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgAvatar16 = forwardRef(function SvgAvatar16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgAvatar16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -48,7 +46,7 @@ const SvgAvatar16 = forwardRef(function SvgAvatar16(
     <svg
       fill='none'
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Avatar24.tsx
+++ b/packages/base/Icons/src/Icon/Avatar24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgAvatar24',
-})
 const SvgAvatar24 = forwardRef(function SvgAvatar24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgAvatar24 = forwardRef(function SvgAvatar24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgAvatar24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -48,7 +46,7 @@ const SvgAvatar24 = forwardRef(function SvgAvatar24(
     <svg
       fill='none'
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Award16.tsx
+++ b/packages/base/Icons/src/Icon/Award16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgAward16',
-})
 const SvgAward16 = forwardRef(function SvgAward16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgAward16 = forwardRef(function SvgAward16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgAward16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgAward16 = forwardRef(function SvgAward16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Award24.tsx
+++ b/packages/base/Icons/src/Icon/Award24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgAward24',
-})
 const SvgAward24 = forwardRef(function SvgAward24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgAward24 = forwardRef(function SvgAward24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgAward24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgAward24 = forwardRef(function SvgAward24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/BackMinor16.tsx
+++ b/packages/base/Icons/src/Icon/BackMinor16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgBackMinor16',
-})
 const SvgBackMinor16 = forwardRef(function SvgBackMinor16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgBackMinor16 = forwardRef(function SvgBackMinor16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgBackMinor16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgBackMinor16 = forwardRef(function SvgBackMinor16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/BackMinor24.tsx
+++ b/packages/base/Icons/src/Icon/BackMinor24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgBackMinor24',
-})
 const SvgBackMinor24 = forwardRef(function SvgBackMinor24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgBackMinor24 = forwardRef(function SvgBackMinor24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgBackMinor24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgBackMinor24 = forwardRef(function SvgBackMinor24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Backspace16.tsx
+++ b/packages/base/Icons/src/Icon/Backspace16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgBackspace16',
-})
 const SvgBackspace16 = forwardRef(function SvgBackspace16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgBackspace16 = forwardRef(function SvgBackspace16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgBackspace16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgBackspace16 = forwardRef(function SvgBackspace16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Backspace24.tsx
+++ b/packages/base/Icons/src/Icon/Backspace24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgBackspace24',
-})
 const SvgBackspace24 = forwardRef(function SvgBackspace24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgBackspace24 = forwardRef(function SvgBackspace24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgBackspace24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgBackspace24 = forwardRef(function SvgBackspace24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/BankWire16.tsx
+++ b/packages/base/Icons/src/Icon/BankWire16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgBankWire16',
-})
 const SvgBankWire16 = forwardRef(function SvgBankWire16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgBankWire16 = forwardRef(function SvgBankWire16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgBankWire16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgBankWire16 = forwardRef(function SvgBankWire16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/BankWire24.tsx
+++ b/packages/base/Icons/src/Icon/BankWire24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgBankWire24',
-})
 const SvgBankWire24 = forwardRef(function SvgBankWire24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgBankWire24 = forwardRef(function SvgBankWire24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgBankWire24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgBankWire24 = forwardRef(function SvgBankWire24(
   return (
     <svg
       viewBox='0 0 32 32'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Behance16.tsx
+++ b/packages/base/Icons/src/Icon/Behance16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgBehance16',
-})
 const SvgBehance16 = forwardRef(function SvgBehance16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgBehance16 = forwardRef(function SvgBehance16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgBehance16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgBehance16 = forwardRef(function SvgBehance16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Behance24.tsx
+++ b/packages/base/Icons/src/Icon/Behance24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgBehance24',
-})
 const SvgBehance24 = forwardRef(function SvgBehance24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgBehance24 = forwardRef(function SvgBehance24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgBehance24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgBehance24 = forwardRef(function SvgBehance24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Bell16.tsx
+++ b/packages/base/Icons/src/Icon/Bell16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgBell16',
-})
 const SvgBell16 = forwardRef(function SvgBell16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgBell16 = forwardRef(function SvgBell16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgBell16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgBell16 = forwardRef(function SvgBell16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Bell24.tsx
+++ b/packages/base/Icons/src/Icon/Bell24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgBell24',
-})
 const SvgBell24 = forwardRef(function SvgBell24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgBell24 = forwardRef(function SvgBell24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgBell24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgBell24 = forwardRef(function SvgBell24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/BellOff16.tsx
+++ b/packages/base/Icons/src/Icon/BellOff16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgBellOff16',
-})
 const SvgBellOff16 = forwardRef(function SvgBellOff16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgBellOff16 = forwardRef(function SvgBellOff16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgBellOff16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgBellOff16 = forwardRef(function SvgBellOff16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/BellOff24.tsx
+++ b/packages/base/Icons/src/Icon/BellOff24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgBellOff24',
-})
 const SvgBellOff24 = forwardRef(function SvgBellOff24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgBellOff24 = forwardRef(function SvgBellOff24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgBellOff24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgBellOff24 = forwardRef(function SvgBellOff24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/BellSolid16.tsx
+++ b/packages/base/Icons/src/Icon/BellSolid16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgBellSolid16',
-})
 const SvgBellSolid16 = forwardRef(function SvgBellSolid16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgBellSolid16 = forwardRef(function SvgBellSolid16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgBellSolid16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -48,7 +46,7 @@ const SvgBellSolid16 = forwardRef(function SvgBellSolid16(
     <svg
       fill='none'
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/BellSolid24.tsx
+++ b/packages/base/Icons/src/Icon/BellSolid24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgBellSolid24',
-})
 const SvgBellSolid24 = forwardRef(function SvgBellSolid24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgBellSolid24 = forwardRef(function SvgBellSolid24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgBellSolid24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -48,7 +46,7 @@ const SvgBellSolid24 = forwardRef(function SvgBellSolid24(
     <svg
       fill='none'
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Billing16.tsx
+++ b/packages/base/Icons/src/Icon/Billing16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgBilling16',
-})
 const SvgBilling16 = forwardRef(function SvgBilling16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgBilling16 = forwardRef(function SvgBilling16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgBilling16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgBilling16 = forwardRef(function SvgBilling16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Billing24.tsx
+++ b/packages/base/Icons/src/Icon/Billing24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgBilling24',
-})
 const SvgBilling24 = forwardRef(function SvgBilling24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgBilling24 = forwardRef(function SvgBilling24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgBilling24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgBilling24 = forwardRef(function SvgBilling24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Bold16.tsx
+++ b/packages/base/Icons/src/Icon/Bold16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgBold16',
-})
 const SvgBold16 = forwardRef(function SvgBold16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgBold16 = forwardRef(function SvgBold16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgBold16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgBold16 = forwardRef(function SvgBold16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Bold24.tsx
+++ b/packages/base/Icons/src/Icon/Bold24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgBold24',
-})
 const SvgBold24 = forwardRef(function SvgBold24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgBold24 = forwardRef(function SvgBold24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgBold24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -48,7 +46,7 @@ const SvgBold24 = forwardRef(function SvgBold24(
     <svg
       fill='none'
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Box16.tsx
+++ b/packages/base/Icons/src/Icon/Box16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgBox16',
-})
 const SvgBox16 = forwardRef(function SvgBox16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgBox16 = forwardRef(function SvgBox16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgBox16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -48,7 +46,7 @@ const SvgBox16 = forwardRef(function SvgBox16(
     <svg
       fill='none'
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Box24.tsx
+++ b/packages/base/Icons/src/Icon/Box24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgBox24',
-})
 const SvgBox24 = forwardRef(function SvgBox24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgBox24 = forwardRef(function SvgBox24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgBox24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -48,7 +46,7 @@ const SvgBox24 = forwardRef(function SvgBox24(
     <svg
       fill='none'
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Bullet16.tsx
+++ b/packages/base/Icons/src/Icon/Bullet16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgBullet16',
-})
 const SvgBullet16 = forwardRef(function SvgBullet16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgBullet16 = forwardRef(function SvgBullet16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgBullet16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgBullet16 = forwardRef(function SvgBullet16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Bullet24.tsx
+++ b/packages/base/Icons/src/Icon/Bullet24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgBullet24',
-})
 const SvgBullet24 = forwardRef(function SvgBullet24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgBullet24 = forwardRef(function SvgBullet24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgBullet24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgBullet24 = forwardRef(function SvgBullet24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Calendar16.tsx
+++ b/packages/base/Icons/src/Icon/Calendar16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgCalendar16',
-})
 const SvgCalendar16 = forwardRef(function SvgCalendar16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgCalendar16 = forwardRef(function SvgCalendar16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgCalendar16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgCalendar16 = forwardRef(function SvgCalendar16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Calendar24.tsx
+++ b/packages/base/Icons/src/Icon/Calendar24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgCalendar24',
-})
 const SvgCalendar24 = forwardRef(function SvgCalendar24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgCalendar24 = forwardRef(function SvgCalendar24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgCalendar24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgCalendar24 = forwardRef(function SvgCalendar24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/CalendarReminder16.tsx
+++ b/packages/base/Icons/src/Icon/CalendarReminder16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgCalendarReminder16',
-})
 const SvgCalendarReminder16 = forwardRef(function SvgCalendarReminder16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgCalendarReminder16 = forwardRef(function SvgCalendarReminder16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgCalendarReminder16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgCalendarReminder16 = forwardRef(function SvgCalendarReminder16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/CalendarReminder24.tsx
+++ b/packages/base/Icons/src/Icon/CalendarReminder24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgCalendarReminder24',
-})
 const SvgCalendarReminder24 = forwardRef(function SvgCalendarReminder24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgCalendarReminder24 = forwardRef(function SvgCalendarReminder24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgCalendarReminder24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgCalendarReminder24 = forwardRef(function SvgCalendarReminder24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Candidates16.tsx
+++ b/packages/base/Icons/src/Icon/Candidates16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgCandidates16',
-})
 const SvgCandidates16 = forwardRef(function SvgCandidates16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgCandidates16 = forwardRef(function SvgCandidates16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgCandidates16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgCandidates16 = forwardRef(function SvgCandidates16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Candidates24.tsx
+++ b/packages/base/Icons/src/Icon/Candidates24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgCandidates24',
-})
 const SvgCandidates24 = forwardRef(function SvgCandidates24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgCandidates24 = forwardRef(function SvgCandidates24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgCandidates24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgCandidates24 = forwardRef(function SvgCandidates24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Career16.tsx
+++ b/packages/base/Icons/src/Icon/Career16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgCareer16',
-})
 const SvgCareer16 = forwardRef(function SvgCareer16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgCareer16 = forwardRef(function SvgCareer16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgCareer16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgCareer16 = forwardRef(function SvgCareer16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Career24.tsx
+++ b/packages/base/Icons/src/Icon/Career24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgCareer24',
-})
 const SvgCareer24 = forwardRef(function SvgCareer24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgCareer24 = forwardRef(function SvgCareer24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgCareer24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgCareer24 = forwardRef(function SvgCareer24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Certificate16.tsx
+++ b/packages/base/Icons/src/Icon/Certificate16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgCertificate16',
-})
 const SvgCertificate16 = forwardRef(function SvgCertificate16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgCertificate16 = forwardRef(function SvgCertificate16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgCertificate16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgCertificate16 = forwardRef(function SvgCertificate16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Certificate24.tsx
+++ b/packages/base/Icons/src/Icon/Certificate24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgCertificate24',
-})
 const SvgCertificate24 = forwardRef(function SvgCertificate24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgCertificate24 = forwardRef(function SvgCertificate24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgCertificate24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgCertificate24 = forwardRef(function SvgCertificate24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Chat16.tsx
+++ b/packages/base/Icons/src/Icon/Chat16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgChat16',
-})
 const SvgChat16 = forwardRef(function SvgChat16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgChat16 = forwardRef(function SvgChat16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgChat16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgChat16 = forwardRef(function SvgChat16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Chat24.tsx
+++ b/packages/base/Icons/src/Icon/Chat24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgChat24',
-})
 const SvgChat24 = forwardRef(function SvgChat24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgChat24 = forwardRef(function SvgChat24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgChat24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgChat24 = forwardRef(function SvgChat24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Check16.tsx
+++ b/packages/base/Icons/src/Icon/Check16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgCheck16',
-})
 const SvgCheck16 = forwardRef(function SvgCheck16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgCheck16 = forwardRef(function SvgCheck16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgCheck16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgCheck16 = forwardRef(function SvgCheck16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Check24.tsx
+++ b/packages/base/Icons/src/Icon/Check24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgCheck24',
-})
 const SvgCheck24 = forwardRef(function SvgCheck24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgCheck24 = forwardRef(function SvgCheck24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgCheck24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgCheck24 = forwardRef(function SvgCheck24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/CheckMinor16.tsx
+++ b/packages/base/Icons/src/Icon/CheckMinor16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgCheckMinor16',
-})
 const SvgCheckMinor16 = forwardRef(function SvgCheckMinor16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgCheckMinor16 = forwardRef(function SvgCheckMinor16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgCheckMinor16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgCheckMinor16 = forwardRef(function SvgCheckMinor16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/CheckMinor24.tsx
+++ b/packages/base/Icons/src/Icon/CheckMinor24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgCheckMinor24',
-})
 const SvgCheckMinor24 = forwardRef(function SvgCheckMinor24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgCheckMinor24 = forwardRef(function SvgCheckMinor24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgCheckMinor24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgCheckMinor24 = forwardRef(function SvgCheckMinor24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/CheckSolid16.tsx
+++ b/packages/base/Icons/src/Icon/CheckSolid16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgCheckSolid16',
-})
 const SvgCheckSolid16 = forwardRef(function SvgCheckSolid16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgCheckSolid16 = forwardRef(function SvgCheckSolid16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgCheckSolid16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgCheckSolid16 = forwardRef(function SvgCheckSolid16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/CheckSolid24.tsx
+++ b/packages/base/Icons/src/Icon/CheckSolid24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgCheckSolid24',
-})
 const SvgCheckSolid24 = forwardRef(function SvgCheckSolid24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgCheckSolid24 = forwardRef(function SvgCheckSolid24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgCheckSolid24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgCheckSolid24 = forwardRef(function SvgCheckSolid24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Chevron16.tsx
+++ b/packages/base/Icons/src/Icon/Chevron16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgChevron16',
-})
 const SvgChevron16 = forwardRef(function SvgChevron16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgChevron16 = forwardRef(function SvgChevron16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgChevron16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgChevron16 = forwardRef(function SvgChevron16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Chevron24.tsx
+++ b/packages/base/Icons/src/Icon/Chevron24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgChevron24',
-})
 const SvgChevron24 = forwardRef(function SvgChevron24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgChevron24 = forwardRef(function SvgChevron24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgChevron24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgChevron24 = forwardRef(function SvgChevron24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/ChevronMinor16.tsx
+++ b/packages/base/Icons/src/Icon/ChevronMinor16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgChevronMinor16',
-})
 const SvgChevronMinor16 = forwardRef(function SvgChevronMinor16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgChevronMinor16 = forwardRef(function SvgChevronMinor16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgChevronMinor16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgChevronMinor16 = forwardRef(function SvgChevronMinor16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/ChevronMinor24.tsx
+++ b/packages/base/Icons/src/Icon/ChevronMinor24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgChevronMinor24',
-})
 const SvgChevronMinor24 = forwardRef(function SvgChevronMinor24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgChevronMinor24 = forwardRef(function SvgChevronMinor24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgChevronMinor24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgChevronMinor24 = forwardRef(function SvgChevronMinor24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/ChevronRight16.tsx
+++ b/packages/base/Icons/src/Icon/ChevronRight16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgChevronRight16',
-})
 const SvgChevronRight16 = forwardRef(function SvgChevronRight16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgChevronRight16 = forwardRef(function SvgChevronRight16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgChevronRight16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgChevronRight16 = forwardRef(function SvgChevronRight16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/ChevronRight24.tsx
+++ b/packages/base/Icons/src/Icon/ChevronRight24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgChevronRight24',
-})
 const SvgChevronRight24 = forwardRef(function SvgChevronRight24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgChevronRight24 = forwardRef(function SvgChevronRight24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgChevronRight24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgChevronRight24 = forwardRef(function SvgChevronRight24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Close16.tsx
+++ b/packages/base/Icons/src/Icon/Close16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgClose16',
-})
 const SvgClose16 = forwardRef(function SvgClose16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgClose16 = forwardRef(function SvgClose16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgClose16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgClose16 = forwardRef(function SvgClose16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Close24.tsx
+++ b/packages/base/Icons/src/Icon/Close24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgClose24',
-})
 const SvgClose24 = forwardRef(function SvgClose24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgClose24 = forwardRef(function SvgClose24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgClose24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgClose24 = forwardRef(function SvgClose24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/CloseMinor16.tsx
+++ b/packages/base/Icons/src/Icon/CloseMinor16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgCloseMinor16',
-})
 const SvgCloseMinor16 = forwardRef(function SvgCloseMinor16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgCloseMinor16 = forwardRef(function SvgCloseMinor16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgCloseMinor16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgCloseMinor16 = forwardRef(function SvgCloseMinor16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/CloseMinor24.tsx
+++ b/packages/base/Icons/src/Icon/CloseMinor24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgCloseMinor24',
-})
 const SvgCloseMinor24 = forwardRef(function SvgCloseMinor24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgCloseMinor24 = forwardRef(function SvgCloseMinor24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgCloseMinor24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgCloseMinor24 = forwardRef(function SvgCloseMinor24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Code16.tsx
+++ b/packages/base/Icons/src/Icon/Code16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgCode16',
-})
 const SvgCode16 = forwardRef(function SvgCode16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgCode16 = forwardRef(function SvgCode16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgCode16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgCode16 = forwardRef(function SvgCode16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Code24.tsx
+++ b/packages/base/Icons/src/Icon/Code24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgCode24',
-})
 const SvgCode24 = forwardRef(function SvgCode24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgCode24 = forwardRef(function SvgCode24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgCode24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgCode24 = forwardRef(function SvgCode24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/CodeBlock16.tsx
+++ b/packages/base/Icons/src/Icon/CodeBlock16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgCodeBlock16',
-})
 const SvgCodeBlock16 = forwardRef(function SvgCodeBlock16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgCodeBlock16 = forwardRef(function SvgCodeBlock16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgCodeBlock16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -48,7 +46,7 @@ const SvgCodeBlock16 = forwardRef(function SvgCodeBlock16(
     <svg
       fill='none'
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/CodeBlock24.tsx
+++ b/packages/base/Icons/src/Icon/CodeBlock24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgCodeBlock24',
-})
 const SvgCodeBlock24 = forwardRef(function SvgCodeBlock24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgCodeBlock24 = forwardRef(function SvgCodeBlock24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgCodeBlock24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -48,7 +46,7 @@ const SvgCodeBlock24 = forwardRef(function SvgCodeBlock24(
     <svg
       fill='none'
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Commission16.tsx
+++ b/packages/base/Icons/src/Icon/Commission16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgCommission16',
-})
 const SvgCommission16 = forwardRef(function SvgCommission16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgCommission16 = forwardRef(function SvgCommission16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgCommission16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgCommission16 = forwardRef(function SvgCommission16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Commission24.tsx
+++ b/packages/base/Icons/src/Icon/Commission24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgCommission24',
-})
 const SvgCommission24 = forwardRef(function SvgCommission24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgCommission24 = forwardRef(function SvgCommission24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgCommission24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgCommission24 = forwardRef(function SvgCommission24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Company16.tsx
+++ b/packages/base/Icons/src/Icon/Company16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgCompany16',
-})
 const SvgCompany16 = forwardRef(function SvgCompany16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgCompany16 = forwardRef(function SvgCompany16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgCompany16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgCompany16 = forwardRef(function SvgCompany16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Company24.tsx
+++ b/packages/base/Icons/src/Icon/Company24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgCompany24',
-})
 const SvgCompany24 = forwardRef(function SvgCompany24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgCompany24 = forwardRef(function SvgCompany24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgCompany24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgCompany24 = forwardRef(function SvgCompany24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Component16.tsx
+++ b/packages/base/Icons/src/Icon/Component16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgComponent16',
-})
 const SvgComponent16 = forwardRef(function SvgComponent16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgComponent16 = forwardRef(function SvgComponent16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgComponent16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgComponent16 = forwardRef(function SvgComponent16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Component24.tsx
+++ b/packages/base/Icons/src/Icon/Component24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgComponent24',
-})
 const SvgComponent24 = forwardRef(function SvgComponent24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgComponent24 = forwardRef(function SvgComponent24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgComponent24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgComponent24 = forwardRef(function SvgComponent24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Confluence16.tsx
+++ b/packages/base/Icons/src/Icon/Confluence16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgConfluence16',
-})
 const SvgConfluence16 = forwardRef(function SvgConfluence16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgConfluence16 = forwardRef(function SvgConfluence16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgConfluence16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgConfluence16 = forwardRef(function SvgConfluence16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Confluence24.tsx
+++ b/packages/base/Icons/src/Icon/Confluence24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgConfluence24',
-})
 const SvgConfluence24 = forwardRef(function SvgConfluence24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgConfluence24 = forwardRef(function SvgConfluence24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgConfluence24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgConfluence24 = forwardRef(function SvgConfluence24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Control16.tsx
+++ b/packages/base/Icons/src/Icon/Control16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgControl16',
-})
 const SvgControl16 = forwardRef(function SvgControl16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgControl16 = forwardRef(function SvgControl16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgControl16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgControl16 = forwardRef(function SvgControl16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Control24.tsx
+++ b/packages/base/Icons/src/Icon/Control24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgControl24',
-})
 const SvgControl24 = forwardRef(function SvgControl24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgControl24 = forwardRef(function SvgControl24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgControl24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgControl24 = forwardRef(function SvgControl24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Copy16.tsx
+++ b/packages/base/Icons/src/Icon/Copy16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgCopy16',
-})
 const SvgCopy16 = forwardRef(function SvgCopy16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgCopy16 = forwardRef(function SvgCopy16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgCopy16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgCopy16 = forwardRef(function SvgCopy16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Copy24.tsx
+++ b/packages/base/Icons/src/Icon/Copy24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgCopy24',
-})
 const SvgCopy24 = forwardRef(function SvgCopy24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgCopy24 = forwardRef(function SvgCopy24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgCopy24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgCopy24 = forwardRef(function SvgCopy24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/CreditCard16.tsx
+++ b/packages/base/Icons/src/Icon/CreditCard16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgCreditCard16',
-})
 const SvgCreditCard16 = forwardRef(function SvgCreditCard16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgCreditCard16 = forwardRef(function SvgCreditCard16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgCreditCard16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgCreditCard16 = forwardRef(function SvgCreditCard16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/CreditCard24.tsx
+++ b/packages/base/Icons/src/Icon/CreditCard24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgCreditCard24',
-})
 const SvgCreditCard24 = forwardRef(function SvgCreditCard24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgCreditCard24 = forwardRef(function SvgCreditCard24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgCreditCard24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -48,7 +46,7 @@ const SvgCreditCard24 = forwardRef(function SvgCreditCard24(
     <svg
       fill='none'
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/CreditCard32.tsx
+++ b/packages/base/Icons/src/Icon/CreditCard32.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 32
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgCreditCard32',
-})
 const SvgCreditCard32 = forwardRef(function SvgCreditCard32(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgCreditCard32 = forwardRef(function SvgCreditCard32(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgCreditCard32', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgCreditCard32 = forwardRef(function SvgCreditCard32(
   return (
     <svg
       viewBox='0 0 32 32'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Critical16.tsx
+++ b/packages/base/Icons/src/Icon/Critical16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgCritical16',
-})
 const SvgCritical16 = forwardRef(function SvgCritical16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgCritical16 = forwardRef(function SvgCritical16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgCritical16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -48,7 +46,7 @@ const SvgCritical16 = forwardRef(function SvgCritical16(
     <svg
       fill='none'
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Critical24.tsx
+++ b/packages/base/Icons/src/Icon/Critical24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgCritical24',
-})
 const SvgCritical24 = forwardRef(function SvgCritical24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgCritical24 = forwardRef(function SvgCritical24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgCritical24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -48,7 +46,7 @@ const SvgCritical24 = forwardRef(function SvgCritical24(
     <svg
       fill='none'
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/CriticalSolid16.tsx
+++ b/packages/base/Icons/src/Icon/CriticalSolid16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgCriticalSolid16',
-})
 const SvgCriticalSolid16 = forwardRef(function SvgCriticalSolid16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgCriticalSolid16 = forwardRef(function SvgCriticalSolid16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgCriticalSolid16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -48,7 +46,7 @@ const SvgCriticalSolid16 = forwardRef(function SvgCriticalSolid16(
     <svg
       fill='none'
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/CriticalSolid24.tsx
+++ b/packages/base/Icons/src/Icon/CriticalSolid24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgCriticalSolid24',
-})
 const SvgCriticalSolid24 = forwardRef(function SvgCriticalSolid24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgCriticalSolid24 = forwardRef(function SvgCriticalSolid24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgCriticalSolid24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -48,7 +46,7 @@ const SvgCriticalSolid24 = forwardRef(function SvgCriticalSolid24(
     <svg
       fill='none'
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/DesignerPencil16.tsx
+++ b/packages/base/Icons/src/Icon/DesignerPencil16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgDesignerPencil16',
-})
 const SvgDesignerPencil16 = forwardRef(function SvgDesignerPencil16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgDesignerPencil16 = forwardRef(function SvgDesignerPencil16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgDesignerPencil16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -48,7 +46,7 @@ const SvgDesignerPencil16 = forwardRef(function SvgDesignerPencil16(
     <svg
       fill='none'
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/DesignerPencil24.tsx
+++ b/packages/base/Icons/src/Icon/DesignerPencil24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgDesignerPencil24',
-})
 const SvgDesignerPencil24 = forwardRef(function SvgDesignerPencil24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgDesignerPencil24 = forwardRef(function SvgDesignerPencil24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgDesignerPencil24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -48,7 +46,7 @@ const SvgDesignerPencil24 = forwardRef(function SvgDesignerPencil24(
     <svg
       fill='none'
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Dialpad16.tsx
+++ b/packages/base/Icons/src/Icon/Dialpad16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgDialpad16',
-})
 const SvgDialpad16 = forwardRef(function SvgDialpad16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgDialpad16 = forwardRef(function SvgDialpad16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgDialpad16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgDialpad16 = forwardRef(function SvgDialpad16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Dialpad24.tsx
+++ b/packages/base/Icons/src/Icon/Dialpad24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgDialpad24',
-})
 const SvgDialpad24 = forwardRef(function SvgDialpad24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgDialpad24 = forwardRef(function SvgDialpad24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgDialpad24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgDialpad24 = forwardRef(function SvgDialpad24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Dispute16.tsx
+++ b/packages/base/Icons/src/Icon/Dispute16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgDispute16',
-})
 const SvgDispute16 = forwardRef(function SvgDispute16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgDispute16 = forwardRef(function SvgDispute16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgDispute16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgDispute16 = forwardRef(function SvgDispute16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Dispute24.tsx
+++ b/packages/base/Icons/src/Icon/Dispute24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgDispute24',
-})
 const SvgDispute24 = forwardRef(function SvgDispute24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgDispute24 = forwardRef(function SvgDispute24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgDispute24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgDispute24 = forwardRef(function SvgDispute24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Dollar16.tsx
+++ b/packages/base/Icons/src/Icon/Dollar16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgDollar16',
-})
 const SvgDollar16 = forwardRef(function SvgDollar16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgDollar16 = forwardRef(function SvgDollar16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgDollar16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -48,7 +46,7 @@ const SvgDollar16 = forwardRef(function SvgDollar16(
     <svg
       fill='none'
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Dollar24.tsx
+++ b/packages/base/Icons/src/Icon/Dollar24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgDollar24',
-})
 const SvgDollar24 = forwardRef(function SvgDollar24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgDollar24 = forwardRef(function SvgDollar24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgDollar24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -48,7 +46,7 @@ const SvgDollar24 = forwardRef(function SvgDollar24(
     <svg
       fill='none'
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Done16.tsx
+++ b/packages/base/Icons/src/Icon/Done16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgDone16',
-})
 const SvgDone16 = forwardRef(function SvgDone16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgDone16 = forwardRef(function SvgDone16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgDone16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgDone16 = forwardRef(function SvgDone16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Done24.tsx
+++ b/packages/base/Icons/src/Icon/Done24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgDone24',
-})
 const SvgDone24 = forwardRef(function SvgDone24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgDone24 = forwardRef(function SvgDone24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgDone24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgDone24 = forwardRef(function SvgDone24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/DoneSolid16.tsx
+++ b/packages/base/Icons/src/Icon/DoneSolid16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgDoneSolid16',
-})
 const SvgDoneSolid16 = forwardRef(function SvgDoneSolid16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgDoneSolid16 = forwardRef(function SvgDoneSolid16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgDoneSolid16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -48,7 +46,7 @@ const SvgDoneSolid16 = forwardRef(function SvgDoneSolid16(
     <svg
       fill='none'
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/DoneSolid24.tsx
+++ b/packages/base/Icons/src/Icon/DoneSolid24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgDoneSolid24',
-})
 const SvgDoneSolid24 = forwardRef(function SvgDoneSolid24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgDoneSolid24 = forwardRef(function SvgDoneSolid24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgDoneSolid24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -48,7 +46,7 @@ const SvgDoneSolid24 = forwardRef(function SvgDoneSolid24(
     <svg
       fill='none'
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Download16.tsx
+++ b/packages/base/Icons/src/Icon/Download16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgDownload16',
-})
 const SvgDownload16 = forwardRef(function SvgDownload16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgDownload16 = forwardRef(function SvgDownload16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgDownload16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgDownload16 = forwardRef(function SvgDownload16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Download24.tsx
+++ b/packages/base/Icons/src/Icon/Download24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgDownload24',
-})
 const SvgDownload24 = forwardRef(function SvgDownload24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgDownload24 = forwardRef(function SvgDownload24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgDownload24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgDownload24 = forwardRef(function SvgDownload24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Drag16.tsx
+++ b/packages/base/Icons/src/Icon/Drag16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgDrag16',
-})
 const SvgDrag16 = forwardRef(function SvgDrag16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgDrag16 = forwardRef(function SvgDrag16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgDrag16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgDrag16 = forwardRef(function SvgDrag16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Drag24.tsx
+++ b/packages/base/Icons/src/Icon/Drag24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgDrag24',
-})
 const SvgDrag24 = forwardRef(function SvgDrag24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgDrag24 = forwardRef(function SvgDrag24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgDrag24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgDrag24 = forwardRef(function SvgDrag24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Dribble16.tsx
+++ b/packages/base/Icons/src/Icon/Dribble16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgDribble16',
-})
 const SvgDribble16 = forwardRef(function SvgDribble16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgDribble16 = forwardRef(function SvgDribble16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgDribble16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgDribble16 = forwardRef(function SvgDribble16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Dribble24.tsx
+++ b/packages/base/Icons/src/Icon/Dribble24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgDribble24',
-})
 const SvgDribble24 = forwardRef(function SvgDribble24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgDribble24 = forwardRef(function SvgDribble24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgDribble24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgDribble24 = forwardRef(function SvgDribble24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/DropdownArrows16.tsx
+++ b/packages/base/Icons/src/Icon/DropdownArrows16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgDropdownArrows16',
-})
 const SvgDropdownArrows16 = forwardRef(function SvgDropdownArrows16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgDropdownArrows16 = forwardRef(function SvgDropdownArrows16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgDropdownArrows16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgDropdownArrows16 = forwardRef(function SvgDropdownArrows16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/DropdownArrows24.tsx
+++ b/packages/base/Icons/src/Icon/DropdownArrows24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgDropdownArrows24',
-})
 const SvgDropdownArrows24 = forwardRef(function SvgDropdownArrows24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgDropdownArrows24 = forwardRef(function SvgDropdownArrows24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgDropdownArrows24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -48,7 +46,7 @@ const SvgDropdownArrows24 = forwardRef(function SvgDropdownArrows24(
     <svg
       fill='none'
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Education16.tsx
+++ b/packages/base/Icons/src/Icon/Education16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgEducation16',
-})
 const SvgEducation16 = forwardRef(function SvgEducation16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgEducation16 = forwardRef(function SvgEducation16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgEducation16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgEducation16 = forwardRef(function SvgEducation16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Education24.tsx
+++ b/packages/base/Icons/src/Icon/Education24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgEducation24',
-})
 const SvgEducation24 = forwardRef(function SvgEducation24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgEducation24 = forwardRef(function SvgEducation24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgEducation24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgEducation24 = forwardRef(function SvgEducation24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Email16.tsx
+++ b/packages/base/Icons/src/Icon/Email16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgEmail16',
-})
 const SvgEmail16 = forwardRef(function SvgEmail16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgEmail16 = forwardRef(function SvgEmail16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgEmail16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgEmail16 = forwardRef(function SvgEmail16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Email24.tsx
+++ b/packages/base/Icons/src/Icon/Email24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgEmail24',
-})
 const SvgEmail24 = forwardRef(function SvgEmail24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgEmail24 = forwardRef(function SvgEmail24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgEmail24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgEmail24 = forwardRef(function SvgEmail24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Employee16.tsx
+++ b/packages/base/Icons/src/Icon/Employee16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgEmployee16',
-})
 const SvgEmployee16 = forwardRef(function SvgEmployee16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgEmployee16 = forwardRef(function SvgEmployee16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgEmployee16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -48,7 +46,7 @@ const SvgEmployee16 = forwardRef(function SvgEmployee16(
     <svg
       fill='none'
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Employee24.tsx
+++ b/packages/base/Icons/src/Icon/Employee24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgEmployee24',
-})
 const SvgEmployee24 = forwardRef(function SvgEmployee24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgEmployee24 = forwardRef(function SvgEmployee24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgEmployee24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -48,7 +46,7 @@ const SvgEmployee24 = forwardRef(function SvgEmployee24(
     <svg
       fill='none'
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Evening16.tsx
+++ b/packages/base/Icons/src/Icon/Evening16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgEvening16',
-})
 const SvgEvening16 = forwardRef(function SvgEvening16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgEvening16 = forwardRef(function SvgEvening16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgEvening16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgEvening16 = forwardRef(function SvgEvening16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Evening24.tsx
+++ b/packages/base/Icons/src/Icon/Evening24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgEvening24',
-})
 const SvgEvening24 = forwardRef(function SvgEvening24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgEvening24 = forwardRef(function SvgEvening24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgEvening24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgEvening24 = forwardRef(function SvgEvening24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Exclamation16.tsx
+++ b/packages/base/Icons/src/Icon/Exclamation16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgExclamation16',
-})
 const SvgExclamation16 = forwardRef(function SvgExclamation16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgExclamation16 = forwardRef(function SvgExclamation16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgExclamation16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgExclamation16 = forwardRef(function SvgExclamation16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Exclamation24.tsx
+++ b/packages/base/Icons/src/Icon/Exclamation24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgExclamation24',
-})
 const SvgExclamation24 = forwardRef(function SvgExclamation24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgExclamation24 = forwardRef(function SvgExclamation24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgExclamation24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgExclamation24 = forwardRef(function SvgExclamation24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/ExclamationSolid16.tsx
+++ b/packages/base/Icons/src/Icon/ExclamationSolid16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgExclamationSolid16',
-})
 const SvgExclamationSolid16 = forwardRef(function SvgExclamationSolid16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgExclamationSolid16 = forwardRef(function SvgExclamationSolid16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgExclamationSolid16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgExclamationSolid16 = forwardRef(function SvgExclamationSolid16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/ExclamationSolid24.tsx
+++ b/packages/base/Icons/src/Icon/ExclamationSolid24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgExclamationSolid24',
-})
 const SvgExclamationSolid24 = forwardRef(function SvgExclamationSolid24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgExclamationSolid24 = forwardRef(function SvgExclamationSolid24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgExclamationSolid24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgExclamationSolid24 = forwardRef(function SvgExclamationSolid24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Eye16.tsx
+++ b/packages/base/Icons/src/Icon/Eye16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgEye16',
-})
 const SvgEye16 = forwardRef(function SvgEye16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgEye16 = forwardRef(function SvgEye16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgEye16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgEye16 = forwardRef(function SvgEye16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Eye24.tsx
+++ b/packages/base/Icons/src/Icon/Eye24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgEye24',
-})
 const SvgEye24 = forwardRef(function SvgEye24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgEye24 = forwardRef(function SvgEye24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgEye24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgEye24 = forwardRef(function SvgEye24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/EyeHidden16.tsx
+++ b/packages/base/Icons/src/Icon/EyeHidden16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgEyeHidden16',
-})
 const SvgEyeHidden16 = forwardRef(function SvgEyeHidden16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgEyeHidden16 = forwardRef(function SvgEyeHidden16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgEyeHidden16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgEyeHidden16 = forwardRef(function SvgEyeHidden16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/EyeHidden24.tsx
+++ b/packages/base/Icons/src/Icon/EyeHidden24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgEyeHidden24',
-})
 const SvgEyeHidden24 = forwardRef(function SvgEyeHidden24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgEyeHidden24 = forwardRef(function SvgEyeHidden24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgEyeHidden24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgEyeHidden24 = forwardRef(function SvgEyeHidden24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Facebook16.tsx
+++ b/packages/base/Icons/src/Icon/Facebook16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgFacebook16',
-})
 const SvgFacebook16 = forwardRef(function SvgFacebook16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgFacebook16 = forwardRef(function SvgFacebook16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgFacebook16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgFacebook16 = forwardRef(function SvgFacebook16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Facebook24.tsx
+++ b/packages/base/Icons/src/Icon/Facebook24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgFacebook24',
-})
 const SvgFacebook24 = forwardRef(function SvgFacebook24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgFacebook24 = forwardRef(function SvgFacebook24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgFacebook24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgFacebook24 = forwardRef(function SvgFacebook24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Filter16.tsx
+++ b/packages/base/Icons/src/Icon/Filter16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgFilter16',
-})
 const SvgFilter16 = forwardRef(function SvgFilter16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgFilter16 = forwardRef(function SvgFilter16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgFilter16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgFilter16 = forwardRef(function SvgFilter16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Filter24.tsx
+++ b/packages/base/Icons/src/Icon/Filter24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgFilter24',
-})
 const SvgFilter24 = forwardRef(function SvgFilter24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgFilter24 = forwardRef(function SvgFilter24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgFilter24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgFilter24 = forwardRef(function SvgFilter24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Flag16.tsx
+++ b/packages/base/Icons/src/Icon/Flag16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgFlag16',
-})
 const SvgFlag16 = forwardRef(function SvgFlag16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgFlag16 = forwardRef(function SvgFlag16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgFlag16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -48,7 +46,7 @@ const SvgFlag16 = forwardRef(function SvgFlag16(
     <svg
       fill='none'
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Flag24.tsx
+++ b/packages/base/Icons/src/Icon/Flag24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgFlag24',
-})
 const SvgFlag24 = forwardRef(function SvgFlag24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgFlag24 = forwardRef(function SvgFlag24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgFlag24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -48,7 +46,7 @@ const SvgFlag24 = forwardRef(function SvgFlag24(
     <svg
       fill='none'
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Flash16.tsx
+++ b/packages/base/Icons/src/Icon/Flash16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgFlash16',
-})
 const SvgFlash16 = forwardRef(function SvgFlash16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgFlash16 = forwardRef(function SvgFlash16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgFlash16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgFlash16 = forwardRef(function SvgFlash16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Flash24.tsx
+++ b/packages/base/Icons/src/Icon/Flash24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgFlash24',
-})
 const SvgFlash24 = forwardRef(function SvgFlash24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgFlash24 = forwardRef(function SvgFlash24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgFlash24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgFlash24 = forwardRef(function SvgFlash24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Folder16.tsx
+++ b/packages/base/Icons/src/Icon/Folder16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgFolder16',
-})
 const SvgFolder16 = forwardRef(function SvgFolder16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgFolder16 = forwardRef(function SvgFolder16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgFolder16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgFolder16 = forwardRef(function SvgFolder16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Folder24.tsx
+++ b/packages/base/Icons/src/Icon/Folder24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgFolder24',
-})
 const SvgFolder24 = forwardRef(function SvgFolder24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgFolder24 = forwardRef(function SvgFolder24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgFolder24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgFolder24 = forwardRef(function SvgFolder24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/FullTime16.tsx
+++ b/packages/base/Icons/src/Icon/FullTime16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgFullTime16',
-})
 const SvgFullTime16 = forwardRef(function SvgFullTime16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgFullTime16 = forwardRef(function SvgFullTime16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgFullTime16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgFullTime16 = forwardRef(function SvgFullTime16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/FullTime24.tsx
+++ b/packages/base/Icons/src/Icon/FullTime24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgFullTime24',
-})
 const SvgFullTime24 = forwardRef(function SvgFullTime24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgFullTime24 = forwardRef(function SvgFullTime24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgFullTime24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgFullTime24 = forwardRef(function SvgFullTime24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Fullscreen16.tsx
+++ b/packages/base/Icons/src/Icon/Fullscreen16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgFullscreen16',
-})
 const SvgFullscreen16 = forwardRef(function SvgFullscreen16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgFullscreen16 = forwardRef(function SvgFullscreen16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgFullscreen16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgFullscreen16 = forwardRef(function SvgFullscreen16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Fullscreen24.tsx
+++ b/packages/base/Icons/src/Icon/Fullscreen24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgFullscreen24',
-})
 const SvgFullscreen24 = forwardRef(function SvgFullscreen24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgFullscreen24 = forwardRef(function SvgFullscreen24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgFullscreen24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgFullscreen24 = forwardRef(function SvgFullscreen24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Function16.tsx
+++ b/packages/base/Icons/src/Icon/Function16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgFunction16',
-})
 const SvgFunction16 = forwardRef(function SvgFunction16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgFunction16 = forwardRef(function SvgFunction16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgFunction16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgFunction16 = forwardRef(function SvgFunction16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Function24.tsx
+++ b/packages/base/Icons/src/Icon/Function24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgFunction24',
-})
 const SvgFunction24 = forwardRef(function SvgFunction24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgFunction24 = forwardRef(function SvgFunction24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgFunction24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgFunction24 = forwardRef(function SvgFunction24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Gift16.tsx
+++ b/packages/base/Icons/src/Icon/Gift16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgGift16',
-})
 const SvgGift16 = forwardRef(function SvgGift16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgGift16 = forwardRef(function SvgGift16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgGift16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgGift16 = forwardRef(function SvgGift16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Gift24.tsx
+++ b/packages/base/Icons/src/Icon/Gift24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgGift24',
-})
 const SvgGift24 = forwardRef(function SvgGift24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgGift24 = forwardRef(function SvgGift24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgGift24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgGift24 = forwardRef(function SvgGift24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Github16.tsx
+++ b/packages/base/Icons/src/Icon/Github16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgGithub16',
-})
 const SvgGithub16 = forwardRef(function SvgGithub16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgGithub16 = forwardRef(function SvgGithub16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgGithub16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgGithub16 = forwardRef(function SvgGithub16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Github24.tsx
+++ b/packages/base/Icons/src/Icon/Github24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgGithub24',
-})
 const SvgGithub24 = forwardRef(function SvgGithub24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgGithub24 = forwardRef(function SvgGithub24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgGithub24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgGithub24 = forwardRef(function SvgGithub24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Globe16.tsx
+++ b/packages/base/Icons/src/Icon/Globe16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgGlobe16',
-})
 const SvgGlobe16 = forwardRef(function SvgGlobe16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgGlobe16 = forwardRef(function SvgGlobe16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgGlobe16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgGlobe16 = forwardRef(function SvgGlobe16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Globe24.tsx
+++ b/packages/base/Icons/src/Icon/Globe24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgGlobe24',
-})
 const SvgGlobe24 = forwardRef(function SvgGlobe24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgGlobe24 = forwardRef(function SvgGlobe24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgGlobe24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgGlobe24 = forwardRef(function SvgGlobe24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Guests16.tsx
+++ b/packages/base/Icons/src/Icon/Guests16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgGuests16',
-})
 const SvgGuests16 = forwardRef(function SvgGuests16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgGuests16 = forwardRef(function SvgGuests16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgGuests16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgGuests16 = forwardRef(function SvgGuests16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Guests24.tsx
+++ b/packages/base/Icons/src/Icon/Guests24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgGuests24',
-})
 const SvgGuests24 = forwardRef(function SvgGuests24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgGuests24 = forwardRef(function SvgGuests24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgGuests24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgGuests24 = forwardRef(function SvgGuests24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Heartbeat16.tsx
+++ b/packages/base/Icons/src/Icon/Heartbeat16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgHeartbeat16',
-})
 const SvgHeartbeat16 = forwardRef(function SvgHeartbeat16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgHeartbeat16 = forwardRef(function SvgHeartbeat16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgHeartbeat16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgHeartbeat16 = forwardRef(function SvgHeartbeat16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Heartbeat24.tsx
+++ b/packages/base/Icons/src/Icon/Heartbeat24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgHeartbeat24',
-})
 const SvgHeartbeat24 = forwardRef(function SvgHeartbeat24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgHeartbeat24 = forwardRef(function SvgHeartbeat24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgHeartbeat24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgHeartbeat24 = forwardRef(function SvgHeartbeat24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Help16.tsx
+++ b/packages/base/Icons/src/Icon/Help16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgHelp16',
-})
 const SvgHelp16 = forwardRef(function SvgHelp16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgHelp16 = forwardRef(function SvgHelp16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgHelp16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgHelp16 = forwardRef(function SvgHelp16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Help24.tsx
+++ b/packages/base/Icons/src/Icon/Help24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgHelp24',
-})
 const SvgHelp24 = forwardRef(function SvgHelp24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgHelp24 = forwardRef(function SvgHelp24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgHelp24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgHelp24 = forwardRef(function SvgHelp24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Home16.tsx
+++ b/packages/base/Icons/src/Icon/Home16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgHome16',
-})
 const SvgHome16 = forwardRef(function SvgHome16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgHome16 = forwardRef(function SvgHome16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgHome16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -48,7 +46,7 @@ const SvgHome16 = forwardRef(function SvgHome16(
     <svg
       fill='none'
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Home24.tsx
+++ b/packages/base/Icons/src/Icon/Home24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgHome24',
-})
 const SvgHome24 = forwardRef(function SvgHome24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgHome24 = forwardRef(function SvgHome24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgHome24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -48,7 +46,7 @@ const SvgHome24 = forwardRef(function SvgHome24(
     <svg
       fill='none'
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Image16.tsx
+++ b/packages/base/Icons/src/Icon/Image16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgImage16',
-})
 const SvgImage16 = forwardRef(function SvgImage16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgImage16 = forwardRef(function SvgImage16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgImage16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -48,7 +46,7 @@ const SvgImage16 = forwardRef(function SvgImage16(
     <svg
       fill='none'
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Image24.tsx
+++ b/packages/base/Icons/src/Icon/Image24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgImage24',
-})
 const SvgImage24 = forwardRef(function SvgImage24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgImage24 = forwardRef(function SvgImage24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgImage24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -48,7 +46,7 @@ const SvgImage24 = forwardRef(function SvgImage24(
     <svg
       fill='none'
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Inbox16.tsx
+++ b/packages/base/Icons/src/Icon/Inbox16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgInbox16',
-})
 const SvgInbox16 = forwardRef(function SvgInbox16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgInbox16 = forwardRef(function SvgInbox16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgInbox16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgInbox16 = forwardRef(function SvgInbox16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Inbox24.tsx
+++ b/packages/base/Icons/src/Icon/Inbox24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgInbox24',
-})
 const SvgInbox24 = forwardRef(function SvgInbox24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgInbox24 = forwardRef(function SvgInbox24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgInbox24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgInbox24 = forwardRef(function SvgInbox24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Info16.tsx
+++ b/packages/base/Icons/src/Icon/Info16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgInfo16',
-})
 const SvgInfo16 = forwardRef(function SvgInfo16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgInfo16 = forwardRef(function SvgInfo16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgInfo16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -48,7 +46,7 @@ const SvgInfo16 = forwardRef(function SvgInfo16(
     <svg
       fill='none'
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Info24.tsx
+++ b/packages/base/Icons/src/Icon/Info24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgInfo24',
-})
 const SvgInfo24 = forwardRef(function SvgInfo24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgInfo24 = forwardRef(function SvgInfo24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgInfo24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -48,7 +46,7 @@ const SvgInfo24 = forwardRef(function SvgInfo24(
     <svg
       fill='none'
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/InfoSolid16.tsx
+++ b/packages/base/Icons/src/Icon/InfoSolid16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgInfoSolid16',
-})
 const SvgInfoSolid16 = forwardRef(function SvgInfoSolid16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgInfoSolid16 = forwardRef(function SvgInfoSolid16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgInfoSolid16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -48,7 +46,7 @@ const SvgInfoSolid16 = forwardRef(function SvgInfoSolid16(
     <svg
       fill='none'
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/InfoSolid24.tsx
+++ b/packages/base/Icons/src/Icon/InfoSolid24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgInfoSolid24',
-})
 const SvgInfoSolid24 = forwardRef(function SvgInfoSolid24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgInfoSolid24 = forwardRef(function SvgInfoSolid24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgInfoSolid24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -48,7 +46,7 @@ const SvgInfoSolid24 = forwardRef(function SvgInfoSolid24(
     <svg
       fill='none'
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Instagram16.tsx
+++ b/packages/base/Icons/src/Icon/Instagram16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgInstagram16',
-})
 const SvgInstagram16 = forwardRef(function SvgInstagram16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgInstagram16 = forwardRef(function SvgInstagram16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgInstagram16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgInstagram16 = forwardRef(function SvgInstagram16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Instagram24.tsx
+++ b/packages/base/Icons/src/Icon/Instagram24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgInstagram24',
-})
 const SvgInstagram24 = forwardRef(function SvgInstagram24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgInstagram24 = forwardRef(function SvgInstagram24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgInstagram24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgInstagram24 = forwardRef(function SvgInstagram24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Italic16.tsx
+++ b/packages/base/Icons/src/Icon/Italic16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgItalic16',
-})
 const SvgItalic16 = forwardRef(function SvgItalic16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgItalic16 = forwardRef(function SvgItalic16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgItalic16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgItalic16 = forwardRef(function SvgItalic16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Italic24.tsx
+++ b/packages/base/Icons/src/Icon/Italic24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgItalic24',
-})
 const SvgItalic24 = forwardRef(function SvgItalic24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgItalic24 = forwardRef(function SvgItalic24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgItalic24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -48,7 +46,7 @@ const SvgItalic24 = forwardRef(function SvgItalic24(
     <svg
       fill='none'
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/JobChange16.tsx
+++ b/packages/base/Icons/src/Icon/JobChange16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgJobChange16',
-})
 const SvgJobChange16 = forwardRef(function SvgJobChange16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgJobChange16 = forwardRef(function SvgJobChange16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgJobChange16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgJobChange16 = forwardRef(function SvgJobChange16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/JobChange24.tsx
+++ b/packages/base/Icons/src/Icon/JobChange24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgJobChange24',
-})
 const SvgJobChange24 = forwardRef(function SvgJobChange24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgJobChange24 = forwardRef(function SvgJobChange24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgJobChange24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgJobChange24 = forwardRef(function SvgJobChange24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Jobs16.tsx
+++ b/packages/base/Icons/src/Icon/Jobs16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgJobs16',
-})
 const SvgJobs16 = forwardRef(function SvgJobs16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgJobs16 = forwardRef(function SvgJobs16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgJobs16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgJobs16 = forwardRef(function SvgJobs16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Jobs24.tsx
+++ b/packages/base/Icons/src/Icon/Jobs24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgJobs24',
-})
 const SvgJobs24 = forwardRef(function SvgJobs24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgJobs24 = forwardRef(function SvgJobs24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgJobs24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgJobs24 = forwardRef(function SvgJobs24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Keyboard16.tsx
+++ b/packages/base/Icons/src/Icon/Keyboard16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgKeyboard16',
-})
 const SvgKeyboard16 = forwardRef(function SvgKeyboard16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgKeyboard16 = forwardRef(function SvgKeyboard16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgKeyboard16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -48,7 +46,7 @@ const SvgKeyboard16 = forwardRef(function SvgKeyboard16(
     <svg
       fill='none'
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Keyboard24.tsx
+++ b/packages/base/Icons/src/Icon/Keyboard24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgKeyboard24',
-})
 const SvgKeyboard24 = forwardRef(function SvgKeyboard24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgKeyboard24 = forwardRef(function SvgKeyboard24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgKeyboard24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -48,7 +46,7 @@ const SvgKeyboard24 = forwardRef(function SvgKeyboard24(
     <svg
       fill='none'
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Language16.tsx
+++ b/packages/base/Icons/src/Icon/Language16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgLanguage16',
-})
 const SvgLanguage16 = forwardRef(function SvgLanguage16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgLanguage16 = forwardRef(function SvgLanguage16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgLanguage16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgLanguage16 = forwardRef(function SvgLanguage16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Language24.tsx
+++ b/packages/base/Icons/src/Icon/Language24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgLanguage24',
-})
 const SvgLanguage24 = forwardRef(function SvgLanguage24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgLanguage24 = forwardRef(function SvgLanguage24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgLanguage24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgLanguage24 = forwardRef(function SvgLanguage24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Layers16.tsx
+++ b/packages/base/Icons/src/Icon/Layers16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgLayers16',
-})
 const SvgLayers16 = forwardRef(function SvgLayers16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgLayers16 = forwardRef(function SvgLayers16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgLayers16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -48,7 +46,7 @@ const SvgLayers16 = forwardRef(function SvgLayers16(
     <svg
       fill='none'
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Layers24.tsx
+++ b/packages/base/Icons/src/Icon/Layers24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgLayers24',
-})
 const SvgLayers24 = forwardRef(function SvgLayers24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgLayers24 = forwardRef(function SvgLayers24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgLayers24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -48,7 +46,7 @@ const SvgLayers24 = forwardRef(function SvgLayers24(
     <svg
       fill='none'
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/LeadOrgUnitJoin16.tsx
+++ b/packages/base/Icons/src/Icon/LeadOrgUnitJoin16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgLeadOrgUnitJoin16',
-})
 const SvgLeadOrgUnitJoin16 = forwardRef(function SvgLeadOrgUnitJoin16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgLeadOrgUnitJoin16 = forwardRef(function SvgLeadOrgUnitJoin16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgLeadOrgUnitJoin16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -48,7 +46,7 @@ const SvgLeadOrgUnitJoin16 = forwardRef(function SvgLeadOrgUnitJoin16(
     <svg
       fill='none'
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/LeadOrgUnitJoin24.tsx
+++ b/packages/base/Icons/src/Icon/LeadOrgUnitJoin24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgLeadOrgUnitJoin24',
-})
 const SvgLeadOrgUnitJoin24 = forwardRef(function SvgLeadOrgUnitJoin24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgLeadOrgUnitJoin24 = forwardRef(function SvgLeadOrgUnitJoin24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgLeadOrgUnitJoin24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -48,7 +46,7 @@ const SvgLeadOrgUnitJoin24 = forwardRef(function SvgLeadOrgUnitJoin24(
     <svg
       fill='none'
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Leave16.tsx
+++ b/packages/base/Icons/src/Icon/Leave16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgLeave16',
-})
 const SvgLeave16 = forwardRef(function SvgLeave16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgLeave16 = forwardRef(function SvgLeave16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgLeave16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgLeave16 = forwardRef(function SvgLeave16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Leave24.tsx
+++ b/packages/base/Icons/src/Icon/Leave24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgLeave24',
-})
 const SvgLeave24 = forwardRef(function SvgLeave24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgLeave24 = forwardRef(function SvgLeave24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgLeave24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgLeave24 = forwardRef(function SvgLeave24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/LegalInfo16.tsx
+++ b/packages/base/Icons/src/Icon/LegalInfo16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgLegalInfo16',
-})
 const SvgLegalInfo16 = forwardRef(function SvgLegalInfo16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgLegalInfo16 = forwardRef(function SvgLegalInfo16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgLegalInfo16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgLegalInfo16 = forwardRef(function SvgLegalInfo16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/LegalInfo24.tsx
+++ b/packages/base/Icons/src/Icon/LegalInfo24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgLegalInfo24',
-})
 const SvgLegalInfo24 = forwardRef(function SvgLegalInfo24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgLegalInfo24 = forwardRef(function SvgLegalInfo24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgLegalInfo24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgLegalInfo24 = forwardRef(function SvgLegalInfo24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Length16.tsx
+++ b/packages/base/Icons/src/Icon/Length16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgLength16',
-})
 const SvgLength16 = forwardRef(function SvgLength16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgLength16 = forwardRef(function SvgLength16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgLength16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgLength16 = forwardRef(function SvgLength16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Length24.tsx
+++ b/packages/base/Icons/src/Icon/Length24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgLength24',
-})
 const SvgLength24 = forwardRef(function SvgLength24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgLength24 = forwardRef(function SvgLength24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgLength24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgLength24 = forwardRef(function SvgLength24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Link16.tsx
+++ b/packages/base/Icons/src/Icon/Link16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgLink16',
-})
 const SvgLink16 = forwardRef(function SvgLink16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgLink16 = forwardRef(function SvgLink16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgLink16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgLink16 = forwardRef(function SvgLink16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Link24.tsx
+++ b/packages/base/Icons/src/Icon/Link24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgLink24',
-})
 const SvgLink24 = forwardRef(function SvgLink24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgLink24 = forwardRef(function SvgLink24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgLink24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgLink24 = forwardRef(function SvgLink24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Linkedin16.tsx
+++ b/packages/base/Icons/src/Icon/Linkedin16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgLinkedin16',
-})
 const SvgLinkedin16 = forwardRef(function SvgLinkedin16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgLinkedin16 = forwardRef(function SvgLinkedin16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgLinkedin16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgLinkedin16 = forwardRef(function SvgLinkedin16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Linkedin24.tsx
+++ b/packages/base/Icons/src/Icon/Linkedin24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgLinkedin24',
-})
 const SvgLinkedin24 = forwardRef(function SvgLinkedin24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgLinkedin24 = forwardRef(function SvgLinkedin24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgLinkedin24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgLinkedin24 = forwardRef(function SvgLinkedin24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/ListOrdered16.tsx
+++ b/packages/base/Icons/src/Icon/ListOrdered16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgListOrdered16',
-})
 const SvgListOrdered16 = forwardRef(function SvgListOrdered16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgListOrdered16 = forwardRef(function SvgListOrdered16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgListOrdered16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgListOrdered16 = forwardRef(function SvgListOrdered16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/ListOrdered24.tsx
+++ b/packages/base/Icons/src/Icon/ListOrdered24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgListOrdered24',
-})
 const SvgListOrdered24 = forwardRef(function SvgListOrdered24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgListOrdered24 = forwardRef(function SvgListOrdered24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgListOrdered24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -48,7 +46,7 @@ const SvgListOrdered24 = forwardRef(function SvgListOrdered24(
     <svg
       fill='none'
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/ListUnordered16.tsx
+++ b/packages/base/Icons/src/Icon/ListUnordered16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgListUnordered16',
-})
 const SvgListUnordered16 = forwardRef(function SvgListUnordered16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgListUnordered16 = forwardRef(function SvgListUnordered16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgListUnordered16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgListUnordered16 = forwardRef(function SvgListUnordered16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/ListUnordered24.tsx
+++ b/packages/base/Icons/src/Icon/ListUnordered24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgListUnordered24',
-})
 const SvgListUnordered24 = forwardRef(function SvgListUnordered24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgListUnordered24 = forwardRef(function SvgListUnordered24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgListUnordered24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -48,7 +46,7 @@ const SvgListUnordered24 = forwardRef(function SvgListUnordered24(
     <svg
       fill='none'
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Lock16.tsx
+++ b/packages/base/Icons/src/Icon/Lock16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgLock16',
-})
 const SvgLock16 = forwardRef(function SvgLock16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgLock16 = forwardRef(function SvgLock16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgLock16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgLock16 = forwardRef(function SvgLock16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Lock24.tsx
+++ b/packages/base/Icons/src/Icon/Lock24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgLock24',
-})
 const SvgLock24 = forwardRef(function SvgLock24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgLock24 = forwardRef(function SvgLock24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgLock24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgLock24 = forwardRef(function SvgLock24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Logo.tsx
+++ b/packages/base/Icons/src/Icon/Logo.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgLogo',
-})
 const SvgLogo = forwardRef(function SvgLogo(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgLogo = forwardRef(function SvgLogo(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgLogo', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgLogo = forwardRef(function SvgLogo(
   return (
     <svg
       viewBox='0 0 109 30'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/LogoEmblem.tsx
+++ b/packages/base/Icons/src/Icon/LogoEmblem.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgLogoEmblem',
-})
 const SvgLogoEmblem = forwardRef(function SvgLogoEmblem(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgLogoEmblem = forwardRef(function SvgLogoEmblem(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgLogoEmblem', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgLogoEmblem = forwardRef(function SvgLogoEmblem(
   return (
     <svg
       viewBox='0 0 21 30'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Message16.tsx
+++ b/packages/base/Icons/src/Icon/Message16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgMessage16',
-})
 const SvgMessage16 = forwardRef(function SvgMessage16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgMessage16 = forwardRef(function SvgMessage16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgMessage16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgMessage16 = forwardRef(function SvgMessage16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Message24.tsx
+++ b/packages/base/Icons/src/Icon/Message24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgMessage24',
-})
 const SvgMessage24 = forwardRef(function SvgMessage24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgMessage24 = forwardRef(function SvgMessage24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgMessage24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgMessage24 = forwardRef(function SvgMessage24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/MicrophoneOff16.tsx
+++ b/packages/base/Icons/src/Icon/MicrophoneOff16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgMicrophoneOff16',
-})
 const SvgMicrophoneOff16 = forwardRef(function SvgMicrophoneOff16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgMicrophoneOff16 = forwardRef(function SvgMicrophoneOff16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgMicrophoneOff16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgMicrophoneOff16 = forwardRef(function SvgMicrophoneOff16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/MicrophoneOff24.tsx
+++ b/packages/base/Icons/src/Icon/MicrophoneOff24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgMicrophoneOff24',
-})
 const SvgMicrophoneOff24 = forwardRef(function SvgMicrophoneOff24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgMicrophoneOff24 = forwardRef(function SvgMicrophoneOff24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgMicrophoneOff24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgMicrophoneOff24 = forwardRef(function SvgMicrophoneOff24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/MicrophoneOn16.tsx
+++ b/packages/base/Icons/src/Icon/MicrophoneOn16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgMicrophoneOn16',
-})
 const SvgMicrophoneOn16 = forwardRef(function SvgMicrophoneOn16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgMicrophoneOn16 = forwardRef(function SvgMicrophoneOn16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgMicrophoneOn16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgMicrophoneOn16 = forwardRef(function SvgMicrophoneOn16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/MicrophoneOn24.tsx
+++ b/packages/base/Icons/src/Icon/MicrophoneOn24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgMicrophoneOn24',
-})
 const SvgMicrophoneOn24 = forwardRef(function SvgMicrophoneOn24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgMicrophoneOn24 = forwardRef(function SvgMicrophoneOn24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgMicrophoneOn24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgMicrophoneOn24 = forwardRef(function SvgMicrophoneOn24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Minus16.tsx
+++ b/packages/base/Icons/src/Icon/Minus16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgMinus16',
-})
 const SvgMinus16 = forwardRef(function SvgMinus16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgMinus16 = forwardRef(function SvgMinus16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgMinus16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgMinus16 = forwardRef(function SvgMinus16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Minus24.tsx
+++ b/packages/base/Icons/src/Icon/Minus24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgMinus24',
-})
 const SvgMinus24 = forwardRef(function SvgMinus24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgMinus24 = forwardRef(function SvgMinus24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgMinus24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgMinus24 = forwardRef(function SvgMinus24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/MissedCall16.tsx
+++ b/packages/base/Icons/src/Icon/MissedCall16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgMissedCall16',
-})
 const SvgMissedCall16 = forwardRef(function SvgMissedCall16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgMissedCall16 = forwardRef(function SvgMissedCall16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgMissedCall16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -48,7 +46,7 @@ const SvgMissedCall16 = forwardRef(function SvgMissedCall16(
     <svg
       fill='none'
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/MissedCall24.tsx
+++ b/packages/base/Icons/src/Icon/MissedCall24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgMissedCall24',
-})
 const SvgMissedCall24 = forwardRef(function SvgMissedCall24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgMissedCall24 = forwardRef(function SvgMissedCall24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgMissedCall24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgMissedCall24 = forwardRef(function SvgMissedCall24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Mobile16.tsx
+++ b/packages/base/Icons/src/Icon/Mobile16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgMobile16',
-})
 const SvgMobile16 = forwardRef(function SvgMobile16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgMobile16 = forwardRef(function SvgMobile16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgMobile16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -48,7 +46,7 @@ const SvgMobile16 = forwardRef(function SvgMobile16(
     <svg
       fill='none'
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Mobile24.tsx
+++ b/packages/base/Icons/src/Icon/Mobile24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgMobile24',
-})
 const SvgMobile24 = forwardRef(function SvgMobile24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgMobile24 = forwardRef(function SvgMobile24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgMobile24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -48,7 +46,7 @@ const SvgMobile24 = forwardRef(function SvgMobile24(
     <svg
       fill='none'
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/More16.tsx
+++ b/packages/base/Icons/src/Icon/More16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgMore16',
-})
 const SvgMore16 = forwardRef(function SvgMore16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgMore16 = forwardRef(function SvgMore16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgMore16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgMore16 = forwardRef(function SvgMore16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/More24.tsx
+++ b/packages/base/Icons/src/Icon/More24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgMore24',
-})
 const SvgMore24 = forwardRef(function SvgMore24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgMore24 = forwardRef(function SvgMore24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgMore24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgMore24 = forwardRef(function SvgMore24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Morning16.tsx
+++ b/packages/base/Icons/src/Icon/Morning16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgMorning16',
-})
 const SvgMorning16 = forwardRef(function SvgMorning16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgMorning16 = forwardRef(function SvgMorning16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgMorning16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgMorning16 = forwardRef(function SvgMorning16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Morning24.tsx
+++ b/packages/base/Icons/src/Icon/Morning24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgMorning24',
-})
 const SvgMorning24 = forwardRef(function SvgMorning24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgMorning24 = forwardRef(function SvgMorning24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgMorning24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgMorning24 = forwardRef(function SvgMorning24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Multi16.tsx
+++ b/packages/base/Icons/src/Icon/Multi16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgMulti16',
-})
 const SvgMulti16 = forwardRef(function SvgMulti16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgMulti16 = forwardRef(function SvgMulti16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgMulti16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgMulti16 = forwardRef(function SvgMulti16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Multi24.tsx
+++ b/packages/base/Icons/src/Icon/Multi24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgMulti24',
-})
 const SvgMulti24 = forwardRef(function SvgMulti24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgMulti24 = forwardRef(function SvgMulti24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgMulti24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgMulti24 = forwardRef(function SvgMulti24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/New16.tsx
+++ b/packages/base/Icons/src/Icon/New16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgNew16',
-})
 const SvgNew16 = forwardRef(function SvgNew16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgNew16 = forwardRef(function SvgNew16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgNew16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -48,7 +46,7 @@ const SvgNew16 = forwardRef(function SvgNew16(
     <svg
       fill='none'
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/New24.tsx
+++ b/packages/base/Icons/src/Icon/New24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgNew24',
-})
 const SvgNew24 = forwardRef(function SvgNew24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgNew24 = forwardRef(function SvgNew24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgNew24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -48,7 +46,7 @@ const SvgNew24 = forwardRef(function SvgNew24(
     <svg
       fill='none'
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/NewCandidate16.tsx
+++ b/packages/base/Icons/src/Icon/NewCandidate16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgNewCandidate16',
-})
 const SvgNewCandidate16 = forwardRef(function SvgNewCandidate16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgNewCandidate16 = forwardRef(function SvgNewCandidate16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgNewCandidate16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgNewCandidate16 = forwardRef(function SvgNewCandidate16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/NewCandidate24.tsx
+++ b/packages/base/Icons/src/Icon/NewCandidate24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgNewCandidate24',
-})
 const SvgNewCandidate24 = forwardRef(function SvgNewCandidate24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgNewCandidate24 = forwardRef(function SvgNewCandidate24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgNewCandidate24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgNewCandidate24 = forwardRef(function SvgNewCandidate24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Night16.tsx
+++ b/packages/base/Icons/src/Icon/Night16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgNight16',
-})
 const SvgNight16 = forwardRef(function SvgNight16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgNight16 = forwardRef(function SvgNight16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgNight16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgNight16 = forwardRef(function SvgNight16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Night24.tsx
+++ b/packages/base/Icons/src/Icon/Night24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgNight24',
-})
 const SvgNight24 = forwardRef(function SvgNight24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgNight24 = forwardRef(function SvgNight24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgNight24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgNight24 = forwardRef(function SvgNight24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/NumericalAnalysis16.tsx
+++ b/packages/base/Icons/src/Icon/NumericalAnalysis16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgNumericalAnalysis16',
-})
 const SvgNumericalAnalysis16 = forwardRef(function SvgNumericalAnalysis16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgNumericalAnalysis16 = forwardRef(function SvgNumericalAnalysis16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgNumericalAnalysis16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgNumericalAnalysis16 = forwardRef(function SvgNumericalAnalysis16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/NumericalAnalysis24.tsx
+++ b/packages/base/Icons/src/Icon/NumericalAnalysis24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgNumericalAnalysis24',
-})
 const SvgNumericalAnalysis24 = forwardRef(function SvgNumericalAnalysis24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgNumericalAnalysis24 = forwardRef(function SvgNumericalAnalysis24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgNumericalAnalysis24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgNumericalAnalysis24 = forwardRef(function SvgNumericalAnalysis24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Okr16.tsx
+++ b/packages/base/Icons/src/Icon/Okr16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgOkr16',
-})
 const SvgOkr16 = forwardRef(function SvgOkr16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgOkr16 = forwardRef(function SvgOkr16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgOkr16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgOkr16 = forwardRef(function SvgOkr16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Okr24.tsx
+++ b/packages/base/Icons/src/Icon/Okr24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgOkr24',
-})
 const SvgOkr24 = forwardRef(function SvgOkr24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgOkr24 = forwardRef(function SvgOkr24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgOkr24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgOkr24 = forwardRef(function SvgOkr24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Overlap16.tsx
+++ b/packages/base/Icons/src/Icon/Overlap16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgOverlap16',
-})
 const SvgOverlap16 = forwardRef(function SvgOverlap16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgOverlap16 = forwardRef(function SvgOverlap16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgOverlap16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgOverlap16 = forwardRef(function SvgOverlap16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Overlap24.tsx
+++ b/packages/base/Icons/src/Icon/Overlap24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgOverlap24',
-})
 const SvgOverlap24 = forwardRef(function SvgOverlap24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgOverlap24 = forwardRef(function SvgOverlap24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgOverlap24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgOverlap24 = forwardRef(function SvgOverlap24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Overview16.tsx
+++ b/packages/base/Icons/src/Icon/Overview16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgOverview16',
-})
 const SvgOverview16 = forwardRef(function SvgOverview16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgOverview16 = forwardRef(function SvgOverview16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgOverview16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgOverview16 = forwardRef(function SvgOverview16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Overview24.tsx
+++ b/packages/base/Icons/src/Icon/Overview24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgOverview24',
-})
 const SvgOverview24 = forwardRef(function SvgOverview24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgOverview24 = forwardRef(function SvgOverview24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgOverview24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgOverview24 = forwardRef(function SvgOverview24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/OwnerDefault16.tsx
+++ b/packages/base/Icons/src/Icon/OwnerDefault16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgOwnerDefault16',
-})
 const SvgOwnerDefault16 = forwardRef(function SvgOwnerDefault16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgOwnerDefault16 = forwardRef(function SvgOwnerDefault16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgOwnerDefault16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgOwnerDefault16 = forwardRef(function SvgOwnerDefault16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/OwnerDefault24.tsx
+++ b/packages/base/Icons/src/Icon/OwnerDefault24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgOwnerDefault24',
-})
 const SvgOwnerDefault24 = forwardRef(function SvgOwnerDefault24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgOwnerDefault24 = forwardRef(function SvgOwnerDefault24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgOwnerDefault24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgOwnerDefault24 = forwardRef(function SvgOwnerDefault24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Page16.tsx
+++ b/packages/base/Icons/src/Icon/Page16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgPage16',
-})
 const SvgPage16 = forwardRef(function SvgPage16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgPage16 = forwardRef(function SvgPage16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgPage16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgPage16 = forwardRef(function SvgPage16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Page24.tsx
+++ b/packages/base/Icons/src/Icon/Page24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgPage24',
-})
 const SvgPage24 = forwardRef(function SvgPage24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgPage24 = forwardRef(function SvgPage24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgPage24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgPage24 = forwardRef(function SvgPage24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/PartTime16.tsx
+++ b/packages/base/Icons/src/Icon/PartTime16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgPartTime16',
-})
 const SvgPartTime16 = forwardRef(function SvgPartTime16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgPartTime16 = forwardRef(function SvgPartTime16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgPartTime16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgPartTime16 = forwardRef(function SvgPartTime16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/PartTime24.tsx
+++ b/packages/base/Icons/src/Icon/PartTime24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgPartTime24',
-})
 const SvgPartTime24 = forwardRef(function SvgPartTime24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgPartTime24 = forwardRef(function SvgPartTime24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgPartTime24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgPartTime24 = forwardRef(function SvgPartTime24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Participants16.tsx
+++ b/packages/base/Icons/src/Icon/Participants16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgParticipants16',
-})
 const SvgParticipants16 = forwardRef(function SvgParticipants16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgParticipants16 = forwardRef(function SvgParticipants16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgParticipants16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgParticipants16 = forwardRef(function SvgParticipants16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Participants24.tsx
+++ b/packages/base/Icons/src/Icon/Participants24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgParticipants24',
-})
 const SvgParticipants24 = forwardRef(function SvgParticipants24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgParticipants24 = forwardRef(function SvgParticipants24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgParticipants24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgParticipants24 = forwardRef(function SvgParticipants24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Pause16.tsx
+++ b/packages/base/Icons/src/Icon/Pause16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgPause16',
-})
 const SvgPause16 = forwardRef(function SvgPause16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgPause16 = forwardRef(function SvgPause16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgPause16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgPause16 = forwardRef(function SvgPause16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Pause24.tsx
+++ b/packages/base/Icons/src/Icon/Pause24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgPause24',
-})
 const SvgPause24 = forwardRef(function SvgPause24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgPause24 = forwardRef(function SvgPause24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgPause24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgPause24 = forwardRef(function SvgPause24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/PauseSolid16.tsx
+++ b/packages/base/Icons/src/Icon/PauseSolid16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgPauseSolid16',
-})
 const SvgPauseSolid16 = forwardRef(function SvgPauseSolid16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgPauseSolid16 = forwardRef(function SvgPauseSolid16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgPauseSolid16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgPauseSolid16 = forwardRef(function SvgPauseSolid16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/PauseSolid24.tsx
+++ b/packages/base/Icons/src/Icon/PauseSolid24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgPauseSolid24',
-})
 const SvgPauseSolid24 = forwardRef(function SvgPauseSolid24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgPauseSolid24 = forwardRef(function SvgPauseSolid24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgPauseSolid24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgPauseSolid24 = forwardRef(function SvgPauseSolid24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Pencil16.tsx
+++ b/packages/base/Icons/src/Icon/Pencil16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgPencil16',
-})
 const SvgPencil16 = forwardRef(function SvgPencil16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgPencil16 = forwardRef(function SvgPencil16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgPencil16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgPencil16 = forwardRef(function SvgPencil16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Pencil24.tsx
+++ b/packages/base/Icons/src/Icon/Pencil24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgPencil24',
-})
 const SvgPencil24 = forwardRef(function SvgPencil24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgPencil24 = forwardRef(function SvgPencil24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgPencil24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgPencil24 = forwardRef(function SvgPencil24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Performance16.tsx
+++ b/packages/base/Icons/src/Icon/Performance16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgPerformance16',
-})
 const SvgPerformance16 = forwardRef(function SvgPerformance16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgPerformance16 = forwardRef(function SvgPerformance16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgPerformance16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgPerformance16 = forwardRef(function SvgPerformance16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Performance24.tsx
+++ b/packages/base/Icons/src/Icon/Performance24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgPerformance24',
-})
 const SvgPerformance24 = forwardRef(function SvgPerformance24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgPerformance24 = forwardRef(function SvgPerformance24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgPerformance24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgPerformance24 = forwardRef(function SvgPerformance24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Phone16.tsx
+++ b/packages/base/Icons/src/Icon/Phone16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgPhone16',
-})
 const SvgPhone16 = forwardRef(function SvgPhone16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgPhone16 = forwardRef(function SvgPhone16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgPhone16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgPhone16 = forwardRef(function SvgPhone16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Phone24.tsx
+++ b/packages/base/Icons/src/Icon/Phone24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgPhone24',
-})
 const SvgPhone24 = forwardRef(function SvgPhone24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgPhone24 = forwardRef(function SvgPhone24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgPhone24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgPhone24 = forwardRef(function SvgPhone24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/PhoneDown16.tsx
+++ b/packages/base/Icons/src/Icon/PhoneDown16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgPhoneDown16',
-})
 const SvgPhoneDown16 = forwardRef(function SvgPhoneDown16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgPhoneDown16 = forwardRef(function SvgPhoneDown16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgPhoneDown16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgPhoneDown16 = forwardRef(function SvgPhoneDown16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/PhoneDown24.tsx
+++ b/packages/base/Icons/src/Icon/PhoneDown24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgPhoneDown24',
-})
 const SvgPhoneDown24 = forwardRef(function SvgPhoneDown24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgPhoneDown24 = forwardRef(function SvgPhoneDown24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgPhoneDown24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgPhoneDown24 = forwardRef(function SvgPhoneDown24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/PieChart16.tsx
+++ b/packages/base/Icons/src/Icon/PieChart16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgPieChart16',
-})
 const SvgPieChart16 = forwardRef(function SvgPieChart16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgPieChart16 = forwardRef(function SvgPieChart16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgPieChart16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgPieChart16 = forwardRef(function SvgPieChart16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/PieChart24.tsx
+++ b/packages/base/Icons/src/Icon/PieChart24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgPieChart24',
-})
 const SvgPieChart24 = forwardRef(function SvgPieChart24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgPieChart24 = forwardRef(function SvgPieChart24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgPieChart24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgPieChart24 = forwardRef(function SvgPieChart24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Pin16.tsx
+++ b/packages/base/Icons/src/Icon/Pin16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgPin16',
-})
 const SvgPin16 = forwardRef(function SvgPin16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgPin16 = forwardRef(function SvgPin16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgPin16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgPin16 = forwardRef(function SvgPin16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Pin24.tsx
+++ b/packages/base/Icons/src/Icon/Pin24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgPin24',
-})
 const SvgPin24 = forwardRef(function SvgPin24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgPin24 = forwardRef(function SvgPin24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgPin24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgPin24 = forwardRef(function SvgPin24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/PinSolid16.tsx
+++ b/packages/base/Icons/src/Icon/PinSolid16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgPinSolid16',
-})
 const SvgPinSolid16 = forwardRef(function SvgPinSolid16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgPinSolid16 = forwardRef(function SvgPinSolid16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgPinSolid16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgPinSolid16 = forwardRef(function SvgPinSolid16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/PinSolid24.tsx
+++ b/packages/base/Icons/src/Icon/PinSolid24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgPinSolid24',
-})
 const SvgPinSolid24 = forwardRef(function SvgPinSolid24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgPinSolid24 = forwardRef(function SvgPinSolid24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgPinSolid24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgPinSolid24 = forwardRef(function SvgPinSolid24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/PlaySolid16.tsx
+++ b/packages/base/Icons/src/Icon/PlaySolid16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgPlaySolid16',
-})
 const SvgPlaySolid16 = forwardRef(function SvgPlaySolid16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgPlaySolid16 = forwardRef(function SvgPlaySolid16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgPlaySolid16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgPlaySolid16 = forwardRef(function SvgPlaySolid16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/PlaySolid24.tsx
+++ b/packages/base/Icons/src/Icon/PlaySolid24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgPlaySolid24',
-})
 const SvgPlaySolid24 = forwardRef(function SvgPlaySolid24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgPlaySolid24 = forwardRef(function SvgPlaySolid24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgPlaySolid24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -48,7 +46,7 @@ const SvgPlaySolid24 = forwardRef(function SvgPlaySolid24(
     <svg
       fill='none'
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Player16.tsx
+++ b/packages/base/Icons/src/Icon/Player16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgPlayer16',
-})
 const SvgPlayer16 = forwardRef(function SvgPlayer16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgPlayer16 = forwardRef(function SvgPlayer16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgPlayer16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgPlayer16 = forwardRef(function SvgPlayer16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Player24.tsx
+++ b/packages/base/Icons/src/Icon/Player24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgPlayer24',
-})
 const SvgPlayer24 = forwardRef(function SvgPlayer24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgPlayer24 = forwardRef(function SvgPlayer24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgPlayer24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgPlayer24 = forwardRef(function SvgPlayer24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Plus16.tsx
+++ b/packages/base/Icons/src/Icon/Plus16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgPlus16',
-})
 const SvgPlus16 = forwardRef(function SvgPlus16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgPlus16 = forwardRef(function SvgPlus16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgPlus16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgPlus16 = forwardRef(function SvgPlus16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Plus24.tsx
+++ b/packages/base/Icons/src/Icon/Plus24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgPlus24',
-})
 const SvgPlus24 = forwardRef(function SvgPlus24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgPlus24 = forwardRef(function SvgPlus24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgPlus24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgPlus24 = forwardRef(function SvgPlus24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Pod16.tsx
+++ b/packages/base/Icons/src/Icon/Pod16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgPod16',
-})
 const SvgPod16 = forwardRef(function SvgPod16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgPod16 = forwardRef(function SvgPod16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgPod16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgPod16 = forwardRef(function SvgPod16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Pod24.tsx
+++ b/packages/base/Icons/src/Icon/Pod24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgPod24',
-})
 const SvgPod24 = forwardRef(function SvgPod24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgPod24 = forwardRef(function SvgPod24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgPod24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgPod24 = forwardRef(function SvgPod24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/PortfolioDesigner16.tsx
+++ b/packages/base/Icons/src/Icon/PortfolioDesigner16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgPortfolioDesigner16',
-})
 const SvgPortfolioDesigner16 = forwardRef(function SvgPortfolioDesigner16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgPortfolioDesigner16 = forwardRef(function SvgPortfolioDesigner16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgPortfolioDesigner16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgPortfolioDesigner16 = forwardRef(function SvgPortfolioDesigner16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/PortfolioDesigner24.tsx
+++ b/packages/base/Icons/src/Icon/PortfolioDesigner24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgPortfolioDesigner24',
-})
 const SvgPortfolioDesigner24 = forwardRef(function SvgPortfolioDesigner24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgPortfolioDesigner24 = forwardRef(function SvgPortfolioDesigner24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgPortfolioDesigner24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgPortfolioDesigner24 = forwardRef(function SvgPortfolioDesigner24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/PortfolioFinance16.tsx
+++ b/packages/base/Icons/src/Icon/PortfolioFinance16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgPortfolioFinance16',
-})
 const SvgPortfolioFinance16 = forwardRef(function SvgPortfolioFinance16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgPortfolioFinance16 = forwardRef(function SvgPortfolioFinance16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgPortfolioFinance16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgPortfolioFinance16 = forwardRef(function SvgPortfolioFinance16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/PortfolioFinance24.tsx
+++ b/packages/base/Icons/src/Icon/PortfolioFinance24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgPortfolioFinance24',
-})
 const SvgPortfolioFinance24 = forwardRef(function SvgPortfolioFinance24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgPortfolioFinance24 = forwardRef(function SvgPortfolioFinance24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgPortfolioFinance24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgPortfolioFinance24 = forwardRef(function SvgPortfolioFinance24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Preview16.tsx
+++ b/packages/base/Icons/src/Icon/Preview16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgPreview16',
-})
 const SvgPreview16 = forwardRef(function SvgPreview16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgPreview16 = forwardRef(function SvgPreview16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgPreview16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -48,7 +46,7 @@ const SvgPreview16 = forwardRef(function SvgPreview16(
     <svg
       fill='none'
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Preview24.tsx
+++ b/packages/base/Icons/src/Icon/Preview24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgPreview24',
-})
 const SvgPreview24 = forwardRef(function SvgPreview24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgPreview24 = forwardRef(function SvgPreview24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgPreview24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -48,7 +46,7 @@ const SvgPreview24 = forwardRef(function SvgPreview24(
     <svg
       fill='none'
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/ProductManager16.tsx
+++ b/packages/base/Icons/src/Icon/ProductManager16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgProductManager16',
-})
 const SvgProductManager16 = forwardRef(function SvgProductManager16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgProductManager16 = forwardRef(function SvgProductManager16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgProductManager16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -48,7 +46,7 @@ const SvgProductManager16 = forwardRef(function SvgProductManager16(
     <svg
       fill='none'
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/ProductManager24.tsx
+++ b/packages/base/Icons/src/Icon/ProductManager24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgProductManager24',
-})
 const SvgProductManager24 = forwardRef(function SvgProductManager24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgProductManager24 = forwardRef(function SvgProductManager24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgProductManager24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -48,7 +46,7 @@ const SvgProductManager24 = forwardRef(function SvgProductManager24(
     <svg
       fill='none'
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Profile16.tsx
+++ b/packages/base/Icons/src/Icon/Profile16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgProfile16',
-})
 const SvgProfile16 = forwardRef(function SvgProfile16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgProfile16 = forwardRef(function SvgProfile16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgProfile16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgProfile16 = forwardRef(function SvgProfile16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Profile24.tsx
+++ b/packages/base/Icons/src/Icon/Profile24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgProfile24',
-})
 const SvgProfile24 = forwardRef(function SvgProfile24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgProfile24 = forwardRef(function SvgProfile24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgProfile24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgProfile24 = forwardRef(function SvgProfile24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/ProfileCrossed16.tsx
+++ b/packages/base/Icons/src/Icon/ProfileCrossed16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgProfileCrossed16',
-})
 const SvgProfileCrossed16 = forwardRef(function SvgProfileCrossed16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgProfileCrossed16 = forwardRef(function SvgProfileCrossed16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgProfileCrossed16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgProfileCrossed16 = forwardRef(function SvgProfileCrossed16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/ProfileCrossed24.tsx
+++ b/packages/base/Icons/src/Icon/ProfileCrossed24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgProfileCrossed24',
-})
 const SvgProfileCrossed24 = forwardRef(function SvgProfileCrossed24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgProfileCrossed24 = forwardRef(function SvgProfileCrossed24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgProfileCrossed24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgProfileCrossed24 = forwardRef(function SvgProfileCrossed24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Project16.tsx
+++ b/packages/base/Icons/src/Icon/Project16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgProject16',
-})
 const SvgProject16 = forwardRef(function SvgProject16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgProject16 = forwardRef(function SvgProject16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgProject16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgProject16 = forwardRef(function SvgProject16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Project24.tsx
+++ b/packages/base/Icons/src/Icon/Project24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgProject24',
-})
 const SvgProject24 = forwardRef(function SvgProject24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgProject24 = forwardRef(function SvgProject24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgProject24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgProject24 = forwardRef(function SvgProject24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/ProjectDiscovery16.tsx
+++ b/packages/base/Icons/src/Icon/ProjectDiscovery16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgProjectDiscovery16',
-})
 const SvgProjectDiscovery16 = forwardRef(function SvgProjectDiscovery16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgProjectDiscovery16 = forwardRef(function SvgProjectDiscovery16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgProjectDiscovery16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -48,7 +46,7 @@ const SvgProjectDiscovery16 = forwardRef(function SvgProjectDiscovery16(
     <svg
       fill='none'
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/ProjectDiscovery24.tsx
+++ b/packages/base/Icons/src/Icon/ProjectDiscovery24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgProjectDiscovery24',
-})
 const SvgProjectDiscovery24 = forwardRef(function SvgProjectDiscovery24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgProjectDiscovery24 = forwardRef(function SvgProjectDiscovery24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgProjectDiscovery24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -48,7 +46,7 @@ const SvgProjectDiscovery24 = forwardRef(function SvgProjectDiscovery24(
     <svg
       fill='none'
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/QuestionMark16.tsx
+++ b/packages/base/Icons/src/Icon/QuestionMark16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgQuestionMark16',
-})
 const SvgQuestionMark16 = forwardRef(function SvgQuestionMark16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgQuestionMark16 = forwardRef(function SvgQuestionMark16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgQuestionMark16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgQuestionMark16 = forwardRef(function SvgQuestionMark16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/QuestionMark24.tsx
+++ b/packages/base/Icons/src/Icon/QuestionMark24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgQuestionMark24',
-})
 const SvgQuestionMark24 = forwardRef(function SvgQuestionMark24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgQuestionMark24 = forwardRef(function SvgQuestionMark24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgQuestionMark24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgQuestionMark24 = forwardRef(function SvgQuestionMark24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Quote16.tsx
+++ b/packages/base/Icons/src/Icon/Quote16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgQuote16',
-})
 const SvgQuote16 = forwardRef(function SvgQuote16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgQuote16 = forwardRef(function SvgQuote16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgQuote16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -48,7 +46,7 @@ const SvgQuote16 = forwardRef(function SvgQuote16(
     <svg
       fill='none'
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Quote24.tsx
+++ b/packages/base/Icons/src/Icon/Quote24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgQuote24',
-})
 const SvgQuote24 = forwardRef(function SvgQuote24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgQuote24 = forwardRef(function SvgQuote24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgQuote24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -48,7 +46,7 @@ const SvgQuote24 = forwardRef(function SvgQuote24(
     <svg
       fill='none'
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/RankOne16.tsx
+++ b/packages/base/Icons/src/Icon/RankOne16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgRankOne16',
-})
 const SvgRankOne16 = forwardRef(function SvgRankOne16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgRankOne16 = forwardRef(function SvgRankOne16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgRankOne16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgRankOne16 = forwardRef(function SvgRankOne16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/RankOne24.tsx
+++ b/packages/base/Icons/src/Icon/RankOne24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgRankOne24',
-})
 const SvgRankOne24 = forwardRef(function SvgRankOne24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgRankOne24 = forwardRef(function SvgRankOne24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgRankOne24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgRankOne24 = forwardRef(function SvgRankOne24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/RankThree16.tsx
+++ b/packages/base/Icons/src/Icon/RankThree16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgRankThree16',
-})
 const SvgRankThree16 = forwardRef(function SvgRankThree16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgRankThree16 = forwardRef(function SvgRankThree16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgRankThree16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgRankThree16 = forwardRef(function SvgRankThree16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/RankThree24.tsx
+++ b/packages/base/Icons/src/Icon/RankThree24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgRankThree24',
-})
 const SvgRankThree24 = forwardRef(function SvgRankThree24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgRankThree24 = forwardRef(function SvgRankThree24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgRankThree24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgRankThree24 = forwardRef(function SvgRankThree24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/RankTwo16.tsx
+++ b/packages/base/Icons/src/Icon/RankTwo16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgRankTwo16',
-})
 const SvgRankTwo16 = forwardRef(function SvgRankTwo16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgRankTwo16 = forwardRef(function SvgRankTwo16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgRankTwo16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgRankTwo16 = forwardRef(function SvgRankTwo16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/RankTwo24.tsx
+++ b/packages/base/Icons/src/Icon/RankTwo24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgRankTwo24',
-})
 const SvgRankTwo24 = forwardRef(function SvgRankTwo24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgRankTwo24 = forwardRef(function SvgRankTwo24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgRankTwo24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgRankTwo24 = forwardRef(function SvgRankTwo24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Referral16.tsx
+++ b/packages/base/Icons/src/Icon/Referral16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgReferral16',
-})
 const SvgReferral16 = forwardRef(function SvgReferral16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgReferral16 = forwardRef(function SvgReferral16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgReferral16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgReferral16 = forwardRef(function SvgReferral16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Referral24.tsx
+++ b/packages/base/Icons/src/Icon/Referral24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgReferral24',
-})
 const SvgReferral24 = forwardRef(function SvgReferral24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgReferral24 = forwardRef(function SvgReferral24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgReferral24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgReferral24 = forwardRef(function SvgReferral24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/ReferralBonus16.tsx
+++ b/packages/base/Icons/src/Icon/ReferralBonus16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgReferralBonus16',
-})
 const SvgReferralBonus16 = forwardRef(function SvgReferralBonus16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgReferralBonus16 = forwardRef(function SvgReferralBonus16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgReferralBonus16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgReferralBonus16 = forwardRef(function SvgReferralBonus16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/ReferralBonus24.tsx
+++ b/packages/base/Icons/src/Icon/ReferralBonus24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgReferralBonus24',
-})
 const SvgReferralBonus24 = forwardRef(function SvgReferralBonus24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgReferralBonus24 = forwardRef(function SvgReferralBonus24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgReferralBonus24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgReferralBonus24 = forwardRef(function SvgReferralBonus24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/ReferralDashboard16.tsx
+++ b/packages/base/Icons/src/Icon/ReferralDashboard16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgReferralDashboard16',
-})
 const SvgReferralDashboard16 = forwardRef(function SvgReferralDashboard16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgReferralDashboard16 = forwardRef(function SvgReferralDashboard16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgReferralDashboard16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgReferralDashboard16 = forwardRef(function SvgReferralDashboard16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/ReferralDashboard24.tsx
+++ b/packages/base/Icons/src/Icon/ReferralDashboard24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgReferralDashboard24',
-})
 const SvgReferralDashboard24 = forwardRef(function SvgReferralDashboard24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgReferralDashboard24 = forwardRef(function SvgReferralDashboard24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgReferralDashboard24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgReferralDashboard24 = forwardRef(function SvgReferralDashboard24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Referrals16.tsx
+++ b/packages/base/Icons/src/Icon/Referrals16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgReferrals16',
-})
 const SvgReferrals16 = forwardRef(function SvgReferrals16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgReferrals16 = forwardRef(function SvgReferrals16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgReferrals16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgReferrals16 = forwardRef(function SvgReferrals16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Referrals24.tsx
+++ b/packages/base/Icons/src/Icon/Referrals24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgReferrals24',
-})
 const SvgReferrals24 = forwardRef(function SvgReferrals24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgReferrals24 = forwardRef(function SvgReferrals24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgReferrals24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgReferrals24 = forwardRef(function SvgReferrals24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Report16.tsx
+++ b/packages/base/Icons/src/Icon/Report16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgReport16',
-})
 const SvgReport16 = forwardRef(function SvgReport16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgReport16 = forwardRef(function SvgReport16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgReport16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgReport16 = forwardRef(function SvgReport16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Report24.tsx
+++ b/packages/base/Icons/src/Icon/Report24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgReport24',
-})
 const SvgReport24 = forwardRef(function SvgReport24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgReport24 = forwardRef(function SvgReport24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgReport24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -48,7 +46,7 @@ const SvgReport24 = forwardRef(function SvgReport24(
     <svg
       fill='none'
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Representatives16.tsx
+++ b/packages/base/Icons/src/Icon/Representatives16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgRepresentatives16',
-})
 const SvgRepresentatives16 = forwardRef(function SvgRepresentatives16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgRepresentatives16 = forwardRef(function SvgRepresentatives16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgRepresentatives16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgRepresentatives16 = forwardRef(function SvgRepresentatives16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Representatives24.tsx
+++ b/packages/base/Icons/src/Icon/Representatives24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgRepresentatives24',
-})
 const SvgRepresentatives24 = forwardRef(function SvgRepresentatives24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgRepresentatives24 = forwardRef(function SvgRepresentatives24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgRepresentatives24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgRepresentatives24 = forwardRef(function SvgRepresentatives24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/RepresentativesSolid16.tsx
+++ b/packages/base/Icons/src/Icon/RepresentativesSolid16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgRepresentativesSolid16',
-})
 const SvgRepresentativesSolid16 = forwardRef(function SvgRepresentativesSolid16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgRepresentativesSolid16 = forwardRef(function SvgRepresentativesSolid16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgRepresentativesSolid16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgRepresentativesSolid16 = forwardRef(function SvgRepresentativesSolid16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/RepresentativesSolid24.tsx
+++ b/packages/base/Icons/src/Icon/RepresentativesSolid24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgRepresentativesSolid24',
-})
 const SvgRepresentativesSolid24 = forwardRef(function SvgRepresentativesSolid24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgRepresentativesSolid24 = forwardRef(function SvgRepresentativesSolid24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgRepresentativesSolid24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgRepresentativesSolid24 = forwardRef(function SvgRepresentativesSolid24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Reset16.tsx
+++ b/packages/base/Icons/src/Icon/Reset16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgReset16',
-})
 const SvgReset16 = forwardRef(function SvgReset16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgReset16 = forwardRef(function SvgReset16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgReset16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgReset16 = forwardRef(function SvgReset16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Reset24.tsx
+++ b/packages/base/Icons/src/Icon/Reset24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgReset24',
-})
 const SvgReset24 = forwardRef(function SvgReset24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgReset24 = forwardRef(function SvgReset24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgReset24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgReset24 = forwardRef(function SvgReset24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Resources16.tsx
+++ b/packages/base/Icons/src/Icon/Resources16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgResources16',
-})
 const SvgResources16 = forwardRef(function SvgResources16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgResources16 = forwardRef(function SvgResources16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgResources16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgResources16 = forwardRef(function SvgResources16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Resources24.tsx
+++ b/packages/base/Icons/src/Icon/Resources24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgResources24',
-})
 const SvgResources24 = forwardRef(function SvgResources24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgResources24 = forwardRef(function SvgResources24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgResources24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgResources24 = forwardRef(function SvgResources24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Rotate16.tsx
+++ b/packages/base/Icons/src/Icon/Rotate16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgRotate16',
-})
 const SvgRotate16 = forwardRef(function SvgRotate16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgRotate16 = forwardRef(function SvgRotate16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgRotate16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgRotate16 = forwardRef(function SvgRotate16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Rotate24.tsx
+++ b/packages/base/Icons/src/Icon/Rotate24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgRotate24',
-})
 const SvgRotate24 = forwardRef(function SvgRotate24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgRotate24 = forwardRef(function SvgRotate24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgRotate24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgRotate24 = forwardRef(function SvgRotate24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/ScheduledPayment16.tsx
+++ b/packages/base/Icons/src/Icon/ScheduledPayment16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgScheduledPayment16',
-})
 const SvgScheduledPayment16 = forwardRef(function SvgScheduledPayment16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgScheduledPayment16 = forwardRef(function SvgScheduledPayment16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgScheduledPayment16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgScheduledPayment16 = forwardRef(function SvgScheduledPayment16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/ScheduledPayment24.tsx
+++ b/packages/base/Icons/src/Icon/ScheduledPayment24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgScheduledPayment24',
-})
 const SvgScheduledPayment24 = forwardRef(function SvgScheduledPayment24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgScheduledPayment24 = forwardRef(function SvgScheduledPayment24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgScheduledPayment24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgScheduledPayment24 = forwardRef(function SvgScheduledPayment24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Search16.tsx
+++ b/packages/base/Icons/src/Icon/Search16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgSearch16',
-})
 const SvgSearch16 = forwardRef(function SvgSearch16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgSearch16 = forwardRef(function SvgSearch16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgSearch16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgSearch16 = forwardRef(function SvgSearch16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Search24.tsx
+++ b/packages/base/Icons/src/Icon/Search24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgSearch24',
-})
 const SvgSearch24 = forwardRef(function SvgSearch24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgSearch24 = forwardRef(function SvgSearch24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgSearch24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgSearch24 = forwardRef(function SvgSearch24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Send16.tsx
+++ b/packages/base/Icons/src/Icon/Send16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgSend16',
-})
 const SvgSend16 = forwardRef(function SvgSend16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgSend16 = forwardRef(function SvgSend16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgSend16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -48,7 +46,7 @@ const SvgSend16 = forwardRef(function SvgSend16(
     <svg
       fill='none'
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Send24.tsx
+++ b/packages/base/Icons/src/Icon/Send24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgSend24',
-})
 const SvgSend24 = forwardRef(function SvgSend24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgSend24 = forwardRef(function SvgSend24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgSend24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -48,7 +46,7 @@ const SvgSend24 = forwardRef(function SvgSend24(
     <svg
       fill='none'
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Services16.tsx
+++ b/packages/base/Icons/src/Icon/Services16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgServices16',
-})
 const SvgServices16 = forwardRef(function SvgServices16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgServices16 = forwardRef(function SvgServices16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgServices16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgServices16 = forwardRef(function SvgServices16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Services24.tsx
+++ b/packages/base/Icons/src/Icon/Services24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgServices24',
-})
 const SvgServices24 = forwardRef(function SvgServices24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgServices24 = forwardRef(function SvgServices24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgServices24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgServices24 = forwardRef(function SvgServices24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Settings16.tsx
+++ b/packages/base/Icons/src/Icon/Settings16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgSettings16',
-})
 const SvgSettings16 = forwardRef(function SvgSettings16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgSettings16 = forwardRef(function SvgSettings16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgSettings16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgSettings16 = forwardRef(function SvgSettings16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Settings24.tsx
+++ b/packages/base/Icons/src/Icon/Settings24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgSettings24',
-})
 const SvgSettings24 = forwardRef(function SvgSettings24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgSettings24 = forwardRef(function SvgSettings24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgSettings24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgSettings24 = forwardRef(function SvgSettings24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Share16.tsx
+++ b/packages/base/Icons/src/Icon/Share16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgShare16',
-})
 const SvgShare16 = forwardRef(function SvgShare16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgShare16 = forwardRef(function SvgShare16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgShare16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgShare16 = forwardRef(function SvgShare16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Share24.tsx
+++ b/packages/base/Icons/src/Icon/Share24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgShare24',
-})
 const SvgShare24 = forwardRef(function SvgShare24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgShare24 = forwardRef(function SvgShare24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgShare24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgShare24 = forwardRef(function SvgShare24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Single16.tsx
+++ b/packages/base/Icons/src/Icon/Single16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgSingle16',
-})
 const SvgSingle16 = forwardRef(function SvgSingle16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgSingle16 = forwardRef(function SvgSingle16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgSingle16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgSingle16 = forwardRef(function SvgSingle16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Single24.tsx
+++ b/packages/base/Icons/src/Icon/Single24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgSingle24',
-})
 const SvgSingle24 = forwardRef(function SvgSingle24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgSingle24 = forwardRef(function SvgSingle24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgSingle24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgSingle24 = forwardRef(function SvgSingle24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Skills16.tsx
+++ b/packages/base/Icons/src/Icon/Skills16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgSkills16',
-})
 const SvgSkills16 = forwardRef(function SvgSkills16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgSkills16 = forwardRef(function SvgSkills16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgSkills16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgSkills16 = forwardRef(function SvgSkills16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Skills24.tsx
+++ b/packages/base/Icons/src/Icon/Skills24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgSkills24',
-})
 const SvgSkills24 = forwardRef(function SvgSkills24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgSkills24 = forwardRef(function SvgSkills24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgSkills24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgSkills24 = forwardRef(function SvgSkills24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Skype16.tsx
+++ b/packages/base/Icons/src/Icon/Skype16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgSkype16',
-})
 const SvgSkype16 = forwardRef(function SvgSkype16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgSkype16 = forwardRef(function SvgSkype16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgSkype16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgSkype16 = forwardRef(function SvgSkype16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Skype24.tsx
+++ b/packages/base/Icons/src/Icon/Skype24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgSkype24',
-})
 const SvgSkype24 = forwardRef(function SvgSkype24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgSkype24 = forwardRef(function SvgSkype24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgSkype24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgSkype24 = forwardRef(function SvgSkype24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Slack16.tsx
+++ b/packages/base/Icons/src/Icon/Slack16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgSlack16',
-})
 const SvgSlack16 = forwardRef(function SvgSlack16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgSlack16 = forwardRef(function SvgSlack16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgSlack16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgSlack16 = forwardRef(function SvgSlack16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Slack24.tsx
+++ b/packages/base/Icons/src/Icon/Slack24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgSlack24',
-})
 const SvgSlack24 = forwardRef(function SvgSlack24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgSlack24 = forwardRef(function SvgSlack24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgSlack24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgSlack24 = forwardRef(function SvgSlack24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Sort16.tsx
+++ b/packages/base/Icons/src/Icon/Sort16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgSort16',
-})
 const SvgSort16 = forwardRef(function SvgSort16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgSort16 = forwardRef(function SvgSort16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgSort16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgSort16 = forwardRef(function SvgSort16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Sort24.tsx
+++ b/packages/base/Icons/src/Icon/Sort24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgSort24',
-})
 const SvgSort24 = forwardRef(function SvgSort24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgSort24 = forwardRef(function SvgSort24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgSort24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgSort24 = forwardRef(function SvgSort24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/SoundOff16.tsx
+++ b/packages/base/Icons/src/Icon/SoundOff16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgSoundOff16',
-})
 const SvgSoundOff16 = forwardRef(function SvgSoundOff16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgSoundOff16 = forwardRef(function SvgSoundOff16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgSoundOff16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgSoundOff16 = forwardRef(function SvgSoundOff16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/SoundOff24.tsx
+++ b/packages/base/Icons/src/Icon/SoundOff24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgSoundOff24',
-})
 const SvgSoundOff24 = forwardRef(function SvgSoundOff24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgSoundOff24 = forwardRef(function SvgSoundOff24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgSoundOff24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -48,7 +46,7 @@ const SvgSoundOff24 = forwardRef(function SvgSoundOff24(
     <svg
       fill='none'
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/SoundOn16.tsx
+++ b/packages/base/Icons/src/Icon/SoundOn16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgSoundOn16',
-})
 const SvgSoundOn16 = forwardRef(function SvgSoundOn16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgSoundOn16 = forwardRef(function SvgSoundOn16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgSoundOn16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgSoundOn16 = forwardRef(function SvgSoundOn16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/SoundOn24.tsx
+++ b/packages/base/Icons/src/Icon/SoundOn24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgSoundOn24',
-})
 const SvgSoundOn24 = forwardRef(function SvgSoundOn24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgSoundOn24 = forwardRef(function SvgSoundOn24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgSoundOn24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -48,7 +46,7 @@ const SvgSoundOn24 = forwardRef(function SvgSoundOn24(
     <svg
       fill='none'
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/SpecialGroup16.tsx
+++ b/packages/base/Icons/src/Icon/SpecialGroup16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgSpecialGroup16',
-})
 const SvgSpecialGroup16 = forwardRef(function SvgSpecialGroup16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgSpecialGroup16 = forwardRef(function SvgSpecialGroup16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgSpecialGroup16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgSpecialGroup16 = forwardRef(function SvgSpecialGroup16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/SpecialGroup24.tsx
+++ b/packages/base/Icons/src/Icon/SpecialGroup24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgSpecialGroup24',
-})
 const SvgSpecialGroup24 = forwardRef(function SvgSpecialGroup24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgSpecialGroup24 = forwardRef(function SvgSpecialGroup24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgSpecialGroup24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgSpecialGroup24 = forwardRef(function SvgSpecialGroup24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Star16.tsx
+++ b/packages/base/Icons/src/Icon/Star16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgStar16',
-})
 const SvgStar16 = forwardRef(function SvgStar16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgStar16 = forwardRef(function SvgStar16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgStar16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgStar16 = forwardRef(function SvgStar16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Star24.tsx
+++ b/packages/base/Icons/src/Icon/Star24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgStar24',
-})
 const SvgStar24 = forwardRef(function SvgStar24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgStar24 = forwardRef(function SvgStar24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgStar24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgStar24 = forwardRef(function SvgStar24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/StarSolid16.tsx
+++ b/packages/base/Icons/src/Icon/StarSolid16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgStarSolid16',
-})
 const SvgStarSolid16 = forwardRef(function SvgStarSolid16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgStarSolid16 = forwardRef(function SvgStarSolid16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgStarSolid16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgStarSolid16 = forwardRef(function SvgStarSolid16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/StarSolid24.tsx
+++ b/packages/base/Icons/src/Icon/StarSolid24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgStarSolid24',
-})
 const SvgStarSolid24 = forwardRef(function SvgStarSolid24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgStarSolid24 = forwardRef(function SvgStarSolid24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgStarSolid24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgStarSolid24 = forwardRef(function SvgStarSolid24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/StopSolid16.tsx
+++ b/packages/base/Icons/src/Icon/StopSolid16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgStopSolid16',
-})
 const SvgStopSolid16 = forwardRef(function SvgStopSolid16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgStopSolid16 = forwardRef(function SvgStopSolid16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgStopSolid16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgStopSolid16 = forwardRef(function SvgStopSolid16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/StopSolid24.tsx
+++ b/packages/base/Icons/src/Icon/StopSolid24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgStopSolid24',
-})
 const SvgStopSolid24 = forwardRef(function SvgStopSolid24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgStopSolid24 = forwardRef(function SvgStopSolid24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgStopSolid24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -48,7 +46,7 @@ const SvgStopSolid24 = forwardRef(function SvgStopSolid24(
     <svg
       fill='none'
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Subfunction16.tsx
+++ b/packages/base/Icons/src/Icon/Subfunction16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgSubfunction16',
-})
 const SvgSubfunction16 = forwardRef(function SvgSubfunction16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgSubfunction16 = forwardRef(function SvgSubfunction16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgSubfunction16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgSubfunction16 = forwardRef(function SvgSubfunction16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Subfunction24.tsx
+++ b/packages/base/Icons/src/Icon/Subfunction24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgSubfunction24',
-})
 const SvgSubfunction24 = forwardRef(function SvgSubfunction24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgSubfunction24 = forwardRef(function SvgSubfunction24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgSubfunction24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgSubfunction24 = forwardRef(function SvgSubfunction24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Support16.tsx
+++ b/packages/base/Icons/src/Icon/Support16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgSupport16',
-})
 const SvgSupport16 = forwardRef(function SvgSupport16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgSupport16 = forwardRef(function SvgSupport16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgSupport16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -48,7 +46,7 @@ const SvgSupport16 = forwardRef(function SvgSupport16(
     <svg
       fill='none'
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Support24.tsx
+++ b/packages/base/Icons/src/Icon/Support24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgSupport24',
-})
 const SvgSupport24 = forwardRef(function SvgSupport24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgSupport24 = forwardRef(function SvgSupport24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgSupport24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -48,7 +46,7 @@ const SvgSupport24 = forwardRef(function SvgSupport24(
     <svg
       fill='none'
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Switch16.tsx
+++ b/packages/base/Icons/src/Icon/Switch16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgSwitch16',
-})
 const SvgSwitch16 = forwardRef(function SvgSwitch16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgSwitch16 = forwardRef(function SvgSwitch16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgSwitch16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgSwitch16 = forwardRef(function SvgSwitch16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Switch24.tsx
+++ b/packages/base/Icons/src/Icon/Switch24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgSwitch24',
-})
 const SvgSwitch24 = forwardRef(function SvgSwitch24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgSwitch24 = forwardRef(function SvgSwitch24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgSwitch24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgSwitch24 = forwardRef(function SvgSwitch24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Tasks16.tsx
+++ b/packages/base/Icons/src/Icon/Tasks16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgTasks16',
-})
 const SvgTasks16 = forwardRef(function SvgTasks16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgTasks16 = forwardRef(function SvgTasks16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgTasks16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgTasks16 = forwardRef(function SvgTasks16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Tasks24.tsx
+++ b/packages/base/Icons/src/Icon/Tasks24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgTasks24',
-})
 const SvgTasks24 = forwardRef(function SvgTasks24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgTasks24 = forwardRef(function SvgTasks24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgTasks24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgTasks24 = forwardRef(function SvgTasks24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Team16.tsx
+++ b/packages/base/Icons/src/Icon/Team16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgTeam16',
-})
 const SvgTeam16 = forwardRef(function SvgTeam16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgTeam16 = forwardRef(function SvgTeam16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgTeam16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgTeam16 = forwardRef(function SvgTeam16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Team24.tsx
+++ b/packages/base/Icons/src/Icon/Team24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgTeam24',
-})
 const SvgTeam24 = forwardRef(function SvgTeam24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgTeam24 = forwardRef(function SvgTeam24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgTeam24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgTeam24 = forwardRef(function SvgTeam24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Telegram16.tsx
+++ b/packages/base/Icons/src/Icon/Telegram16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgTelegram16',
-})
 const SvgTelegram16 = forwardRef(function SvgTelegram16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgTelegram16 = forwardRef(function SvgTelegram16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgTelegram16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgTelegram16 = forwardRef(function SvgTelegram16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Telegram24.tsx
+++ b/packages/base/Icons/src/Icon/Telegram24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgTelegram24',
-})
 const SvgTelegram24 = forwardRef(function SvgTelegram24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgTelegram24 = forwardRef(function SvgTelegram24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgTelegram24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgTelegram24 = forwardRef(function SvgTelegram24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Terms16.tsx
+++ b/packages/base/Icons/src/Icon/Terms16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgTerms16',
-})
 const SvgTerms16 = forwardRef(function SvgTerms16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgTerms16 = forwardRef(function SvgTerms16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgTerms16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgTerms16 = forwardRef(function SvgTerms16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Terms24.tsx
+++ b/packages/base/Icons/src/Icon/Terms24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgTerms24',
-})
 const SvgTerms24 = forwardRef(function SvgTerms24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgTerms24 = forwardRef(function SvgTerms24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgTerms24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgTerms24 = forwardRef(function SvgTerms24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/ThumbsDown16.tsx
+++ b/packages/base/Icons/src/Icon/ThumbsDown16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgThumbsDown16',
-})
 const SvgThumbsDown16 = forwardRef(function SvgThumbsDown16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgThumbsDown16 = forwardRef(function SvgThumbsDown16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgThumbsDown16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgThumbsDown16 = forwardRef(function SvgThumbsDown16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/ThumbsDown24.tsx
+++ b/packages/base/Icons/src/Icon/ThumbsDown24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgThumbsDown24',
-})
 const SvgThumbsDown24 = forwardRef(function SvgThumbsDown24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgThumbsDown24 = forwardRef(function SvgThumbsDown24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgThumbsDown24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgThumbsDown24 = forwardRef(function SvgThumbsDown24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/ThumbsUp16.tsx
+++ b/packages/base/Icons/src/Icon/ThumbsUp16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgThumbsUp16',
-})
 const SvgThumbsUp16 = forwardRef(function SvgThumbsUp16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgThumbsUp16 = forwardRef(function SvgThumbsUp16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgThumbsUp16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgThumbsUp16 = forwardRef(function SvgThumbsUp16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/ThumbsUp24.tsx
+++ b/packages/base/Icons/src/Icon/ThumbsUp24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgThumbsUp24',
-})
 const SvgThumbsUp24 = forwardRef(function SvgThumbsUp24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgThumbsUp24 = forwardRef(function SvgThumbsUp24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgThumbsUp24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgThumbsUp24 = forwardRef(function SvgThumbsUp24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Time16.tsx
+++ b/packages/base/Icons/src/Icon/Time16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgTime16',
-})
 const SvgTime16 = forwardRef(function SvgTime16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgTime16 = forwardRef(function SvgTime16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgTime16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgTime16 = forwardRef(function SvgTime16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Time24.tsx
+++ b/packages/base/Icons/src/Icon/Time24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgTime24',
-})
 const SvgTime24 = forwardRef(function SvgTime24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgTime24 = forwardRef(function SvgTime24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgTime24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgTime24 = forwardRef(function SvgTime24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/TimeConvert16.tsx
+++ b/packages/base/Icons/src/Icon/TimeConvert16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgTimeConvert16',
-})
 const SvgTimeConvert16 = forwardRef(function SvgTimeConvert16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgTimeConvert16 = forwardRef(function SvgTimeConvert16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgTimeConvert16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgTimeConvert16 = forwardRef(function SvgTimeConvert16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/TimeConvert24.tsx
+++ b/packages/base/Icons/src/Icon/TimeConvert24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgTimeConvert24',
-})
 const SvgTimeConvert24 = forwardRef(function SvgTimeConvert24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgTimeConvert24 = forwardRef(function SvgTimeConvert24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgTimeConvert24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgTimeConvert24 = forwardRef(function SvgTimeConvert24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/TimeSolid16.tsx
+++ b/packages/base/Icons/src/Icon/TimeSolid16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgTimeSolid16',
-})
 const SvgTimeSolid16 = forwardRef(function SvgTimeSolid16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgTimeSolid16 = forwardRef(function SvgTimeSolid16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgTimeSolid16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -48,7 +46,7 @@ const SvgTimeSolid16 = forwardRef(function SvgTimeSolid16(
     <svg
       fill='none'
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/TimeSolid24.tsx
+++ b/packages/base/Icons/src/Icon/TimeSolid24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgTimeSolid24',
-})
 const SvgTimeSolid24 = forwardRef(function SvgTimeSolid24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgTimeSolid24 = forwardRef(function SvgTimeSolid24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgTimeSolid24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -48,7 +46,7 @@ const SvgTimeSolid24 = forwardRef(function SvgTimeSolid24(
     <svg
       fill='none'
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Timesheet16.tsx
+++ b/packages/base/Icons/src/Icon/Timesheet16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgTimesheet16',
-})
 const SvgTimesheet16 = forwardRef(function SvgTimesheet16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgTimesheet16 = forwardRef(function SvgTimesheet16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgTimesheet16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgTimesheet16 = forwardRef(function SvgTimesheet16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Timesheet24.tsx
+++ b/packages/base/Icons/src/Icon/Timesheet24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgTimesheet24',
-})
 const SvgTimesheet24 = forwardRef(function SvgTimesheet24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgTimesheet24 = forwardRef(function SvgTimesheet24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgTimesheet24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgTimesheet24 = forwardRef(function SvgTimesheet24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Transfer16.tsx
+++ b/packages/base/Icons/src/Icon/Transfer16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgTransfer16',
-})
 const SvgTransfer16 = forwardRef(function SvgTransfer16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgTransfer16 = forwardRef(function SvgTransfer16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgTransfer16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgTransfer16 = forwardRef(function SvgTransfer16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Transfer24.tsx
+++ b/packages/base/Icons/src/Icon/Transfer24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgTransfer24',
-})
 const SvgTransfer24 = forwardRef(function SvgTransfer24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgTransfer24 = forwardRef(function SvgTransfer24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgTransfer24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgTransfer24 = forwardRef(function SvgTransfer24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Trash16.tsx
+++ b/packages/base/Icons/src/Icon/Trash16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgTrash16',
-})
 const SvgTrash16 = forwardRef(function SvgTrash16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgTrash16 = forwardRef(function SvgTrash16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgTrash16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgTrash16 = forwardRef(function SvgTrash16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Trash24.tsx
+++ b/packages/base/Icons/src/Icon/Trash24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgTrash24',
-})
 const SvgTrash24 = forwardRef(function SvgTrash24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgTrash24 = forwardRef(function SvgTrash24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgTrash24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgTrash24 = forwardRef(function SvgTrash24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/TriangleLeftMinorSolid16.tsx
+++ b/packages/base/Icons/src/Icon/TriangleLeftMinorSolid16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgTriangleLeftMinorSolid16',
-})
 const SvgTriangleLeftMinorSolid16 = forwardRef(
   function SvgTriangleLeftMinorSolid16(props: Props, ref: Ref<SVGSVGElement>) {
     const {
@@ -27,13 +23,15 @@ const SvgTriangleLeftMinorSolid16 = forwardRef(
       base,
       'data-testid': testId,
     } = props
-    const classes: Record<string, string> = useStyles(props)
-    const classNames = [classes.root, className]
+    const classNames = ['PicassoSvgTriangleLeftMinorSolid16', classes.root]
     const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
     const colorClassName = kebabToCamelCase(`${color}`)
 
     if (classes[colorClassName]) {
       classNames.push(classes[colorClassName])
+    }
+    if (className) {
+      classNames.push(className)
     }
 
     const svgStyle = {
@@ -45,7 +43,7 @@ const SvgTriangleLeftMinorSolid16 = forwardRef(
     return (
       <svg
         viewBox='0 0 16 16'
-        className={cx(...classNames)}
+        className={twMerge(...classNames)}
         style={svgStyle}
         ref={ref}
         data-testid={testId}

--- a/packages/base/Icons/src/Icon/TriangleLeftMinorSolid24.tsx
+++ b/packages/base/Icons/src/Icon/TriangleLeftMinorSolid24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgTriangleLeftMinorSolid24',
-})
 const SvgTriangleLeftMinorSolid24 = forwardRef(
   function SvgTriangleLeftMinorSolid24(props: Props, ref: Ref<SVGSVGElement>) {
     const {
@@ -27,13 +23,15 @@ const SvgTriangleLeftMinorSolid24 = forwardRef(
       base,
       'data-testid': testId,
     } = props
-    const classes: Record<string, string> = useStyles(props)
-    const classNames = [classes.root, className]
+    const classNames = ['PicassoSvgTriangleLeftMinorSolid24', classes.root]
     const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
     const colorClassName = kebabToCamelCase(`${color}`)
 
     if (classes[colorClassName]) {
       classNames.push(classes[colorClassName])
+    }
+    if (className) {
+      classNames.push(className)
     }
 
     const svgStyle = {
@@ -45,7 +43,7 @@ const SvgTriangleLeftMinorSolid24 = forwardRef(
     return (
       <svg
         viewBox='0 0 24 24'
-        className={cx(...classNames)}
+        className={twMerge(...classNames)}
         style={svgStyle}
         ref={ref}
         data-testid={testId}

--- a/packages/base/Icons/src/Icon/TriangleRightMinorSolid16.tsx
+++ b/packages/base/Icons/src/Icon/TriangleRightMinorSolid16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgTriangleRightMinorSolid16',
-})
 const SvgTriangleRightMinorSolid16 = forwardRef(
   function SvgTriangleRightMinorSolid16(props: Props, ref: Ref<SVGSVGElement>) {
     const {
@@ -27,13 +23,15 @@ const SvgTriangleRightMinorSolid16 = forwardRef(
       base,
       'data-testid': testId,
     } = props
-    const classes: Record<string, string> = useStyles(props)
-    const classNames = [classes.root, className]
+    const classNames = ['PicassoSvgTriangleRightMinorSolid16', classes.root]
     const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
     const colorClassName = kebabToCamelCase(`${color}`)
 
     if (classes[colorClassName]) {
       classNames.push(classes[colorClassName])
+    }
+    if (className) {
+      classNames.push(className)
     }
 
     const svgStyle = {
@@ -45,7 +43,7 @@ const SvgTriangleRightMinorSolid16 = forwardRef(
     return (
       <svg
         viewBox='0 0 16 16'
-        className={cx(...classNames)}
+        className={twMerge(...classNames)}
         style={svgStyle}
         ref={ref}
         data-testid={testId}

--- a/packages/base/Icons/src/Icon/TriangleRightMinorSolid24.tsx
+++ b/packages/base/Icons/src/Icon/TriangleRightMinorSolid24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgTriangleRightMinorSolid24',
-})
 const SvgTriangleRightMinorSolid24 = forwardRef(
   function SvgTriangleRightMinorSolid24(props: Props, ref: Ref<SVGSVGElement>) {
     const {
@@ -27,13 +23,15 @@ const SvgTriangleRightMinorSolid24 = forwardRef(
       base,
       'data-testid': testId,
     } = props
-    const classes: Record<string, string> = useStyles(props)
-    const classNames = [classes.root, className]
+    const classNames = ['PicassoSvgTriangleRightMinorSolid24', classes.root]
     const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
     const colorClassName = kebabToCamelCase(`${color}`)
 
     if (classes[colorClassName]) {
       classNames.push(classes[colorClassName])
+    }
+    if (className) {
+      classNames.push(className)
     }
 
     const svgStyle = {
@@ -45,7 +43,7 @@ const SvgTriangleRightMinorSolid24 = forwardRef(
     return (
       <svg
         viewBox='0 0 24 24'
-        className={cx(...classNames)}
+        className={twMerge(...classNames)}
         style={svgStyle}
         ref={ref}
         data-testid={testId}

--- a/packages/base/Icons/src/Icon/Twitter16.tsx
+++ b/packages/base/Icons/src/Icon/Twitter16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgTwitter16',
-})
 const SvgTwitter16 = forwardRef(function SvgTwitter16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgTwitter16 = forwardRef(function SvgTwitter16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgTwitter16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -48,7 +46,7 @@ const SvgTwitter16 = forwardRef(function SvgTwitter16(
     <svg
       fill='none'
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Twitter24.tsx
+++ b/packages/base/Icons/src/Icon/Twitter24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgTwitter24',
-})
 const SvgTwitter24 = forwardRef(function SvgTwitter24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgTwitter24 = forwardRef(function SvgTwitter24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgTwitter24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -48,7 +46,7 @@ const SvgTwitter24 = forwardRef(function SvgTwitter24(
     <svg
       fill='none'
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/UiGuidelines16.tsx
+++ b/packages/base/Icons/src/Icon/UiGuidelines16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgUiGuidelines16',
-})
 const SvgUiGuidelines16 = forwardRef(function SvgUiGuidelines16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgUiGuidelines16 = forwardRef(function SvgUiGuidelines16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgUiGuidelines16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgUiGuidelines16 = forwardRef(function SvgUiGuidelines16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/UiGuidelines24.tsx
+++ b/packages/base/Icons/src/Icon/UiGuidelines24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgUiGuidelines24',
-})
 const SvgUiGuidelines24 = forwardRef(function SvgUiGuidelines24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgUiGuidelines24 = forwardRef(function SvgUiGuidelines24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgUiGuidelines24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgUiGuidelines24 = forwardRef(function SvgUiGuidelines24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Unavailable16.tsx
+++ b/packages/base/Icons/src/Icon/Unavailable16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgUnavailable16',
-})
 const SvgUnavailable16 = forwardRef(function SvgUnavailable16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgUnavailable16 = forwardRef(function SvgUnavailable16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgUnavailable16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgUnavailable16 = forwardRef(function SvgUnavailable16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Unavailable24.tsx
+++ b/packages/base/Icons/src/Icon/Unavailable24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgUnavailable24',
-})
 const SvgUnavailable24 = forwardRef(function SvgUnavailable24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgUnavailable24 = forwardRef(function SvgUnavailable24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgUnavailable24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgUnavailable24 = forwardRef(function SvgUnavailable24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Unlink16.tsx
+++ b/packages/base/Icons/src/Icon/Unlink16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgUnlink16',
-})
 const SvgUnlink16 = forwardRef(function SvgUnlink16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgUnlink16 = forwardRef(function SvgUnlink16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgUnlink16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgUnlink16 = forwardRef(function SvgUnlink16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Unlink24.tsx
+++ b/packages/base/Icons/src/Icon/Unlink24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgUnlink24',
-})
 const SvgUnlink24 = forwardRef(function SvgUnlink24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgUnlink24 = forwardRef(function SvgUnlink24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgUnlink24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgUnlink24 = forwardRef(function SvgUnlink24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Update16.tsx
+++ b/packages/base/Icons/src/Icon/Update16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgUpdate16',
-})
 const SvgUpdate16 = forwardRef(function SvgUpdate16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgUpdate16 = forwardRef(function SvgUpdate16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgUpdate16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgUpdate16 = forwardRef(function SvgUpdate16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Update24.tsx
+++ b/packages/base/Icons/src/Icon/Update24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgUpdate24',
-})
 const SvgUpdate24 = forwardRef(function SvgUpdate24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgUpdate24 = forwardRef(function SvgUpdate24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgUpdate24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgUpdate24 = forwardRef(function SvgUpdate24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Upload16.tsx
+++ b/packages/base/Icons/src/Icon/Upload16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgUpload16',
-})
 const SvgUpload16 = forwardRef(function SvgUpload16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgUpload16 = forwardRef(function SvgUpload16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgUpload16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgUpload16 = forwardRef(function SvgUpload16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Upload24.tsx
+++ b/packages/base/Icons/src/Icon/Upload24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgUpload24',
-})
 const SvgUpload24 = forwardRef(function SvgUpload24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgUpload24 = forwardRef(function SvgUpload24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgUpload24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgUpload24 = forwardRef(function SvgUpload24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/UploadDocument16.tsx
+++ b/packages/base/Icons/src/Icon/UploadDocument16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgUploadDocument16',
-})
 const SvgUploadDocument16 = forwardRef(function SvgUploadDocument16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgUploadDocument16 = forwardRef(function SvgUploadDocument16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgUploadDocument16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgUploadDocument16 = forwardRef(function SvgUploadDocument16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/UploadDocument24.tsx
+++ b/packages/base/Icons/src/Icon/UploadDocument24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgUploadDocument24',
-})
 const SvgUploadDocument24 = forwardRef(function SvgUploadDocument24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgUploadDocument24 = forwardRef(function SvgUploadDocument24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgUploadDocument24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgUploadDocument24 = forwardRef(function SvgUploadDocument24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/VerificationBadge16.tsx
+++ b/packages/base/Icons/src/Icon/VerificationBadge16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgVerificationBadge16',
-})
 const SvgVerificationBadge16 = forwardRef(function SvgVerificationBadge16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgVerificationBadge16 = forwardRef(function SvgVerificationBadge16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgVerificationBadge16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -48,7 +46,7 @@ const SvgVerificationBadge16 = forwardRef(function SvgVerificationBadge16(
     <svg
       fill='none'
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/VerificationBadge24.tsx
+++ b/packages/base/Icons/src/Icon/VerificationBadge24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgVerificationBadge24',
-})
 const SvgVerificationBadge24 = forwardRef(function SvgVerificationBadge24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgVerificationBadge24 = forwardRef(function SvgVerificationBadge24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgVerificationBadge24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -48,7 +46,7 @@ const SvgVerificationBadge24 = forwardRef(function SvgVerificationBadge24(
     <svg
       fill='none'
       viewBox='0 0 26 26'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/VideoOff16.tsx
+++ b/packages/base/Icons/src/Icon/VideoOff16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgVideoOff16',
-})
 const SvgVideoOff16 = forwardRef(function SvgVideoOff16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgVideoOff16 = forwardRef(function SvgVideoOff16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgVideoOff16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgVideoOff16 = forwardRef(function SvgVideoOff16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/VideoOff24.tsx
+++ b/packages/base/Icons/src/Icon/VideoOff24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgVideoOff24',
-})
 const SvgVideoOff24 = forwardRef(function SvgVideoOff24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgVideoOff24 = forwardRef(function SvgVideoOff24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgVideoOff24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgVideoOff24 = forwardRef(function SvgVideoOff24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/VideoOn16.tsx
+++ b/packages/base/Icons/src/Icon/VideoOn16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgVideoOn16',
-})
 const SvgVideoOn16 = forwardRef(function SvgVideoOn16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgVideoOn16 = forwardRef(function SvgVideoOn16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgVideoOn16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgVideoOn16 = forwardRef(function SvgVideoOn16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/VideoOn24.tsx
+++ b/packages/base/Icons/src/Icon/VideoOn24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgVideoOn24',
-})
 const SvgVideoOn24 = forwardRef(function SvgVideoOn24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgVideoOn24 = forwardRef(function SvgVideoOn24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgVideoOn24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgVideoOn24 = forwardRef(function SvgVideoOn24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/View16.tsx
+++ b/packages/base/Icons/src/Icon/View16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgView16',
-})
 const SvgView16 = forwardRef(function SvgView16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgView16 = forwardRef(function SvgView16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgView16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgView16 = forwardRef(function SvgView16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/View24.tsx
+++ b/packages/base/Icons/src/Icon/View24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgView24',
-})
 const SvgView24 = forwardRef(function SvgView24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgView24 = forwardRef(function SvgView24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgView24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgView24 = forwardRef(function SvgView24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Warning16.tsx
+++ b/packages/base/Icons/src/Icon/Warning16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgWarning16',
-})
 const SvgWarning16 = forwardRef(function SvgWarning16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgWarning16 = forwardRef(function SvgWarning16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgWarning16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -48,7 +46,7 @@ const SvgWarning16 = forwardRef(function SvgWarning16(
     <svg
       fill='none'
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Warning24.tsx
+++ b/packages/base/Icons/src/Icon/Warning24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgWarning24',
-})
 const SvgWarning24 = forwardRef(function SvgWarning24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgWarning24 = forwardRef(function SvgWarning24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgWarning24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -48,7 +46,7 @@ const SvgWarning24 = forwardRef(function SvgWarning24(
     <svg
       fill='none'
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/WarningSolid16.tsx
+++ b/packages/base/Icons/src/Icon/WarningSolid16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgWarningSolid16',
-})
 const SvgWarningSolid16 = forwardRef(function SvgWarningSolid16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgWarningSolid16 = forwardRef(function SvgWarningSolid16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgWarningSolid16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -48,7 +46,7 @@ const SvgWarningSolid16 = forwardRef(function SvgWarningSolid16(
     <svg
       fill='none'
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/WarningSolid24.tsx
+++ b/packages/base/Icons/src/Icon/WarningSolid24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgWarningSolid24',
-})
 const SvgWarningSolid24 = forwardRef(function SvgWarningSolid24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgWarningSolid24 = forwardRef(function SvgWarningSolid24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgWarningSolid24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -48,7 +46,7 @@ const SvgWarningSolid24 = forwardRef(function SvgWarningSolid24(
     <svg
       fill='none'
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Whatsapp16.tsx
+++ b/packages/base/Icons/src/Icon/Whatsapp16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgWhatsapp16',
-})
 const SvgWhatsapp16 = forwardRef(function SvgWhatsapp16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgWhatsapp16 = forwardRef(function SvgWhatsapp16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgWhatsapp16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgWhatsapp16 = forwardRef(function SvgWhatsapp16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/Whatsapp24.tsx
+++ b/packages/base/Icons/src/Icon/Whatsapp24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgWhatsapp24',
-})
 const SvgWhatsapp24 = forwardRef(function SvgWhatsapp24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgWhatsapp24 = forwardRef(function SvgWhatsapp24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgWhatsapp24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgWhatsapp24 = forwardRef(function SvgWhatsapp24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/WhitePaper16.tsx
+++ b/packages/base/Icons/src/Icon/WhitePaper16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgWhitePaper16',
-})
 const SvgWhitePaper16 = forwardRef(function SvgWhitePaper16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgWhitePaper16 = forwardRef(function SvgWhitePaper16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgWhitePaper16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgWhitePaper16 = forwardRef(function SvgWhitePaper16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/WhitePaper24.tsx
+++ b/packages/base/Icons/src/Icon/WhitePaper24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgWhitePaper24',
-})
 const SvgWhitePaper24 = forwardRef(function SvgWhitePaper24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgWhitePaper24 = forwardRef(function SvgWhitePaper24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgWhitePaper24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgWhitePaper24 = forwardRef(function SvgWhitePaper24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/WorkExperience16.tsx
+++ b/packages/base/Icons/src/Icon/WorkExperience16.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 16
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgWorkExperience16',
-})
 const SvgWorkExperience16 = forwardRef(function SvgWorkExperience16(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgWorkExperience16 = forwardRef(function SvgWorkExperience16(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgWorkExperience16', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgWorkExperience16 = forwardRef(function SvgWorkExperience16(
   return (
     <svg
       viewBox='0 0 16 16'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/WorkExperience24.tsx
+++ b/packages/base/Icons/src/Icon/WorkExperience24.tsx
@@ -1,11 +1,10 @@
 import type { Ref } from 'react'
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import { makeStyles } from '@material-ui/core/styles'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps } from '@toptal/picasso-shared'
 import { kebabToCamelCase } from '@toptal/picasso-utils'
 
-import styles from './styles'
+import { classes } from './styles'
 const BASE_SIZE = 24
 
 type ScaleType = 1 | 2 | 3 | 4
@@ -14,9 +13,6 @@ export interface Props extends StandardProps {
   color?: string
   base?: number
 }
-const useStyles = makeStyles(styles, {
-  name: 'PicassoSvgWorkExperience24',
-})
 const SvgWorkExperience24 = forwardRef(function SvgWorkExperience24(
   props: Props,
   ref: Ref<SVGSVGElement>
@@ -29,13 +25,15 @@ const SvgWorkExperience24 = forwardRef(function SvgWorkExperience24(
     base,
     'data-testid': testId,
   } = props
-  const classes: Record<string, string> = useStyles(props)
-  const classNames = [classes.root, className]
+  const classNames = ['PicassoSvgWorkExperience24', classes.root]
   const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
   const colorClassName = kebabToCamelCase(`${color}`)
 
   if (classes[colorClassName]) {
     classNames.push(classes[colorClassName])
+  }
+  if (className) {
+    classNames.push(className)
   }
 
   const svgStyle = {
@@ -47,7 +45,7 @@ const SvgWorkExperience24 = forwardRef(function SvgWorkExperience24(
   return (
     <svg
       viewBox='0 0 24 24'
-      className={cx(...classNames)}
+      className={twMerge(...classNames)}
       style={svgStyle}
       ref={ref}
       data-testid={testId}

--- a/packages/base/Icons/src/Icon/_generatorTemplate.js
+++ b/packages/base/Icons/src/Icon/_generatorTemplate.js
@@ -1,7 +1,7 @@
 const types = require('@babel/types')
 
 /**
- * Add `className={cx(classes.root, className)}` to the svg tag
+ * Add `className={twMerge(classes.root, className)}` to the svg tag
  */
 const decorateWithClassNameProp = svgElement => {
   svgElement.attributes = [
@@ -9,7 +9,7 @@ const decorateWithClassNameProp = svgElement => {
     types.jsxAttribute(
       types.jsxIdentifier('className'),
       types.jsxExpressionContainer(
-        types.callExpression(types.identifier('cx'), [
+        types.callExpression(types.identifier('twMerge'), [
           types.identifier('...classNames'),
         ])
       )
@@ -49,7 +49,7 @@ const iconTemplate = ({ componentName, jsx }, { tpl }) => {
 
   const svgElement = jsx.openingElement
 
-  // add `className={cx(classes.root, classes[colorClassName], className)}` to svg root tag
+  // add `className={twMerge(classes.root, classes[colorClassName], className)}` to svg root tag
   decorateWithClassNameProp(svgElement)
   // add `style={style}` to svg root tag
   decorateWithProp(svgElement, 'style', 'svgStyle')
@@ -60,12 +60,11 @@ const iconTemplate = ({ componentName, jsx }, { tpl }) => {
 
   return tpl`
     import React, { forwardRef, Ref } from 'react'
-    import cx from 'classnames'
-    import { makeStyles } from '@material-ui/core/styles'
+    import { twMerge } from '@toptal/picasso-tailwind-merge'
     import { StandardProps } from '@toptal/picasso-shared'
     ${'\n'}
     import { kebabToCamelCase } from '@toptal/picasso-utils'
-    import styles from './styles'
+    import { classes } from './styles'
     const BASE_SIZE = ${baseSize}
     ${'\n'}
     type ScaleType =
@@ -78,23 +77,23 @@ const iconTemplate = ({ componentName, jsx }, { tpl }) => {
       color?: string,
       base?: number
     }
-    const useStyles = makeStyles(styles, {
-      name: '${styleName}'
-    })
     const ${componentName} = forwardRef(function ${componentName}(
       props: Props,
       ref: Ref<SVGSVGElement>
     ) {
       const { className, style = {}, color, scale, base, 'data-testid': testId } = props
 
-      const classes: Record<string, string> = useStyles(props)
-      const classNames = [classes.root, className]
+      const classNames = [${JSON.stringify(styleName)}, classes.root]
 
       const scaledSize = base || BASE_SIZE * Math.ceil(scale || 1)
       const colorClassName = kebabToCamelCase(\`\${color}\`)
 
       if (classes[colorClassName]) {
         classNames.push(classes[colorClassName])
+      }
+
+      if (className) {
+        classNames.push(className)
       }
       ${'\n'}
       const svgStyle = {

--- a/packages/base/Icons/src/Icon/styles.tsx
+++ b/packages/base/Icons/src/Icon/styles.tsx
@@ -1,54 +1,18 @@
-import type { Theme } from '@material-ui/core'
-import { createStyles } from '@material-ui/core'
+export const classes: Record<string, string> = {
+  root: 'fill-current inline-block font-inherit-size h-[1em] align-[-.125em]',
+  green: 'text-green-500',
+  darkGreen: 'text-green-600',
+  red: 'text-red-500',
+  lightBlue: 'text-blue-400',
+  blue: 'text-blue-500',
+  yellow: 'text-yellow-500',
+  white: 'text-white',
 
-export default ({ palette }: Theme) =>
-  createStyles({
-    root: {
-      fill: 'currentColor',
-      display: 'inline-block',
-      fontSize: 'inherit',
-      height: '1em',
-      verticalAlign: '-.125em',
-    },
+  lightGrey: 'text-gray-400',
+  grey: 'text-gray-500',
+  darkGrey: 'text-graphite-700',
 
-    // colors
-    green: {
-      color: palette.green.main,
-    },
-    darkGreen: {
-      color: palette.green.dark,
-    },
-    red: {
-      color: palette.red.main,
-    },
-    lightBlue: {
-      color: palette.blue.light,
-    },
-    blue: {
-      color: palette.primary.main,
-    },
-    yellow: {
-      color: palette.yellow.main,
-    },
-    white: {
-      color: palette.common.white,
-    },
-    lightGrey: {
-      color: palette.grey.light2,
-    },
-    grey: {
-      color: palette.grey.main,
-    },
-    darkGrey: {
-      color: palette.text.primary,
-    },
-    black: {
-      color: palette.common.black,
-    },
-    invert: {
-      color: palette.common.white,
-    },
-    inherit: {
-      color: 'inherit',
-    },
-  })
+  black: 'text-black',
+  invert: 'text-white',
+  inherit: 'text-inheritColor',
+}

--- a/packages/base/Icons/tsconfig.json
+++ b/packages/base/Icons/tsconfig.json
@@ -2,5 +2,10 @@
   "extends": "../../../tsconfig.base.json",
   "compilerOptions": { "outDir": "dist-package" },
   "include": ["src"],
-  "references": [{ "path": "../../picasso-provider" }, { "path": "../Utils" }]
+  "references": [
+    { "path": "../../picasso-provider" },
+    { "path": "../../picasso-tailwind" },
+    { "path": "../../picasso-tailwind-merge" },
+    { "path": "../Utils" }
+  ]
 }

--- a/packages/base/Input/src/Input/__snapshots__/test.tsx.snap
+++ b/packages/base/Input/src/Input/__snapshots__/test.tsx.snap
@@ -12,7 +12,7 @@ exports[`Input renders icon in the beginning 1`] = `
         class="text-graphite h-auto flex items-center whitespace-nowrap max-h pointer-events"
       >
         <svg
-          class="PicassoSvgSearch16-root grow shrink basis-0"
+          class="PicassoSvgSearch16 fill-current inline-block font-inherit h-[1em] align-[-.125em] grow shrink basis-0"
           style="min-width: 16px; min-height: 16px;"
           viewBox="0 0 16 16"
         >
@@ -45,7 +45,7 @@ exports[`Input renders icon in the end 1`] = `
         class="text-graphite h-auto flex items-center whitespace-nowrap max-h pointer-events"
       >
         <svg
-          class="PicassoSvgSearch16-root grow shrink basis-0"
+          class="PicassoSvgSearch16 fill-current inline-block font-inherit h-[1em] align-[-.125em] grow shrink basis-0"
           style="min-width: 16px; min-height: 16px;"
           viewBox="0 0 16 16"
         >
@@ -126,7 +126,7 @@ exports[`Input should show reset button 1`] = `
             class="items-center inline-flex font-semibold whitespace-nowrap text-button"
           >
             <svg
-              class="PicassoSvgCloseMinor16-root text-[1.2em] flex-1"
+              class="PicassoSvgCloseMinor16 fill-current inline-block h-[1em] align-[-.125em] text-[1.2em] flex-1"
               style="min-width: 16px; min-height: 16px;"
               viewBox="0 0 16 16"
             >

--- a/packages/base/Menu/src/MenuItem/__snapshots__/test.tsx.snap
+++ b/packages/base/Menu/src/MenuItem/__snapshots__/test.tsx.snap
@@ -57,7 +57,7 @@ exports[`MenuItem renders checkmarked 1`] = `
               class="w-4 inline-flex mr-2"
             >
               <svg
-                class="PicassoSvgCheckMinor16-root"
+                class="PicassoSvgCheckMinor16 fill-current inline-block font-inherit h-[1em] align-[-.125em]"
                 style="min-width: 16px; min-height: 16px;"
                 viewBox="0 0 16 16"
               >
@@ -178,7 +178,7 @@ exports[`MenuItem renders with a sub menu arrow 1`] = `
               class="inline-flex ml-2"
             >
               <svg
-                class="PicassoSvgChevronMinor16-root"
+                class="PicassoSvgChevronMinor16 fill-current inline-block font-inherit h-[1em] align-[-.125em]"
                 style="min-width: 16px; min-height: 16px;"
                 viewBox="0 0 16 16"
               >

--- a/packages/base/Modal/src/Modal/__snapshots__/test.tsx.snap
+++ b/packages/base/Modal/src/Modal/__snapshots__/test.tsx.snap
@@ -91,7 +91,7 @@ exports[`Modal renders 1`] = `
           class="items-center inline-flex font-semibold whitespace-nowrap text-button"
         >
           <svg
-            class="PicassoSvgCloseMinor16-root"
+            class="PicassoSvgCloseMinor16 fill-current inline-block font-inherit h-[1em] align-[-.125em]"
             style="min-width: 16px; min-height: 16px;"
             viewBox="0 0 16 16"
           >

--- a/packages/base/Notification/src/Notification/__snapshots__/test.tsx.snap
+++ b/packages/base/Notification/src/Notification/__snapshots__/test.tsx.snap
@@ -16,7 +16,7 @@ exports[`Notification renders 1`] = `
           class="items-center flex mr-[1em] h-[1em] min-w mt-[2px] basis-0"
         >
           <svg
-            class="PicassoSvgExclamationSolid16-root PicassoSvgExclamationSolid16-yellow"
+            class="PicassoSvgExclamationSolid16 fill-current inline-block font-inherit h-[1em] align-[-.125em] text-yellow"
             style="min-width: 16px; min-height: 16px;"
             viewBox="0 0 16 16"
           >

--- a/packages/base/Notification/src/NotificationActions/__snapshots__/test.tsx.snap
+++ b/packages/base/Notification/src/NotificationActions/__snapshots__/test.tsx.snap
@@ -16,7 +16,7 @@ exports[`NotificationActions renders 1`] = `
           class="items-center flex mr-[1em] h-[1em] min-w mt-[2px] basis-0"
         >
           <svg
-            class="PicassoSvgExclamationSolid16-root PicassoSvgExclamationSolid16-yellow"
+            class="PicassoSvgExclamationSolid16 fill-current inline-block font-inherit h-[1em] align-[-.125em] text-yellow"
             style="min-width: 16px; min-height: 16px;"
             viewBox="0 0 16 16"
           >

--- a/packages/base/Notification/src/use-notification/__snapshots__/test.tsx.snap
+++ b/packages/base/Notification/src/use-notification/__snapshots__/test.tsx.snap
@@ -73,7 +73,7 @@ exports[`useNotifications error notification render 1`] = `
                   class="items-center flex min-w mr-[1em] h-[1.5em] basis-[1.5em]"
                 >
                   <svg
-                    class="PicassoSvgExclamationSolid24-root PicassoSvgExclamationSolid24-red"
+                    class="PicassoSvgExclamationSolid24 fill-current inline-block font-inherit h-[1em] align-[-.125em] text-red"
                     style="min-width: 24px; min-height: 24px;"
                     viewBox="0 0 24 24"
                   >
@@ -99,7 +99,7 @@ exports[`useNotifications error notification render 1`] = `
                     class="items-center inline-flex font-semibold whitespace-nowrap text-button"
                   >
                     <svg
-                      class="PicassoSvgCloseMinor16-root text-[1.2em] flex-1 PicassoSvgCloseMinor16-darkGrey"
+                      class="PicassoSvgCloseMinor16 fill-current inline-block h-[1em] align-[-.125em] text-graphite text-[1.2em] flex-1"
                       style="min-width: 16px; min-height: 16px;"
                       viewBox="0 0 16 16"
                     >
@@ -192,7 +192,7 @@ exports[`useNotifications info notification render 1`] = `
                   class="items-center flex min-w mr-[1em] h-[1.5em] basis-[1.5em]"
                 >
                   <svg
-                    class="PicassoSvgInfo24-root PicassoSvgInfo24-grey"
+                    class="PicassoSvgInfo24 fill-current inline-block font-inherit h-[1em] align-[-.125em] text-gray"
                     fill="none"
                     style="min-width: 24px; min-height: 24px;"
                     viewBox="0 0 24 24"
@@ -221,7 +221,7 @@ exports[`useNotifications info notification render 1`] = `
                     class="items-center inline-flex font-semibold whitespace-nowrap text-button"
                   >
                     <svg
-                      class="PicassoSvgCloseMinor16-root text-[1.2em] flex-1 PicassoSvgCloseMinor16-darkGrey"
+                      class="PicassoSvgCloseMinor16 fill-current inline-block h-[1em] align-[-.125em] text-graphite text-[1.2em] flex-1"
                       style="min-width: 16px; min-height: 16px;"
                       viewBox="0 0 16 16"
                     >
@@ -314,7 +314,7 @@ exports[`useNotifications success notification render 1`] = `
                   class="items-center flex min-w mr-[1em] h-[1.5em] basis-[1.5em]"
                 >
                   <svg
-                    class="PicassoSvgCheckSolid24-root PicassoSvgCheckSolid24-green"
+                    class="PicassoSvgCheckSolid24 fill-current inline-block font-inherit h-[1em] align-[-.125em] text-green"
                     style="min-width: 24px; min-height: 24px;"
                     viewBox="0 0 24 24"
                   >
@@ -340,7 +340,7 @@ exports[`useNotifications success notification render 1`] = `
                     class="items-center inline-flex font-semibold whitespace-nowrap text-button"
                   >
                     <svg
-                      class="PicassoSvgCloseMinor16-root text-[1.2em] flex-1 PicassoSvgCloseMinor16-darkGrey"
+                      class="PicassoSvgCloseMinor16 fill-current inline-block h-[1em] align-[-.125em] text-graphite text-[1.2em] flex-1"
                       style="min-width: 16px; min-height: 16px;"
                       viewBox="0 0 16 16"
                     >

--- a/packages/base/NumberInput/src/NumberInput/__snapshots__/test.tsx.snap
+++ b/packages/base/NumberInput/src/NumberInput/__snapshots__/test.tsx.snap
@@ -26,7 +26,7 @@ exports[`NumberInput renders 1`] = `
           class="flex relative items-center justify-center align-middle p-0 bottom-0 cursor-pointer text-graphite decoration-graphite bg-inherit bg-transparent border-t border-b border-l border-r border-l border-r border-l-gray border-r hover:bg-gray hover:border-gray [&+&]:border-t [&+&]:border-solid [&+&]:border-t-gray active:[&+&]:border-t active:[&+&]:border-t active:[&+&]:border-gray active:bg-gray active:border-t-gray [&:first-child]:rounded-tr [&:last-child]:rounded-br transition-[color,_border,_background] ease-out duration-350 h-4 w-[1.625rem]"
         >
           <svg
-            class="PicassoSvgArrowUpMinor16-root"
+            class="PicassoSvgArrowUpMinor16 fill-current inline-block font-inherit h-[1em] align-[-.125em]"
             style="min-width: 16px; min-height: 16px;"
             viewBox="0 0 16 16"
           >
@@ -39,7 +39,7 @@ exports[`NumberInput renders 1`] = `
           class="flex relative items-center justify-center align-middle p-0 bottom-0 cursor-pointer text-graphite decoration-graphite bg-inherit bg-transparent border-t border-b border-l border-r border-l border-r border-l-gray border-r hover:bg-gray hover:border-gray [&+&]:border-t [&+&]:border-solid [&+&]:border-t-gray active:[&+&]:border-t active:[&+&]:border-t active:[&+&]:border-gray active:bg-gray active:border-t-gray [&:first-child]:rounded-tr [&:last-child]:rounded-br transition-[color,_border,_background] ease-out duration-350 h-4 w-[1.625rem]"
         >
           <svg
-            class="PicassoSvgArrowDownMinor16-root"
+            class="PicassoSvgArrowDownMinor16 fill-current inline-block font-inherit h-[1em] align-[-.125em]"
             style="min-width: 16px; min-height: 16px;"
             viewBox="0 0 16 16"
           >

--- a/packages/base/Page/src/PageAutocomplete/__snapshots__/test.tsx.snap
+++ b/packages/base/Page/src/PageAutocomplete/__snapshots__/test.tsx.snap
@@ -43,7 +43,7 @@ exports[`PageAutocomplete renders 1`] = `
                 class="items-center inline-flex font-semibold whitespace-nowrap text-button"
               >
                 <svg
-                  class="PicassoSvgCloseMinor16-root text-[1.2em] flex-1"
+                  class="PicassoSvgCloseMinor16 fill-current inline-block h-[1em] align-[-.125em] text-[1.2em] flex-1"
                   style="min-width: 16px; min-height: 16px;"
                   viewBox="0 0 16 16"
                 >

--- a/packages/base/Page/src/PageTopBar/__snapshots__/test.tsx.snap
+++ b/packages/base/Page/src/PageTopBar/__snapshots__/test.tsx.snap
@@ -38,7 +38,7 @@ exports[`Page.TopBar render with custom logo 1`] = `
                       class="items-center inline-flex font-semibold whitespace-nowrap text-button"
                     >
                       <svg
-                        class="PicassoSvgOverview24-root text-[1.2em] flex-1 PageHamburger-hamburger"
+                        class="PicassoSvgOverview24 fill-current inline-block h-[1em] align-[-.125em] text-[1.2em] flex-1 PageHamburger-hamburger"
                         style="min-width: 24px; min-height: 24px;"
                         viewBox="0 0 24 24"
                       >
@@ -137,7 +137,7 @@ exports[`Page.TopBar render with link 1`] = `
                       class="items-center inline-flex font-semibold whitespace-nowrap text-button"
                     >
                       <svg
-                        class="PicassoSvgOverview24-root text-[1.2em] flex-1 PageHamburger-hamburger"
+                        class="PicassoSvgOverview24 fill-current inline-block h-[1em] align-[-.125em] text-[1.2em] flex-1 PageHamburger-hamburger"
                         style="min-width: 24px; min-height: 24px;"
                         viewBox="0 0 24 24"
                       >
@@ -172,7 +172,7 @@ exports[`Page.TopBar render with link 1`] = `
                 href="https://www.toptal.com"
               >
                 <svg
-                  class="PicassoSvgLogoEmblem-root PicassoLogo-root PicassoLogo-white PicassoTopBar-logoEmblem"
+                  class="PicassoSvgLogoEmblem fill-current inline-block font-inherit h-[1em] align-[-.125em] PicassoLogo-root PicassoLogo-white PicassoTopBar-logoEmblem"
                   style="min-width: 16px; min-height: 16px;"
                   viewBox="0 0 21 30"
                 >
@@ -182,7 +182,7 @@ exports[`Page.TopBar render with link 1`] = `
                   />
                 </svg>
                 <svg
-                  class="PicassoSvgLogo-root PicassoLogo-root PicassoLogo-white PicassoTopBar-logo"
+                  class="PicassoSvgLogo fill-current inline-block font-inherit h-[1em] align-[-.125em] PicassoLogo-root PicassoLogo-white PicassoTopBar-logo"
                   style="min-width: 16px; min-height: 16px;"
                   viewBox="0 0 109 30"
                 >
@@ -262,7 +262,7 @@ exports[`Page.TopBar renders 1`] = `
                       class="items-center inline-flex font-semibold whitespace-nowrap text-button"
                     >
                       <svg
-                        class="PicassoSvgOverview24-root text-[1.2em] flex-1 PageHamburger-hamburger"
+                        class="PicassoSvgOverview24 fill-current inline-block h-[1em] align-[-.125em] text-[1.2em] flex-1 PageHamburger-hamburger"
                         style="min-width: 24px; min-height: 24px;"
                         viewBox="0 0 24 24"
                       >
@@ -293,7 +293,7 @@ exports[`Page.TopBar renders 1`] = `
                 </div>
               </div>
               <svg
-                class="PicassoSvgLogoEmblem-root PicassoLogo-root PicassoLogo-white PicassoTopBar-logoEmblem"
+                class="PicassoSvgLogoEmblem fill-current inline-block font-inherit h-[1em] align-[-.125em] PicassoLogo-root PicassoLogo-white PicassoTopBar-logoEmblem"
                 style="min-width: 16px; min-height: 16px;"
                 viewBox="0 0 21 30"
               >
@@ -303,7 +303,7 @@ exports[`Page.TopBar renders 1`] = `
                 />
               </svg>
               <svg
-                class="PicassoSvgLogo-root PicassoLogo-root PicassoLogo-white PicassoTopBar-logo"
+                class="PicassoSvgLogo fill-current inline-block font-inherit h-[1em] align-[-.125em] PicassoLogo-root PicassoLogo-white PicassoTopBar-logo"
                 style="min-width: 16px; min-height: 16px;"
                 viewBox="0 0 109 30"
               >

--- a/packages/base/Page/src/SidebarItem/__snapshots__/test.tsx.snap
+++ b/packages/base/Page/src/SidebarItem/__snapshots__/test.tsx.snap
@@ -68,7 +68,7 @@ exports[`SidebarItem collapsible menu is expanded when one of the children is se
                     </div>
                   </li>
                   <svg
-                    class="PicassoSvgArrowDownMinor16-root PicassoSidebarItemAccordion-expandIcon PicassoSidebarItemAccordion-lightExpandIcon PicassoAccordion-expandIcon PicassoAccordion-expandIconExpanded"
+                    class="PicassoSvgArrowDownMinor16 fill-current inline-block font-inherit h-[1em] align-[-.125em] PicassoSidebarItemAccordion-expandIcon PicassoSidebarItemAccordion-lightExpandIcon PicassoAccordion-expandIcon PicassoAccordion-expandIconExpanded"
                     style="min-width: 16px; min-height: 16px;"
                     viewBox="0 0 16 16"
                   >
@@ -214,7 +214,7 @@ exports[`SidebarItem collapsible menu is expanded when one of the children is se
                     </div>
                   </li>
                   <svg
-                    class="PicassoSvgArrowDownMinor16-root PicassoSidebarItemAccordion-expandIcon PicassoSidebarItemAccordion-lightExpandIcon PicassoAccordion-expandIcon PicassoAccordion-expandIconExpanded"
+                    class="PicassoSvgArrowDownMinor16 fill-current inline-block font-inherit h-[1em] align-[-.125em] PicassoSidebarItemAccordion-expandIcon PicassoSidebarItemAccordion-lightExpandIcon PicassoAccordion-expandIcon PicassoAccordion-expandIconExpanded"
                     style="min-width: 16px; min-height: 16px;"
                     viewBox="0 0 16 16"
                   >
@@ -316,7 +316,7 @@ exports[`SidebarItem don't use accordion for non-collapsible with menu 1`] = `
               class="gap-2 items-center inline-flex PicassoSidebarItemContent-noWrap"
             >
               <svg
-                class="PicassoSvgCandidates16-root"
+                class="PicassoSvgCandidates16 fill-current inline-block font-inherit h-[1em] align-[-.125em]"
                 style="min-width: 16px; min-height: 16px;"
                 viewBox="0 0 16 16"
               >
@@ -406,7 +406,7 @@ exports[`SidebarItem is selected 1`] = `
               class="gap-2 items-center inline-flex PicassoSidebarItemContent-noWrap"
             >
               <svg
-                class="PicassoSvgCandidates16-root"
+                class="PicassoSvgCandidates16 fill-current inline-block font-inherit h-[1em] align-[-.125em]"
                 style="min-width: 16px; min-height: 16px;"
                 viewBox="0 0 16 16"
               >
@@ -510,7 +510,7 @@ exports[`SidebarItem use accordion for collapsible with menu 1`] = `
                     class="gap-2 items-center inline-flex PicassoSidebarItemContent-noWrap"
                   >
                     <svg
-                      class="PicassoSvgCandidates16-root"
+                      class="PicassoSvgCandidates16 fill-current inline-block font-inherit h-[1em] align-[-.125em]"
                       style="min-width: 16px; min-height: 16px;"
                       viewBox="0 0 16 16"
                     >
@@ -533,7 +533,7 @@ exports[`SidebarItem use accordion for collapsible with menu 1`] = `
             </div>
           </li>
           <svg
-            class="PicassoSvgArrowDownMinor16-root PicassoSidebarItemAccordion-expandIcon PicassoSidebarItemAccordion-lightExpandIcon PicassoAccordion-expandIcon"
+            class="PicassoSvgArrowDownMinor16 fill-current inline-block font-inherit h-[1em] align-[-.125em] PicassoSidebarItemAccordion-expandIcon PicassoSidebarItemAccordion-lightExpandIcon PicassoAccordion-expandIcon"
             style="min-width: 16px; min-height: 16px;"
             viewBox="0 0 16 16"
           >
@@ -631,7 +631,7 @@ exports[`SidebarItem with icon 1`] = `
               class="gap-2 items-center inline-flex PicassoSidebarItemContent-noWrap"
             >
               <svg
-                class="PicassoSvgCandidates16-root"
+                class="PicassoSvgCandidates16 fill-current inline-block font-inherit h-[1em] align-[-.125em]"
                 style="min-width: 16px; min-height: 16px;"
                 viewBox="0 0 16 16"
               >

--- a/packages/base/Page/src/SidebarLogo/__snapshots__/test.tsx.snap
+++ b/packages/base/Page/src/SidebarLogo/__snapshots__/test.tsx.snap
@@ -9,7 +9,7 @@ exports[`SidebarLogo renders 1`] = `
       class="mb-2 ml-8 PicassoSidebarLogo-root"
     >
       <svg
-        class="PicassoSvgLogo-root PicassoLogo-root PicassoLogo-default"
+        class="PicassoSvgLogo fill-current inline-block font-inherit h-[1em] align-[-.125em] PicassoLogo-root PicassoLogo-default"
         style="min-width: 16px; min-height: 16px;"
         viewBox="0 0 109 30"
       >

--- a/packages/base/Rating/src/RatingIcon/__snapshots__/test.tsx.snap
+++ b/packages/base/Rating/src/RatingIcon/__snapshots__/test.tsx.snap
@@ -7,7 +7,7 @@ exports[`RatingIcon renders 1`] = `
   >
     <span>
       <svg
-        class="PicassoSvgStarSolid16-root PicassoRatingIcon-clickableIcon PicassoSvgStarSolid16-yellow"
+        class="PicassoSvgStarSolid16 fill-current inline-block font-inherit h-[1em] align-[-.125em] text-yellow PicassoRatingIcon-clickableIcon"
         style="min-width: 16px; min-height: 16px;"
         viewBox="0 0 16 16"
       >

--- a/packages/base/Rating/src/RatingStars/__snapshots__/test.tsx.snap
+++ b/packages/base/Rating/src/RatingStars/__snapshots__/test.tsx.snap
@@ -14,7 +14,7 @@ exports[`Rating.Stars renders 1`] = `
       >
         <span>
           <svg
-            class="PicassoSvgStarSolid16-root PicassoRatingIcon-clickableIcon PicassoSvgStarSolid16-yellow"
+            class="PicassoSvgStarSolid16 fill-current inline-block font-inherit h-[1em] align-[-.125em] text-yellow PicassoRatingIcon-clickableIcon"
             style="min-width: 16px; min-height: 16px;"
             viewBox="0 0 16 16"
           >
@@ -38,7 +38,7 @@ exports[`Rating.Stars renders 1`] = `
       >
         <span>
           <svg
-            class="PicassoSvgStarSolid16-root PicassoRatingIcon-clickableIcon PicassoSvgStarSolid16-yellow"
+            class="PicassoSvgStarSolid16 fill-current inline-block font-inherit h-[1em] align-[-.125em] text-yellow PicassoRatingIcon-clickableIcon"
             style="min-width: 16px; min-height: 16px;"
             viewBox="0 0 16 16"
           >
@@ -62,7 +62,7 @@ exports[`Rating.Stars renders 1`] = `
       >
         <span>
           <svg
-            class="PicassoSvgStarSolid16-root PicassoRatingIcon-clickableIcon PicassoSvgStarSolid16-yellow"
+            class="PicassoSvgStarSolid16 fill-current inline-block font-inherit h-[1em] align-[-.125em] text-yellow PicassoRatingIcon-clickableIcon"
             style="min-width: 16px; min-height: 16px;"
             viewBox="0 0 16 16"
           >
@@ -87,7 +87,7 @@ exports[`Rating.Stars renders 1`] = `
       >
         <span>
           <svg
-            class="PicassoSvgStar16-root PicassoRatingIcon-clickableIcon PicassoSvgStar16-yellow"
+            class="PicassoSvgStar16 fill-current inline-block font-inherit h-[1em] align-[-.125em] text-yellow PicassoRatingIcon-clickableIcon"
             style="min-width: 16px; min-height: 16px;"
             viewBox="0 0 16 16"
           >
@@ -111,7 +111,7 @@ exports[`Rating.Stars renders 1`] = `
       >
         <span>
           <svg
-            class="PicassoSvgStar16-root PicassoRatingIcon-clickableIcon PicassoSvgStar16-yellow"
+            class="PicassoSvgStar16 fill-current inline-block font-inherit h-[1em] align-[-.125em] text-yellow PicassoRatingIcon-clickableIcon"
             style="min-width: 16px; min-height: 16px;"
             viewBox="0 0 16 16"
           >

--- a/packages/base/Section/src/Section/__snapshots__/test.tsx.snap
+++ b/packages/base/Section/src/Section/__snapshots__/test.tsx.snap
@@ -29,7 +29,7 @@ exports[`Section renders collapsible initially collapsed 1`] = `
               class="items-center inline-flex font-semibold whitespace-nowrap text-button"
             >
               <svg
-                class="PicassoSvgArrowDownMinor16-root text-[1.2em] flex-1 Rotate180-transition"
+                class="PicassoSvgArrowDownMinor16 fill-current inline-block h-[1em] align-[-.125em] text-[1.2em] flex-1 Rotate180-transition"
                 style="min-width: 16px; min-height: 16px;"
                 viewBox="0 0 16 16"
               >
@@ -75,7 +75,7 @@ exports[`Section renders collapsible initially expanded 1`] = `
               class="items-center inline-flex font-semibold whitespace-nowrap text-button"
             >
               <svg
-                class="PicassoSvgArrowDownMinor16-root text-[1.2em] flex-1 Rotate180-transition Rotate180-rotate180"
+                class="PicassoSvgArrowDownMinor16 fill-current inline-block h-[1em] align-[-.125em] text-[1.2em] flex-1 Rotate180-transition Rotate180-rotate180"
                 style="min-width: 16px; min-height: 16px;"
                 viewBox="0 0 16 16"
               >

--- a/packages/base/Select/src/NativeSelect/__snapshots__/test.tsx.snap
+++ b/packages/base/Select/src/NativeSelect/__snapshots__/test.tsx.snap
@@ -42,7 +42,7 @@ exports[`NativeSelect renders native select 1`] = `
           </option>
         </select>
         <svg
-          class="PicassoSvgDropdownArrows16-root absolute top-[calc(50%-0.5rem)] right-[0.3125rem] text-graphite text-[1rem] cursor-inherit pointer-events"
+          class="PicassoSvgDropdownArrows16 fill-current inline-block h-[1em] align-[-.125em] absolute top-[calc(50%-0.5rem)] right-[0.3125rem] text-graphite text-[1rem] cursor-inherit pointer-events"
           style="min-width: 16px; min-height: 16px;"
           viewBox="0 0 16 16"
         >
@@ -97,7 +97,7 @@ exports[`NativeSelect renders native select with the empty option enabled when e
           </option>
         </select>
         <svg
-          class="PicassoSvgDropdownArrows16-root absolute top-[calc(50%-0.5rem)] right-[0.3125rem] text-graphite text-[1rem] cursor-inherit pointer-events"
+          class="PicassoSvgDropdownArrows16 fill-current inline-block h-[1em] align-[-.125em] absolute top-[calc(50%-0.5rem)] right-[0.3125rem] text-graphite text-[1rem] cursor-inherit pointer-events"
           style="min-width: 16px; min-height: 16px;"
           viewBox="0 0 16 16"
         >

--- a/packages/base/Select/src/NonNativeSelect/__snapshots__/test.tsx.snap
+++ b/packages/base/Select/src/NonNativeSelect/__snapshots__/test.tsx.snap
@@ -26,7 +26,7 @@ exports[`NonNativeSelect renders 1`] = `
           />
         </div>
         <svg
-          class="PicassoSvgDropdownArrows16-root absolute top-[calc(50%-0.5rem)] right-[0.3125rem] text-graphite text-[1rem] cursor-inherit pointer-events"
+          class="PicassoSvgDropdownArrows16 fill-current inline-block h-[1em] align-[-.125em] absolute top-[calc(50%-0.5rem)] right-[0.3125rem] text-graphite text-[1rem] cursor-inherit pointer-events"
           style="min-width: 16px; min-height: 16px;"
           viewBox="0 0 16 16"
         >

--- a/packages/base/Select/src/NonNativeSelectOption/__snapshots__/test.tsx.snap
+++ b/packages/base/Select/src/NonNativeSelectOption/__snapshots__/test.tsx.snap
@@ -71,7 +71,7 @@ exports[`NonNativeSelectOption sets attributes correctly 1`] = `
               class="w-4 inline-flex mr-2"
             >
               <svg
-                class="PicassoSvgCheckMinor16-root"
+                class="PicassoSvgCheckMinor16 fill-current inline-block font-inherit h-[1em] align-[-.125em]"
                 style="min-width: 16px; min-height: 16px;"
                 viewBox="0 0 16 16"
               >

--- a/packages/base/Select/src/SelectCaret/__snapshots__/test.tsx.snap
+++ b/packages/base/Select/src/SelectCaret/__snapshots__/test.tsx.snap
@@ -6,7 +6,7 @@ exports[`SelectCaret renders 1`] = `
     class="Picasso-root"
   >
     <svg
-      class="PicassoSvgDropdownArrows16-root absolute top-[calc(50%-0.5rem)] right-[0.3125rem] text-graphite text-[1rem] cursor-inherit pointer-events"
+      class="PicassoSvgDropdownArrows16 fill-current inline-block h-[1em] align-[-.125em] absolute top-[calc(50%-0.5rem)] right-[0.3125rem] text-graphite text-[1rem] cursor-inherit pointer-events"
       style="min-width: 16px; min-height: 16px;"
       viewBox="0 0 16 16"
     >
@@ -24,7 +24,7 @@ exports[`SelectCaret renders disabled 1`] = `
     class="Picasso-root"
   >
     <svg
-      class="PicassoSvgDropdownArrows16-root absolute top-[calc(50%-0.5rem)] right-[0.3125rem] text-graphite text-[1rem] cursor-inherit pointer-events text-graphite z-[1]"
+      class="PicassoSvgDropdownArrows16 fill-current inline-block h-[1em] align-[-.125em] absolute top-[calc(50%-0.5rem)] right-[0.3125rem] text-[1rem] cursor-inherit pointer-events text-graphite z-[1]"
       style="min-width: 16px; min-height: 16px;"
       viewBox="0 0 16 16"
     >

--- a/packages/base/ShowMore/src/ShowMore/__snapshots__/test.tsx.snap
+++ b/packages/base/ShowMore/src/ShowMore/__snapshots__/test.tsx.snap
@@ -38,7 +38,7 @@ exports[`ShowMore renders 1`] = `
           class="text-[1.2em] flex-1 w-4 h-4 text-graphite ml-[0.5rem] PicassoShowMore-iconWrapper"
         >
           <svg
-            class="PicassoSvgChevronRight16-root PicassoShowMore-icon"
+            class="PicassoSvgChevronRight16 fill-current inline-block font-inherit h-[1em] align-[-.125em] PicassoShowMore-icon"
             style="min-width: 16px; min-height: 16px;"
             viewBox="0 0 16 16"
           >
@@ -91,7 +91,7 @@ exports[`ShowMore when custom lessText text is specified should render with cust
           class="text-[1.2em] flex-1 w-4 h-4 text-graphite ml-[0.5rem] PicassoShowMore-iconWrapper"
         >
           <svg
-            class="PicassoSvgChevronRight16-root PicassoShowMore-icon"
+            class="PicassoSvgChevronRight16 fill-current inline-block font-inherit h-[1em] align-[-.125em] PicassoShowMore-icon"
             style="min-width: 16px; min-height: 16px;"
             viewBox="0 0 16 16"
           >
@@ -144,7 +144,7 @@ exports[`ShowMore when custom showMore text is specified should render with cust
           class="text-[1.2em] flex-1 w-4 h-4 text-graphite ml-[0.5rem] PicassoShowMore-iconWrapper"
         >
           <svg
-            class="PicassoSvgChevronRight16-root PicassoShowMore-icon"
+            class="PicassoSvgChevronRight16 fill-current inline-block font-inherit h-[1em] align-[-.125em] PicassoShowMore-icon"
             style="min-width: 16px; min-height: 16px;"
             viewBox="0 0 16 16"
           >
@@ -211,7 +211,7 @@ exports[`ShowMore when initialExpanded prop is true should render expanded versi
           class="text-[1.2em] flex-1 w-4 h-4 text-graphite ml-[0.5rem] PicassoShowMore-iconWrapper"
         >
           <svg
-            class="PicassoSvgChevronRight16-root PicassoShowMore-icon PicassoShowMore-expandedIcon"
+            class="PicassoSvgChevronRight16 fill-current inline-block font-inherit h-[1em] align-[-.125em] PicassoShowMore-icon PicassoShowMore-expandedIcon"
             style="min-width: 16px; min-height: 16px;"
             viewBox="0 0 16 16"
           >
@@ -264,7 +264,7 @@ exports[`ShowMore when initialExpanded prop is true when show less link is click
           class="text-[1.2em] flex-1 w-4 h-4 text-graphite ml-[0.5rem] PicassoShowMore-iconWrapper"
         >
           <svg
-            class="PicassoSvgChevronRight16-root PicassoShowMore-icon"
+            class="PicassoSvgChevronRight16 fill-current inline-block font-inherit h-[1em] align-[-.125em] PicassoShowMore-icon"
             style="min-width: 16px; min-height: 16px;"
             viewBox="0 0 16 16"
           >
@@ -305,7 +305,7 @@ exports[`ShowMore when show more link is clicked should render expanded version 
           class="text-[1.2em] flex-1 w-4 h-4 text-graphite ml-[0.5rem] PicassoShowMore-iconWrapper"
         >
           <svg
-            class="PicassoSvgChevronRight16-root PicassoShowMore-icon PicassoShowMore-expandedIcon"
+            class="PicassoSvgChevronRight16 fill-current inline-block font-inherit h-[1em] align-[-.125em] PicassoShowMore-icon PicassoShowMore-expandedIcon"
             style="min-width: 16px; min-height: 16px;"
             viewBox="0 0 16 16"
           >

--- a/packages/base/Step/src/Stepper/__snapshots__/test.tsx.snap
+++ b/packages/base/Step/src/Stepper/__snapshots__/test.tsx.snap
@@ -15,7 +15,7 @@ exports[`Stepper render with all steps completed 1`] = `
           class="h-[1.5em] w-[1.5em] flex justify-center items-center rounded-[50%] shrink-0 text-green"
         >
           <svg
-            class="PicassoSvgCheckSolid24-root"
+            class="PicassoSvgCheckSolid24 fill-current inline-block font-inherit h-[1em] align-[-.125em]"
             style="min-width: 24px; min-height: 24px;"
             viewBox="0 0 24 24"
           >
@@ -31,7 +31,7 @@ exports[`Stepper render with all steps completed 1`] = `
         </span>
       </div>
       <svg
-        class="PicassoSvgChevronRight16-root text-gray"
+        class="PicassoSvgChevronRight16 fill-current inline-block font-inherit h-[1em] align-[-.125em] text-gray"
         style="min-width: 16px; min-height: 16px;"
         viewBox="0 0 16 16"
       >
@@ -46,7 +46,7 @@ exports[`Stepper render with all steps completed 1`] = `
           class="h-[1.5em] w-[1.5em] flex justify-center items-center rounded-[50%] shrink-0 text-green"
         >
           <svg
-            class="PicassoSvgCheckSolid24-root"
+            class="PicassoSvgCheckSolid24 fill-current inline-block font-inherit h-[1em] align-[-.125em]"
             style="min-width: 24px; min-height: 24px;"
             viewBox="0 0 24 24"
           >
@@ -62,7 +62,7 @@ exports[`Stepper render with all steps completed 1`] = `
         </span>
       </div>
       <svg
-        class="PicassoSvgChevronRight16-root text-gray"
+        class="PicassoSvgChevronRight16 fill-current inline-block font-inherit h-[1em] align-[-.125em] text-gray"
         style="min-width: 16px; min-height: 16px;"
         viewBox="0 0 16 16"
       >
@@ -77,7 +77,7 @@ exports[`Stepper render with all steps completed 1`] = `
           class="h-[1.5em] w-[1.5em] flex justify-center items-center rounded-[50%] shrink-0 text-green"
         >
           <svg
-            class="PicassoSvgCheckSolid24-root"
+            class="PicassoSvgCheckSolid24 fill-current inline-block font-inherit h-[1em] align-[-.125em]"
             style="min-width: 24px; min-height: 24px;"
             viewBox="0 0 24 24"
           >
@@ -93,7 +93,7 @@ exports[`Stepper render with all steps completed 1`] = `
         </span>
       </div>
       <svg
-        class="PicassoSvgChevronRight16-root text-gray"
+        class="PicassoSvgChevronRight16 fill-current inline-block font-inherit h-[1em] align-[-.125em] text-gray"
         style="min-width: 16px; min-height: 16px;"
         viewBox="0 0 16 16"
       >
@@ -108,7 +108,7 @@ exports[`Stepper render with all steps completed 1`] = `
           class="h-[1.5em] w-[1.5em] flex justify-center items-center rounded-[50%] shrink-0 text-green"
         >
           <svg
-            class="PicassoSvgCheckSolid24-root"
+            class="PicassoSvgCheckSolid24 fill-current inline-block font-inherit h-[1em] align-[-.125em]"
             style="min-width: 24px; min-height: 24px;"
             viewBox="0 0 24 24"
           >
@@ -143,7 +143,7 @@ exports[`Stepper render with hidden labels 1`] = `
           class="h-[1.5em] w-[1.5em] flex justify-center items-center rounded-[50%] shrink-0 text-green"
         >
           <svg
-            class="PicassoSvgCheckSolid24-root"
+            class="PicassoSvgCheckSolid24 fill-current inline-block font-inherit h-[1em] align-[-.125em]"
             style="min-width: 24px; min-height: 24px;"
             viewBox="0 0 24 24"
           >
@@ -154,7 +154,7 @@ exports[`Stepper render with hidden labels 1`] = `
         </div>
       </div>
       <svg
-        class="PicassoSvgChevronRight16-root text-gray"
+        class="PicassoSvgChevronRight16 fill-current inline-block font-inherit h-[1em] align-[-.125em] text-gray"
         style="min-width: 16px; min-height: 16px;"
         viewBox="0 0 16 16"
       >
@@ -169,7 +169,7 @@ exports[`Stepper render with hidden labels 1`] = `
           class="h-[1.5em] w-[1.5em] flex justify-center items-center rounded-[50%] shrink-0 text-green"
         >
           <svg
-            class="PicassoSvgCheckSolid24-root"
+            class="PicassoSvgCheckSolid24 fill-current inline-block font-inherit h-[1em] align-[-.125em]"
             style="min-width: 24px; min-height: 24px;"
             viewBox="0 0 24 24"
           >
@@ -180,7 +180,7 @@ exports[`Stepper render with hidden labels 1`] = `
         </div>
       </div>
       <svg
-        class="PicassoSvgChevronRight16-root text-gray"
+        class="PicassoSvgChevronRight16 fill-current inline-block font-inherit h-[1em] align-[-.125em] text-gray"
         style="min-width: 16px; min-height: 16px;"
         viewBox="0 0 16 16"
       >
@@ -195,7 +195,7 @@ exports[`Stepper render with hidden labels 1`] = `
           class="h-[1.5em] w-[1.5em] flex justify-center items-center rounded-[50%] shrink-0 text-green"
         >
           <svg
-            class="PicassoSvgCheckSolid24-root"
+            class="PicassoSvgCheckSolid24 fill-current inline-block font-inherit h-[1em] align-[-.125em]"
             style="min-width: 24px; min-height: 24px;"
             viewBox="0 0 24 24"
           >
@@ -206,7 +206,7 @@ exports[`Stepper render with hidden labels 1`] = `
         </div>
       </div>
       <svg
-        class="PicassoSvgChevronRight16-root text-gray"
+        class="PicassoSvgChevronRight16 fill-current inline-block font-inherit h-[1em] align-[-.125em] text-gray"
         style="min-width: 16px; min-height: 16px;"
         viewBox="0 0 16 16"
       >
@@ -221,7 +221,7 @@ exports[`Stepper render with hidden labels 1`] = `
           class="h-[1.5em] w-[1.5em] flex justify-center items-center rounded-[50%] shrink-0 text-green"
         >
           <svg
-            class="PicassoSvgCheckSolid24-root"
+            class="PicassoSvgCheckSolid24 fill-current inline-block font-inherit h-[1em] align-[-.125em]"
             style="min-width: 24px; min-height: 24px;"
             viewBox="0 0 24 24"
           >
@@ -251,7 +251,7 @@ exports[`Stepper renders 1`] = `
           class="h-[1.5em] w-[1.5em] flex justify-center items-center rounded-[50%] shrink-0 text-green"
         >
           <svg
-            class="PicassoSvgCheckSolid24-root"
+            class="PicassoSvgCheckSolid24 fill-current inline-block font-inherit h-[1em] align-[-.125em]"
             style="min-width: 24px; min-height: 24px;"
             viewBox="0 0 24 24"
           >
@@ -267,7 +267,7 @@ exports[`Stepper renders 1`] = `
         </span>
       </div>
       <svg
-        class="PicassoSvgChevronRight16-root text-gray"
+        class="PicassoSvgChevronRight16 fill-current inline-block font-inherit h-[1em] align-[-.125em] text-gray"
         style="min-width: 16px; min-height: 16px;"
         viewBox="0 0 16 16"
       >
@@ -282,7 +282,7 @@ exports[`Stepper renders 1`] = `
           class="h-[1.5em] w-[1.5em] flex justify-center items-center rounded-[50%] shrink-0 text-green"
         >
           <svg
-            class="PicassoSvgCheckSolid24-root"
+            class="PicassoSvgCheckSolid24 fill-current inline-block font-inherit h-[1em] align-[-.125em]"
             style="min-width: 24px; min-height: 24px;"
             viewBox="0 0 24 24"
           >
@@ -298,7 +298,7 @@ exports[`Stepper renders 1`] = `
         </span>
       </div>
       <svg
-        class="PicassoSvgChevronRight16-root text-gray"
+        class="PicassoSvgChevronRight16 fill-current inline-block font-inherit h-[1em] align-[-.125em] text-gray"
         style="min-width: 16px; min-height: 16px;"
         viewBox="0 0 16 16"
       >
@@ -319,7 +319,7 @@ exports[`Stepper renders 1`] = `
         </span>
       </div>
       <svg
-        class="PicassoSvgChevronRight16-root text-gray"
+        class="PicassoSvgChevronRight16 fill-current inline-block font-inherit h-[1em] align-[-.125em] text-gray"
         style="min-width: 16px; min-height: 16px;"
         viewBox="0 0 16 16"
       >
@@ -359,7 +359,7 @@ exports[`Stepper when steps are custom nodes renders 1`] = `
           class="h-[1.5em] w-[1.5em] flex justify-center items-center rounded-[50%] shrink-0 text-green"
         >
           <svg
-            class="PicassoSvgCheckSolid24-root"
+            class="PicassoSvgCheckSolid24 fill-current inline-block font-inherit h-[1em] align-[-.125em]"
             style="min-width: 24px; min-height: 24px;"
             viewBox="0 0 24 24"
           >
@@ -377,7 +377,7 @@ exports[`Stepper when steps are custom nodes renders 1`] = `
         </span>
       </div>
       <svg
-        class="PicassoSvgChevronRight16-root text-gray"
+        class="PicassoSvgChevronRight16 fill-current inline-block font-inherit h-[1em] align-[-.125em] text-gray"
         style="min-width: 16px; min-height: 16px;"
         viewBox="0 0 16 16"
       >
@@ -392,7 +392,7 @@ exports[`Stepper when steps are custom nodes renders 1`] = `
           class="h-[1.5em] w-[1.5em] flex justify-center items-center rounded-[50%] shrink-0 text-green"
         >
           <svg
-            class="PicassoSvgCheckSolid24-root"
+            class="PicassoSvgCheckSolid24 fill-current inline-block font-inherit h-[1em] align-[-.125em]"
             style="min-width: 24px; min-height: 24px;"
             viewBox="0 0 24 24"
           >
@@ -410,7 +410,7 @@ exports[`Stepper when steps are custom nodes renders 1`] = `
         </span>
       </div>
       <svg
-        class="PicassoSvgChevronRight16-root text-gray"
+        class="PicassoSvgChevronRight16 fill-current inline-block font-inherit h-[1em] align-[-.125em] text-gray"
         style="min-width: 16px; min-height: 16px;"
         viewBox="0 0 16 16"
       >
@@ -433,7 +433,7 @@ exports[`Stepper when steps are custom nodes renders 1`] = `
         </span>
       </div>
       <svg
-        class="PicassoSvgChevronRight16-root text-gray"
+        class="PicassoSvgChevronRight16 fill-current inline-block font-inherit h-[1em] align-[-.125em] text-gray"
         style="min-width: 16px; min-height: 16px;"
         viewBox="0 0 16 16"
       >

--- a/packages/base/Step/src/StepperVertical/__snapshots__/test.tsx.snap
+++ b/packages/base/Step/src/StepperVertical/__snapshots__/test.tsx.snap
@@ -15,7 +15,7 @@ exports[`StepperVertical render with all steps completed 1`] = `
           class="h-[1.5em] w-[1.5em] flex justify-center items-center rounded-[50%] shrink-0 text-green"
         >
           <svg
-            class="PicassoSvgCheckSolid24-root"
+            class="PicassoSvgCheckSolid24 fill-current inline-block font-inherit h-[1em] align-[-.125em]"
             style="min-width: 24px; min-height: 24px;"
             viewBox="0 0 24 24"
           >
@@ -40,7 +40,7 @@ exports[`StepperVertical render with all steps completed 1`] = `
           class="h-[1.5em] w-[1.5em] flex justify-center items-center rounded-[50%] shrink-0 text-green"
         >
           <svg
-            class="PicassoSvgCheckSolid24-root"
+            class="PicassoSvgCheckSolid24 fill-current inline-block font-inherit h-[1em] align-[-.125em]"
             style="min-width: 24px; min-height: 24px;"
             viewBox="0 0 24 24"
           >
@@ -65,7 +65,7 @@ exports[`StepperVertical render with all steps completed 1`] = `
           class="h-[1.5em] w-[1.5em] flex justify-center items-center rounded-[50%] shrink-0 text-green"
         >
           <svg
-            class="PicassoSvgCheckSolid24-root"
+            class="PicassoSvgCheckSolid24 fill-current inline-block font-inherit h-[1em] align-[-.125em]"
             style="min-width: 24px; min-height: 24px;"
             viewBox="0 0 24 24"
           >
@@ -90,7 +90,7 @@ exports[`StepperVertical render with all steps completed 1`] = `
           class="h-[1.5em] w-[1.5em] flex justify-center items-center rounded-[50%] shrink-0 text-green"
         >
           <svg
-            class="PicassoSvgCheckSolid24-root"
+            class="PicassoSvgCheckSolid24 fill-current inline-block font-inherit h-[1em] align-[-.125em]"
             style="min-width: 24px; min-height: 24px;"
             viewBox="0 0 24 24"
           >
@@ -125,7 +125,7 @@ exports[`StepperVertical renders 1`] = `
           class="h-[1.5em] w-[1.5em] flex justify-center items-center rounded-[50%] shrink-0 text-green"
         >
           <svg
-            class="PicassoSvgCheckSolid24-root"
+            class="PicassoSvgCheckSolid24 fill-current inline-block font-inherit h-[1em] align-[-.125em]"
             style="min-width: 24px; min-height: 24px;"
             viewBox="0 0 24 24"
           >
@@ -150,7 +150,7 @@ exports[`StepperVertical renders 1`] = `
           class="h-[1.5em] w-[1.5em] flex justify-center items-center rounded-[50%] shrink-0 text-green"
         >
           <svg
-            class="PicassoSvgCheckSolid24-root"
+            class="PicassoSvgCheckSolid24 fill-current inline-block font-inherit h-[1em] align-[-.125em]"
             style="min-width: 24px; min-height: 24px;"
             viewBox="0 0 24 24"
           >

--- a/packages/base/Table/src/TableSortableCell/__snapshots__/test.tsx.snap
+++ b/packages/base/Table/src/TableSortableCell/__snapshots__/test.tsx.snap
@@ -31,7 +31,7 @@ exports[`TableCell sort direction is asc renders with a sort button in the right
                   class="items-center inline-flex font-semibold whitespace-nowrap text-button"
                 >
                   <svg
-                    class="PicassoSvgArrowLongUp16-root text-[1.2em] flex-1"
+                    class="PicassoSvgArrowLongUp16 fill-current inline-block h-[1em] align-[-.125em] text-[1.2em] flex-1"
                     style="min-width: 16px; min-height: 16px;"
                     viewBox="0 0 16 16"
                   >
@@ -79,7 +79,7 @@ exports[`TableCell sort direction is desc renders with a sort button in the righ
                   class="items-center inline-flex font-semibold whitespace-nowrap text-button"
                 >
                   <svg
-                    class="PicassoSvgArrowLongDown16-root text-[1.2em] flex-1"
+                    class="PicassoSvgArrowLongDown16 fill-current inline-block h-[1em] align-[-.125em] text-[1.2em] flex-1"
                     style="min-width: 16px; min-height: 16px;"
                     viewBox="0 0 16 16"
                   >

--- a/packages/base/Tag/src/Tag/__snapshots__/test.tsx.snap
+++ b/packages/base/Tag/src/Tag/__snapshots__/test.tsx.snap
@@ -26,7 +26,7 @@ exports[`Tag dismissable label should render dismissable label 1`] = `
         role="button"
       >
         <svg
-          class="PicassoSvgCloseMinor16-root"
+          class="PicassoSvgCloseMinor16 fill-current inline-block font-inherit h-[1em] align-[-.125em]"
           style="min-width: 16px; min-height: 16px;"
           viewBox="0 0 16 16"
         >
@@ -107,7 +107,7 @@ exports[`Tag renders with adornment 1`] = `
           class="m-0 text-xxs font-regular inline-flex items-center gap-[5px] text-gray group-aria-disabled:text-gray"
         >
           <svg
-            class="PicassoSvgLink16-root"
+            class="PicassoSvgLink16 fill-current inline-block font-inherit h-[1em] align-[-.125em]"
             style="min-width: 16px; min-height: 16px;"
             viewBox="0 0 16 16"
           >
@@ -133,7 +133,7 @@ exports[`Tag renders with connection and icon 1`] = `
       data-testid="tag"
     >
       <svg
-        class="PicassoSvgSettings16-root flex items-center -mr ml-3 PicassoSvgSettings16-darkGrey"
+        class="PicassoSvgSettings16 fill-current font-inherit h-[1em] align-[-.125em] text-graphite flex items-center -mr ml-3"
         style="min-width: 16px; min-height: 16px;"
         viewBox="0 0 16 16"
       >
@@ -153,7 +153,7 @@ exports[`Tag renders with connection and icon 1`] = `
           class="m-0 text-xxs font-regular inline-flex items-center gap-[5px] text-gray group-aria-disabled:text-gray"
         >
           <svg
-            class="PicassoSvgLink16-root"
+            class="PicassoSvgLink16 fill-current inline-block font-inherit h-[1em] align-[-.125em]"
             style="min-width: 16px; min-height: 16px;"
             viewBox="0 0 16 16"
           >

--- a/packages/base/Tagselector/src/TagSelector/__snapshots__/test.tsx.snap
+++ b/packages/base/Tagselector/src/TagSelector/__snapshots__/test.tsx.snap
@@ -38,7 +38,7 @@ exports[`TagSelector disabled render 1`] = `
               role="button"
             >
               <svg
-                class="PicassoSvgCloseMinor16-root"
+                class="PicassoSvgCloseMinor16 fill-current inline-block font-inherit h-[1em] align-[-.125em]"
                 style="min-width: 16px; min-height: 16px;"
                 viewBox="0 0 16 16"
               >
@@ -105,7 +105,7 @@ exports[`TagSelector preselected value 1`] = `
                 role="button"
               >
                 <svg
-                  class="PicassoSvgCloseMinor16-root"
+                  class="PicassoSvgCloseMinor16 fill-current inline-block font-inherit h-[1em] align-[-.125em]"
                   style="min-width: 16px; min-height: 16px;"
                   viewBox="0 0 16 16"
                 >

--- a/packages/base/Timepicker/src/TimePicker/__snapshots__/test.tsx.snap
+++ b/packages/base/Timepicker/src/TimePicker/__snapshots__/test.tsx.snap
@@ -20,7 +20,7 @@ exports[`TimePicker renders 1`] = `
         class="text-graphite h-auto flex items-center whitespace-nowrap max-h justify-end ml-auto flex-grow flex-shrink basis-auto pointer-events"
       >
         <svg
-          class="PicassoSvgTime16-root bg-white absolute right-[0.625rem] pointer-events m-0 select-none grow shrink basis-0"
+          class="PicassoSvgTime16 fill-current inline-block font-inherit h-[1em] align-[-.125em] grow shrink basis-0"
           style="min-width: 16px; min-height: 16px;"
           viewBox="0 0 16 16"
         >

--- a/packages/picasso-forms/src/Rating/__snapshots__/test.tsx.snap
+++ b/packages/picasso-forms/src/Rating/__snapshots__/test.tsx.snap
@@ -26,7 +26,7 @@ exports[`Rating Thumbs renders default Stars 1`] = `
             >
               <span>
                 <svg
-                  class="PicassoSvgStar16-root PicassoRatingIcon-clickableIcon PicassoSvgStar16-yellow"
+                  class="PicassoSvgStar16 fill-current inline-block font-inherit h-[1em] align-[-.125em] text-yellow PicassoRatingIcon-clickableIcon"
                   style="min-width: 16px; min-height: 16px;"
                   viewBox="0 0 16 16"
                 >
@@ -50,7 +50,7 @@ exports[`Rating Thumbs renders default Stars 1`] = `
             >
               <span>
                 <svg
-                  class="PicassoSvgStar16-root PicassoRatingIcon-clickableIcon PicassoSvgStar16-yellow"
+                  class="PicassoSvgStar16 fill-current inline-block font-inherit h-[1em] align-[-.125em] text-yellow PicassoRatingIcon-clickableIcon"
                   style="min-width: 16px; min-height: 16px;"
                   viewBox="0 0 16 16"
                 >
@@ -74,7 +74,7 @@ exports[`Rating Thumbs renders default Stars 1`] = `
             >
               <span>
                 <svg
-                  class="PicassoSvgStar16-root PicassoRatingIcon-clickableIcon PicassoSvgStar16-yellow"
+                  class="PicassoSvgStar16 fill-current inline-block font-inherit h-[1em] align-[-.125em] text-yellow PicassoRatingIcon-clickableIcon"
                   style="min-width: 16px; min-height: 16px;"
                   viewBox="0 0 16 16"
                 >
@@ -98,7 +98,7 @@ exports[`Rating Thumbs renders default Stars 1`] = `
             >
               <span>
                 <svg
-                  class="PicassoSvgStar16-root PicassoRatingIcon-clickableIcon PicassoSvgStar16-yellow"
+                  class="PicassoSvgStar16 fill-current inline-block font-inherit h-[1em] align-[-.125em] text-yellow PicassoRatingIcon-clickableIcon"
                   style="min-width: 16px; min-height: 16px;"
                   viewBox="0 0 16 16"
                 >
@@ -122,7 +122,7 @@ exports[`Rating Thumbs renders default Stars 1`] = `
             >
               <span>
                 <svg
-                  class="PicassoSvgStar16-root PicassoRatingIcon-clickableIcon PicassoSvgStar16-yellow"
+                  class="PicassoSvgStar16 fill-current inline-block font-inherit h-[1em] align-[-.125em] text-yellow PicassoRatingIcon-clickableIcon"
                   style="min-width: 16px; min-height: 16px;"
                   viewBox="0 0 16 16"
                 >
@@ -178,7 +178,7 @@ exports[`Rating Thumbs renders default Thumbs 1`] = `
               for="0-posititve"
             >
               <svg
-                class="PicassoSvgThumbsUp16-root makeStyles-thumbs makeStyles-interactiveThumbs"
+                class="PicassoSvgThumbsUp16 fill-current inline-block font-inherit h-[1em] align-[-.125em] makeStyles-thumbs makeStyles-interactiveThumbs"
                 style="min-width: 16px; min-height: 16px;"
                 viewBox="0 0 16 16"
               >
@@ -200,7 +200,7 @@ exports[`Rating Thumbs renders default Thumbs 1`] = `
               for="0-negative"
             >
               <svg
-                class="PicassoSvgThumbsDown16-root makeStyles-thumbs makeStyles-interactiveThumbs"
+                class="PicassoSvgThumbsDown16 fill-current inline-block font-inherit h-[1em] align-[-.125em] makeStyles-thumbs makeStyles-interactiveThumbs"
                 style="min-width: 16px; min-height: 16px;"
                 viewBox="0 0 16 16"
               >

--- a/yarn.lock
+++ b/yarn.lock
@@ -15918,14 +15918,14 @@ json-stringify-safe@^5.0.1, json-stringify-safe@~5.0.1:
   resolved "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
   integrity sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==
 
-json5@1, json5@^1.0.1, json5@^1.0.2:
+json5@1, json5@^1.0.1, json5@^1.0.2, json5@^2.1.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/json5/-/json5-1.0.2.tgz#63d98d60f21b313b77c4d6da18bfa69d80e1d593"
   integrity sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==
   dependencies:
     minimist "^1.2.0"
 
-json5@2.2.3, json5@^2.1.0, json5@^2.1.1, json5@^2.1.2, json5@^2.2.0, json5@^2.2.2, json5@^2.2.3, json5@^2.x:
+json5@2.2.3, json5@^2.1.0, json5@^2.1.2, json5@^2.2.0, json5@^2.2.2, json5@^2.2.3, json5@^2.x:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.3.tgz#78cd6f1a19bdc12b73db5ad0c61efd66c1e29283"
   integrity sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -15918,14 +15918,14 @@ json-stringify-safe@^5.0.1, json-stringify-safe@~5.0.1:
   resolved "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
   integrity sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==
 
-json5@1, json5@^1.0.1, json5@^1.0.2, json5@^2.1.1:
+json5@1, json5@^1.0.1, json5@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/json5/-/json5-1.0.2.tgz#63d98d60f21b313b77c4d6da18bfa69d80e1d593"
   integrity sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==
   dependencies:
     minimist "^1.2.0"
 
-json5@2.2.3, json5@^2.1.0, json5@^2.1.2, json5@^2.2.0, json5@^2.2.2, json5@^2.2.3, json5@^2.x:
+json5@2.2.3, json5@^2.1.0, json5@^2.1.1, json5@^2.1.2, json5@^2.2.0, json5@^2.2.2, json5@^2.2.3, json5@^2.x:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.3.tgz#78cd6f1a19bdc12b73db5ad0c61efd66c1e29283"
   integrity sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==


### PR DESCRIPTION
[FX-5541]


> [!TIP]
> The commits on this PR are purposefully written in a step-by-step manner. Because there is a lot of changed files by automation, reading the commits separately can make reviewing this PR a lot simpler.
> 
> The most important commit is [the first one](https://github.com/toptal/picasso/pull/4465/commits/08653e5a6fa5e7c99060d3f4d21321c8171081b7), the remaining commits are mostly result of running the Icons generator and updating test snapshots

### Description

Refactoring Icons to use Tailwind classes instead of MUI styles

### How to test

<!-- The temploy link will be automatically updated when the temploy is deployed -->
- [Temploy](https://picasso.toptal.net/fx-5541-refactor-icons-to-tailwind)
- Check temploy and Happo

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| Insert screenshots or screen recordings | Insert screenshots or screen recordings |

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests ([visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md) included)

**Breaking change**

- [x] codemod is created and showcased in the changeset
- [x] test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-5541]: https://toptal-core.atlassian.net/browse/FX-5541?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ