### PR TITLE
[FX-4714] Delete bare props exports

### DIFF
--- a/.changeset/short-hornets-punch.md
+++ b/.changeset/short-hornets-punch.md
@@ -9,13 +9,8 @@
 '@toptal/picasso-form': major
 '@toptal/picasso': major
 '@toptal/picasso-forms': major
-'@toptal/picasso-tagselector': patch
 ---
 
 ### Autocomplete, FileInput, Checkbox, Tooltip, Switch, Input, Radio, Form
 
 - breaking change: components no longer export `Props` type. Import prop types as `component name + Props` (e.g. `AutocompleteProps`, `FileInputProps`, etc.)
-
-### TagSelector
-
-- fix `Props` import

--- a/.changeset/short-hornets-punch.md
+++ b/.changeset/short-hornets-punch.md
@@ -1,0 +1,15 @@
+---
+'@toptal/picasso-autocomplete': major
+'@toptal/picasso-file-input': major
+'@toptal/picasso-checkbox': major
+'@toptal/picasso-tooltip': major
+'@toptal/picasso-switch': major
+'@toptal/picasso-input': major
+'@toptal/picasso-radio': major
+'@toptal/picasso-form': major
+'@toptal/picasso': major
+---
+
+### Autocomplete, FileInput, Checkbox, Tooltip, Switch, Input, Radio, Form
+
+- breaking change: components no longer export `Props` type. Import prop types as `component name + Props` (e.g. `AutocompleteProps`, `FileInputProps`, etc.)

--- a/.changeset/short-hornets-punch.md
+++ b/.changeset/short-hornets-punch.md
@@ -9,8 +9,13 @@
 '@toptal/picasso-form': major
 '@toptal/picasso': major
 '@toptal/picasso-forms': major
+'@toptal/picasso-tagselector': patch
 ---
 
 ### Autocomplete, FileInput, Checkbox, Tooltip, Switch, Input, Radio, Form
 
 - breaking change: components no longer export `Props` type. Import prop types as `component name + Props` (e.g. `AutocompleteProps`, `FileInputProps`, etc.)
+
+### TagSelector
+
+- fix `Props` import

--- a/.changeset/short-hornets-punch.md
+++ b/.changeset/short-hornets-punch.md
@@ -8,6 +8,7 @@
 '@toptal/picasso-radio': major
 '@toptal/picasso-form': major
 '@toptal/picasso': major
+'@toptal/picasso-forms': major
 ---
 
 ### Autocomplete, FileInput, Checkbox, Tooltip, Switch, Input, Radio, Form

--- a/.changeset/short-hornets-ranch.md
+++ b/.changeset/short-hornets-ranch.md
@@ -1,0 +1,7 @@
+---
+'@toptal/picasso-tagselector': patch
+---
+
+### TagSelector
+
+- fix `Props` import

--- a/packages/base/Autocomplete/src/Autocomplete/index.ts
+++ b/packages/base/Autocomplete/src/Autocomplete/index.ts
@@ -4,5 +4,3 @@ import type { Props as OuterProps } from './Autocomplete'
 export { default as Autocomplete } from './Autocomplete'
 export * from './types'
 export type AutocompleteProps = OmitInternalProps<OuterProps>
-/** @deprecated [FX-4714] Use AutocompleteProps instead */
-export type Props = AutocompleteProps

--- a/packages/base/Checkbox/src/Checkbox/index.ts
+++ b/packages/base/Checkbox/src/Checkbox/index.ts
@@ -3,5 +3,3 @@ import type { OmitInternalProps } from '@toptal/picasso-shared'
 import type { Props as InternalCheckboxProps } from './Checkbox'
 export { default as Checkbox } from './Checkbox'
 export type CheckboxProps = OmitInternalProps<InternalCheckboxProps>
-/** @deprecated [FX-4714] Use CheckboxProps instead */
-export type Props = CheckboxProps

--- a/packages/base/FileInput/src/FileInput/index.ts
+++ b/packages/base/FileInput/src/FileInput/index.ts
@@ -4,5 +4,3 @@ import type { Props as InternalFileInputProps } from './FileInput'
 export { default as FileInput } from './FileInput'
 export * from './types'
 export type FileInputProps = OmitInternalProps<InternalFileInputProps>
-/** @deprecated [FX-4714] Use FileInputProps instead */
-export type Props = FileInputProps

--- a/packages/base/Form/src/Form/index.ts
+++ b/packages/base/Form/src/Form/index.ts
@@ -3,5 +3,3 @@ import type { OmitInternalProps } from '@toptal/picasso-shared'
 import type { Props as InternalFormProps } from './Form'
 export { default as Form } from './Form'
 export type FormProps = OmitInternalProps<InternalFormProps>
-/** @deprecated [FX-4714] Use FormProps instead */
-export type Props = FormProps

--- a/packages/base/Input/src/Input/index.ts
+++ b/packages/base/Input/src/Input/index.ts
@@ -3,5 +3,3 @@ import type { OmitInternalProps } from '@toptal/picasso-shared'
 import type { Props as InternalInputProps } from './Input'
 export { default as Input } from './Input'
 export type InputProps = OmitInternalProps<InternalInputProps>
-/** @deprecated [FX-4714] Use InputProps instead */
-export type Props = InputProps

--- a/packages/base/Radio/src/Radio/index.ts
+++ b/packages/base/Radio/src/Radio/index.ts
@@ -3,5 +3,3 @@ import type { OmitInternalProps } from '@toptal/picasso-shared'
 import type { Props as InternalRadioProps } from './Radio'
 export { default as Radio } from './Radio'
 export type RadioProps = OmitInternalProps<InternalRadioProps>
-/** @deprecated [FX-4714] Use RadioProps instead */
-export type Props = RadioProps

--- a/packages/base/Radio/src/RadioGroup/index.ts
+++ b/packages/base/Radio/src/RadioGroup/index.ts
@@ -3,5 +3,3 @@ import type { OmitInternalProps } from '@toptal/picasso-shared'
 import type { Props as InternalRadioGroupProps } from './RadioGroup'
 export { default as RadioGroup } from './RadioGroup'
 export type RadioGroupProps = OmitInternalProps<InternalRadioGroupProps>
-/** @deprecated [FX-4714] Use RadioGroupProps instead */
-export type Props = RadioGroupProps

--- a/packages/base/Switch/src/Switch/index.ts
+++ b/packages/base/Switch/src/Switch/index.ts
@@ -3,5 +3,3 @@ import type { OmitInternalProps } from '@toptal/picasso-shared'
 import type { Props as InternalSwitchProps } from './Switch'
 export { default as Switch } from './Switch'
 export type SwitchProps = OmitInternalProps<InternalSwitchProps>
-/** @deprecated [FX-4714] Use SwitchProps instead */
-export type Props = SwitchProps

--- a/packages/base/Tagselector/src/TagSelector/TagSelector.tsx
+++ b/packages/base/Tagselector/src/TagSelector/TagSelector.tsx
@@ -18,7 +18,7 @@ import type {
   AutocompleteProps,
   Item as AutocompleteItem,
 } from '@toptal/picasso-autocomplete'
-import type { Props as InputProps } from '@toptal/picasso-input'
+import type { InputProps } from '@toptal/picasso-input'
 import type { Status } from '@toptal/picasso-outlined-input'
 
 import { TagSelectorInput } from '../TagSelectorInput'

--- a/packages/base/Tagselector/src/TagSelectorInput/TagSelectorInput.tsx
+++ b/packages/base/Tagselector/src/TagSelectorInput/TagSelectorInput.tsx
@@ -2,7 +2,7 @@ import React, { forwardRef } from 'react'
 import cx from 'classnames'
 import { OutlinedInput } from '@toptal/picasso-outlined-input'
 import { usePropDeprecationWarning } from '@toptal/picasso-utils'
-import type { Props as InputProps } from '@toptal/picasso-input'
+import type { InputProps } from '@toptal/picasso-input'
 
 export const TagSelectorInput = forwardRef<HTMLInputElement, InputProps>(
   function TagSelectorInput(props, ref) {

--- a/packages/base/Tooltip/src/Tooltip/index.ts
+++ b/packages/base/Tooltip/src/Tooltip/index.ts
@@ -4,5 +4,3 @@ import type { Props as InternalTooltipProps } from './Tooltip'
 export { default as Tooltip } from './Tooltip'
 export type TooltipProps = OmitInternalProps<InternalTooltipProps>
 export type { DelayType, MaxWidthType, PlacementType } from './Tooltip'
-/** @deprecated [FX-4714] Use TooltipProps instead */
-export type Props = TooltipProps


### PR DESCRIPTION
[FX-4714]

### Description

This pull request deletes previously deprecated exports of plain `Props`.

### How to test

<!-- The temploy link will be automatically updated when the temploy is deployed -->
- [Temploy](https://picasso.toptal.net/fx-4714-remove-bare-props-inner-exports)
- All checks should pass

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Self reviewed

**Breaking change**

- [N/A] codemod is created and showcased in the changeset
- [N/A] test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-4714]: https://toptal-core.atlassian.net/browse/FX-4714?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ