### PR TITLE
[FX-5837] Disable autocomplete in tag selector

### DIFF
--- a/.changeset/three-coats-dress.md
+++ b/.changeset/three-coats-dress.md
@@ -1,0 +1,8 @@
+---
+'@toptal/picasso-autocomplete': patch
+---
+
+### Autocomplete
+
+- fix: do not show empty popper container when there are no options and no empty options message
+- refactor: dropdown options menu renders in separate component

--- a/.changeset/three-coats-press.md
+++ b/.changeset/three-coats-press.md
@@ -1,0 +1,7 @@
+---
+'@toptal/picasso-tagselector': minor
+---
+
+### TagSelector
+
+- feature: use `submitOtherOptionOnEnter` property to submit other option on Enter key press

--- a/cypress/component/TagSelector.spec.tsx
+++ b/cypress/component/TagSelector.spec.tsx
@@ -47,6 +47,7 @@ const TagSelectorExample = ({
     <Container padded='medium'>
       <TagSelector
         {...props}
+        getKey={item => item.code as string}
         placeholder='Start typing...'
         options={filteredOptions}
         getDisplayValue={getDisplayValue}

--- a/packages/base/Autocomplete/src/Autocomplete/Autocomplete.tsx
+++ b/packages/base/Autocomplete/src/Autocomplete/Autocomplete.tsx
@@ -224,7 +224,10 @@ export const Autocomplete = forwardRef<HTMLInputElement, Props>(
 
     const optionsLength = options ? options.length : 0
 
-    const optionsMenu = options && (
+    console.log('@@@ options', options)
+
+    const hideOptionsCompletely = optionsLength === 0 && !noOptionsText
+    const optionsMenu = !hideOptionsCompletely && options && (
       <SelectOptions
         data-testid={testIds?.scrollMenu}
         selectedIndex={highlightedIndex}

--- a/packages/base/Autocomplete/src/Autocomplete/Autocomplete.tsx
+++ b/packages/base/Autocomplete/src/Autocomplete/Autocomplete.tsx
@@ -17,25 +17,30 @@ import type { PopperOptions } from 'popper.js'
 import { Input } from '@toptal/picasso-input'
 import { Container } from '@toptal/picasso-container'
 import { Loader } from '@toptal/picasso-loader'
-import { SelectOptions } from '@toptal/picasso-select'
 import { Popper } from '@toptal/picasso-popper'
 import { InputAdornment } from '@toptal/picasso-input-adornment'
 import { unsafeErrorLog } from '@toptal/picasso-utils'
 import type { InputProps } from '@toptal/picasso-input'
-import { MenuItem } from '@toptal/picasso-menu'
 import type { BaseInputProps, Status } from '@toptal/picasso-outlined-input'
 import { useFieldsLayoutContext } from '@toptal/picasso-form'
 import { twMerge } from '@toptal/picasso-tailwind-merge'
 
-import PoweredByGoogle from './PoweredByGoogle'
-import NoOptionsMenuItem from './NoOptionsMenuItem'
-import OtherOptionMenuItem from './OtherOptionMenuItem'
 import type { Item, ChangedOptions } from './types'
 import { useAutocomplete, EMPTY_INPUT_VALUE } from './use-autocomplete'
 import { rootClassByWidth } from './styles'
+import type { OptionsMenuProps } from './OptionsMenu'
+import OptionsMenu from './OptionsMenu'
 
 export interface Props
   extends BaseProps,
+    Pick<
+      OptionsMenuProps,
+      | 'otherOptionText'
+      | 'renderOtherOption'
+      | 'noOptionsText'
+      | 'renderOption'
+      | 'poweredByGoogle'
+    >,
     Omit<
       InputHTMLAttributes<HTMLInputElement>,
       'defaultValue' | 'value' | 'onChange' | 'onSelect' | 'onKeyDown' | 'size'
@@ -57,10 +62,6 @@ export interface Props
   ) => void
   /** Placeholder for value */
   placeholder?: string
-  /** Text prefix for other option */
-  otherOptionText?: string
-  /** Callback responsible for rendering the other option given the input's value */
-  renderOtherOption?: (value: string) => ReactNode
   /** Width of the component */
   width?: 'full' | 'shrink' | 'auto'
   /** Width of the menu */
@@ -69,12 +70,10 @@ export interface Props
   loading?: boolean
   /** Allow to show the other option in the list of options */
   showOtherOption?: boolean
-  /** Label to show when no options were found */
-  noOptionsText?: string | null
   /** List of options */
   options?: Item[] | null
   /** A function that takes a display value from the option item */
-  getDisplayValue?: (item: Item | null) => string
+  getDisplayValue?: OptionsMenuProps['getDisplayValue']
   /**  Callback invoked when key is pressed */
   onKeyDown?: (
     event: KeyboardEvent<HTMLInputElement>,
@@ -94,8 +93,6 @@ export interface Props
   icon?: ReactNode
   /** Custom input component */
   inputComponent?: ComponentType<InputProps>
-  /** Callback responsible for rendering the option given the option and its index in the list of options */
-  renderOption?: (option: Item, index: number) => ReactNode
   /** Provide unique key for each option */
   getKey?: (item: Item) => string
   /** Specifies whether the autofill enabled or not, disabled by default */
@@ -111,8 +108,6 @@ export interface Props
   /** Options provided to the popper.js instance */
   popperOptions?: PopperOptions
   inputProps?: BaseInputProps
-  /** Show the "Powered By Google" label */
-  poweredByGoogle?: boolean
   testIds?: InputProps['testIds'] & {
     menuItem?: string
     scrollMenu?: string
@@ -138,13 +133,13 @@ export const Autocomplete = forwardRef<HTMLInputElement, Props>(
       endAdornment,
       status,
       getDisplayValue = getItemText,
-      getKey: customGetKey,
+      getKey,
       icon,
       inputComponent,
       loading,
       menuWidth,
       name,
-      noOptionsText = 'No options',
+      noOptionsText,
       closeOnSelect,
       onBlur,
       onChange,
@@ -181,22 +176,6 @@ export const Autocomplete = forwardRef<HTMLInputElement, Props>(
       )
     }
 
-    const getKey = (item: Item) => {
-      if (customGetKey) {
-        return customGetKey(item)
-      }
-
-      const displayValue = getDisplayValue(item)
-
-      if (!displayValue) {
-        unsafeErrorLog(
-          'Autocomplete expects you to provide key prop value with getKey or Item.value!'
-        )
-      }
-
-      return displayValue
-    }
-
     const {
       highlightedIndex,
       isOpen,
@@ -222,49 +201,23 @@ export const Autocomplete = forwardRef<HTMLInputElement, Props>(
       ref,
     })
 
-    const optionsLength = options ? options.length : 0
-
-    console.log('@@@ options', options)
-
-    const hideOptionsCompletely = optionsLength === 0 && !noOptionsText
-    const optionsMenu = !hideOptionsCompletely && options && (
-      <SelectOptions
-        data-testid={testIds?.scrollMenu}
-        selectedIndex={highlightedIndex}
-        fixedFooter={
-          optionsLength > 0 && poweredByGoogle && <PoweredByGoogle />
-        }
-      >
-        {options?.map((option, index) => (
-          <MenuItem
-            data-testid={
-              testIds?.menuItem ? `${testIds?.menuItem}-${index}` : undefined
-            }
-            key={getKey(option)}
-            {...getItemProps(index, option)}
-            titleCase={false}
-            description={option.description}
-          >
-            {renderOption
-              ? renderOption(option, index)
-              : getDisplayValue(option)}
-          </MenuItem>
-        ))}
-        {shouldShowOtherOption && (
-          <OtherOptionMenuItem
-            data-testid={testIds?.otherOption}
-            value={value}
-            renderOtherOption={renderOtherOption}
-            otherOptionText={otherOptionText}
-            {...getOtherItemProps(optionsLength, value)}
-          />
-        )}
-        {!optionsLength && !shouldShowOtherOption && noOptionsText && (
-          <NoOptionsMenuItem data-testid={testIds?.noOptions}>
-            {noOptionsText}
-          </NoOptionsMenuItem>
-        )}
-      </SelectOptions>
+    const optionsMenu = (
+      <OptionsMenu
+        value={value}
+        shouldShowOtherOption={shouldShowOtherOption}
+        options={options}
+        highlightedIndex={highlightedIndex}
+        testIds={testIds}
+        poweredByGoogle={poweredByGoogle}
+        renderOtherOption={renderOtherOption}
+        otherOptionText={otherOptionText}
+        getKey={getKey}
+        getDisplayValue={getDisplayValue}
+        getItemProps={getItemProps}
+        getOtherItemProps={getOtherItemProps}
+        renderOption={renderOption}
+        noOptionsText={noOptionsText}
+      />
     )
 
     const { layout } = useFieldsLayoutContext()

--- a/packages/base/Autocomplete/src/Autocomplete/OptionsMenu.tsx
+++ b/packages/base/Autocomplete/src/Autocomplete/OptionsMenu.tsx
@@ -1,0 +1,133 @@
+import type { ReactNode } from 'react'
+import React from 'react'
+import { SelectOptions } from '@toptal/picasso-select'
+import { MenuItem } from '@toptal/picasso-menu'
+import { unsafeErrorLog } from '@toptal/picasso-utils'
+
+import PoweredByGoogle from './PoweredByGoogle'
+import NoOptionsMenuItem from './NoOptionsMenuItem'
+import OtherOptionMenuItem from './OtherOptionMenuItem'
+import type { Item } from './types'
+import type {
+  GetItemPropsSignature,
+  GetOtherItemPropsSignature,
+} from './use-autocomplete/use-autocomplete'
+
+export type OptionsMenuProps = {
+  options?: Item[] | null
+  /** Show the "Powered By Google" label */
+  poweredByGoogle?: boolean
+  /** Callback responsible for rendering the other option given the input's value */
+  renderOtherOption?: (value: string) => ReactNode
+  /** Label to show when no options were found */
+  noOptionsText?: string | null
+  /** Text prefix for other option */
+  otherOptionText?: string
+  /** Callback responsible for rendering the option given the option and its index in the list of options */
+  renderOption?: (option: Item, index: number) => ReactNode
+  highlightedIndex: number
+  testIds?: {
+    menuItem?: string
+    scrollMenu?: string
+    otherOption?: string
+    noOptions?: string
+  }
+  getKey?: (item: Item) => string
+  getDisplayValue: (item: Item | null) => string
+  value: string
+  getItemProps: GetItemPropsSignature
+  getOtherItemProps: GetOtherItemPropsSignature
+  shouldShowOtherOption: boolean
+}
+
+const OptionsMenu = ({
+  options,
+  getItemProps,
+  getOtherItemProps,
+  renderOtherOption,
+  otherOptionText = 'Other option: ',
+  getDisplayValue,
+  value,
+  getKey: customGetKey,
+  renderOption,
+  noOptionsText,
+  poweredByGoogle,
+  shouldShowOtherOption,
+  highlightedIndex,
+  testIds,
+}: OptionsMenuProps) => {
+  const getKey = (item: Item) => {
+    if (customGetKey) {
+      return customGetKey(item)
+    }
+
+    const displayValue = getDisplayValue(item)
+
+    if (!displayValue) {
+      unsafeErrorLog(
+        'Autocomplete expects you to provide key prop value with getKey or Item.value!'
+      )
+    }
+
+    return displayValue
+  }
+
+  const optionsLength = options ? options.length : 0
+  const menuItems =
+    options?.map((option, index) => (
+      <MenuItem
+        data-testid={
+          testIds?.menuItem ? `${testIds?.menuItem}-${index}` : undefined
+        }
+        key={getKey(option)}
+        {...getItemProps(index, option)}
+        titleCase={false}
+        description={option.description}
+      >
+        {renderOption ? renderOption(option, index) : getDisplayValue(option)}
+      </MenuItem>
+    )) || []
+
+  if (shouldShowOtherOption) {
+    menuItems.push(
+      <OtherOptionMenuItem
+        key='other-option-menu-item'
+        data-testid={testIds?.otherOption}
+        value={value}
+        renderOtherOption={renderOtherOption}
+        otherOptionText={otherOptionText}
+        {...getOtherItemProps(optionsLength, value)}
+      />
+    )
+  }
+
+  const showNoOptionsText =
+    !optionsLength && !shouldShowOtherOption && noOptionsText
+
+  if (showNoOptionsText) {
+    menuItems.push(
+      <NoOptionsMenuItem
+        key='no-options-menu-item'
+        data-testid={testIds?.noOptions}
+      >
+        {noOptionsText}
+      </NoOptionsMenuItem>
+    )
+  }
+
+  if (menuItems.length === 0) {
+    return null
+  }
+
+  return (
+    <SelectOptions
+      data-testid={testIds?.scrollMenu}
+      selectedIndex={highlightedIndex}
+      fixedFooter={optionsLength > 0 && poweredByGoogle && <PoweredByGoogle />}
+    >
+      {menuItems}
+    </SelectOptions>
+  )
+}
+
+export default OptionsMenu

--- a/packages/base/Autocomplete/src/Autocomplete/OptionsMenu.tsx
+++ b/packages/base/Autocomplete/src/Autocomplete/OptionsMenu.tsx
@@ -7,11 +7,11 @@ import { unsafeErrorLog } from '@toptal/picasso-utils'
 import PoweredByGoogle from './PoweredByGoogle'
 import NoOptionsMenuItem from './NoOptionsMenuItem'
 import OtherOptionMenuItem from './OtherOptionMenuItem'
-import type { Item } from './types'
 import type {
+  Item,
   GetItemPropsSignature,
   GetOtherItemPropsSignature,
-} from './use-autocomplete/use-autocomplete'
+} from './types'
 
 export type OptionsMenuProps = {
   options?: Item[] | null

--- a/packages/base/Autocomplete/src/Autocomplete/OptionsMenu.tsx
+++ b/packages/base/Autocomplete/src/Autocomplete/OptionsMenu.tsx
@@ -19,7 +19,7 @@ export type OptionsMenuProps = {
   poweredByGoogle?: boolean
   /** Callback responsible for rendering the other option given the input's value */
   renderOtherOption?: (value: string) => ReactNode
-  /** Label to show when no options were found */
+  /** Label to show when no options were found (pass "null" to hide label completely) */
   noOptionsText?: string | null
   /** Text prefix for other option */
   otherOptionText?: string

--- a/packages/base/Autocomplete/src/Autocomplete/test.tsx
+++ b/packages/base/Autocomplete/src/Autocomplete/test.tsx
@@ -129,11 +129,15 @@ describe('Autocomplete', () => {
     it('uses custom menu keys', () => {
       const getKey = jest.fn(({ value }) => value)
 
-      renderAutocomplete({
+      const { getByTestId } = renderAutocomplete({
         options: testOptions,
         value: '',
         getKey,
       })
+
+      const input = getByTestId('autocomplete')
+
+      fireEvent.click(input)
 
       expect(getKey).toHaveBeenCalledTimes(testOptions.length)
     })
@@ -224,9 +228,8 @@ describe('Autocomplete', () => {
 
       fireEvent.click(input)
 
-      // 5 times on first render
-      // another 5 times on second rerender after click
-      expect(renderOption).toHaveBeenCalledTimes(10)
+      // 5 times on rerender after click
+      expect(renderOption).toHaveBeenCalledTimes(5)
       expect(getAllByTestId('custom-option')).toHaveLength(5)
       expect(getDisplayValue).not.toHaveBeenCalled()
       expect(getByTestId(testIds.scrollMenu)).toMatchSnapshot()
@@ -245,7 +248,7 @@ describe('Autocomplete', () => {
       fireEvent.click(input)
 
       // when getKey is not passed, getDisplayValue is called twice for each option on every render
-      expect(getDisplayValue).toHaveBeenCalledTimes(20)
+      expect(getDisplayValue).toHaveBeenCalledTimes(10)
       expect(getByTestId(testIds.scrollMenu)).toMatchSnapshot()
     })
 
@@ -264,7 +267,7 @@ describe('Autocomplete', () => {
 
       fireEvent.click(input)
 
-      expect(renderOption).toHaveBeenCalledTimes(10)
+      expect(renderOption).toHaveBeenCalledTimes(5)
       expect(getDisplayValue).not.toHaveBeenCalled()
     })
 

--- a/packages/base/Autocomplete/src/Autocomplete/types.ts
+++ b/packages/base/Autocomplete/src/Autocomplete/types.ts
@@ -1,3 +1,5 @@
+import type { MouseEvent } from 'react'
+
 export type Item = {
   text?: string
   description?: string
@@ -6,4 +8,26 @@ export type Item = {
 
 export type ChangedOptions = {
   isSelected: boolean
+}
+
+type BaseItemsProps = {
+  role: string
+  'aria-selected': boolean
+  selected: boolean
+  onMouseMove: () => void
+  onMouseDown: (event: React.MouseEvent) => void
+}
+
+export type GetBaseItemPropsSignature = (index: number) => BaseItemsProps
+
+export type GetItemPropsSignature = (
+  index: number,
+  item: Item
+) => BaseItemsProps
+
+export type GetOtherItemPropsSignature = (
+  index: number,
+  newValue: string
+) => BaseItemsProps & {
+  onClick: (event: MouseEvent) => void
 }

--- a/packages/base/Autocomplete/src/Autocomplete/use-autocomplete/use-autocomplete.ts
+++ b/packages/base/Autocomplete/src/Autocomplete/use-autocomplete/use-autocomplete.ts
@@ -8,7 +8,13 @@ import type {
 } from 'react'
 import { useState, useEffect, useMemo } from 'react'
 
-import type { Item, ChangedOptions } from '../types'
+import type {
+  Item,
+  ChangedOptions,
+  GetOtherItemPropsSignature,
+  GetItemPropsSignature,
+  GetBaseItemPropsSignature,
+} from '../types'
 
 export const EMPTY_INPUT_VALUE = ''
 export const INITIAL_HIGHLIGHT_INDEX = 0
@@ -93,28 +99,6 @@ export interface Props {
   showOtherOption?: boolean
   disabled?: boolean
   ref?: Ref<HTMLInputElement>
-}
-
-type BaseItemsProps = {
-  role: string
-  'aria-selected': boolean
-  selected: boolean
-  onMouseMove: () => void
-  onMouseDown: (event: React.MouseEvent) => void
-}
-
-export type GetBaseItemPropsSignature = (index: number) => BaseItemsProps
-
-export type GetItemPropsSignature = (
-  index: number,
-  item: Item
-) => BaseItemsProps
-
-export type GetOtherItemPropsSignature = (
-  index: number,
-  newValue: string
-) => BaseItemsProps & {
-  onClick: (event: MouseEvent) => void
 }
 
 export const useAutocomplete = ({

--- a/packages/base/Autocomplete/src/Autocomplete/use-autocomplete/use-autocomplete.ts
+++ b/packages/base/Autocomplete/src/Autocomplete/use-autocomplete/use-autocomplete.ts
@@ -1,5 +1,4 @@
 /* eslint-disable complexity, max-statements */ // Squiggly lines makes code difficult to work with
-
 import type {
   MouseEvent,
   KeyboardEvent,
@@ -96,6 +95,28 @@ export interface Props {
   ref?: Ref<HTMLInputElement>
 }
 
+type BaseItemsProps = {
+  role: string
+  'aria-selected': boolean
+  selected: boolean
+  onMouseMove: () => void
+  onMouseDown: (event: React.MouseEvent) => void
+}
+
+export type GetBaseItemPropsSignature = (index: number) => BaseItemsProps
+
+export type GetItemPropsSignature = (
+  index: number,
+  item: Item
+) => BaseItemsProps
+
+export type GetOtherItemPropsSignature = (
+  index: number,
+  newValue: string
+) => BaseItemsProps & {
+  onClick: (event: MouseEvent) => void
+}
+
 export const useAutocomplete = ({
   value,
   options = [],
@@ -167,7 +188,7 @@ export const useAutocomplete = ({
     onSelect(item, event)
   }
 
-  const getBaseItemProps = (index: number) => ({
+  const getBaseItemProps: GetBaseItemPropsSignature = (index: number) => ({
     role: 'option',
     'aria-selected': highlightedIndex === index,
     selected: highlightedIndex === index,
@@ -186,7 +207,7 @@ export const useAutocomplete = ({
     },
   })
 
-  const getItemProps = (index: number, item: Item) => ({
+  const getItemProps: GetItemPropsSignature = (index: number, item: Item) => ({
     ...getBaseItemProps(index),
     onClick: (event: MouseEvent) => {
       if (closeOnSelect) {
@@ -197,7 +218,10 @@ export const useAutocomplete = ({
     },
   })
 
-  const getOtherItemProps = (index: number, newValue: string) => ({
+  const getOtherItemProps: GetOtherItemPropsSignature = (
+    index: number,
+    newValue: string
+  ) => ({
     ...getBaseItemProps(index),
     onClick: (event: MouseEvent) => {
       if (closeOnSelect) {

--- a/packages/base/Tagselector/src/TagSelector/TagSelector.tsx
+++ b/packages/base/Tagselector/src/TagSelector/TagSelector.tsx
@@ -62,6 +62,8 @@ export interface Props
   otherOptionLabel?: string
   /** Callback invoked when other option selected */
   onOtherOptionSelect?: (value: string) => void
+  /** Select other option on Enter key press */
+  submitOtherOptionOnEnter?: boolean
   /** Allow to show the other option in the list of options */
   showOtherOption?: boolean
   /** Label to show when no options were found */
@@ -127,6 +129,7 @@ export const TagSelector = forwardRef<HTMLInputElement, Props>(
       placeholder,
       renderLabel: customRenderLabel,
       renderOption,
+      submitOtherOptionOnEnter,
       showOtherOption,
       value: values = [],
       width,
@@ -160,8 +163,7 @@ export const TagSelector = forwardRef<HTMLInputElement, Props>(
         handleDelete(values[values.length - 1])
       }
 
-      if (isEnter) {
-        console.log('@@@', newInputValue, values)
+      if (submitOtherOptionOnEnter && isEnter && newInputValue !== '') {
         handleOtherOptionSelect(newInputValue)
       }
     }

--- a/packages/base/Tagselector/src/TagSelector/TagSelector.tsx
+++ b/packages/base/Tagselector/src/TagSelector/TagSelector.tsx
@@ -65,7 +65,7 @@ export interface Props
   /** Allow to show the other option in the list of options */
   showOtherOption?: boolean
   /** Label to show when no options were found */
-  noOptionsText?: string
+  noOptionsText?: string | null
   /** List of options with unique labels */
   options?: Item[] | null
   /** The list of values of the selected options, required for a controlled component. */
@@ -154,9 +154,15 @@ export const TagSelector = forwardRef<HTMLInputElement, Props>(
     ) => {
       const hasSelection = values.length
       const isDeleting = event.key === 'Backspace'
+      const isEnter = event.key === 'Enter'
 
       if (hasSelection && !newInputValue && isDeleting) {
         handleDelete(values[values.length - 1])
+      }
+
+      if (isEnter) {
+        console.log('@@@', newInputValue, values)
+        handleOtherOptionSelect(newInputValue)
       }
     }
 

--- a/packages/base/Tagselector/src/TagSelector/TagSelector.tsx
+++ b/packages/base/Tagselector/src/TagSelector/TagSelector.tsx
@@ -66,7 +66,7 @@ export interface Props
   submitOtherOptionOnEnter?: boolean
   /** Allow to show the other option in the list of options */
   showOtherOption?: boolean
-  /** Label to show when no options were found */
+  /** Label to show when no options were found (pass "null" to hide label completely) */
   noOptionsText?: string | null
   /** List of options with unique labels */
   options?: Item[] | null

--- a/packages/base/Tagselector/src/TagSelector/story/InitialSetValue.example.tsx
+++ b/packages/base/Tagselector/src/TagSelector/story/InitialSetValue.example.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react'
 import type { AutocompleteItem } from '@toptal/picasso'
 import { TagSelector } from '@toptal/picasso'
-// import { isSubstring } from '@toptal/picasso-utils'
+import { isSubstring } from '@toptal/picasso-utils'
 
 const allOptions = [
   { value: 'AF', text: 'Afghanistan' },
@@ -19,24 +19,22 @@ const allOptions = [
 const EMPTY_INPUT_VALUE = ''
 const getDisplayValue = (item: AutocompleteItem | null) =>
   item && item.text ? item.text : EMPTY_INPUT_VALUE
-// const filterOptions = (value: string) =>
-//   value !== ''
-//     ? allOptions.filter(option => isSubstring(value, getDisplayValue(option)))
-//     : allOptions
+const filterOptions = (value: string) =>
+  value !== ''
+    ? allOptions.filter(option => isSubstring(value, getDisplayValue(option)))
+    : allOptions
 
 const Example = () => {
-  // const [options, setOptions] = useState<AutocompleteItem[] | undefined>(
-  //   allOptions
-  // )
+  const [options, setOptions] = useState<AutocompleteItem[] | undefined>(
+    allOptions
+  )
   const [value, setValue] = useState<AutocompleteItem[]>(allOptions.slice(0, 3))
   const [inputValue, setInputValue] = useState(EMPTY_INPUT_VALUE)
 
   return (
     <div>
       <TagSelector
-        //showOtherOption
-        //options={options}
-        noOptionsText={null}
+        options={options}
         placeholder='Start typing...'
         value={value}
         inputValue={inputValue}
@@ -45,14 +43,10 @@ const Example = () => {
           window.console.log('onChange values: ', selectedValues)
           setValue(selectedValues)
         }}
-        onOtherOptionSelect={otherOption => {
-          console.log('@@@', otherOption, value)
-          setValue([...value, { value: otherOption, text: otherOption }])
-        }}
         onInputChange={newInputValue => {
           window.console.log('onInputChange value: ', newInputValue)
           setInputValue(newInputValue)
-          //setOptions(filterOptions(newInputValue))
+          setOptions(filterOptions(newInputValue))
         }}
       />
     </div>

--- a/packages/base/Tagselector/src/TagSelector/story/InitialSetValue.example.tsx
+++ b/packages/base/Tagselector/src/TagSelector/story/InitialSetValue.example.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react'
 import type { AutocompleteItem } from '@toptal/picasso'
 import { TagSelector } from '@toptal/picasso'
-import { isSubstring } from '@toptal/picasso-utils'
+// import { isSubstring } from '@toptal/picasso-utils'
 
 const allOptions = [
   { value: 'AF', text: 'Afghanistan' },
@@ -19,22 +19,24 @@ const allOptions = [
 const EMPTY_INPUT_VALUE = ''
 const getDisplayValue = (item: AutocompleteItem | null) =>
   item && item.text ? item.text : EMPTY_INPUT_VALUE
-const filterOptions = (value: string) =>
-  value !== ''
-    ? allOptions.filter(option => isSubstring(value, getDisplayValue(option)))
-    : allOptions
+// const filterOptions = (value: string) =>
+//   value !== ''
+//     ? allOptions.filter(option => isSubstring(value, getDisplayValue(option)))
+//     : allOptions
 
 const Example = () => {
-  const [options, setOptions] = useState<AutocompleteItem[] | undefined>(
-    allOptions
-  )
+  // const [options, setOptions] = useState<AutocompleteItem[] | undefined>(
+  //   allOptions
+  // )
   const [value, setValue] = useState<AutocompleteItem[]>(allOptions.slice(0, 3))
   const [inputValue, setInputValue] = useState(EMPTY_INPUT_VALUE)
 
   return (
     <div>
       <TagSelector
-        options={options}
+        //showOtherOption
+        //options={options}
+        noOptionsText={null}
         placeholder='Start typing...'
         value={value}
         inputValue={inputValue}
@@ -43,10 +45,14 @@ const Example = () => {
           window.console.log('onChange values: ', selectedValues)
           setValue(selectedValues)
         }}
+        onOtherOptionSelect={otherOption => {
+          console.log('@@@', otherOption, value)
+          setValue([...value, { value: otherOption, text: otherOption }])
+        }}
         onInputChange={newInputValue => {
           window.console.log('onInputChange value: ', newInputValue)
           setInputValue(newInputValue)
-          setOptions(filterOptions(newInputValue))
+          //setOptions(filterOptions(newInputValue))
         }}
       />
     </div>

--- a/packages/base/Tagselector/src/TagSelector/story/OtherOptionSubmissionOnEnter.example.tsx
+++ b/packages/base/Tagselector/src/TagSelector/story/OtherOptionSubmissionOnEnter.example.tsx
@@ -1,0 +1,38 @@
+import React, { useState } from 'react'
+import type { AutocompleteItem } from '@toptal/picasso'
+import { TagSelector } from '@toptal/picasso'
+
+const EMPTY_INPUT_VALUE = ''
+const getDisplayValue = (item: AutocompleteItem | null) =>
+  item && item.text ? item.text : EMPTY_INPUT_VALUE
+
+const Example = () => {
+  const [value, setValue] = useState<AutocompleteItem[]>([])
+  const [inputValue, setInputValue] = useState(EMPTY_INPUT_VALUE)
+
+  return (
+    <div>
+      <TagSelector
+        options={null}
+        noOptionsText={null}
+        placeholder='Type and press Enter to select...'
+        value={value}
+        inputValue={inputValue}
+        getDisplayValue={getDisplayValue}
+        onChange={selectedValues => {
+          window.console.log('onChange values: ', selectedValues)
+          setValue(selectedValues)
+        }}
+        onOtherOptionSelect={otherOption => {
+          setValue([...value, { value: otherOption, text: otherOption }])
+        }}
+        onInputChange={newInputValue => {
+          window.console.log('onInputChange value: ', newInputValue)
+          setInputValue(newInputValue)
+        }}
+      />
+    </div>
+  )
+}
+
+export default Example

--- a/packages/base/Tagselector/src/TagSelector/story/OtherOptionSubmissionOnEnter.example.tsx
+++ b/packages/base/Tagselector/src/TagSelector/story/OtherOptionSubmissionOnEnter.example.tsx
@@ -13,7 +13,6 @@ const Example = () => {
   return (
     <div>
       <TagSelector
-        options={null}
         noOptionsText={null}
         placeholder='Type and press Enter to select...'
         value={value}

--- a/packages/base/Tagselector/src/TagSelector/story/index.jsx
+++ b/packages/base/Tagselector/src/TagSelector/story/index.jsx
@@ -17,67 +17,67 @@ page
 
 page
   .createChapter()
-  .addExample(
-    'TagSelector/story/Default.example.tsx',
-    'Default',
-    'base/Tagselector'
-  )
-  .addExample(
-    'TagSelector/story/OtherOption.example.tsx',
-    {
-      title: 'Other option',
-      takeScreenshot: false,
-    },
-    'base/Tagselector'
-  )
+  // .addExample(
+  //   'TagSelector/story/Default.example.tsx',
+  //   'Default',
+  //   'base/Tagselector'
+  // )
+  // .addExample(
+  //   'TagSelector/story/OtherOption.example.tsx',
+  //   {
+  //     title: 'Other option',
+  //     takeScreenshot: false,
+  //   },
+  //   'base/Tagselector'
+  // )
   .addExample(
     'TagSelector/story/InitialSetValue.example.tsx',
     'Initially set value',
     'base/Tagselector'
   )
-  .addExample(
-    'TagSelector/story/KeepOpen.example.tsx',
-    {
-      title: 'With closeOnSelect disabled',
-      description:
-        'Disabling closeOnSelect can be useful when the user always have to select multiple values at the same time',
-      takeScreenshot: false,
-    },
-    'base/Tagselector'
-  )
-  .addExample(
-    'TagSelector/story/CustomOptionRenderer.example.tsx',
-    {
-      title: 'Custom option rendering',
-      takeScreenshot: false,
-    },
-    'base/Tagselector'
-  )
-  .addExample(
-    'TagSelector/story/CustomLabelRenderer.example.tsx',
-    {
-      title: 'Custom label rendering',
-      takeScreenshot: false,
-    },
-    'base/Tagselector'
-  )
-  .addExample(
-    'TagSelector/story/Loading.example.tsx',
-    'Loading',
-    'base/Tagselector'
-  )
-  .addExample(
-    'TagSelector/story/Disabled.example.tsx',
-    'Disabled',
-    'base/Tagselector'
-  )
-  .addExample(
-    'TagSelector/story/FullWidth.example.tsx',
-    'Full width',
-    'base/Tagselector'
-  )
-  .addExample(
-    'TagSelector/story/Status.example.tsx',
-    'Status',
-    'base/Tagselector'
-  )
+// .addExample(
+//   'TagSelector/story/KeepOpen.example.tsx',
+//   {
+//     title: 'With closeOnSelect disabled',
+//     description:
+//       'Disabling closeOnSelect can be useful when the user always have to select multiple values at the same time',
+//     takeScreenshot: false,
+//   },
+//   'base/Tagselector'
+// )
+// .addExample(
+//   'TagSelector/story/CustomOptionRenderer.example.tsx',
+//   {
+//     title: 'Custom option rendering',
+//     takeScreenshot: false,
+//   },
+//   'base/Tagselector'
+// )
+// .addExample(
+//   'TagSelector/story/CustomLabelRenderer.example.tsx',
+//   {
+//     title: 'Custom label rendering',
+//     takeScreenshot: false,
+//   },
+//   'base/Tagselector'
+// )
+// .addExample(
+//   'TagSelector/story/Loading.example.tsx',
+//   'Loading',
+//   'base/Tagselector'
+// )
+// .addExample(
+//   'TagSelector/story/Disabled.example.tsx',
+//   'Disabled',
+//   'base/Tagselector'
+// )
+// .addExample(
+//   'TagSelector/story/FullWidth.example.tsx',
+//   'Full width',
+//   'base/Tagselector'
+// )
+// .addExample(
+//   'TagSelector/story/Status.example.tsx',
+//   'Status',
+//   'base/Tagselector'
+// )

--- a/packages/base/Tagselector/src/TagSelector/story/index.jsx
+++ b/packages/base/Tagselector/src/TagSelector/story/index.jsx
@@ -17,67 +17,77 @@ page
 
 page
   .createChapter()
-  // .addExample(
-  //   'TagSelector/story/Default.example.tsx',
-  //   'Default',
-  //   'base/Tagselector'
-  // )
-  // .addExample(
-  //   'TagSelector/story/OtherOption.example.tsx',
-  //   {
-  //     title: 'Other option',
-  //     takeScreenshot: false,
-  //   },
-  //   'base/Tagselector'
-  // )
+  .addExample(
+    'TagSelector/story/Default.example.tsx',
+    'Default',
+    'base/Tagselector'
+  )
+  .addExample(
+    'TagSelector/story/OtherOption.example.tsx',
+    {
+      title: 'Other option',
+      takeScreenshot: false,
+    },
+    'base/Tagselector'
+  )
+  .addExample(
+    'TagSelector/story/OtherOptionSubmissionOnEnter.example.tsx',
+    {
+      title: 'Other option submission on Enter',
+      description:
+        'Press Enter to submit other option value. Combine it with empty `options` and `noOptionsText` properties to hide the options dropdown and achieve regular input behavior and look.',
+      takeScreenshot: false,
+    },
+    'base/Tagselector'
+  )
   .addExample(
     'TagSelector/story/InitialSetValue.example.tsx',
     'Initially set value',
     'base/Tagselector'
   )
-// .addExample(
-//   'TagSelector/story/KeepOpen.example.tsx',
-//   {
-//     title: 'With closeOnSelect disabled',
-//     description:
-//       'Disabling closeOnSelect can be useful when the user always have to select multiple values at the same time',
-//     takeScreenshot: false,
-//   },
-//   'base/Tagselector'
-// )
-// .addExample(
-//   'TagSelector/story/CustomOptionRenderer.example.tsx',
-//   {
-//     title: 'Custom option rendering',
-//     takeScreenshot: false,
-//   },
-//   'base/Tagselector'
-// )
-// .addExample(
-//   'TagSelector/story/CustomLabelRenderer.example.tsx',
-//   {
-//     title: 'Custom label rendering',
-//     takeScreenshot: false,
-//   },
-//   'base/Tagselector'
-// )
-// .addExample(
-//   'TagSelector/story/Loading.example.tsx',
-//   'Loading',
-//   'base/Tagselector'
-// )
-// .addExample(
-//   'TagSelector/story/Disabled.example.tsx',
-//   'Disabled',
-//   'base/Tagselector'
-// )
-// .addExample(
-//   'TagSelector/story/FullWidth.example.tsx',
-//   'Full width',
-//   'base/Tagselector'
-// )
-// .addExample(
-//   'TagSelector/story/Status.example.tsx',
-//   'Status',
-//   'base/Tagselector'
-// )
+  .addExample(
+    'TagSelector/story/KeepOpen.example.tsx',
+    {
+      title: 'With closeOnSelect disabled',
+      description:
+        'Disabling closeOnSelect can be useful when the user always have to select multiple values at the same time',
+      takeScreenshot: false,
+    },
+    'base/Tagselector'
+  )
+  .addExample(
+    'TagSelector/story/CustomOptionRenderer.example.tsx',
+    {
+      title: 'Custom option rendering',
+      takeScreenshot: false,
+    },
+    'base/Tagselector'
+  )
+  .addExample(
+    'TagSelector/story/CustomLabelRenderer.example.tsx',
+    {
+      title: 'Custom label rendering',
+      takeScreenshot: false,
+    },
+    'base/Tagselector'
+  )
+  .addExample(
+    'TagSelector/story/Loading.example.tsx',
+    'Loading',
+    'base/Tagselector'
+  )
+  .addExample(
+    'TagSelector/story/Disabled.example.tsx',
+    'Disabled',
+    'base/Tagselector'
+  )
+  .addExample(
+    'TagSelector/story/FullWidth.example.tsx',
+    'Full width',
+    'base/Tagselector'
+  )
+  .addExample(
+    'TagSelector/story/Status.example.tsx',
+    'Status',
+    'base/Tagselector'
+  )


### PR DESCRIPTION
[FX-5837]

### Description

This pull request does two closely related things:

- fixes bug with thin popper container appearing when there are no options and no "empty options" text in `Autocomplete`. Use the code below to observe it in https://picasso.toptal.net/

<img width="352" alt="Screenshot 2024-09-09 at 10 57 05" src="https://github.com/user-attachments/assets/a01a24af-da97-45c1-934d-737549f893ff">

<details>
  <summary>Reproduction code</summary>

```
import React, { useState } from 'react'
import type { AutocompleteItem } from '@toptal/picasso'
import { Autocomplete, Form } from '@toptal/picasso'
import { isSubstring } from '@toptal/picasso-utils'

const Example = () => {
  const [value, setValue] = useState('')
  const [options, setOptions] = useState<AutocompleteItem[] | null>([])

  return (
    <div>
      <Form autoComplete='off'>
        <Autocomplete
          placeholder='Start typing country...'
          value={value}
          options={[]}
          noOptionsText={null}
          onChange={newValue => {
            console.log('onChange returns just item value:', newValue)

            setOptions(filterOptions(newValue))
            setValue(newValue)
          }}
          data-testid='autocomplete'
        />
      </Form>
    </div>
  )
}

export default Example
```
</details>

- adds support for non-dropdown option submission in `TagSelector` component (it heavily relies on `Autocomplete`) via `submitOtherOptionOnEnter` prop. To achieve the behavior from the [original thread](https://toptal-core.slack.com/archives/CCC3GP6CC/p1724313176283519), consumers need to specify certain combination of other properties (dedicated story was added).

### How to test

<!-- The temploy link will be automatically updated when the temploy is deployed -->
- Check `Other option submission on Enter` story at [temploy](https://picasso.toptal.net/fx-5837-disable-autocomplete-in-tag-selector/?path=/story/forms-tagselector--tagselector)
- Client Portal tests in https://github.com/toptal/client-portal/pull/9733 are fine

### Screenshots

https://github.com/user-attachments/assets/fc676d4c-ee4d-47b9-a0d0-844473fe51da

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [N/A] Double check if `picasso-tailwind-merge` requires major update (check its `README.md`)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests ([visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md) included)

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-5837]: https://toptal-core.atlassian.net/browse/FX-5837?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ