### PR TITLE
[PF-201] Fix duplicate sidebar rendering

### DIFF
--- a/packages/base/Page/src/PageHamburger/PageHamburger.tsx
+++ b/packages/base/Page/src/PageHamburger/PageHamburger.tsx
@@ -2,7 +2,6 @@ import React, { useState } from 'react'
 import { ButtonCircular } from '@toptal/picasso-button'
 import { Dropdown } from '@toptal/picasso-dropdown'
 import { Close24, Overview24 } from '@toptal/picasso-icons'
-import { useScreenSize } from '@toptal/picasso-provider'
 
 import { useHamburgerContext } from './PageHamburgerContext'
 
@@ -18,10 +17,7 @@ const PageHamburger = ({ id, 'data-testid': dataTestId }: Props) => {
   const handleShowContent = () => setShowContent(true)
   const handleHideContent = () => setShowContent(false)
 
-  const screenSize = useScreenSize()
-  const isScreenSmall = screenSize < 1280
-
-  if (!showSidebarMenu || !isScreenSmall) {
+  if (!showSidebarMenu) {
     return null
   }
 

--- a/packages/base/Page/src/PageHamburger/PageHamburger.tsx
+++ b/packages/base/Page/src/PageHamburger/PageHamburger.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react'
 import { ButtonCircular } from '@toptal/picasso-button'
 import { Dropdown } from '@toptal/picasso-dropdown'
 import { Close24, Overview24 } from '@toptal/picasso-icons'
+import { useScreenSize } from '@toptal/picasso-provider'
 
 import { useHamburgerContext } from './PageHamburgerContext'
 
@@ -17,10 +18,16 @@ const PageHamburger = ({ id, 'data-testid': dataTestId }: Props) => {
   const handleShowContent = () => setShowContent(true)
   const handleHideContent = () => setShowContent(false)
 
+  const screenSize = useScreenSize()
+  const isScreenSmall = screenSize < 1280
+
+  if (!showSidebarMenu || !isScreenSmall) {
+    return null
+  }
+
   return (
     <Dropdown
       content={<div id={id} ref={hamburgerRef} />}
-      className={!showSidebarMenu ? 'hidden' : 'min-[1280px]:hidden'}
       classes={{
         content: `!shadow-[inset_-1px_0px_0px_0px] !shadow-gray-200 max-h-[calc(100vh-var(--header-height,3.5rem))] !bg-gray-100`,
         popper: 'mt-4',

--- a/packages/base/Page/src/PageHamburger/PageHamburgerContext.tsx
+++ b/packages/base/Page/src/PageHamburger/PageHamburgerContext.tsx
@@ -16,14 +16,15 @@ interface InternalHamburgerContextProps {
   hasTopBar: boolean
   setHasTopBar: (val: boolean) => void
   hamburgerRef?: React.RefObject<HTMLDivElement>
+  hasPageHamburger: boolean
+  setHasPageHamburger: (val: boolean) => void
 }
 
-export interface HamburgerContextProps {
-  hamburgerId: string
+export type HamburgerContextProps = Omit<
+  InternalHamburgerContextProps,
+  'menuCount' | 'setMenuCount'
+> & {
   showSidebarMenu: boolean
-  hasTopBar: boolean
-  setHasTopBar: (val: boolean) => void
-  hamburgerRef?: React.RefObject<HTMLDivElement>
 }
 
 const PageHamburgerContext = createContext<InternalHamburgerContextProps>({
@@ -32,6 +33,8 @@ const PageHamburgerContext = createContext<InternalHamburgerContextProps>({
   menuCount: 0,
   setHasTopBar: noop,
   hasTopBar: false,
+  setHasPageHamburger: noop,
+  hasPageHamburger: false,
 })
 
 interface Props {
@@ -44,6 +47,7 @@ export const PageHamburgerContextProvider = ({
   hamburgerId,
 }: Props) => {
   const [hasTopBar, setHasTopBar] = useState(true)
+  const [hasPageHamburger, setHasPageHamburger] = useState(false)
   const [menuCount, setMenuCount] = useState(0)
 
   const hamburgerRef = useRef<HTMLDivElement>(null)
@@ -55,6 +59,8 @@ export const PageHamburgerContextProvider = ({
     hamburgerRef,
     setMenuCount,
     menuCount,
+    setHasPageHamburger,
+    hasPageHamburger,
   }
 
   return (
@@ -65,8 +71,15 @@ export const PageHamburgerContextProvider = ({
 }
 
 export const useHamburgerContext = (): HamburgerContextProps => {
-  const { hamburgerId, hasTopBar, setHasTopBar, hamburgerRef, menuCount } =
-    useContext(PageHamburgerContext)
+  const {
+    hamburgerId,
+    hasTopBar,
+    setHasTopBar,
+    hamburgerRef,
+    menuCount,
+    setHasPageHamburger,
+    hasPageHamburger,
+  } = useContext(PageHamburgerContext)
 
   const hasSidebar = menuCount > 0
 
@@ -76,6 +89,8 @@ export const useHamburgerContext = (): HamburgerContextProps => {
     setHasTopBar,
     hamburgerRef,
     showSidebarMenu: hasSidebar && hasTopBar,
+    setHasPageHamburger,
+    hasPageHamburger,
   }
 }
 

--- a/packages/base/Page/src/PageHamburger/PageHamburgerPortal.tsx
+++ b/packages/base/Page/src/PageHamburger/PageHamburgerPortal.tsx
@@ -20,8 +20,12 @@ const PageHamburgerPortal = ({ children }: Props) => {
   }, [hamburgerRef, isMounted])
 
   if (!container || !showSidebarMenu) {
+    console.log('PageHamburgerPortal NULL', showSidebarMenu, container)
+
     return null
   }
+
+  console.log('PageHamburgerPortal active', showSidebarMenu, container)
 
   return createPortal(children, container)
 }

--- a/packages/base/Page/src/PageHamburger/PageHamburgerPortal.tsx
+++ b/packages/base/Page/src/PageHamburger/PageHamburgerPortal.tsx
@@ -20,12 +20,8 @@ const PageHamburgerPortal = ({ children }: Props) => {
   }, [hamburgerRef, isMounted])
 
   if (!container || !showSidebarMenu) {
-    console.log('PageHamburgerPortal NULL', showSidebarMenu, container)
-
     return null
   }
-
-  console.log('PageHamburgerPortal active', showSidebarMenu, container)
 
   return createPortal(children, container)
 }

--- a/packages/base/Page/src/PageSidebar/PageSidebar.tsx
+++ b/packages/base/Page/src/PageSidebar/PageSidebar.tsx
@@ -111,7 +111,7 @@ export const PageSidebar = forwardRef<HTMLDivElement, Props>(function Sidebar(
         'text-lg/[inherit]',
         'relative',
         'transition-[width] ease-in-out delay-[225ms]',
-        'hidden min-[1280px]:block',
+        'hidden lg:block',
         '[&]:before:absolute',
         '[&]:before:content-[""]',
         '[&]:before:left-0',

--- a/packages/base/Page/src/PageSidebar/PageSidebar.tsx
+++ b/packages/base/Page/src/PageSidebar/PageSidebar.tsx
@@ -1,4 +1,4 @@
-import { useSidebar, useScreenSize } from '@toptal/picasso-provider'
+import { useSidebar } from '@toptal/picasso-provider'
 import type { BaseProps, SizeType } from '@toptal/picasso-shared'
 import { twMerge, twJoin } from '@toptal/picasso-tailwind-merge'
 import type { ReactNode } from 'react'
@@ -76,7 +76,8 @@ export const PageSidebar = forwardRef<HTMLDivElement, Props>(function Sidebar(
   const [isCollapsed, setIsCollapsed] = useState(!!defaultCollapsed)
   const [isHovered, setIsHovered] = useState(false)
   const [expandedItemKey, setExpandedItemKey] = useState<number | null>(null)
-  const { hasTopBar } = useHamburgerContext()
+
+  const { hasTopBar, hasPageHamburger } = useHamburgerContext()
 
   useEffect(() => {
     // Clear expanded submenu on sidebar collapse
@@ -94,9 +95,6 @@ export const PageSidebar = forwardRef<HTMLDivElement, Props>(function Sidebar(
   }, [setHasSidebar])
 
   useRegisterMenu()
-
-  const screenSize = useScreenSize()
-  const isScreenSmall = screenSize < 1280
 
   const handleCollapseButtonClick = useCallback(() => {
     setIsCollapsed(previousState => !previousState)
@@ -137,8 +135,10 @@ export const PageSidebar = forwardRef<HTMLDivElement, Props>(function Sidebar(
       onMouseEnter={collapsible ? () => setIsHovered(true) : noop}
       onMouseLeave={collapsible ? () => setIsHovered(false) : noop}
     >
-      {isScreenSmall && <PageHamburgerPortal>{children}</PageHamburgerPortal>}
-      {!isScreenSmall && (
+      {hasPageHamburger && (
+        <PageHamburgerPortal>{children}</PageHamburgerPortal>
+      )}
+      {!hasPageHamburger && (
         <div
           style={{
             maxHeight: wrapperMaxHeight,

--- a/packages/base/Page/src/PageSidebar/PageSidebar.tsx
+++ b/packages/base/Page/src/PageSidebar/PageSidebar.tsx
@@ -98,9 +98,6 @@ export const PageSidebar = forwardRef<HTMLDivElement, Props>(function Sidebar(
   const screenSize = useScreenSize()
   const isScreenSmall = screenSize < 1280
 
-  console.log('screenSize', screenSize)
-  console.log('isScreenSmall', isScreenSmall)
-
   const handleCollapseButtonClick = useCallback(() => {
     setIsCollapsed(previousState => !previousState)
     onCollapse()

--- a/packages/base/Page/src/PageSidebar/PageSidebar.tsx
+++ b/packages/base/Page/src/PageSidebar/PageSidebar.tsx
@@ -1,4 +1,4 @@
-import { useSidebar } from '@toptal/picasso-provider'
+import { useSidebar, useScreenSize } from '@toptal/picasso-provider'
 import type { BaseProps, SizeType } from '@toptal/picasso-shared'
 import { twMerge, twJoin } from '@toptal/picasso-tailwind-merge'
 import type { ReactNode } from 'react'
@@ -95,6 +95,12 @@ export const PageSidebar = forwardRef<HTMLDivElement, Props>(function Sidebar(
 
   useRegisterMenu()
 
+  const screenSize = useScreenSize()
+  const isScreenSmall = screenSize < 1280
+
+  console.log('screenSize', screenSize)
+  console.log('isScreenSmall', isScreenSmall)
+
   const handleCollapseButtonClick = useCallback(() => {
     setIsCollapsed(previousState => !previousState)
     onCollapse()
@@ -134,50 +140,51 @@ export const PageSidebar = forwardRef<HTMLDivElement, Props>(function Sidebar(
       onMouseEnter={collapsible ? () => setIsHovered(true) : noop}
       onMouseLeave={collapsible ? () => setIsHovered(false) : noop}
     >
-      <PageHamburgerPortal>{children}</PageHamburgerPortal>
-
-      <div
-        style={{
-          maxHeight: wrapperMaxHeight,
-        }}
-        className={twJoin(
-          'h-full',
-          !disableSticky &&
-            'max-h-[calc(100vh-var(--header-height,3.5rem))] sticky top-[var(--header-height,3.5rem)]'
-        )}
-      >
-        <Container
-          flex
-          direction='column'
-          className='scrollable-content h-full overflow-y-auto pt-4 pb-2 px-0'
-          data-testid={testIds?.scrollableContainer}
-        >
-          {collapsible && (
-            <ButtonCircular
-              className={twMerge(
-                // TODO: [FX-XXXX] technical debt: button color/background/radius/shadow shouldn't be overwritten
-                'absolute -right-3 top-3 invisible text-graphite-700 bg-white rounded-full shadow-[0_0_0_1px_rgba(0,0,0,0.04),0_0_8px_0_rgba(0,0,0,0.16)] z-[100] hover:text-white hover:bg-blue-500',
-                isHovered && 'visible'
-              )}
-              onClick={handleCollapseButtonClick}
-              icon={isCollapsed ? <ChevronRight16 /> : <BackMinor16 />}
-              aria-label='collapse sidebar'
-              variant='primary'
-              data-testid={testIds?.collapseButton}
-            />
+      {isScreenSmall && <PageHamburgerPortal>{children}</PageHamburgerPortal>}
+      {!isScreenSmall && (
+        <div
+          style={{
+            maxHeight: wrapperMaxHeight,
+          }}
+          className={twJoin(
+            'h-full',
+            !disableSticky &&
+              'max-h-[calc(100vh-var(--header-height,3.5rem))] sticky top-[var(--header-height,3.5rem)]'
           )}
-          <div className='order-[50] flex-1 h-full' />
-          <SidebarContextProvider
-            isCollapsed={isCollapsed}
-            isHovered={isHovered}
-            variant={variant}
-            expandedItemKey={expandedItemKey}
-            setExpandedItemKey={setExpandedItemKey}
+        >
+          <Container
+            flex
+            direction='column'
+            className='scrollable-content h-full overflow-y-auto pt-4 pb-2 px-0'
+            data-testid={testIds?.scrollableContainer}
           >
-            {children}
-          </SidebarContextProvider>
-        </Container>
-      </div>
+            {collapsible && (
+              <ButtonCircular
+                className={twMerge(
+                  // TODO: [FX-XXXX] technical debt: button color/background/radius/shadow shouldn't be overwritten
+                  'absolute -right-3 top-3 invisible text-graphite-700 bg-white rounded-full shadow-[0_0_0_1px_rgba(0,0,0,0.04),0_0_8px_0_rgba(0,0,0,0.16)] z-[100] hover:text-white hover:bg-blue-500',
+                  isHovered && 'visible'
+                )}
+                onClick={handleCollapseButtonClick}
+                icon={isCollapsed ? <ChevronRight16 /> : <BackMinor16 />}
+                aria-label='collapse sidebar'
+                variant='primary'
+                data-testid={testIds?.collapseButton}
+              />
+            )}
+            <div className='order-[50] flex-1 h-full' />
+            <SidebarContextProvider
+              isCollapsed={isCollapsed}
+              isHovered={isHovered}
+              variant={variant}
+              expandedItemKey={expandedItemKey}
+              setExpandedItemKey={setExpandedItemKey}
+            >
+              {children}
+            </SidebarContextProvider>
+          </Container>
+        </div>
+      )}
     </Container>
   )
 })

--- a/packages/base/Page/src/PageSidebar/__snapshots__/test.tsx.snap
+++ b/packages/base/Page/src/PageSidebar/__snapshots__/test.tsx.snap
@@ -6,7 +6,7 @@ exports[`PageSidebar renders 1`] = `
     class="Picasso-root"
   >
     <div
-      class="h-full shadow-[inset_-1px_0_0_0] text-lg/[inherit] relative transition-[width] ease-in delay-[225ms] min-[1280px]:block [&]:before:absolute [&]:before:content-[""] [&]:before:left-0 [&]:before:top-0 [&]:before:w-[15.5rem] [&]:before:h-full shadow-gray bg-gray w-[236px] xs:max-md:overflow-y block"
+      class="h-full shadow-[inset_-1px_0_0_0] text-lg/[inherit] relative transition-[width] ease-in delay-[225ms] lg:block [&]:before:absolute [&]:before:content-[""] [&]:before:left-0 [&]:before:top-0 [&]:before:w-[15.5rem] [&]:before:h-full shadow-gray bg-gray w-[236px] xs:max-md:overflow-y block"
     >
       <div
         class="h-full max-h-[calc(100vh-var(--header sticky top-[var(--header"
@@ -30,7 +30,7 @@ exports[`PageSidebar with menu 1`] = `
     class="Picasso-root"
   >
     <div
-      class="h-full shadow-[inset_-1px_0_0_0] text-lg/[inherit] relative transition-[width] ease-in delay-[225ms] min-[1280px]:block [&]:before:absolute [&]:before:content-[""] [&]:before:left-0 [&]:before:top-0 [&]:before:w-[15.5rem] [&]:before:h-full shadow-gray bg-gray w-[236px] xs:max-md:overflow-y block"
+      class="h-full shadow-[inset_-1px_0_0_0] text-lg/[inherit] relative transition-[width] ease-in delay-[225ms] lg:block [&]:before:absolute [&]:before:content-[""] [&]:before:left-0 [&]:before:top-0 [&]:before:w-[15.5rem] [&]:before:h-full shadow-gray bg-gray w-[236px] xs:max-md:overflow-y block"
     >
       <div
         class="h-full max-h-[calc(100vh-var(--header sticky top-[var(--header"
@@ -59,7 +59,7 @@ exports[`PageSidebar with one normal and one bottom menu 1`] = `
     class="Picasso-root"
   >
     <div
-      class="h-full shadow-[inset_-1px_0_0_0] text-lg/[inherit] relative transition-[width] ease-in delay-[225ms] min-[1280px]:block [&]:before:absolute [&]:before:content-[""] [&]:before:left-0 [&]:before:top-0 [&]:before:w-[15.5rem] [&]:before:h-full shadow-gray bg-gray w-[236px] xs:max-md:overflow-y block"
+      class="h-full shadow-[inset_-1px_0_0_0] text-lg/[inherit] relative transition-[width] ease-in delay-[225ms] lg:block [&]:before:absolute [&]:before:content-[""] [&]:before:left-0 [&]:before:top-0 [&]:before:w-[15.5rem] [&]:before:h-full shadow-gray bg-gray w-[236px] xs:max-md:overflow-y block"
     >
       <div
         class="h-full max-h-[calc(100vh-var(--header sticky top-[var(--header"

--- a/packages/base/Page/src/PageTopBar/PageTopBar.tsx
+++ b/packages/base/Page/src/PageTopBar/PageTopBar.tsx
@@ -12,7 +12,7 @@ import { makeStyles } from '@material-ui/core/styles'
 import { Logo } from '@toptal/picasso-logo'
 import { Container } from '@toptal/picasso-container'
 import { Typography } from '@toptal/picasso-typography'
-import { useIsomorphicLayoutEffect } from '@toptal/picasso-utils'
+import { useIsomorphicLayoutEffect, useBreakpoint } from '@toptal/picasso-utils'
 
 import { PageContext } from '../Page'
 import type { PageContextProps } from '../Page'
@@ -95,10 +95,17 @@ export const PageTopBar = forwardRef<HTMLElement, Props>(function PageTopBar(
   }, [hasTopBar, setHasTopBarHamburger])
 
   const { width, fullWidth } = useContext<PageContextProps>(PageContext)
-  const { hamburgerId } = useHamburgerContext()
+
+  const { hamburgerId, setHasPageHamburger } = useHamburgerContext()
+  const isSmallScreen = useBreakpoint(['xs', 'sm', 'md'])
+
+  useEffect(() => {
+    setHasPageHamburger(isSmallScreen)
+
+    return () => setHasPageHamburger(false)
+  }, [setHasPageHamburger, isSmallScreen])
 
   const isDark = ['dark', 'grey'].includes(variant)
-
   const logoVariant = isDark ? 'white' : 'default'
   const logoDefault = (
     <>
@@ -150,10 +157,12 @@ export const PageTopBar = forwardRef<HTMLElement, Props>(function PageTopBar(
             {/*  Left part: Hamburger, Logo, Tagline, Search bar */}
             <div className={classes.left}>
               <Container flex alignItems='center' gap='small'>
-                <PageHamburger
-                  id={hamburgerId}
-                  data-testid={testIds?.hamburger}
-                />
+                {isSmallScreen && (
+                  <PageHamburger
+                    id={hamburgerId}
+                    data-testid={testIds?.hamburger}
+                  />
+                )}
                 {logoLink
                   ? React.cloneElement(logoLink, {}, logoComponent)
                   : logoComponent}

--- a/packages/base/Page/src/SidebarItem/__snapshots__/test.tsx.snap
+++ b/packages/base/Page/src/SidebarItem/__snapshots__/test.tsx.snap
@@ -6,7 +6,7 @@ exports[`SidebarItem collapsible menu is expanded when one of the children is se
     class="Picasso-root"
   >
     <div
-      class="h-full shadow-[inset_-1px_0_0_0] text-lg/[inherit] relative transition-[width] ease-in delay-[225ms] min-[1280px]:block [&]:before:absolute [&]:before:content-[""] [&]:before:left-0 [&]:before:top-0 [&]:before:w-[15.5rem] [&]:before:h-full shadow-gray bg-gray w-[236px] xs:max-md:overflow-y block"
+      class="h-full shadow-[inset_-1px_0_0_0] text-lg/[inherit] relative transition-[width] ease-in delay-[225ms] lg:block [&]:before:absolute [&]:before:content-[""] [&]:before:left-0 [&]:before:top-0 [&]:before:w-[15.5rem] [&]:before:h-full shadow-gray bg-gray w-[236px] xs:max-md:overflow-y block"
     >
       <div
         class="h-full max-h-[calc(100vh-var(--header sticky top-[var(--header"
@@ -152,7 +152,7 @@ exports[`SidebarItem collapsible menu is expanded when one of the children is se
     class="Picasso-root"
   >
     <div
-      class="h-full shadow-[inset_-1px_0_0_0] text-lg/[inherit] relative transition-[width] ease-in delay-[225ms] min-[1280px]:block [&]:before:absolute [&]:before:content-[""] [&]:before:left-0 [&]:before:top-0 [&]:before:w-[15.5rem] [&]:before:h-full shadow-gray bg-gray w-[236px] xs:max-md:overflow-y block"
+      class="h-full shadow-[inset_-1px_0_0_0] text-lg/[inherit] relative transition-[width] ease-in delay-[225ms] lg:block [&]:before:absolute [&]:before:content-[""] [&]:before:left-0 [&]:before:top-0 [&]:before:w-[15.5rem] [&]:before:h-full shadow-gray bg-gray w-[236px] xs:max-md:overflow-y block"
     >
       <div
         class="h-full max-h-[calc(100vh-var(--header sticky top-[var(--header"

--- a/packages/base/Page/src/TopBarItem/TopBarItem.tsx
+++ b/packages/base/Page/src/TopBarItem/TopBarItem.tsx
@@ -25,19 +25,17 @@ export interface Props extends BaseProps, TextLabelProps {
 }
 
 const rootClasses = [
-  'min-[1280px]:text-gray-600 min-[1280px]:p-0 min-[1280px]:h-auto',
-  'min-[1280px]:w-auto min-[1280px]:m-0 min-[1280px]:flex-auto',
-  'min-[1280px]:[&_p]:text-sm',
+  'lg:text-gray-600 lg:p-0 lg:h-auto',
+  'lg:w-auto lg:m-0 lg:flex-auto',
+  'lg:[&_p]:text-sm',
 ]
 const separatorClasses = [
-  'min-[1280px]:before:[&:not(:first-child)]:content-[""]',
-  'min-[1280px]:before:bg-gray-600 min-[1280px]:before:inline-block',
-  'min-[1280px]:before:h-2 min-[1280px]:before:mx-2 min-[1280px]:before:w-[1px]',
+  'lg:before:[&:not(:first-child)]:content-[""]',
+  'lg:before:bg-gray-600 lg:before:inline-block',
+  'lg:before:h-2 lg:before:mx-2 lg:before:w-[1px]',
 ]
-const bgClasses =
-  'min-[1280px]:hover:bg-transparent min-[1280px]:focus:bg-transparent'
-const textColorClasses =
-  'min-[1280px]:hover:text-gray-400 min-[1280px]:hover:text-white'
+const bgClasses = 'lg:hover:bg-transparent lg:focus:bg-transparent'
+const textColorClasses = 'lg:hover:text-gray-400 lg:hover:text-white'
 
 export const TopBarItem: OverridableComponent<Props> = memo(
   forwardRef<HTMLElement, Props>(function TopBarItem(props, ref) {
@@ -51,9 +49,8 @@ export const TopBarItem: OverridableComponent<Props> = memo(
           separatorClasses,
           bgClasses,
           textColorClasses,
-          icon && 'min-[1280px]:[&_svg]:w-[1em]',
-          props.selected &&
-            'min-[1280px]:bg-transparent min-[1280px]:text-white',
+          icon && 'lg:[&_svg]:w-[1em]',
+          props.selected && 'lg:bg-transparent lg:text-white',
           className
         )}
         ref={ref}

--- a/packages/base/Page/src/TopBarMenu/TopBarMenu.tsx
+++ b/packages/base/Page/src/TopBarMenu/TopBarMenu.tsx
@@ -24,7 +24,7 @@ export const TopBarMenu = forwardRef<HTMLUListElement, Props>(
         {...rest}
         allowNestedNavigation={false}
         ref={ref}
-        className='block min-[1280px]:flex shadow-0'
+        className='block lg:flex shadow-0'
       >
         {items}
       </Menu>


### PR DESCRIPTION
[FX-201]

### Description

As part of performance bottleneck research, I found case where we re-render sidebar twice because desktop and mobile sidebar are mounted.

### How to test

Go to...

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| Insert screenshots or screen recordings | Insert screenshots or screen recordings |

### Development checks

- [ ] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [ ] Double check if `picasso-tailwind-merge` requires major update (check its `README.md`)
- [ ] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [ ] Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [ ] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [ ] Self reviewed
- [ ] Covered with tests ([visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md) included)

**Breaking change**

- [ ] codemod is created and showcased in the changeset
- [ ] test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-201]: https://toptal-core.atlassian.net/browse/FX-201?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ