### PR TITLE
[FX-5973] Update tag to span

### DIFF
--- a/.changeset/eighty-eagles-warn.md
+++ b/.changeset/eighty-eagles-warn.md
@@ -1,0 +1,6 @@
+---
+'@toptal/picasso-tag': patch
+'@toptal/picasso': patch
+---
+
+- update HTML tag of Tag.Rectangular to span

--- a/packages/base/Tag/src/TagRectangular/TagRectangular.tsx
+++ b/packages/base/Tag/src/TagRectangular/TagRectangular.tsx
@@ -48,6 +48,7 @@ export const TagRectangular = forwardRef<HTMLDivElement, Props>(
             variant === 'light-grey' ? 'text-graphite-800' : 'text-white'
           )}
           titleCase={titleCase}
+          as='span'
         >
           {children}
         </Typography>

--- a/packages/base/Tag/src/TagRectangular/__snapshots__/test.tsx.snap
+++ b/packages/base/Tag/src/TagRectangular/__snapshots__/test.tsx.snap
@@ -8,11 +8,11 @@ exports[`TagRectangular renders rectangular Tag 1`] = `
     <div
       class="text-lg transition-none rounded-sm font-semibold h-4 inline-flex content-center justify-center align-middle bg-gray"
     >
-      <p
+      <span
         class="m-0 text-2xs font-semibold whitespace-nowrap overflow-ellipsis overflow-hidden mx-1 w-max text-graphite"
       >
         Reactangular Tag
-      </p>
+      </span>
     </div>
   </div>
 </div>


### PR DESCRIPTION
[FX-5973]

### Description

As we allow pass ReactNode to the `Tag.Rectangular`, users have errors when passing something else than span, because different tags cannot be rendered inside paragraph. `Tag` is also rendered as a span.

### How to test

<!-- The temploy link will be automatically updated when the temploy is deployed -->
- [Temploy](https://picasso.toptal.net/fx-5973-tag)
- FIXME: Add the steps describing how to verify your changes

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| Insert screenshots or screen recordings | Insert screenshots or screen recordings |

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- Double check if `picasso-tailwind-merge` requires major update (check its `README.md`)
- Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- Annotate all `props` in component with documentation
- Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- Covered with tests ([visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md) included)

**Breaking change**

- codemod is created and showcased in the changeset
- test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-5973]: https://toptal-core.atlassian.net/browse/FX-5973?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ