### PR TITLE
[FX-6101] Disable value change on mouse wheel

### DIFF
--- a/.changeset/brave-games-explode.md
+++ b/.changeset/brave-games-explode.md
@@ -1,0 +1,8 @@
+---
+'@toptal/picasso-number-input': patch
+'@toptal/picasso': patch
+---
+
+### NumberInput
+
+- disable value change on mouse wheel (to enable the behavior, use `enableMouseWheelChange` prop)

--- a/packages/base/NumberInput/src/NumberInput/NumberInput.tsx
+++ b/packages/base/NumberInput/src/NumberInput/NumberInput.tsx
@@ -23,6 +23,8 @@ export interface Props
   max?: number | string
   /** Next value of the `input` element will be calculated based on step */
   step?: number | string
+  /** Enable value change on mouse wheel */
+  enableChangeOnMouseWheel?: boolean
   /** Should controls be hidden or not */
   hideControls?: boolean
   /** Specify icon which should be rendered inside NumberInput */
@@ -41,6 +43,7 @@ export const NumberInput = forwardRef<HTMLInputElement, Props>(
       min = -Infinity,
       max = Infinity,
       hideControls,
+      enableChangeOnMouseWheel,
       value,
       onChange,
       disabled,
@@ -96,6 +99,10 @@ export const NumberInput = forwardRef<HTMLInputElement, Props>(
           step,
           min,
           max,
+          // TODO: [FX-6102] Add test for wheel event
+          onWheel: enableChangeOnMouseWheel
+            ? undefined
+            : event => event.currentTarget.blur(),
         }}
         width={width}
         onResetClick={onResetClick}


### PR DESCRIPTION
[FX-6101]

### Description

This pull request disables the value change on wheel scroll in `NumberInput`. 

Tests will be added in https://toptal-core.atlassian.net/browse/FX-6102.

### How to test

<!-- The temploy link will be automatically updated when the temploy is deployed -->
- [Temploy](https://picasso.toptal.net/fx-6101-unexpected-behavior-when-scrolling-through-numberinput-field-in-production-environment)
- Check how input behaves with and without `enableChangeOnMouseWheel` property

### Screenshots


https://github.com/user-attachments/assets/e9a97a1b-cb76-42b1-abd3-14fda595365f


### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [N/A] Double check if `picasso-tailwind-merge` requires major update (check its `README.md`)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [x] Annotate all `props` in component with documentation
- [N/A] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [N/A] Covered with tests ([visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md) included)

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-6101]: https://toptal-core.atlassian.net/browse/FX-6101?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ