### PR TITLE
[FX-5766] Fix multiline input adornment position for horizontal layout

### DIFF
--- a/.changeset/few-jeans-itch.md
+++ b/.changeset/few-jeans-itch.md
@@ -1,0 +1,5 @@
+---
+'@toptal/picasso-input': patch
+---
+
+- fix multiline adornment position for horizontal layout

--- a/packages/base/Input/src/Input/Input.tsx
+++ b/packages/base/Input/src/Input/Input.tsx
@@ -197,10 +197,12 @@ const MultilineAdornment = ({
   testIds,
 }: MultilineAdornmentProps) => {
   const { layout } = useFieldsLayoutContext()
-  const isHorizontal = layout === 'horizontal'
 
   return (
-    <Container flex className={isHorizontal ? '[grid-area:error]' : ''}>
+    <Container
+      flex
+      className={layout === 'horizontal' ? '[grid-area:error]' : ''}
+    >
       {showCounter && (
         <InputLimitAdornment
           testIds={testIds}

--- a/packages/base/Input/src/Input/Input.tsx
+++ b/packages/base/Input/src/Input/Input.tsx
@@ -25,6 +25,7 @@ import type {
   InputIconAdornmentProps,
 } from '@toptal/picasso-input-adornment'
 import type { BaseInputProps, Status } from '@toptal/picasso-outlined-input'
+import { useFieldsLayoutContext } from '@toptal/picasso-form'
 
 export interface Props
   extends BaseProps,
@@ -195,8 +196,11 @@ const MultilineAdornment = ({
   status,
   testIds,
 }: MultilineAdornmentProps) => {
+  const { layout } = useFieldsLayoutContext()
+  const isHorizontal = layout === 'horizontal'
+
   return (
-    <Container flex>
+    <Container flex className={isHorizontal ? '[grid-area:error]' : ''}>
       {showCounter && (
         <InputLimitAdornment
           testIds={testIds}

--- a/packages/base/Input/src/Input/story/StatusHorizontal.example.tsx
+++ b/packages/base/Input/src/Input/story/StatusHorizontal.example.tsx
@@ -5,18 +5,6 @@ const Example = () => {
   return (
     <Form layout='horizontal'>
       <Form.Field>
-        <Form.Label>Default</Form.Label>
-        <Input value='Ukraine' status='default' />
-      </Form.Field>
-      <Form.Field>
-        <Form.Label>Error</Form.Label>
-        <Input value='Ukraine' status='error' />
-      </Form.Field>
-      <Form.Field>
-        <Form.Label>Success</Form.Label>
-        <Input value='Ukraine' status='success' />
-      </Form.Field>
-      <Form.Field>
         <Form.Label>Multiline Success</Form.Label>
         <Input value='Ukraine' multiline rows={4} status='success' />
       </Form.Field>

--- a/packages/base/Input/src/Input/story/StatusHorizontal.example.tsx
+++ b/packages/base/Input/src/Input/story/StatusHorizontal.example.tsx
@@ -1,0 +1,37 @@
+import React from 'react'
+import { Input, Form } from '@toptal/picasso'
+
+const Example = () => {
+  return (
+    <Form layout='horizontal'>
+      <Form.Field>
+        <Form.Label>Default</Form.Label>
+        <Input value='Ukraine' status='default' />
+      </Form.Field>
+      <Form.Field>
+        <Form.Label>Error</Form.Label>
+        <Input value='Ukraine' status='error' />
+      </Form.Field>
+      <Form.Field>
+        <Form.Label>Success</Form.Label>
+        <Input value='Ukraine' status='success' />
+      </Form.Field>
+      <Form.Field>
+        <Form.Label>Multiline Success</Form.Label>
+        <Input value='Ukraine' multiline rows={4} status='success' />
+      </Form.Field>
+      <Form.Field>
+        <Form.Label>Multiline Success With Counter</Form.Label>
+        <Input
+          value='Ukraine'
+          multiline
+          rows={4}
+          status='success'
+          counter='entered'
+        />
+      </Form.Field>
+    </Form>
+  )
+}
+
+export default Example

--- a/packages/base/Input/src/Input/story/index.jsx
+++ b/packages/base/Input/src/Input/story/index.jsx
@@ -32,6 +32,11 @@ page
   )
   .addExample('Input/story/Disabled.example.tsx', 'Disabled', 'base/Input')
   .addExample('Input/story/Status.example.tsx', 'Status', 'base/Input')
+  .addExample(
+    'Input/story/StatusHorizontal.example.tsx',
+    'Status horizontal',
+    'base/Input'
+  )
   .addExample('Input/story/WithIcon.example.tsx', 'With icon', 'base/Input')
   .addExample('Input/story/Sizes.example.tsx', 'Sizes', 'base/Input')
   .addExample('Input/story/FullWidth.example.tsx', 'Full width', 'base/Input')

--- a/packages/base/Input/src/Input/story/index.jsx
+++ b/packages/base/Input/src/Input/story/index.jsx
@@ -34,7 +34,7 @@ page
   .addExample('Input/story/Status.example.tsx', 'Status', 'base/Input')
   .addExample(
     'Input/story/StatusHorizontal.example.tsx',
-    'Status horizontal',
+    'Multiline status horizontal',
     'base/Input'
   )
   .addExample('Input/story/WithIcon.example.tsx', 'With icon', 'base/Input')


### PR DESCRIPTION
[FX-5766]

### Description

Fix multiline input adornment position for horizontal layout.

### How to test

Go to http://localhost:9001/?path=/story/forms-input--input and check the `Status horizontal` story.

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| ![image](https://github.com/user-attachments/assets/b10f4a4d-47e3-4fda-a0c9-80d620590430) | ![image](https://github.com/user-attachments/assets/2b47746e-06aa-425b-ab40-3bac336534dc) |

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- ~Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core~
- ~Annotate all `props` in component with documentation~
- [x] Create `examples` for component
- ~Ensure that deployed demo has expected results and good examples~
- ~Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).~
- [x] Self reviewed
- [x] Covered with tests ([visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md) included)

**Breaking change**

- ~codemod is created and showcased in the changeset~
- ~test alpha package of Picasso in StaffPortal~

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-5766]: https://toptal-core.atlassian.net/browse/FX-5766?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ