### PR TITLE
[CPS-1474] Fix TimePicker size property

### DIFF
--- a/.changeset/purple-beans-help.md
+++ b/.changeset/purple-beans-help.md
@@ -1,0 +1,5 @@
+---
+'@toptal/picasso-timepicker': patch
+---
+
+- fix size prop

--- a/packages/base/Timepicker/src/TimePicker/TimePicker.tsx
+++ b/packages/base/Timepicker/src/TimePicker/TimePicker.tsx
@@ -50,6 +50,7 @@ export const TimePicker = (props: Props) => {
     className,
     status,
     highlight,
+    size,
     ...rest
   } = props
 
@@ -114,6 +115,7 @@ export const TimePicker = (props: Props) => {
         status={status}
         className={inputClassName}
         highlight={highlight}
+        size={size}
         inputProps={{
           className: inputPropClassName,
           ...rest,
@@ -142,6 +144,7 @@ export const TimePicker = (props: Props) => {
       highlight={highlight}
       icon={icon}
       width={width}
+      size={size}
       status={status}
       inputProps={{
         className: inputPropClassName,


### PR DESCRIPTION
[CPS-1474]

### Description

Fix `size` prop for TimePicker

### How to test

<!-- The temploy link will be automatically updated when the temploy is deployed -->
- [Temploy](https://picasso.toptal.net/cps-1474-fix-timepicker-size)
- Go to this story: /?path=/story/forms-timepicker--timepicker
- Add `size='small'` and see that it works

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| <img width="335" alt="image" src="https://github.com/user-attachments/assets/f24a7ec1-6741-4037-9f56-19bc3727cb6f" /> | <img width="372" alt="image" src="https://github.com/user-attachments/assets/45dd8ce5-6d48-4cb7-b03e-021fd149fbc1" /> |

Tested on Staff Portal storybook:
<img width="660" alt="image" src="https://github.com/user-attachments/assets/b4dccbd1-a1a3-4e0c-9802-14999abd8223" />


### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Double check if `picasso-tailwind-merge` requires major update (check its `README.md`)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- N/A Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- N/A Annotate all `props` in component with documentation
- N/A Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- N/A Covered with tests ([visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md) included)

**Breaking change**

- N/A codemod is created and showcased in the changeset
- N/A test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[CPS-1474]: https://toptal-core.atlassian.net/browse/CPS-1474?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ