### PR TITLE
[MP-672] Support `endAdornment` properly in NumberInput

### DIFF
--- a/.changeset/perfect-dolls-march.md
+++ b/.changeset/perfect-dolls-march.md
@@ -1,0 +1,5 @@
+---
+'@toptal/picasso-number-input': minor
+---
+
+- support custom `endAdornment` in NumberInput

--- a/packages/base/NumberInput/src/NumberInput/NumberInput.tsx
+++ b/packages/base/NumberInput/src/NumberInput/NumberInput.tsx
@@ -78,13 +78,11 @@ export const NumberInput = forwardRef<HTMLInputElement, Props>(
 
     const endAdornment = hideControls ? (
       customEndAdornment
-    ) : customEndAdornment ? (
+    ) : (
       <>
         {customEndAdornment}
         {defaultEndAdornment}
       </>
-    ) : (
-      defaultEndAdornment
     )
 
     const startAdornment = icon ? (

--- a/packages/base/NumberInput/src/NumberInput/NumberInput.tsx
+++ b/packages/base/NumberInput/src/NumberInput/NumberInput.tsx
@@ -50,6 +50,7 @@ export const NumberInput = forwardRef<HTMLInputElement, Props>(
       status,
       onResetClick,
       enableReset,
+      endAdornment: customEndAdornment = null,
       width,
       icon,
       size,
@@ -63,7 +64,7 @@ export const NumberInput = forwardRef<HTMLInputElement, Props>(
       useRef<HTMLInputElement>(null)
     )
 
-    const endAdornment = hideControls ? null : (
+    const defaultEndAdornment = (
       <NumberInputEndAdornment
         step={step}
         min={min}
@@ -73,6 +74,17 @@ export const NumberInput = forwardRef<HTMLInputElement, Props>(
         size={size}
         inputRef={inputRef}
       />
+    )
+
+    const endAdornment = hideControls ? (
+      customEndAdornment
+    ) : customEndAdornment ? (
+      <>
+        {customEndAdornment}
+        {defaultEndAdornment}
+      </>
+    ) : (
+      defaultEndAdornment
     )
 
     const startAdornment = icon ? (

--- a/packages/base/NumberInput/src/NumberInput/story/WithEndAdornment.example.tsx
+++ b/packages/base/NumberInput/src/NumberInput/story/WithEndAdornment.example.tsx
@@ -1,0 +1,26 @@
+import type { ChangeEventHandler } from 'react'
+import React, { useState } from 'react'
+import { NumberInput, Container, Typography } from '@toptal/picasso'
+
+const WithEndAdornmentExample = () => {
+  const [value, setValue] = useState('1')
+
+  const handleChange: ChangeEventHandler<HTMLInputElement> = event => {
+    setValue(event.target.value)
+  }
+
+  return (
+    <Container>
+      <NumberInput
+        value={value}
+        onChange={handleChange}
+        step='5'
+        max='100'
+        min='-100'
+        endAdornment={<Typography color='dark-grey'>$/hr</Typography>}
+      />
+    </Container>
+  )
+}
+
+export default WithEndAdornmentExample

--- a/packages/base/NumberInput/src/NumberInput/story/index.jsx
+++ b/packages/base/NumberInput/src/NumberInput/story/index.jsx
@@ -4,7 +4,7 @@ import PicassoBook from '~/.storybook/components/PicassoBook'
 const page = PicassoBook.section('Forms').createPage(
   'NumberInput',
   `Input component for numbers
-  
+
   ${PicassoBook.createSourceLink(__filename)}
   `
 )
@@ -33,6 +33,11 @@ page
   .addExample(
     'NumberInput/story/WithIcon.example.tsx',
     'With Icon',
+    'base/NumberInput'
+  )
+  .addExample(
+    'NumberInput/story/WithEndAdornment.example.tsx',
+    'With End Adornment',
     'base/NumberInput'
   )
   .addExample(

--- a/packages/base/NumberInput/src/NumberInput/test.tsx
+++ b/packages/base/NumberInput/src/NumberInput/test.tsx
@@ -22,6 +22,8 @@ const NumberInputRenderer = (
       value={value}
       onChange={handleChange}
       status={props.status}
+      endAdornment={props.endAdornment}
+      hideControls={props.hideControls}
       testIds={props.testIds}
     />
   )
@@ -148,6 +150,37 @@ describe('NumberInput', () => {
       rerender(<NumberInput {...testProps} status='error' />)
 
       expect(validIcon).not.toBeVisible()
+    })
+  })
+
+  describe('end adornment', () => {
+    describe('when endAdornment is passed', () => {
+      it('renders endAdornment with control buttons', () => {
+        const testProps: NumberInputProps = {
+          value: '10',
+          endAdornment: <div data-testid='custom-end-adornment' />,
+        }
+
+        const { getByTestId, getAllByRole } = renderNumberInput(testProps)
+
+        expect(getByTestId('custom-end-adornment')).toBeVisible()
+        expect(getAllByRole('button')).toHaveLength(2)
+      })
+    })
+
+    describe('when endAdornment is passed and controls are hidden', () => {
+      it('renders endAdornment without control buttons', () => {
+        const testProps: NumberInputProps = {
+          value: '10',
+          endAdornment: <div data-testid='custom-end-adornment' />,
+          hideControls: true,
+        }
+
+        const { getByTestId, queryAllByRole } = renderNumberInput(testProps)
+
+        expect(getByTestId('custom-end-adornment')).toBeVisible()
+        expect(queryAllByRole('button')).toHaveLength(0)
+      })
     })
   })
 })


### PR DESCRIPTION
[MP-672]

### Description

`NumberInput` has the prop `endAdornment` but never uses it. This change aims to render `endAdornment` aside the controls, or isolated (when `hideControls` is `true`).

### How to test

<!-- The temploy link will be automatically updated when the temploy is deployed -->
- [Temploy](https://picasso.toptal.net/MP-672-support-end-adornment-properly-in-number-input)
- Check NumberInput component on temploy

### Screenshots

| Picasso | Example in Talent Portal with alpha |
| ---- | ---- |
| ![image](https://github.com/user-attachments/assets/efec3329-2cb4-4b7f-a12f-7dbe28ade805) | ![image](https://github.com/user-attachments/assets/e065bef8-79df-40a9-bc0d-d10332e3599c) |

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [n/a] Double check if `picasso-tailwind-merge` requires major update (check its `README.md`)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [n/a] Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [n/a] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests ([visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md) included)

**Breaking change**

- [n/a] codemod is created and showcased in the changeset
- [n/a] test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[MP-672]: https://toptal-core.atlassian.net/browse/MP-672?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ