### PR TITLE
[FX-5841] Fix disabled state color 

### DIFF
--- a/.changeset/gentle-toes-deliver.md
+++ b/.changeset/gentle-toes-deliver.md
@@ -1,0 +1,5 @@
+---
+'@toptal/picasso-rich-text-editor': patch
+---
+
+- fix background and border color for disabled state

--- a/.changeset/nasty-crews-own.md
+++ b/.changeset/nasty-crews-own.md
@@ -1,0 +1,5 @@
+---
+'@toptal/picasso-dropzone': patch
+---
+
+- fix background and text color for disabled state

--- a/.changeset/purple-worms-agree.md
+++ b/.changeset/purple-worms-agree.md
@@ -1,0 +1,5 @@
+---
+'@toptal/picasso-form': minor
+---
+
+- component `FormHint` got new prop `disabled`

--- a/.changeset/soft-insects-sparkle.md
+++ b/.changeset/soft-insects-sparkle.md
@@ -1,0 +1,5 @@
+---
+'@toptal/picasso-outlined-input': patch
+---
+
+- fix background and border color for disabled state

--- a/packages/base/Dropzone/src/Dropzone/Dropzone.tsx
+++ b/packages/base/Dropzone/src/Dropzone/Dropzone.tsx
@@ -88,7 +88,7 @@ const getBorderColorClasses: StateToClassMatcher = ({
 }
 
 const getBackgroundColorClasses: StateToClassMatcher = ({ isDisabled }) =>
-  isDisabled ? 'bg-gray-100' : 'bg-white'
+  isDisabled ? 'bg-gray-200' : 'bg-white'
 
 export const Dropzone = forwardRef<HTMLInputElement, Props>(function Dropzone(
   props,
@@ -157,7 +157,6 @@ export const Dropzone = forwardRef<HTMLInputElement, Props>(function Dropzone(
         className={twJoin(
           'border border-dashed',
           'box-border',
-          'text-graphite-700',
           'gap-2',
           'transition-all ease-out duration-350',
           getCursorClasses(componentState),
@@ -169,12 +168,19 @@ export const Dropzone = forwardRef<HTMLInputElement, Props>(function Dropzone(
         <input {...getInputProps()} />
         <Upload24 color='darkGrey' />
         {!hideContentText && (
-          <Typography size='medium' color='black' weight='semibold'>
+          <Typography
+            size='medium'
+            color={isDisabled ? 'grey-main-2' : 'black'}
+            weight='semibold'
+          >
             Click or drag to upload
           </Typography>
         )}
         {hint && (
-          <FormHint className={twJoin('m-0', '[&>*]:leading-4')}>
+          <FormHint
+            className={twJoin('m-0', '[&>*]:leading-4')}
+            disabled={isDisabled}
+          >
             {hint}
           </FormHint>
         )}

--- a/packages/base/Dropzone/src/Dropzone/__snapshots__/test.tsx.snap
+++ b/packages/base/Dropzone/src/Dropzone/__snapshots__/test.tsx.snap
@@ -10,7 +10,7 @@ exports[`Dropzone renders 1`] = `
     >
       <div
         aria-disabled="false"
-        class="p-6 items-center rounded-md flex flex-col border border-dashed box-border text-graphite gap-2 transition-all ease-out duration-350 hover:cursor-pointer focus:cursor-pointer border-gray hover:border-blue focus:border-blue bg-white"
+        class="p-6 items-center rounded-md flex flex-col border border-dashed box-border gap-2 transition-all ease-out duration-350 hover:cursor-pointer focus:cursor-pointer border-gray hover:border-blue focus:border-blue bg-white"
         role="presentation"
         tabindex="0"
       >

--- a/packages/base/Form/src/FormHint/FormHint.tsx
+++ b/packages/base/Form/src/FormHint/FormHint.tsx
@@ -7,13 +7,15 @@ import { twMerge } from '@toptal/picasso-tailwind-merge'
 export interface Props extends BaseProps, HTMLAttributes<HTMLDivElement> {
   /** The text of the hint */
   children: ReactNode
+  /** Whether the FormHint is disabled */
+  disabled?: boolean
 }
 
 export const FormHint = forwardRef<HTMLDivElement, Props>(function FormHint(
   props,
   ref
 ) {
-  const { children, className, style, ...rest } = props
+  const { children, className, style, disabled, ...rest } = props
 
   return (
     <div
@@ -22,7 +24,9 @@ export const FormHint = forwardRef<HTMLDivElement, Props>(function FormHint(
       className={twMerge('mt-1', className)}
       style={style}
     >
-      <Typography size='xxsmall'>{children}</Typography>
+      <Typography size='xxsmall' color={disabled ? 'grey-main-2' : undefined}>
+        {children}
+      </Typography>
     </div>
   )
 })

--- a/packages/base/OutlinedInput/src/OutlinedInput/stylesRoot.ts
+++ b/packages/base/OutlinedInput/src/OutlinedInput/stylesRoot.ts
@@ -29,7 +29,7 @@ export const cursorClass = {
 }
 
 export const bgClasses = {
-  disabled: 'bg-gray-100',
+  disabled: 'bg-gray-200',
   dark: 'bg-[#081237]',
   highlight: 'bg-yellow-100/60',
   default: 'bg-white',
@@ -63,7 +63,7 @@ export const borderPseudoClassesByState = {
   borderColor: {
     dark: '',
     default: ['after:border-gray-400', '[&:has(:focus)]:after:border-blue-500'],
-    disabled: 'after:border-gray-200',
+    disabled: 'after:border-gray-400',
     error: ['after:border-red-500', '[&:has(:focus)]:after:border-red-500'],
     hoverWithoutFocus: 'hover:[&:not(:has(:focus))]:after:border-gray-600',
   },

--- a/packages/picasso-rich-text-editor/src/RichTextEditor/styles.ts
+++ b/packages/picasso-rich-text-editor/src/RichTextEditor/styles.ts
@@ -19,8 +19,8 @@ export default (theme: Theme) => {
 
     disabled: {
       pointerEvents: 'none',
-      background: palette.grey.lighter,
-      border: `1px solid ${palette.grey.lighter2}`,
+      background: palette.grey.lighter2,
+      border: `1px solid ${palette.grey.light2}`,
     },
 
     error: {


### PR DESCRIPTION
[FX-5841]

### Description

Disabled state colors were not aligned with designs. This PR fixes this. 

### How to test

<!-- The temploy link will be automatically updated when the temploy is deployed -->
- [Temploy](https://picasso.toptal.net/fx-5841-fix-disabled-state-color)

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| ![image](https://github.com/user-attachments/assets/fecb0737-a165-4845-a9c8-2b57a734cfef) | ![image](https://github.com/user-attachments/assets/717976fb-7534-4ba2-a2e2-884a44047782) |
| ![image](https://github.com/user-attachments/assets/77eb01ce-8612-46a9-b66c-a19af5203241) | ![image](https://github.com/user-attachments/assets/a82addea-47ef-4405-a7d7-398924112e2b) |
| ![image](https://github.com/user-attachments/assets/4aae6df8-2186-453e-9671-28155bdd4231) | ![image](https://github.com/user-attachments/assets/81e2a65a-a610-45a3-b36c-d696b7e30651) |
| ![image](https://github.com/user-attachments/assets/2a9b4207-36f8-49a1-a330-8dc7d4c0d3ce) | ![image](https://github.com/user-attachments/assets/c8a59350-3dec-41aa-9dc8-f84a309bdf9d) |
| ![image](https://github.com/user-attachments/assets/7779049e-c5ac-4e8c-844b-095406cd0f47) | ![image](https://github.com/user-attachments/assets/a9b377f8-96f3-4627-b3a4-73b9b030d28a) |
| ![image](https://github.com/user-attachments/assets/f26943fe-c436-4b50-abf8-ac7db32211eb) | ![image](https://github.com/user-attachments/assets/b9a5db93-61d2-408a-8228-b43064da187e) |
| ![image](https://github.com/user-attachments/assets/c2a677c4-693e-44c0-ad4e-46ebfa059c34) | ![image](https://github.com/user-attachments/assets/e8f96b60-4f1d-4918-8b63-40d9730e0921) |

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Double check if `picasso-tailwind-merge` requires major update (check its `README.md`)
- ~Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)~
- [x] Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [x] Annotate all `props` in component with documentation
- ~Create `examples` for component~
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- ~Covered with tests ([visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md) included)~

**Breaking change**

- ~codemod is created and showcased in the changeset
- ~test alpha package of Picasso in StaffPortal~

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-5841]: https://toptal-core.atlassian.net/browse/FX-5841?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ