### PR TITLE
[FX-5974] Fix disabled state when compact and collapsible

### DIFF
--- a/.changeset/curly-mails-admire.md
+++ b/.changeset/curly-mails-admire.md
@@ -1,0 +1,8 @@
+---
+'@toptal/picasso-dropdown': minor
+'@toptal/picasso': minor
+---
+
+### Dropdown
+
+- support disabled state

--- a/.changeset/four-drinks-wonder.md
+++ b/.changeset/four-drinks-wonder.md
@@ -1,0 +1,8 @@
+---
+'@toptal/picasso-page': patch
+'@toptal/picasso': patch
+---
+
+### PageSidebar
+
+- fix disabled state for collapsible compact sidebar item

--- a/packages/base/Dropdown/src/Dropdown/Dropdown.tsx
+++ b/packages/base/Dropdown/src/Dropdown/Dropdown.tsx
@@ -37,6 +37,8 @@ interface InternalProps
   content: ReactNode
   /** The placement of the content element relative to anchor element. */
   placement?: PopperPlacementType
+  /** Disabled */
+  disabled?: boolean
   /** Disable auto focus of first item in list or item */
   disableAutoFocus?: boolean
   /** Disable close on generic close events */
@@ -131,6 +133,7 @@ export const Dropdown: DropdownProps = forwardRef<
     content,
     offset,
     placement,
+    disabled,
     disableAutoClose,
     disableAutoFocus,
     disablePortal,
@@ -258,8 +261,11 @@ export const Dropdown: DropdownProps = forwardRef<
       style={style}
     >
       <div
-        className='inline-flex items-center cursor-pointer'
-        onClick={handleAnchorClick}
+        className={twJoin(
+          'inline-flex items-center',
+          disabled ? 'pointer-events-none' : 'cursor-pointer'
+        )}
+        onClick={disabled ? () => {} : handleAnchorClick}
       >
         {typeof children === 'function' ? children({ isOpen }) : children}
       </div>

--- a/packages/base/Page/src/SidebarItem/SidebarItemCompact.tsx
+++ b/packages/base/Page/src/SidebarItem/SidebarItemCompact.tsx
@@ -17,7 +17,7 @@ const useStyles = makeStyles<Theme>(styles, {
 
 export const SidebarItemCompact = forwardRef<HTMLElement, Props>(
   function CompactSidebarItem(props: Props, ref) {
-    const { menu, index, compact, icon } = props
+    const { menu, index, compact, icon, disabled } = props
     const [isOpened, handleOpen, handleClose] = useOpen()
     const classes = useStyles()
 
@@ -35,6 +35,7 @@ export const SidebarItemCompact = forwardRef<HTMLElement, Props>(
         <Container left='small' right='small'>
           <Dropdown
             classes={{ popper: classes.compactDropdown }}
+            disabled={disabled}
             placement='right-start'
             content={subMenu}
             keepMounted

--- a/packages/base/Page/src/SidebarItem/story/WithBadgeAndTag.example.tsx
+++ b/packages/base/Page/src/SidebarItem/story/WithBadgeAndTag.example.tsx
@@ -51,6 +51,7 @@ const Menu = () => (
     <Page.Sidebar.Item
       collapsible
       icon={<AddDocument16 />}
+      disabled
       menu={
         <Page.Sidebar.Menu>
           <Page.Sidebar.Item badge={5} tag='New'>


### PR DESCRIPTION
[FX-5974]

### Description

Issue well described here https://toptal-core.slack.com/archives/CERF5NHT3/p1726711479310889

### How to test

<!-- The temploy link will be automatically updated when the temploy is deployed -->
- [Temploy](https://picasso.toptal.net/fx-5974-sidebar-item)
- FIXME: Add the steps describing how to verify your changes

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| Insert screenshots or screen recordings | Insert screenshots or screen recordings |

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- Double check if `picasso-tailwind-merge` requires major update (check its `README.md`)
- Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- Covered with tests ([visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md) included)

**Breaking change**

- codemod is created and showcased in the changeset
- test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-5974]: https://toptal-core.atlassian.net/browse/FX-5974?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ