### PR TITLE
[FX-5544] Migrate Logo to TailwindCSS

### DIFF
--- a/.changeset/quiet-cheetahs-collect.md
+++ b/.changeset/quiet-cheetahs-collect.md
@@ -1,0 +1,7 @@
+---
+'@toptal/picasso-logo': major
+'@toptal/picasso': patch
+---
+
+- migrate to TailwindCSS, material-ui@4 is no longer required for this package
+- make @toptal/picasso-tailwind-merge a peer dependency

--- a/.changeset/quiet-cheetahs-collect.md
+++ b/.changeset/quiet-cheetahs-collect.md
@@ -3,5 +3,7 @@
 '@toptal/picasso': patch
 ---
 
+### Logo
+
 - migrate to TailwindCSS, material-ui@4 is no longer required for this package
 - make @toptal/picasso-tailwind-merge a peer dependency

--- a/packages/base/Logo/package.json
+++ b/packages/base/Logo/package.json
@@ -23,15 +23,14 @@
   "homepage": "https://github.com/toptal/picasso/tree/master/packages/picasso#readme",
   "dependencies": {
     "@toptal/picasso-icons": "1.6.0",
-    "@toptal/picasso-utils": "1.0.3",
-    "classnames": "^2.5.1"
+    "@toptal/picasso-utils": "1.0.3"
   },
   "sideEffects": [
     "**/styles.ts",
     "**/styles.js"
   ],
   "peerDependencies": {
-    "@material-ui/core": "4.12.4",
+    "@toptal/picasso-tailwind-merge": "^2.0.0",
     "react": ">=16.12.0 < 19.0.0"
   },
   "exports": {

--- a/packages/base/Logo/src/Logo/Logo.tsx
+++ b/packages/base/Logo/src/Logo/Logo.tsx
@@ -1,14 +1,12 @@
 import React, { forwardRef } from 'react'
-import cx from 'classnames'
-import type { Theme } from '@material-ui/core/styles'
-import { makeStyles } from '@material-ui/core/styles'
 import type { BaseProps } from '@toptal/picasso-shared'
 import {
   Logo as LogoIcon,
   LogoEmblem as LogoEmblemIcon,
 } from '@toptal/picasso-icons'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 
-import styles from './styles'
+import { colorClass } from './styles'
 
 type VariantType = 'default' | 'white' | 'black' | 'grey' | 'blue'
 
@@ -19,8 +17,6 @@ export interface Props extends BaseProps {
   variant?: VariantType
 }
 
-const useStyles = makeStyles<Theme>(styles, { name: 'PicassoLogo' })
-
 export const Logo = forwardRef<SVGSVGElement, Props>(function Logo(props, ref) {
   const {
     emblem,
@@ -30,15 +26,16 @@ export const Logo = forwardRef<SVGSVGElement, Props>(function Logo(props, ref) {
     'data-testid': testId,
   } = props
 
-  const classes = useStyles()
-
-  const colorClass = classes[variant]
   const LogoComponent = emblem ? LogoEmblemIcon : LogoIcon
 
   return (
     <LogoComponent
       ref={ref}
-      className={cx(classes.root, colorClass, className)}
+      className={twMerge(
+        'text-[1.875rem] align-baseline',
+        colorClass[variant],
+        className
+      )}
       style={style}
       data-testid={testId}
     />

--- a/packages/base/Logo/src/Logo/Logo.tsx
+++ b/packages/base/Logo/src/Logo/Logo.tsx
@@ -8,7 +8,7 @@ import { twMerge } from '@toptal/picasso-tailwind-merge'
 
 import { colorClass } from './styles'
 
-type VariantType = 'default' | 'white' | 'black' | 'grey' | 'blue'
+export type VariantType = 'default' | 'white' | 'black' | 'grey' | 'blue'
 
 export interface Props extends BaseProps {
   /** Whether logo should be shown as TT emblem or full word mark */

--- a/packages/base/Logo/src/Logo/styles.ts
+++ b/packages/base/Logo/src/Logo/styles.ts
@@ -1,4 +1,6 @@
-export const colorClass = {
+import type { VariantType } from './Logo'
+
+export const colorClass: Record<VariantType, string> = {
   default:
     'text-blue-500 [--logo-text-color:black] [--logo-emblem-color:#204ECF]',
   // deprecated backward-compatible variant with default

--- a/packages/base/Logo/src/Logo/styles.ts
+++ b/packages/base/Logo/src/Logo/styles.ts
@@ -1,36 +1,9 @@
-import type { Theme } from '@material-ui/core/styles'
-import { createStyles } from '@material-ui/core/styles'
-
-export default ({ palette }: Theme) =>
-  createStyles({
-    root: {
-      fontSize: '1.875rem',
-      verticalAlign: 'baseline',
-    },
-    default: {
-      color: palette.blue.main,
-      '--logo-text-color': palette.common.black,
-      '--logo-emblem-color': palette.blue.main,
-    },
-    blue: {
-      // deprecated backward-compatible variant with default
-      color: palette.blue.main,
-      '--logo-text-color': palette.common.black,
-      '--logo-emblem-color': palette.blue.main,
-    },
-    white: {
-      color: palette.common.white,
-      '--logo-text-color': palette.common.white,
-      '--logo-emblem-color': palette.common.white,
-    },
-    black: {
-      color: palette.common.black,
-      '--logo-text-color': palette.common.black,
-      '--logo-emblem-color': palette.common.black,
-    },
-    grey: {
-      color: palette.grey.darker,
-      '--logo-text-color': palette.grey.darker,
-      '--logo-emblem-color': palette.grey.darker,
-    },
-  })
+export const colorClass = {
+  default:
+    'text-blue-500 [--logo-text-color:black] [--logo-emblem-color:#204ECF]',
+  // deprecated backward-compatible variant with default
+  blue: 'text-blue-500 [--logo-text-color:black] [--logo-emblem-color:#204ECF]',
+  white: 'text-white [--logo-text-color:white] [--logo-emblem-color:white]',
+  black: 'text-black [--logo-text-color:black] [--logo-emblem-color:black]',
+  grey: 'text-graphite-800 [--logo-text-color:#262D3D] [--logo-emblem-color:#262D3D]',
+}

--- a/packages/base/Logo/tsconfig.json
+++ b/packages/base/Logo/tsconfig.json
@@ -2,5 +2,9 @@
   "extends": "../../../tsconfig.base.json",
   "compilerOptions": { "outDir": "dist-package" },
   "include": ["src"],
-  "references": [{ "path": "../Icons" }, { "path": "../Utils" }]
+  "references": [
+    { "path": "../../picasso-tailwind-merge" },
+    { "path": "../Icons" },
+    { "path": "../Utils" }
+  ]
 }

--- a/packages/base/Page/src/PageTopBar/__snapshots__/test.tsx.snap
+++ b/packages/base/Page/src/PageTopBar/__snapshots__/test.tsx.snap
@@ -172,7 +172,7 @@ exports[`Page.TopBar render with link 1`] = `
                 href="https://www.toptal.com"
               >
                 <svg
-                  class="PicassoSvgLogoEmblem-root PicassoLogo-root PicassoLogo-white PicassoTopBar-logoEmblem"
+                  class="PicassoSvgLogoEmblem-root text-[1.875rem] align-baseline text-white [--logo-text [--logo-emblem PicassoTopBar-logoEmblem"
                   style="min-width: 16px; min-height: 16px;"
                   viewBox="0 0 21 30"
                 >
@@ -182,7 +182,7 @@ exports[`Page.TopBar render with link 1`] = `
                   />
                 </svg>
                 <svg
-                  class="PicassoSvgLogo-root PicassoLogo-root PicassoLogo-white PicassoTopBar-logo"
+                  class="PicassoSvgLogo-root text-[1.875rem] align-baseline text-white [--logo-text [--logo-emblem PicassoTopBar-logo"
                   style="min-width: 16px; min-height: 16px;"
                   viewBox="0 0 109 30"
                 >
@@ -293,7 +293,7 @@ exports[`Page.TopBar renders 1`] = `
                 </div>
               </div>
               <svg
-                class="PicassoSvgLogoEmblem-root PicassoLogo-root PicassoLogo-white PicassoTopBar-logoEmblem"
+                class="PicassoSvgLogoEmblem-root text-[1.875rem] align-baseline text-white [--logo-text [--logo-emblem PicassoTopBar-logoEmblem"
                 style="min-width: 16px; min-height: 16px;"
                 viewBox="0 0 21 30"
               >
@@ -303,7 +303,7 @@ exports[`Page.TopBar renders 1`] = `
                 />
               </svg>
               <svg
-                class="PicassoSvgLogo-root PicassoLogo-root PicassoLogo-white PicassoTopBar-logo"
+                class="PicassoSvgLogo-root text-[1.875rem] align-baseline text-white [--logo-text [--logo-emblem PicassoTopBar-logo"
                 style="min-width: 16px; min-height: 16px;"
                 viewBox="0 0 109 30"
               >

--- a/packages/base/Page/src/SidebarLogo/__snapshots__/test.tsx.snap
+++ b/packages/base/Page/src/SidebarLogo/__snapshots__/test.tsx.snap
@@ -9,7 +9,7 @@ exports[`SidebarLogo renders 1`] = `
       class="mb-2 ml-8 PicassoSidebarLogo-root"
     >
       <svg
-        class="PicassoSvgLogo-root PicassoLogo-root PicassoLogo-default"
+        class="PicassoSvgLogo-root text-[1.875rem] align-baseline text-blue [--logo-text [--logo-emblem"
         style="min-width: 16px; min-height: 16px;"
         viewBox="0 0 109 30"
       >


### PR DESCRIPTION
[FX-5544]

### Description

This PR removes material-ui styles and replace them with Tailwind CSS classes.

### How to test

<!-- The temploy link will be automatically updated when the temploy is deployed -->
- [Temploy](https://picasso.toptal.net/fx-5544-logo)
- Check the [production](https://picasso.toptal.net/?path=/story/components-logo--logo) and compare it with the temploy.

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Double check if `picasso-tailwind-merge` requires major update (check its `README.md`)
- ~Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)~
- [x] Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- ~Annotate all `props` in component with documentation~
- ~Create `examples` for component~
- ~Ensure that deployed demo has expected results and good examples~
- ~Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).~
- [x] Self reviewed
- ~Covered with tests ([visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md) included)~

**Breaking change**

- ~codemod is created and showcased in the changeset~
- ~test alpha package of Picasso in StaffPortal~

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-5544]: https://toptal-core.atlassian.net/browse/FX-5544?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ