### PR TITLE
[FX-6105] Fix number input controls border

### DIFF
--- a/.changeset/good-eagles-begin.md
+++ b/.changeset/good-eagles-begin.md
@@ -1,0 +1,8 @@
+---
+'@toptal/picasso-number-input': patch
+'@toptal/picasso': patch
+---
+
+### NumberInput
+
+- fix border rendering for controls

--- a/packages/base/NumberInput/src/NumberInput/__snapshots__/test.tsx.snap
+++ b/packages/base/NumberInput/src/NumberInput/__snapshots__/test.tsx.snap
@@ -23,7 +23,7 @@ exports[`NumberInput renders 1`] = `
         class="inline-flex flex-col"
       >
         <button
-          class="flex relative items-center justify-center align-middle p-0 bottom-0 cursor-pointer text-graphite decoration-graphite bg-inherit bg-transparent border-t border-b border-l border-r border-l border-r border-l-gray border-r hover:bg-gray hover:border-gray [&+&]:border-t [&+&]:border-solid [&+&]:border-t-gray active:[&+&]:border-t active:[&+&]:border-t active:[&+&]:border-gray active:bg-gray active:border-t-gray [&:first-child]:rounded-tr [&:last-child]:rounded-br transition-[color,_border,_background] ease-out duration-350 h-4 w-[1.625rem]"
+          class="flex relative items-center justify-center align-middle p-0 bottom-0 cursor-pointer text-graphite decoration-graphite bg-inherit bg-transparent border-y border-x border-x border-l-gray border-r hover:bg-gray hover:border-gray [&]:border-solid [&+&]:border-t [&+&]:border-solid [&+&]:border-t-gray active:[&+&]:border-t active:[&+&]:border-t active:[&+&]:border-gray active:bg-gray active:border-t-gray [&:first-child]:rounded-tr [&:last-child]:rounded-br transition-[color,_border,_background] ease-out duration-350 h-4 w-[1.625rem]"
           type="button"
         >
           <svg
@@ -37,7 +37,7 @@ exports[`NumberInput renders 1`] = `
           </svg>
         </button>
         <button
-          class="flex relative items-center justify-center align-middle p-0 bottom-0 cursor-pointer text-graphite decoration-graphite bg-inherit bg-transparent border-t border-b border-l border-r border-l border-r border-l-gray border-r hover:bg-gray hover:border-gray [&+&]:border-t [&+&]:border-solid [&+&]:border-t-gray active:[&+&]:border-t active:[&+&]:border-t active:[&+&]:border-gray active:bg-gray active:border-t-gray [&:first-child]:rounded-tr [&:last-child]:rounded-br transition-[color,_border,_background] ease-out duration-350 h-4 w-[1.625rem]"
+          class="flex relative items-center justify-center align-middle p-0 bottom-0 cursor-pointer text-graphite decoration-graphite bg-inherit bg-transparent border-y border-x border-x border-l-gray border-r hover:bg-gray hover:border-gray [&]:border-solid [&+&]:border-t [&+&]:border-solid [&+&]:border-t-gray active:[&+&]:border-t active:[&+&]:border-t active:[&+&]:border-gray active:bg-gray active:border-t-gray [&:first-child]:rounded-tr [&:last-child]:rounded-br transition-[color,_border,_background] ease-out duration-350 h-4 w-[1.625rem]"
           type="button"
         >
           <svg

--- a/packages/base/NumberInput/src/NumberInputEndAdornment/NumberInputEndAdornment.tsx
+++ b/packages/base/NumberInput/src/NumberInputEndAdornment/NumberInputEndAdornment.tsx
@@ -132,14 +132,15 @@ export const NumberInputEndAdornment = (props: Props) => {
     p-0 bottom-0 cursor-pointer
 
     text-graphite-700 decoration-graphite-700 bg-inherit bg-transparent
-    
-    border-t-0 border-b-0 border-l border-r border-l-solid border-r-solid 
+
+    border-y-0 border-x border-x-solid
     border-l-gray-400 border-r-transparent
-    
+
     hover:bg-gray-400 hover:border-gray-400
 
-    [&+&]:border-t [&+&]:border-solid 
-    [&+&]:border-t-gray-400 
+    [&]:border-solid
+    [&+&]:border-t [&+&]:border-solid
+    [&+&]:border-t-gray-400
 
     active:[&+&]:border-t active:[&+&]:border-t-solid 
     active:[&+&]:border-gray-500


### PR DESCRIPTION
[FX-6105]

### Description

This pull request fixes the border rendering in Safari.

The problem was found in https://github.com/toptal/client-portal/pull/9943.

### How to test

<!-- The temploy link will be automatically updated when the temploy is deployed -->
- [Temploy](https://picasso.toptal.net/FX-6105-fix-input-border)
- Open `NumberInput` story in Chrome, Firefox, and Safari and make sure that it looks as expected

### Screenshots in Safari

**Before**

<img width="399" alt="Screenshot 2024-10-22 at 09 42 14" src="https://github.com/user-attachments/assets/2d9be636-cd56-4cc2-9107-7f748ad721fd">

**After**

https://github.com/user-attachments/assets/24770870-ca29-4241-8242-ea30e3f55d1f

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [N/A] Double check if `picasso-tailwind-merge` requires major update (check its `README.md`)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [N/A] Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [N/A] Annotate all `props` in component with documentation
- [N/A] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [N/A] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [N/A] Covered with tests ([visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md) included)

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-6105]: https://toptal-core.atlassian.net/browse/FX-6105?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ