### PR TITLE
[FX-NULL] Auto merge release pull requests

### DIFF
--- a/.github/workflows/automerge-release.yaml
+++ b/.github/workflows/automerge-release.yaml
@@ -1,4 +1,4 @@
-name: Automatically merge non-major release PR
+name: Automatically merge release PR
 
 on:
   pull_request:
@@ -7,9 +7,6 @@ on:
     types:
       - opened
 
-env:
-  PR_NUMBER: ${{ github.event.number }}
-  PR_BODY: ${{ github.event.pull_request.body }}
 jobs:
   merge-release-pr:
     if: ${{ github.event.pull_request.head.ref == 'changeset-release/master' }}
@@ -39,35 +36,23 @@ jobs:
         with:
           json: ${{ steps.secrets_manager.outputs.secrets }}
 
-      - name: Set ENV Variables
-        run: |-
-          echo "DEVBOT_TOKEN=${{ steps.parse_secrets.outputs.TOPTAL_DEVBOT_TOKEN }}" >> $GITHUB_ENV
-
-      - name: Merge pull request if the release is not major
+      - name: Merge pull request
         uses: actions/github-script@v7
         with:
-          github-token: ${{ env.DEVBOT_TOKEN }}
+          github-token: ${{ steps.parse_secrets.outputs.TOPTAL_DEVBOT_TOKEN }}
           script: |
-            const { PR_NUMBER, PR_BODY } = process.env
-            const repository = context.repo
-
-            const isMajorRelease = PR_BODY.includes("### Major Changes")
-            const commentBody = isMajorRelease ?
-              "This pull request seems to be a **major** release and will **not** be merged automatically"
-              : "This pull request seems to be a **non-major** release and will be merged automatically"
+            const commentBody = "This release pull request will be merged automatically"
 
             await github.rest.issues.createComment({
               owner: repository.owner,
-              issue_number: PR_NUMBER,
+              issue_number: ${{ github.event.number }},
               repo: repository.repo,
               body: commentBody,
             })
 
-            if (!isMajorRelease) {
-              await github.rest.pulls.merge({
-                merge_method: "squash",
-                owner: repository.owner,
-                pull_number: PR_NUMBER,
-                repo: repository.repo,
-              })
-            }
+            await github.rest.pulls.merge({
+              merge_method: "squash",
+              owner: repository.owner,
+              pull_number: ${{ github.event.number }},
+              repo: repository.repo,
+            })


### PR DESCRIPTION
### Description

This pull request enables automatic merging of major release pull requests.

Similar pull requests

- https://github.com/toptal/topkit/pull/783 (works as seen in https://github.com/toptal/topkit/pull/784) ✅ 
- https://github.com/toptal/davinci/pull/2493 ⌛ 

### How to test

- Will be tested after merge

### Development checks

- [N/A] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Double check if `picasso-tailwind-merge` requires major update (check its `README.md`)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [N/A] Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [N/A] Annotate all `props` in component with documentation
- [N/A] Create `examples` for component
- [N/A] Ensure that deployed demo has expected results and good examples
- [N/A] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [N/A] Covered with tests ([visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md) included)

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>
