### PR TITLE
[FX-NULL] Do not render dropdown when options are empty

### DIFF
--- a/.changeset/friendly-scissors-explain.md
+++ b/.changeset/friendly-scissors-explain.md
@@ -1,0 +1,5 @@
+---
+'@toptal/picasso-autocomplete': patch
+---
+
+- do not render options dropdown when options is null or undefined

--- a/packages/base/Autocomplete/src/Autocomplete/OptionsMenu.tsx
+++ b/packages/base/Autocomplete/src/Autocomplete/OptionsMenu.tsx
@@ -120,17 +120,13 @@ const OptionsMenu = ({
   }
 
   return (
-    options && (
-      <SelectOptions
-        data-testid={testIds?.scrollMenu}
-        selectedIndex={highlightedIndex}
-        fixedFooter={
-          optionsLength > 0 && poweredByGoogle && <PoweredByGoogle />
-        }
-      >
-        {menuItems}
-      </SelectOptions>
-    )
+    <SelectOptions
+      data-testid={testIds?.scrollMenu}
+      selectedIndex={highlightedIndex}
+      fixedFooter={optionsLength > 0 && poweredByGoogle && <PoweredByGoogle />}
+    >
+      {menuItems}
+    </SelectOptions>
   )
 }
 

--- a/packages/base/Autocomplete/src/Autocomplete/OptionsMenu.tsx
+++ b/packages/base/Autocomplete/src/Autocomplete/OptionsMenu.tsx
@@ -115,18 +115,22 @@ const OptionsMenu = ({
     )
   }
 
-  if (menuItems.length === 0) {
+  if (menuItems.length === 0 || !options) {
     return null
   }
 
   return (
-    <SelectOptions
-      data-testid={testIds?.scrollMenu}
-      selectedIndex={highlightedIndex}
-      fixedFooter={optionsLength > 0 && poweredByGoogle && <PoweredByGoogle />}
-    >
-      {menuItems}
-    </SelectOptions>
+    options && (
+      <SelectOptions
+        data-testid={testIds?.scrollMenu}
+        selectedIndex={highlightedIndex}
+        fixedFooter={
+          optionsLength > 0 && poweredByGoogle && <PoweredByGoogle />
+        }
+      >
+        {menuItems}
+      </SelectOptions>
+    )
   )
 }
 

--- a/packages/base/Autocomplete/src/Autocomplete/test.tsx
+++ b/packages/base/Autocomplete/src/Autocomplete/test.tsx
@@ -562,6 +562,21 @@ describe('Autocomplete', () => {
       expect(myOtherOption).not.toBeNull()
       expect(myOtherOption).toMatchSnapshot()
     })
+
+    describe('when options is null', () => {
+      it('does not render dropdown', async () => {
+        const { getByTestId, queryByText } = renderAutocomplete({
+          options: null,
+          value: 'Ruby',
+        })
+
+        const input = getByTestId('autocomplete') as HTMLInputElement
+
+        fireEvent.change(input, { target: { value: '' } })
+
+        expect(queryByText('No options')).not.toBeInTheDocument()
+      })
+    })
   })
 
   describe('Autofill', () => {


### PR DESCRIPTION
### Description

This pull request returns the important condition omitted in https://github.com/toptal/picasso/pull/4534 during refactoring. 

Some consumers rely on dropdown not to be shown when `options` is set to `null` or `undefined` (for example, [here](https://github.com/toptal/staff-portal/blob/3c0c9ebfc1dd6bfe36bc50c0929bc6dcc3f5b99a/namespaces/gigs/libs/gigs/src/components/RequestSkills/components/SearchInput/SearchInput.tsx#L110)). Some Staff Portal Jest and Cypress tests started failing so the expected behavior is back.

Example of failing test that does not expect dropdown to be visible (the test fails to click covered `Save` button)

https://github.com/user-attachments/assets/9d4364bc-eabc-4198-85c5-df5ae323d969


### How to test

<!-- The temploy link will be automatically updated when the temploy is deployed -->
- [Temploy](https://picasso.toptal.net/FX-NULL-fix-options-rendering)
- Staff Portal pull request is green with alpha packages in https://github.com/toptal/staff-portal/pull/13716

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [N/A] Double check if `picasso-tailwind-merge` requires major update (check its `README.md`)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [N/A] Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [N/A] Annotate all `props` in component with documentation
- [N/A] Create `examples` for component
- [N/A] Ensure that deployed demo has expected results and good examples
- [N/A] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests ([visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md) included)

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>
