### PR TITLE
[FX-5908] Fix initial position of Slider

### DIFF
--- a/.changeset/thick-peaches-build.md
+++ b/.changeset/thick-peaches-build.md
@@ -1,0 +1,8 @@
+---
+'@toptal/picasso-slider': patch
+'@toptal/picasso': patch
+---
+
+### Slider
+
+- fix initial position of Tooltip

--- a/.changeset/tiny-news-compete.md
+++ b/.changeset/tiny-news-compete.md
@@ -1,0 +1,5 @@
+---
+'@toptal/picasso-carousel': patch
+---
+
+- refactor useOnScreen usage after the breaking change

--- a/.changeset/twelve-years-play.md
+++ b/.changeset/twelve-years-play.md
@@ -1,0 +1,13 @@
+---
+'@toptal/picasso-utils': major
+'@toptal/picasso': major
+---
+
+### useOnScreen
+
+- change return value of the hook to let component know when the oberver starts observing
+
+```diff
+-const isOnScreen = useOnScreen({...})
++const { isOnScreen, isObserved } = useOnScreen({...})
+```

--- a/cypress/component/Slider.spec.tsx
+++ b/cypress/component/Slider.spec.tsx
@@ -36,6 +36,7 @@ describe('Slider', () => {
   it('renders range with tooltips intersect', () => {
     cy.mount(<TestSlider value={[10, 11]} tooltipFormat={renderLabel} />)
 
+    cy.contains('GMT+10:00').should('be.visible')
     cy.get('body').happoScreenshot({
       component,
       variant: 'range/when-tooltip-intersect',

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,2 +1,27 @@
+
+
+// Mock for IntersectionObserver
+class IntersectionObserverMock {
+  constructor(callback) {
+    this.callback = callback;
+    this.observables = [];
+  }
+
+  observe(element) {
+    this.observables.push(element);
+    this.callback([{ isIntersecting: true, target: element }]); // Customize as needed
+  }
+
+  unobserve(element) {
+    this.observables = this.observables.filter(obs => obs !== element);
+  }
+
+  disconnect() {
+    this.observables = [];
+  }
+}
+
+// Mock global IntersectionObserver
+global.IntersectionObserver = IntersectionObserverMock;
 global.TextEncoder = require('util').TextEncoder;
 global.TextDecoder = require('util').TextDecoder;

--- a/packages/base/Carousel/src/Carousel/hooks/useAutoplay/use-autoplay.ts
+++ b/packages/base/Carousel/src/Carousel/hooks/useAutoplay/use-autoplay.ts
@@ -17,7 +17,7 @@ const useAutoplay = ({
   rewind,
   isLastPage,
 }: Props) => {
-  const isOnScreen = useOnScreen({ ref: wrapperRef })
+  const { isOnScreen } = useOnScreen({ ref: wrapperRef })
   const isMouseOver = useMouseEnter(wrapperRef)
 
   useInterval({

--- a/packages/base/Slider/src/Slider/Slider.tsx
+++ b/packages/base/Slider/src/Slider/Slider.tsx
@@ -1,5 +1,5 @@
 // import type { ComponentProps } from 'react'
-import React, { forwardRef, useRef } from 'react'
+import React, { forwardRef, useEffect, useRef } from 'react'
 import { Slider as MUIBaseSlider } from '@mui/base/Slider'
 import { useCombinedRefs, useOnScreen } from '@toptal/picasso-utils'
 import { twJoin, twMerge } from '@toptal/picasso-tailwind-merge'
@@ -66,7 +66,7 @@ export const Slider = forwardRef<HTMLElement, Props>(function Slider(
     marks,
     value,
     defaultValue = 0,
-    tooltip = 'off',
+    tooltip: externalTooltip = 'off',
     tooltipFormat,
     step,
     disabled,
@@ -82,6 +82,7 @@ export const Slider = forwardRef<HTMLElement, Props>(function Slider(
     'data-private': dataPrivate,
     'data-testid': dataTestid,
   } = props
+  const [tooltip, setTooltip] = React.useState('off')
   const containerRef = useRef<HTMLDivElement>(null)
   const sliderRef = useCombinedRefs<HTMLElement>(ref, useRef<HTMLElement>(null))
   const { isPartiallyOverlapped, handleValueLabelOnRender } = useLabelOverlap({
@@ -93,11 +94,17 @@ export const Slider = forwardRef<HTMLElement, Props>(function Slider(
 
   // The rootMargin is not working correctly in the storybooks iframe
   // To test properly we can open the iframe in new window
-  const isContainerOnScreen = useOnScreen({
+  const { isOnScreen, isObserved } = useOnScreen({
     ref: containerRef,
     rootMargin: '-24px 0px 0px 0px',
     threshold: 1,
   })
+
+  useEffect(() => {
+    if (containerRef.current) {
+      setTooltip(externalTooltip)
+    }
+  }, [externalTooltip])
 
   return (
     <div
@@ -153,9 +160,9 @@ export const Slider = forwardRef<HTMLElement, Props>(function Slider(
             ),
           },
           valueLabel: {
-            tooltip,
+            tooltip: isObserved ? tooltip : 'off',
             onRender: handleValueLabelOnRender,
-            yPlacement: isContainerOnScreen ? 'top' : 'bottom',
+            yPlacement: isOnScreen ? 'top' : 'bottom',
             isOverlaped: isPartiallyOverlapped,
           },
         }}

--- a/packages/base/Slider/src/Slider/Slider.tsx
+++ b/packages/base/Slider/src/Slider/Slider.tsx
@@ -1,5 +1,5 @@
 // import type { ComponentProps } from 'react'
-import React, { forwardRef, useEffect, useRef } from 'react'
+import React, { forwardRef, useRef } from 'react'
 import { Slider as MUIBaseSlider } from '@mui/base/Slider'
 import { useCombinedRefs, useOnScreen } from '@toptal/picasso-utils'
 import { twJoin, twMerge } from '@toptal/picasso-tailwind-merge'
@@ -66,7 +66,7 @@ export const Slider = forwardRef<HTMLElement, Props>(function Slider(
     marks,
     value,
     defaultValue = 0,
-    tooltip: externalTooltip = 'off',
+    tooltip = 'off',
     tooltipFormat,
     step,
     disabled,
@@ -82,15 +82,8 @@ export const Slider = forwardRef<HTMLElement, Props>(function Slider(
     'data-private': dataPrivate,
     'data-testid': dataTestid,
   } = props
-  const [tooltip, setTooltip] = React.useState('off')
   const containerRef = useRef<HTMLDivElement>(null)
   const sliderRef = useCombinedRefs<HTMLElement>(ref, useRef<HTMLElement>(null))
-  const { isPartiallyOverlapped, handleValueLabelOnRender } = useLabelOverlap({
-    value,
-  })
-
-  const isThumbHidden =
-    hideThumbOnEmpty && (typeof value === 'undefined' || value === null)
 
   // The rootMargin is not working correctly in the storybooks iframe
   // To test properly we can open the iframe in new window
@@ -100,11 +93,14 @@ export const Slider = forwardRef<HTMLElement, Props>(function Slider(
     threshold: 1,
   })
 
-  useEffect(() => {
-    if (containerRef.current) {
-      setTooltip(externalTooltip)
-    }
-  }, [externalTooltip])
+  const { isPartiallyOverlapped, handleValueLabelOnRender } = useLabelOverlap({
+    value,
+    // until IntersectionObserver starts observing the element, we don't render the tooltip
+    isTooltipRendered: isObserved,
+  })
+
+  const isThumbHidden =
+    hideThumbOnEmpty && (typeof value === 'undefined' || value === null)
 
   return (
     <div

--- a/packages/base/Slider/src/Slider/__snapshots__/test.tsx.snap
+++ b/packages/base/Slider/src/Slider/__snapshots__/test.tsx.snap
@@ -35,7 +35,7 @@ exports[`Slider renders 1`] = `
           value="0"
         />
         <span
-          class="absolute will-change transition-transform hidden top-[calc(100%+2px)] left-[calc(100%-13px)]"
+          class="absolute will-change transition-transform hidden bottom-[calc(100%+2px)] left-[calc(100%-13px)]"
         >
           <span
             class="shadow-4 text-sm text-white bg-graphite m-1 rounded-sm py-[2px] px-2 max-w break-words"
@@ -84,7 +84,7 @@ exports[`Slider with initial value 1`] = `
           value="4"
         />
         <span
-          class="absolute will-change transition-transform hidden top-[calc(100%+2px)] left-[calc(100%-13px)]"
+          class="absolute will-change transition-transform hidden bottom-[calc(100%+2px)] left-[calc(100%-13px)]"
         >
           <span
             class="shadow-4 text-sm text-white bg-graphite m-1 rounded-sm py-[2px] px-2 max-w break-words"

--- a/packages/base/Slider/src/Slider/hooks/use-label-overlap.ts
+++ b/packages/base/Slider/src/Slider/hooks/use-label-overlap.ts
@@ -3,7 +3,13 @@ import { useCallback, useEffect, useState } from 'react'
 
 import { checkOverlap } from '../../utils'
 
-export const useLabelOverlap = ({ value }: { value?: number | number[] }) => {
+export const useLabelOverlap = ({
+  value,
+  isTooltipRendered,
+}: {
+  value?: number | number[]
+  isTooltipRendered: boolean
+}) => {
   const [isPartiallyOverlapped, setIsPartiallyOverlapped] = useState(false)
   const [valueLabels, setValueLabels] = useState<RefObject<HTMLSpanElement>[]>(
     []
@@ -11,7 +17,7 @@ export const useLabelOverlap = ({ value }: { value?: number | number[] }) => {
   const isRangeSlider = Array.isArray(value)
 
   useEffect(() => {
-    if (!isRangeSlider) {
+    if (!isRangeSlider || !isTooltipRendered) {
       return
     }
     const isFullyOverlaped = value[0] === value[1]
@@ -31,7 +37,13 @@ export const useLabelOverlap = ({ value }: { value?: number | number[] }) => {
         })
       )
     }
-  }, [value, isRangeSlider, isPartiallyOverlapped, valueLabels])
+  }, [
+    value,
+    isRangeSlider,
+    isPartiallyOverlapped,
+    valueLabels,
+    isTooltipRendered,
+  ])
 
   const handleValueLabelOnRender = useCallback(
     (index: number, labelRef: RefObject<HTMLSpanElement>) => {

--- a/packages/base/Slider/src/Slider/story/Default.example.tsx
+++ b/packages/base/Slider/src/Slider/story/Default.example.tsx
@@ -1,16 +1,18 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { Container, Slider } from '@toptal/picasso'
 
 type Value = number | number[]
 
 const Example = () => {
-  const handleChange = (_: React.ChangeEvent<{}>, value: Value) => {
-    window.console.log('onChange: ', value)
+  const [value, setValue] = useState<Value>(0)
+
+  const handleChange = (_: Event, newValue: Value) => {
+    setValue(newValue)
   }
 
   return (
     <Container>
-      <Slider onChange={handleChange} />
+      <Slider value={value} onChange={handleChange} />
     </Container>
   )
 }

--- a/packages/base/Slider/src/Slider/test.tsx
+++ b/packages/base/Slider/src/Slider/test.tsx
@@ -1,29 +1,23 @@
-import type { ReactNode } from 'react'
 import { describe, expect, it } from '@jest/globals'
 import React from 'react'
 import type { RenderResult } from '@testing-library/react'
 import { render } from '@testing-library/react'
 import type { OmitInternalProps } from '@toptal/picasso-shared'
 
-jest.mock('@toptal/picasso-utils', () => ({
-  ...jest.requireActual('@toptal/picasso-utils'),
-  useOnScreen: jest.fn().mockRejectedValueOnce(true),
-}))
-
 import type { Props } from './Slider'
 import { Slider } from './Slider'
 
-const renderSlider = (children: ReactNode, props: OmitInternalProps<Props>) => {
+const renderSlider = (props: OmitInternalProps<Props>) => {
   const { value } = props
 
-  return render(<Slider value={value}>{children}</Slider>)
+  return render(<Slider value={value} />)
 }
 
 describe('Slider', () => {
   let api: RenderResult
 
   beforeEach(() => {
-    api = renderSlider(null, {})
+    api = renderSlider({})
   })
 
   it('renders', () => {
@@ -33,7 +27,7 @@ describe('Slider', () => {
   })
 
   it('with initial value', () => {
-    const { container } = renderSlider(null, { value: 4 })
+    const { container } = renderSlider({ value: 4 })
 
     expect(container).toMatchSnapshot()
   })

--- a/packages/base/Slider/src/SliderValueLabel/SliderValueLabel.tsx
+++ b/packages/base/Slider/src/SliderValueLabel/SliderValueLabel.tsx
@@ -67,7 +67,7 @@ const SliderValueLabel = ({
       })
     )
     // we need to recalculate on value change to get new rect
-  }, [isOverlaped, index, xPlacement, value])
+  }, [isOverlaped, index, xPlacement, value, tooltip])
 
   return (
     <span

--- a/packages/base/Slider/src/SliderValueLabel/SliderValueLabel.tsx
+++ b/packages/base/Slider/src/SliderValueLabel/SliderValueLabel.tsx
@@ -67,7 +67,7 @@ const SliderValueLabel = ({
       })
     )
     // we need to recalculate on value change to get new rect
-  }, [isOverlaped, index, xPlacement, value, tooltip])
+  }, [isOverlaped, index, xPlacement, value])
 
   return (
     <span

--- a/packages/base/Utils/src/utils/useOnScreen/use-on-screen.ts
+++ b/packages/base/Utils/src/utils/useOnScreen/use-on-screen.ts
@@ -13,13 +13,15 @@ const useOnScreen = ({
   rootMargin,
   threshold,
 }: UseOnScreenProps) => {
-  const [isIntersecting, setIntersecting] = useState(false)
+  const [isOnScreen, setIntersecting] = useState(false)
+  const [isObserved, setObserved] = useState(false)
 
   const observer = useMemo(
     () =>
       new IntersectionObserver(
         ([entry]) => {
           setIntersecting(entry.isIntersecting)
+          setObserved(true)
         },
         {
           root: root?.current,
@@ -44,7 +46,7 @@ const useOnScreen = ({
     }
   }, [observer, ref])
 
-  return isIntersecting
+  return { isOnScreen, isObserved }
 }
 
 export default useOnScreen

--- a/packages/base/Utils/src/utils/useOnScreen/use-on-screen.ts
+++ b/packages/base/Utils/src/utils/useOnScreen/use-on-screen.ts
@@ -13,14 +13,14 @@ const useOnScreen = ({
   rootMargin,
   threshold,
 }: UseOnScreenProps) => {
-  const [isOnScreen, setIntersecting] = useState(false)
+  const [isOnScreen, setIsOnScreen] = useState(false)
   const [isObserved, setObserved] = useState(false)
 
   const observer = useMemo(
     () =>
       new IntersectionObserver(
         ([entry]) => {
-          setIntersecting(entry.isIntersecting)
+          setIsOnScreen(entry.isIntersecting)
           setObserved(true)
         },
         {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -3,7 +3,10 @@
 
 /** @type {import('tailwindcss').Config} */
 module.exports = {
-  content: ['packages/**/*.{ts,tsx}'],
+  content: [
+    'packages/base/*/src/**/*.{ts,tsx}',
+    'packages/*/src/**/*.{ts,tsx}',
+  ],
   presets: [
     require('@toptal/base-tailwind'),
     require('@toptal/picasso-tailwind'),


### PR DESCRIPTION
[FX-5908]

### Description

Fix initial position of Slider when rendered directly on visible screen. `useOnScreen` is returning `false` by default, so before the `IntersectionObserver` actually starts observing, the tooltip blinks from the bottom to the top. I enhanced the hook to also return `isObserved`, so the component can check if the returned value is correct.

### How to test

<!-- The temploy link will be automatically updated when the temploy is deployed -->
- [Temploy](https://picasso.toptal.net/fx-5908-slider)
- Go to the slider default story and add `tooltip='on'`
- there should not be any jumping of the tooltip

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| Insert screenshots or screen recordings | Insert screenshots or screen recordings |

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- Double check if `picasso-tailwind-merge` requires major update (check its `README.md`)
- Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- Annotate all `props` in component with documentation
- Create `examples` for component
- Ensure that deployed demo has expected results and good examples
- Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- Covered with tests ([visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md) included)

**Breaking change**

- codemod is created and showcased in the changeset
- test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-5908]: https://toptal-core.atlassian.net/browse/FX-5908?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ