### PR TITLE
[FX-5808] Fix badge placement in tabs and checkbox spacing

### DIFF
--- a/.changeset/twelve-steaks-melt.md
+++ b/.changeset/twelve-steaks-melt.md
@@ -1,7 +1,9 @@
 ---
 '@toptal/picasso-badge': patch
 '@toptal/picasso-tabs': patch
+'@toptal/picasso-checkbox': patch
 ---
 
 - fix styles in Badge component
 - add "badge in tab" case to Tabs storybook stories
+- fix font size for Checkbox root

--- a/.changeset/twelve-steaks-melt.md
+++ b/.changeset/twelve-steaks-melt.md
@@ -1,0 +1,7 @@
+---
+'@toptal/picasso-badge': patch
+'@toptal/picasso-tabs': patch
+---
+
+- fix styles in Badge component
+- add "badge in tab" case to Tabs storybook stories

--- a/packages/base/Badge/src/Badge/Badge.tsx
+++ b/packages/base/Badge/src/Badge/Badge.tsx
@@ -58,8 +58,7 @@ export const Badge = forwardRef<HTMLDivElement, Props>(function Badge(
         root: {
           className: twMerge(
             `inline-flex flex-shrink-0 content-middle flex-nowrap justify-normal 
-            text-[10px] font-semibold leading-3 align-middle text-graphite-700 
-            top-0 right-0`,
+            text-[10px] font-semibold leading-3 align-middle text-graphite-700`,
             hasChildren ? 'relative' : 'static',
             className
           ),

--- a/packages/base/Badge/src/Badge/__snapshots__/test.tsx.snap
+++ b/packages/base/Badge/src/Badge/__snapshots__/test.tsx.snap
@@ -6,7 +6,7 @@ exports[`Badge renders 1`] = `
     class="Picasso-root"
   >
     <span
-      class="base-Badge inline-flex flex-shrink content-middle flex-nowrap justify-normal text-[10px] font-semibold leading-3 align-middle text-graphite top-0 right-0 static"
+      class="base-Badge inline-flex flex-shrink content-middle flex-nowrap justify-normal text-[10px] font-semibold leading-3 align-middle text-graphite static"
     >
       <span
         class="base-Badge border-solid items-center content-center inline-flex flex-nowrap justify-center z-[1] border rounded-full bg-white text-graphite border-gray static px-[3px] h-[1.25rem] min-w"
@@ -24,7 +24,7 @@ exports[`Badge renders in red variant 1`] = `
     class="Picasso-root"
   >
     <span
-      class="base-Badge inline-flex flex-shrink content-middle flex-nowrap justify-normal text-[10px] font-semibold leading-3 align-middle text-graphite top-0 right-0 static"
+      class="base-Badge inline-flex flex-shrink content-middle flex-nowrap justify-normal text-[10px] font-semibold leading-3 align-middle text-graphite static"
     >
       <span
         class="base-Badge border-solid items-center content-center inline-flex flex-nowrap justify-center z-[1] border rounded-full text-white bg-red border-red static px-[3px] h-[1.25rem] min-w"

--- a/packages/base/Checkbox/src/Checkbox/Checkbox.tsx
+++ b/packages/base/Checkbox/src/Checkbox/Checkbox.tsx
@@ -112,6 +112,7 @@ export const Checkbox = forwardRef<HTMLButtonElement | HTMLLabelElement, Props>(
         style={labelStyle}
         ref={ref as React.ForwardedRef<HTMLLabelElement>}
         classes={{
+          root: 'text-[1rem]',
           label: twJoin(
             'max-w-[calc(100%_-_1.5em_+_1px)]',
             'ml-[0.5em]',

--- a/packages/base/Checkbox/src/Checkbox/__snapshots__/test.tsx.snap
+++ b/packages/base/Checkbox/src/Checkbox/__snapshots__/test.tsx.snap
@@ -15,7 +15,7 @@ exports[`Checkbox Checkbox.Group renders checkbox in a grid group 1`] = `
           class="box-border m-0 p-[8px] sm:basis-4/12 sm:max-w leading-none pt-0 pb-0 [&_.picasso-checkbox]:mb-[0.5em]"
         >
           <label
-            class="inline-flex items-center max-w align-middle -webkit-tap-highlight-color mx-0 cursor-pointer picasso-checkbox"
+            class="inline-flex items-center max-w align-middle -webkit-tap-highlight-color mx-0 cursor-pointer text-[1rem] picasso-checkbox"
           >
             <span
               class="inline-flex PicassoCheckbox-checkboxWrapper"
@@ -54,7 +54,7 @@ exports[`Checkbox Checkbox.Group renders checkbox in a grid group 1`] = `
           class="box-border m-0 p-[8px] sm:basis-4/12 sm:max-w leading-none pt-0 pb-0 [&_.picasso-checkbox]:mb-[0.5em]"
         >
           <label
-            class="inline-flex items-center max-w align-middle -webkit-tap-highlight-color mx-0 cursor-pointer picasso-checkbox"
+            class="inline-flex items-center max-w align-middle -webkit-tap-highlight-color mx-0 cursor-pointer text-[1rem] picasso-checkbox"
           >
             <span
               class="inline-flex PicassoCheckbox-checkboxWrapper"
@@ -93,7 +93,7 @@ exports[`Checkbox Checkbox.Group renders checkbox in a grid group 1`] = `
           class="box-border m-0 p-[8px] sm:basis-4/12 sm:max-w leading-none pt-0 pb-0 [&_.picasso-checkbox]:mb-[0.5em]"
         >
           <label
-            class="inline-flex items-center max-w align-middle -webkit-tap-highlight-color mx-0 cursor-pointer picasso-checkbox"
+            class="inline-flex items-center max-w align-middle -webkit-tap-highlight-color mx-0 cursor-pointer text-[1rem] picasso-checkbox"
           >
             <span
               class="inline-flex PicassoCheckbox-checkboxWrapper"
@@ -132,7 +132,7 @@ exports[`Checkbox Checkbox.Group renders checkbox in a grid group 1`] = `
           class="box-border m-0 p-[8px] sm:basis-4/12 sm:max-w leading-none pt-0 pb-0 [&_.picasso-checkbox]:mb-[0.5em]"
         >
           <label
-            class="inline-flex items-center max-w align-middle -webkit-tap-highlight-color mx-0 cursor-pointer picasso-checkbox"
+            class="inline-flex items-center max-w align-middle -webkit-tap-highlight-color mx-0 cursor-pointer text-[1rem] picasso-checkbox"
           >
             <span
               class="inline-flex PicassoCheckbox-checkboxWrapper"
@@ -171,7 +171,7 @@ exports[`Checkbox Checkbox.Group renders checkbox in a grid group 1`] = `
           class="box-border m-0 p-[8px] sm:basis-4/12 sm:max-w leading-none pt-0 pb-0 [&_.picasso-checkbox]:mb-[0.5em]"
         >
           <label
-            class="inline-flex items-center max-w align-middle -webkit-tap-highlight-color mx-0 cursor-pointer picasso-checkbox"
+            class="inline-flex items-center max-w align-middle -webkit-tap-highlight-color mx-0 cursor-pointer text-[1rem] picasso-checkbox"
           >
             <span
               class="inline-flex PicassoCheckbox-checkboxWrapper"
@@ -210,7 +210,7 @@ exports[`Checkbox Checkbox.Group renders checkbox in a grid group 1`] = `
           class="box-border m-0 p-[8px] sm:basis-4/12 sm:max-w leading-none pt-0 pb-0 [&_.picasso-checkbox]:mb-[0.5em]"
         >
           <label
-            class="inline-flex items-center max-w align-middle -webkit-tap-highlight-color mx-0 cursor-pointer picasso-checkbox"
+            class="inline-flex items-center max-w align-middle -webkit-tap-highlight-color mx-0 cursor-pointer text-[1rem] picasso-checkbox"
           >
             <span
               class="inline-flex PicassoCheckbox-checkboxWrapper"
@@ -257,7 +257,7 @@ exports[`Checkbox checkbox interaction should render checked checkbox 1`] = `
     class="Picasso-root"
   >
     <label
-      class="inline-flex items-center max-w align-middle -webkit-tap-highlight-color mx-0 cursor-pointer picasso-checkbox"
+      class="inline-flex items-center max-w align-middle -webkit-tap-highlight-color mx-0 cursor-pointer text-[1rem] picasso-checkbox"
     >
       <span
         class="inline-flex PicassoCheckbox-checkboxWrapper"
@@ -458,7 +458,7 @@ exports[`Checkbox should render default checkbox with label 1`] = `
     class="Picasso-root"
   >
     <label
-      class="inline-flex items-center max-w align-middle -webkit-tap-highlight-color mx-0 cursor-pointer picasso-checkbox"
+      class="inline-flex items-center max-w align-middle -webkit-tap-highlight-color mx-0 cursor-pointer text-[1rem] picasso-checkbox"
     >
       <span
         class="inline-flex PicassoCheckbox-checkboxWrapper"

--- a/packages/base/Tabs/src/Tab/story/IconOrBadge.example.tsx
+++ b/packages/base/Tabs/src/Tab/story/IconOrBadge.example.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Container, Tabs, Tooltip } from '@toptal/picasso'
+import { Container, Tabs, Tooltip, Badge } from '@toptal/picasso'
 import { SPACING_4 } from '@toptal/picasso-utils'
 import { Exclamation16 } from '@toptal/picasso-icons'
 
@@ -24,16 +24,7 @@ const Example = () => {
           }
         />
         <Tabs.Tab label='Label' />
-        <Tabs.Tab
-          label='Label'
-          icon={
-            <Tooltip content='Some content...' placement='top'>
-              <span>
-                <Exclamation16 color='red' />
-              </span>
-            </Tooltip>
-          }
-        />
+        <Tabs.Tab label='Label' icon={<Badge content={10} variant='white' />} />
       </Tabs>
 
       {value === 0 && (

--- a/packages/base/Tabs/src/Tab/story/index.jsx
+++ b/packages/base/Tabs/src/Tab/story/index.jsx
@@ -6,20 +6,20 @@ const componentDocs = PicassoBook.createComponentDocs(Tab, 'Tabs.Tab')
 const chapter = PicassoBook.connectToPage(page => {
   page
     .createChapter('Tabs.Tab')
-    // .addExample(
-    //   'Tab/story/Vertical.example.tsx',
-    //   {
-    //     title: 'Vertical tab',
-    //     takeScreenshot: false,
-    //   },
-    //   'base/Tabs'
-    // )
-    // .addExample('Tab/story/Disabled.example.tsx', 'Disabled tab', 'base/Tabs')
-    // .addExample(
-    //   'Tab/story/CustomValue.example.tsx',
-    //   'Using custom value',
-    //   'base/Tabs'
-    // )
+    .addExample(
+      'Tab/story/Vertical.example.tsx',
+      {
+        title: 'Vertical tab',
+        takeScreenshot: false,
+      },
+      'base/Tabs'
+    )
+    .addExample('Tab/story/Disabled.example.tsx', 'Disabled tab', 'base/Tabs')
+    .addExample(
+      'Tab/story/CustomValue.example.tsx',
+      'Using custom value',
+      'base/Tabs'
+    )
     .addExample(
       'Tab/story/IconOrBadge.example.tsx',
       'With Icon or Badge',

--- a/packages/base/Tabs/src/Tab/story/index.jsx
+++ b/packages/base/Tabs/src/Tab/story/index.jsx
@@ -6,21 +6,25 @@ const componentDocs = PicassoBook.createComponentDocs(Tab, 'Tabs.Tab')
 const chapter = PicassoBook.connectToPage(page => {
   page
     .createChapter('Tabs.Tab')
+    // .addExample(
+    //   'Tab/story/Vertical.example.tsx',
+    //   {
+    //     title: 'Vertical tab',
+    //     takeScreenshot: false,
+    //   },
+    //   'base/Tabs'
+    // )
+    // .addExample('Tab/story/Disabled.example.tsx', 'Disabled tab', 'base/Tabs')
+    // .addExample(
+    //   'Tab/story/CustomValue.example.tsx',
+    //   'Using custom value',
+    //   'base/Tabs'
+    // )
     .addExample(
-      'Tab/story/Vertical.example.tsx',
-      {
-        title: 'Vertical tab',
-        takeScreenshot: false,
-      },
+      'Tab/story/IconOrBadge.example.tsx',
+      'With Icon or Badge',
       'base/Tabs'
     )
-    .addExample('Tab/story/Disabled.example.tsx', 'Disabled tab', 'base/Tabs')
-    .addExample(
-      'Tab/story/CustomValue.example.tsx',
-      'Using custom value',
-      'base/Tabs'
-    )
-    .addExample('Tab/story/Icon.example.tsx', 'With Icon', 'base/Tabs')
 })
 
 export default {

--- a/packages/base/Tabs/src/Tabs/story/index.jsx
+++ b/packages/base/Tabs/src/Tabs/story/index.jsx
@@ -20,39 +20,38 @@ page
   .addComponentDocs({ component: Tabs, name: 'Tabs' })
   .addComponentDocs(tabStory.componentDocs)
 
-page
-  .createChapter()
-  .addExample(
-    'Tabs/story/Default.example.tsx',
-    {
-      title: 'Default',
-      takeScreenshot: false,
-    },
-    'base/Tabs'
-  )
-  .addExample(
-    'Tabs/story/Vertical.example.tsx',
-    {
-      title: 'Vertical',
-      takeScreenshot: false,
-      description: '⚠️ Not responsive',
-    },
-    'base/Tabs'
-  )
-  .addExample(
-    'Tabs/story/ScrollButtons.example.tsx',
-    {
-      title: 'Scroll buttons',
-      takeScreenshot: false,
-    },
-    'base/Tabs'
-  )
-  .addExample(
-    'Tabs/story/FullWidth.example.tsx',
-    {
-      title: 'Full Width',
-      screenshotBreakpoints: true,
-    },
-    'base/Tabs'
-  )
+page.createChapter()
+// .addExample(
+//   'Tabs/story/Default.example.tsx',
+//   {
+//     title: 'Default',
+//     takeScreenshot: false,
+//   },
+//   'base/Tabs'
+// )
+// .addExample(
+//   'Tabs/story/Vertical.example.tsx',
+//   {
+//     title: 'Vertical',
+//     takeScreenshot: false,
+//     description: '⚠️ Not responsive',
+//   },
+//   'base/Tabs'
+// )
+// .addExample(
+//   'Tabs/story/ScrollButtons.example.tsx',
+//   {
+//     title: 'Scroll buttons',
+//     takeScreenshot: false,
+//   },
+//   'base/Tabs'
+// )
+// .addExample(
+//   'Tabs/story/FullWidth.example.tsx',
+//   {
+//     title: 'Full Width',
+//     screenshotBreakpoints: true,
+//   },
+//   'base/Tabs'
+// )
 page.connect(tabStory.chapter)

--- a/packages/base/Tabs/src/Tabs/story/index.jsx
+++ b/packages/base/Tabs/src/Tabs/story/index.jsx
@@ -20,38 +20,39 @@ page
   .addComponentDocs({ component: Tabs, name: 'Tabs' })
   .addComponentDocs(tabStory.componentDocs)
 
-page.createChapter()
-// .addExample(
-//   'Tabs/story/Default.example.tsx',
-//   {
-//     title: 'Default',
-//     takeScreenshot: false,
-//   },
-//   'base/Tabs'
-// )
-// .addExample(
-//   'Tabs/story/Vertical.example.tsx',
-//   {
-//     title: 'Vertical',
-//     takeScreenshot: false,
-//     description: '⚠️ Not responsive',
-//   },
-//   'base/Tabs'
-// )
-// .addExample(
-//   'Tabs/story/ScrollButtons.example.tsx',
-//   {
-//     title: 'Scroll buttons',
-//     takeScreenshot: false,
-//   },
-//   'base/Tabs'
-// )
-// .addExample(
-//   'Tabs/story/FullWidth.example.tsx',
-//   {
-//     title: 'Full Width',
-//     screenshotBreakpoints: true,
-//   },
-//   'base/Tabs'
-// )
+page
+  .createChapter()
+  .addExample(
+    'Tabs/story/Default.example.tsx',
+    {
+      title: 'Default',
+      takeScreenshot: false,
+    },
+    'base/Tabs'
+  )
+  .addExample(
+    'Tabs/story/Vertical.example.tsx',
+    {
+      title: 'Vertical',
+      takeScreenshot: false,
+      description: '⚠️ Not responsive',
+    },
+    'base/Tabs'
+  )
+  .addExample(
+    'Tabs/story/ScrollButtons.example.tsx',
+    {
+      title: 'Scroll buttons',
+      takeScreenshot: false,
+    },
+    'base/Tabs'
+  )
+  .addExample(
+    'Tabs/story/FullWidth.example.tsx',
+    {
+      title: 'Full Width',
+      screenshotBreakpoints: true,
+    },
+    'base/Tabs'
+  )
 page.connect(tabStory.chapter)

--- a/packages/picasso-forms/src/Checkbox/__snapshots__/test.tsx.snap
+++ b/packages/picasso-forms/src/Checkbox/__snapshots__/test.tsx.snap
@@ -37,7 +37,7 @@ exports[`Form.Checkbox default render for checkboxes in a group 1`] = `
                 class="box-border m-0 leading-none pt-0 pb-0 [&_.picasso-checkbox]:mb-[0.5em]"
               >
                 <label
-                  class="inline-flex items-center max-w align-middle -webkit-tap-highlight-color mx-0 cursor-pointer picasso-checkbox"
+                  class="inline-flex items-center max-w align-middle -webkit-tap-highlight-color mx-0 cursor-pointer text-[1rem] picasso-checkbox"
                 >
                   <span
                     class="inline-flex PicassoCheckbox-checkboxWrapper"
@@ -77,7 +77,7 @@ exports[`Form.Checkbox default render for checkboxes in a group 1`] = `
                 class="box-border m-0 leading-none pt-0 pb-0 [&_.picasso-checkbox]:mb-[0.5em]"
               >
                 <label
-                  class="inline-flex items-center max-w align-middle -webkit-tap-highlight-color mx-0 cursor-pointer picasso-checkbox"
+                  class="inline-flex items-center max-w align-middle -webkit-tap-highlight-color mx-0 cursor-pointer text-[1rem] picasso-checkbox"
                 >
                   <span
                     class="inline-flex PicassoCheckbox-checkboxWrapper"
@@ -139,7 +139,7 @@ exports[`Form.Checkbox default render for single checkbox 1`] = `
           data-testid="single-checkbox"
         >
           <label
-            class="inline-flex items-center max-w align-middle -webkit-tap-highlight-color mx-0 cursor-pointer picasso-checkbox"
+            class="inline-flex items-center max-w align-middle -webkit-tap-highlight-color mx-0 cursor-pointer text-[1rem] picasso-checkbox"
           >
             <span
               class="inline-flex PicassoCheckbox-checkboxWrapper"
@@ -199,7 +199,7 @@ exports[`Form.Checkbox required with asterisk single checkbox 1`] = `
           data-testid="single-checkbox"
         >
           <label
-            class="inline-flex items-center max-w align-middle -webkit-tap-highlight-color mx-0 cursor-pointer picasso-checkbox"
+            class="inline-flex items-center max-w align-middle -webkit-tap-highlight-color mx-0 cursor-pointer text-[1rem] picasso-checkbox"
           >
             <span
               class="inline-flex PicassoCheckbox-checkboxWrapper"


### PR DESCRIPTION
[FX-5808]

### Description

This pull request

- removes `top-0 right-0` classes from Badge component.

[Original MUIv4 implementation](https://mui.com/base-ui/react-badge/components-api/) has these styles only for the badge (not root) itself in https://github.com/mui/material-ui/blob/v4.x/packages/material-ui/src/Badge/Badge.js#L78 (particularly `anchorOriginTopRightRectangular` as this is the only way Picasso used to use Badge).

- restores original font size for Checkbox root

### How to test

<!-- The temploy link will be automatically updated when the temploy is deployed -->
- [Temploy](https://picasso.toptal.net/fx-5808-badges-are-misplaced)
- Check how tabs look in Staff Portal in https://t-staff-portal-pr-13553.toptal.net/clients/160751
- Check visual changes https://happo.io/a/675/p/1189/compare/b6f2db484bda3bfb5ffd325f92aeb174639783ab/187a936cb83477f540b33d1e2cd57cbb021a90f1?t=added

### Screenshots

**Tabs**

Before https://staff-portal.toptal.net/clients/160751

<img width="892" alt="Screenshot 2024-08-19 at 17 33 54" src="https://github.com/user-attachments/assets/9f5a89c1-efdf-4fb3-a5a7-a1c2575147a3">

After https://t-staff-portal-pr-13553.toptal.net/clients/160751

<img width="882" alt="Screenshot 2024-08-19 at 17 34 14" src="https://github.com/user-attachments/assets/68e1baf7-5039-4756-a119-e1528d88c6f9">

Checkbox

Before 

<img width="727" alt="Screenshot 2024-08-20 at 12 16 28" src="https://github.com/user-attachments/assets/be2817d8-6236-4f8c-a781-7f219f90a2ba">

After https://t-staff-portal-pr-13553.toptal.net/sourcing_requests/1515/update

<img width="725" alt="Screenshot 2024-08-20 at 12 33 08" src="https://github.com/user-attachments/assets/daff7622-0d40-4ddb-ab30-4c838845f513">



### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Ensure that deployed demo has expected results and good examples
- [N/A] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests ([visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md) included)

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-5808]: https://toptal-core.atlassian.net/browse/FX-5808?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ