### PR TITLE
[FX-5795] Prevent the form from validation

### DIFF
--- a/.changeset/odd-monkeys-divide.md
+++ b/.changeset/odd-monkeys-divide.md
@@ -1,0 +1,5 @@
+---
+'@toptal/picasso-number-input': patch
+---
+
+- prevent the form from validation

--- a/packages/base/NumberInput/src/NumberInputEndAdornment/NumberInputEndAdornment.tsx
+++ b/packages/base/NumberInput/src/NumberInputEndAdornment/NumberInputEndAdornment.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
-import type { RefObject } from 'react'
+import type { MouseEventHandler, RefObject } from 'react'
 import React from 'react'
 import type { BaseProps, SizeType } from '@toptal/picasso-shared'
 import { isBrowser } from '@toptal/picasso-shared'
@@ -84,7 +84,9 @@ export const NumberInputEndAdornment = (props: Props) => {
     }
   }
 
-  const handleUpClick = () => {
+  const handleUpClick: MouseEventHandler<HTMLButtonElement> = e => {
+    e.preventDefault()
+
     if (typeof value === 'undefined') {
       return
     }
@@ -103,7 +105,9 @@ export const NumberInputEndAdornment = (props: Props) => {
     }
   }
 
-  const handleDownClick = () => {
+  const handleDownClick: MouseEventHandler<HTMLButtonElement> = e => {
+    e.preventDefault()
+
     if (typeof value === 'undefined') {
       return
     }


### PR DESCRIPTION
[FX-5795]

### Description

We should prevent the default action when click NumberInput's actions.

### How to test

- [Temploy](https://picasso.toptal.net/fx-5795-fix-number-input)

### Screenshots

<img width="413" alt="Screenshot 2024-08-15 at 11 26 21" src="https://github.com/user-attachments/assets/e8a8e5e7-db60-4569-b323-cbf1a83520ed">


### Development checks

- [ ] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [ ] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- N/A Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- N/A Annotate all `props` in component with documentation
- N/A Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [ ] Self reviewed
- N/A Covered with tests ([visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md) included)


> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-5795]: https://toptal-core.atlassian.net/browse/FX-5795?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ