### PR TITLE
[FX-6047] Fix UserBadge padding in PageTopBarMenu

### DIFF
--- a/.changeset/four-fishes-kneel.md
+++ b/.changeset/four-fishes-kneel.md
@@ -1,0 +1,5 @@
+---
+'@toptal/picasso-user-badge': patch
+---
+
+- fix missing uses of classes.root

--- a/.changeset/strange-bulldogs-unite.md
+++ b/.changeset/strange-bulldogs-unite.md
@@ -1,0 +1,5 @@
+---
+'@toptal/picasso-page': patch
+---
+
+- fix padding for `PageTopBarMenu`

--- a/cypress/component/PageTopBarMenu.spec.tsx
+++ b/cypress/component/PageTopBarMenu.spec.tsx
@@ -1,0 +1,69 @@
+import React from 'react'
+import {
+  Page,
+  Menu,
+  PortfolioDesigner16,
+  Profile16,
+  Globe16,
+  Referral16,
+  Award16,
+  Box16,
+} from '@toptal/picasso'
+
+export enum TestIds {
+  TopBarMenu = 'page-top-bar-menu-dropdown',
+}
+
+const Example = ({ src }: { src: string | null }) => (
+  <Page hamburgerId='hamburger-withicons-example'>
+    <Page.TopBar
+      variant='grey'
+      centerContent={
+        <Page.TopBar.Menu>
+          <Page.TopBar.Item icon={<PortfolioDesigner16 />}>
+            Item 1
+          </Page.TopBar.Item>
+          <Page.TopBar.Item icon={<Profile16 />}>Item 2</Page.TopBar.Item>
+          <Page.TopBar.Item icon={<Globe16 />}>Item 3</Page.TopBar.Item>
+          <Page.TopBar.Item icon={<Award16 />}>Item 4</Page.TopBar.Item>
+          <Page.TopBar.Item icon={<Referral16 />}>Item 5</Page.TopBar.Item>
+          <Page.TopBar.Item icon={<Box16 />}>Item 6</Page.TopBar.Item>
+        </Page.TopBar.Menu>
+      }
+      rightContent={
+        <Page.TopBarMenu
+          name='Jacqueline Roque'
+          avatar={src || ''}
+          data-testid={TestIds.TopBarMenu}
+        >
+          <Menu>
+            <Menu.Item>My Account</Menu.Item>
+            <Menu.Item>Log Out</Menu.Item>
+          </Menu>
+        </Page.TopBarMenu>
+      }
+    />
+  </Page>
+)
+
+describe('PageTopBarMenu', () => {
+  let src: string | null = null
+
+  before(() => {
+    // eslint-disable-next-line promise/catch-or-return
+    cy.fixture('pablo.jpg').then(image => {
+      src = 'data:image/jpg;base64,' + image
+
+      return image
+    })
+  })
+
+  it('renders correctly on small screens', () => {
+    cy.viewport(767, 800)
+    cy.mount(<Example src={src} />)
+
+    cy.getByTestId(TestIds.TopBarMenu).click()
+
+    cy.get('body').happoScreenshot()
+  })
+})

--- a/cypress/component/PageTopBarMenu.spec.tsx
+++ b/cypress/component/PageTopBarMenu.spec.tsx
@@ -9,6 +9,7 @@ import {
   Award16,
   Box16,
 } from '@toptal/picasso'
+import { HAPPO_TARGETS } from '@toptal/picasso-test-utils'
 
 export enum TestIds {
   TopBarMenu = 'page-top-bar-menu-dropdown',
@@ -58,12 +59,20 @@ describe('PageTopBarMenu', () => {
     })
   })
 
-  it('renders correctly on small screens', () => {
-    cy.viewport(767, 800)
-    cy.mount(<Example src={src} />)
+  Cypress._.each(HAPPO_TARGETS, happoTarget => {
+    const { width } = happoTarget
 
-    cy.getByTestId(TestIds.TopBarMenu).click()
+    it(`renders correctly on ${width}px`, () => {
+      cy.viewport(width, 800)
+      cy.mount(<Example src={src} />)
 
-    cy.get('body').happoScreenshot()
+      cy.getByTestId(TestIds.TopBarMenu).click()
+
+      cy.get('body').happoScreenshot({
+        component: 'PageTopBarMenu',
+        variant: `width-${width}`,
+        targets: [happoTarget],
+      })
+    })
   })
 })

--- a/packages/base/Page/src/PageTopBarMenu/PageTopBarMenu.tsx
+++ b/packages/base/Page/src/PageTopBarMenu/PageTopBarMenu.tsx
@@ -63,7 +63,7 @@ export const PageTopBarMenu = forwardRef<HTMLDivElement, Props>(
           size='xxsmall'
           data-private={dataPrivate}
           classes={{
-            root: 'p-[1em] [z-index:1] bg-white relative user-badge-root',
+            root: 'p-[1em] [z-index:1] bg-white relative',
             avatar: 'text-[0.9rem]',
             name: twJoin('font-[400]', truncateTextClasses),
           }}

--- a/packages/base/Page/src/PageTopBarMenu/PageTopBarMenu.tsx
+++ b/packages/base/Page/src/PageTopBarMenu/PageTopBarMenu.tsx
@@ -63,7 +63,7 @@ export const PageTopBarMenu = forwardRef<HTMLDivElement, Props>(
           size='xxsmall'
           data-private={dataPrivate}
           classes={{
-            root: 'p-2 [z-index:1] bg-white relative',
+            root: 'p-[1em] [z-index:1] bg-white relative user-badge-root',
             avatar: 'text-[0.9rem]',
             name: twJoin('font-[400]', truncateTextClasses),
           }}

--- a/packages/base/UserBadge/src/UserBadge/UserBadge.tsx
+++ b/packages/base/UserBadge/src/UserBadge/UserBadge.tsx
@@ -101,7 +101,7 @@ export const UserBadge = forwardRef<HTMLDivElement, Props>(function UserBadge(
       ref={ref}
       flex
       alignItems={alignItems}
-      className={twMerge('text-[1rem]', className)}
+      className={twMerge('text-[1rem]', classes?.root, className)}
       style={style}
     >
       {UserBadgeAvatar}

--- a/packages/base/UserBadge/src/UserBadge/test.tsx
+++ b/packages/base/UserBadge/src/UserBadge/test.tsx
@@ -1,16 +1,23 @@
 import React from 'react'
 import { render } from '@toptal/picasso-test-utils'
-import type { OmitInternalProps } from '@toptal/picasso-shared'
 import { Typography } from '@toptal/picasso-typography'
+import { screen } from '@testing-library/react'
 
 import type { Props } from './UserBadge'
 import { UserBadge } from './UserBadge'
 
-const renderUserBadge = (
-  children: React.ReactNode,
-  props: OmitInternalProps<Props>
-) => {
-  const { size, center, name, title, invert, renderName, renderTitle } = props
+const renderUserBadge = (children: React.ReactNode, props: Props) => {
+  const {
+    size,
+    center,
+    name,
+    title,
+    invert,
+    renderName,
+    renderTitle,
+    classes,
+    'data-testid': dataTestId,
+  } = props
 
   return render(
     <UserBadge
@@ -21,6 +28,8 @@ const renderUserBadge = (
       invert={invert}
       renderName={renderName}
       renderTitle={renderTitle}
+      classes={classes}
+      data-testid={dataTestId}
     >
       {children}
     </UserBadge>
@@ -97,5 +106,17 @@ describe('UserBadge', () => {
     })
 
     expect(container).toMatchSnapshot()
+  })
+
+  it('passes classes.root to the root element', () => {
+    renderUserBadge(<Typography>QA tester</Typography>, {
+      name: 'Joe Doe',
+      classes: { root: 'custom-root' },
+      'data-testid': 'user-badge',
+    })
+
+    const root = screen.getByTestId('user-badge')
+
+    expect(root).toHaveClass('custom-root')
   })
 })

--- a/packages/base/UserBadge/src/UserBadge/test.tsx
+++ b/packages/base/UserBadge/src/UserBadge/test.tsx
@@ -109,14 +109,17 @@ describe('UserBadge', () => {
   })
 
   it('passes classes.root to the root element', () => {
+    const testId = 'user-badge'
+    const rootClass = 'custom-root'
+
     renderUserBadge(<Typography>QA tester</Typography>, {
       name: 'Joe Doe',
-      classes: { root: 'custom-root' },
-      'data-testid': 'user-badge',
+      classes: { root: rootClass },
+      'data-testid': testId,
     })
 
-    const root = screen.getByTestId('user-badge')
+    const root = screen.getByTestId(testId)
 
-    expect(root).toHaveClass('custom-root')
+    expect(root).toHaveClass(rootClass)
   })
 })


### PR DESCRIPTION
[FX-6047]

### Description

Describe the changes and motivations for the pull request.

### How to test

<!-- The temploy link will be automatically updated when the temploy is deployed -->
- [Temploy](https://picasso.toptal.net/fx-6047-fix-pagetopbar-menu-padding)

1. Go to `PageTopBar` stories page. 
2. Go to `Page.TopBar.Menu` stories.
3. Change screen size to `<1000px` and click on avatar in the right corner of `PageTopBar`. 

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| ![image](https://github.com/user-attachments/assets/d65f67f2-2bd3-462d-b3f8-f3c949f0ccae) | ![image](https://github.com/user-attachments/assets/197e7c37-d4b1-4961-b26b-f38e60aa8ddc) |

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Double check if `picasso-tailwind-merge` requires major update (check its `README.md`)
- ~Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)~
- ~Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core~
- ~Annotate all `props` in component with documentation~
-  ~Create `examples` for component~
- ~Ensure that deployed demo has expected results and good examples~
- ~Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).~
- [x] Self reviewed
- [x] Covered with tests ([visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md) included)

**Breaking change**

- ~codemod is created and showcased in the changeset~
- ~test alpha package of Picasso in StaffPortal~

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
4. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
5. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-6047]: https://toptal-core.atlassian.net/browse/FX-6047?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ