### PR TITLE
[FX-NULL] Add ability to snooze notification

### DIFF
--- a/.github/workflows/notify-about-pending-release-pull-requests.yaml
+++ b/.github/workflows/notify-about-pending-release-pull-requests.yaml
@@ -24,14 +24,13 @@ jobs:
           SNOOZE_UNTIL: ${{ vars.STALE_VERSION_PACKAGES_NOTIFICATION_SNOOZE_UNITL }}
         with:
           script: |
-            # Get the current time and the time from the environment variable
             const snoozeUntil = new Date(process.env.SNOOZE_UNTIL)
             const now = new Date()
     
             console.log("Snooze until: ", snoozeUntil.toISOString())
             console.log("Current time: ", now.toISOString())
 
-            return now <= snoozeUntil
+            return (now <= snoozeUntil)
 
   check-pending-release-pull-requests:
     runs-on: ubuntu-latest

--- a/.github/workflows/notify-about-pending-release-pull-requests.yaml
+++ b/.github/workflows/notify-about-pending-release-pull-requests.yaml
@@ -1,3 +1,9 @@
+# Description: This workflow sends a Slack notification to the #frontend-exp-team-notifications channel
+# if there is a pending pull request with the title "Version Packages" that has been open for more than 3 hours.
+#
+# Use STALE_VERSION_PACKAGES_NOTIFICATION_SNOOZE_UNITL repository variable (https://github.com/toptal/picasso/settings/variables/actions)
+# to snooze notification unitl specific moment of time. The variable value should be in the date ISO format.
+
 name: Notify about pending release pull requests
 
 on:
@@ -6,8 +12,31 @@ on:
   workflow_dispatch:
 
 jobs:
+  check-if-notification-is-snoozed:
+    runs-on: ubuntu-latest
+    outputs:
+      snooze-notification: ${{ steps.snooze-notification.outputs.result }}
+    steps:
+      - name: Check if the notification is snoozed
+        uses: actions/github-script@v7
+        id: snooze-notification
+        env:
+          SNOOZE_UNTIL: ${{ vars.STALE_VERSION_PACKAGES_NOTIFICATION_SNOOZE_UNITL }}
+        with:
+          script: |
+            # Get the current time and the time from the environment variable
+            const snoozeUntil = new Date(process.env.SNOOZE_UNTIL)
+            const now = new Date()
+    
+            console.log("Snooze until: ", snoozeUntil.toISOString())
+            console.log("Current time: ", now.toISOString())
+
+            return now <= snoozeUntil
+
   check-pending-release-pull-requests:
     runs-on: ubuntu-latest
+    needs: check-if-notification-is-snoozed
+    if: ${{ needs.check-if-notification-is-snoozed.outputs.snooze-notification == 'false' }}
     permissions:
       contents: write
       id-token: write
@@ -15,59 +44,59 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-    - name: Check out the repository
-      uses: actions/checkout@v4
+      - name: Check out the repository
+        uses: actions/checkout@v4
 
-    - name: GSM Secrets
-      id: secrets_manager
-      uses: toptal/davinci-github-actions/gsm-secrets@v15.3.1
-      with:
-        workload_identity_provider: ${{ secrets.IDENTITY_POOL }}
-        service_account: ${{ secrets.SA_IDENTITY_POOL }}
-        secrets_name: |-
-          SLACK_BOT_TOKEN:toptal-ci/SLACK_BOT_TOKEN
-          TOPTAL_DEVBOT_TOKEN:toptal-ci/TOPTAL_DEVBOT_TOKEN
+      - name: GSM Secrets
+        id: secrets_manager
+        uses: toptal/davinci-github-actions/gsm-secrets@v15.3.1
+        with:
+          workload_identity_provider: ${{ secrets.IDENTITY_POOL }}
+          service_account: ${{ secrets.SA_IDENTITY_POOL }}
+          secrets_name: |-
+            SLACK_BOT_TOKEN:toptal-ci/SLACK_BOT_TOKEN
+            TOPTAL_DEVBOT_TOKEN:toptal-ci/TOPTAL_DEVBOT_TOKEN
 
-    - name: Parse secrets
-      id: parse_secrets
-      uses: toptal/davinci-github-actions/expose-json-outputs@v15.3.1
-      with:
-        json: ${{ steps.secrets_manager.outputs.secrets }}
+      - name: Parse secrets
+        id: parse_secrets
+        uses: toptal/davinci-github-actions/expose-json-outputs@v15.3.1
+        with:
+          json: ${{ steps.secrets_manager.outputs.secrets }}
 
-    - name: Set ENV Variables
-      shell: bash
-      run: |-
-        echo "SLACK_BOT_TOKEN=${{ steps.parse_secrets.outputs.SLACK_BOT_TOKEN }}" >> $GITHUB_ENV
-        echo "GITHUB_TOKEN=${{ steps.parse_secrets.outputs.TOPTAL_DEVBOT_TOKEN }}" >> $GITHUB_ENV
+      - name: Set ENV Variables
+        shell: bash
+        run: |-
+          echo "SLACK_BOT_TOKEN=${{ steps.parse_secrets.outputs.SLACK_BOT_TOKEN }}" >> $GITHUB_ENV
+          echo "GITHUB_TOKEN=${{ steps.parse_secrets.outputs.TOPTAL_DEVBOT_TOKEN }}" >> $GITHUB_ENV
 
-    - name: Find version packages pull requests
-      uses: actions/github-script@v7
-      id: find-pull-requests
-      with:
-        github-token: ${{ env.GITHUB_TOKEN }}
-        script: |
-          const { data: prs } = await github.rest.pulls.list({
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            state: 'open',
-          })
+      - name: Find version packages pull requests
+        uses: actions/github-script@v7
+        id: find-pull-requests
+        with:
+          github-token: ${{ env.GITHUB_TOKEN }}
+          script: |
+            const { data: prs } = await github.rest.pulls.list({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+            })
 
-          const threeHoursInMilliseconds = 3 * 60 * 60 * 1000
+            const threeHoursInMilliseconds = 3 * 60 * 60 * 1000
 
-          // Find a PR with the title "Version Packages" that has been open long enough
-          const now = new Date()
-          const targetPR = prs.find(pr => pr.title.includes('Version Packages') && (now - new Date(pr.created_at)) > threeHoursInMilliseconds)
+            // Find a PR with the title "Version Packages" that has been open long enough
+            const now = new Date()
+            const targetPR = prs.find(pr => pr.title.includes('Version Packages') && (now - new Date(pr.created_at)) > threeHoursInMilliseconds)
 
-          if (targetPR) {
-            // If there is at least one stale pull request, require notification
-            core.setOutput('notification_is_needed', 'true')
-          }
-    
-    - name: Send a Slack notification
-      if: ${{ steps.find-pull-requests.outputs.notification_is_needed == 'true' }}
-      uses: slackapi/slack-github-action@v1.27.0
-      env:
-        SLACK_BOT_TOKEN: ${{ env.SLACK_BOT_TOKEN }}
-      with:
-        channel-id: "-frontend-exp-team-notifications"
-        slack-message: ":x: <!here> There is stale Version Packages pull request in <https://github.com/toptal/picasso/pulls|Picasso>, review and merge it."
+            if (targetPR) {
+              // If there is at least one stale pull request, require notification
+              core.setOutput('notification_is_needed', 'true')
+            }
+      
+      - name: Send a Slack notification
+        if: ${{ steps.find-pull-requests.outputs.notification_is_needed == 'true' }}
+        uses: slackapi/slack-github-action@v1.27.0
+        env:
+          SLACK_BOT_TOKEN: ${{ env.SLACK_BOT_TOKEN }}
+        with:
+          channel-id: "-frontend-exp-team-notifications"
+          slack-message: ":x: <!here> There is stale Version Packages pull request in <https://github.com/toptal/picasso/pulls|Picasso>, review and merge it."

--- a/.github/workflows/notify-about-pending-release-pull-requests.yaml
+++ b/.github/workflows/notify-about-pending-release-pull-requests.yaml
@@ -1,4 +1,4 @@
-# Description: This workflow sends a Slack notification to the #frontend-exp-team-notifications channel
+# This workflow sends a Slack notification to the #frontend-exp-team-notifications channel
 # if there is a pending pull request with the title "Version Packages" that has been open for more than 3 hours.
 #
 # Use STALE_VERSION_PACKAGES_NOTIFICATION_SNOOZE_UNITL repository variable (https://github.com/toptal/picasso/settings/variables/actions)
@@ -98,4 +98,4 @@ jobs:
           SLACK_BOT_TOKEN: ${{ env.SLACK_BOT_TOKEN }}
         with:
           channel-id: "-frontend-exp-team-notifications"
-          slack-message: ":x: <!here> There is stale Version Packages pull request in <https://github.com/toptal/picasso/pulls|Picasso>, review and merge it."
+          slack-message: ":x: <!here> There is stale Version Packages pull request in <https://github.com/toptal/picasso/pulls|Picasso>, review and merge it. To snooze notifications, refer to the documentaion in the workflow code."


### PR DESCRIPTION
### Description

This pull request adds ability to snooze notifications via `STALE_VERSION_PACKAGES_NOTIFICATION_SNOOZE_UNITL` environment variable.

### Development checks

- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>
