### PR TITLE
[FX-6107] Pass min and max to number input form field

### DIFF
--- a/.changeset/strong-needles-flow.md
+++ b/.changeset/strong-needles-flow.md
@@ -1,0 +1,5 @@
+---
+'@toptal/picasso-forms': patch
+---
+
+- pass min and max to number input in forms

--- a/packages/picasso-forms/src/NumberInput/NumberInput.tsx
+++ b/packages/picasso-forms/src/NumberInput/NumberInput.tsx
@@ -42,6 +42,8 @@ export const NumberInput = (props: Props) => {
 
   return (
     <InputField<NumberInputProps>
+      min={min}
+      max={max}
       {...rest}
       validate={composeValidators([validateNumberLimits, validate])}
       label={

--- a/packages/picasso-forms/src/NumberInput/test.tsx
+++ b/packages/picasso-forms/src/NumberInput/test.tsx
@@ -1,0 +1,42 @@
+import React from 'react'
+import { render } from '@toptal/picasso-test-utils'
+
+import { FormCompound as Form } from '../FormCompound'
+import { NumberInput, type Props } from './NumberInput'
+
+const numberInputMock = jest.fn()
+
+jest.mock('@toptal/picasso-number-input', () => ({
+  ...jest.requireActual('@toptal/picasso-number-input'),
+  NumberInput: (props: any) => numberInputMock(props),
+}))
+
+const renderFormWithNumberInput = (props: Props) =>
+  render(
+    <Form.ConfigProvider value={{}}>
+      <Form onSubmit={() => {}}>
+        <NumberInput label='Test' data-testid='number-input' {...props} />
+      </Form>
+    </Form.ConfigProvider>
+  )
+
+describe('Form.NumberInput', () => {
+  describe('when "min" and "max" props are provided', () => {
+    it('passes them to NumberInput', () => {
+      renderFormWithNumberInput({
+        min: '8',
+        max: '12',
+        name: 'test-input',
+      })
+
+      expect(numberInputMock).toHaveBeenCalledTimes(1)
+      expect(numberInputMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          min: '8',
+          max: '12',
+          name: 'test-input',
+        })
+      )
+    })
+  })
+})


### PR DESCRIPTION
[FX-6107]

### Description

This pull request makes `NumberInput` form control respect `min` and `max` parameters (there were not passed at all before).

### How to test

<!-- The temploy link will be automatically updated when the temploy is deployed -->
- Check out branch locally
- Test the following code in any story

```jsx
import React from 'react'
import { FormActionsContainer } from '@toptal/picasso'
import { SPACING_4 } from '@toptal/picasso-utils'

import {
  FormNonCompound as Form,
  NumberInput,
  SubmitButton,
} from '@toptal/picasso-forms'

const initialValues = {}

const Example = () => {
  return (
    <Form
      onSubmit={values => window.alert(JSON.stringify(values, undefined, 2))}
    >
      <NumberInput
        required
        name='default-age'
        label="What's your age?"
        min='20'
        placeholder='Minimum value - 20'
      />
 
      <FormActionsContainer top={SPACING_4}>
        <SubmitButton>Submit</SubmitButton>
      </FormActionsContainer>
    </Form>
  )
}

export default Example
```

### Screenshots

https://github.com/user-attachments/assets/49d016f8-1231-4f11-a02c-007eb311585a

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [N/A] Double check if `picasso-tailwind-merge` requires major update (check its `README.md`)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [N/A] Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [N/A] Annotate all `props` in component with documentation
- [N/A] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [N/A] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests ([visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md) included)

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-6107]: https://toptal-core.atlassian.net/browse/FX-6107?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ