### PR TITLE
[MP-598] Align tabs with base design

### DIFF
--- a/.changeset/friendly-crabs-serve.md
+++ b/.changeset/friendly-crabs-serve.md
@@ -1,0 +1,5 @@
+---
+'@toptal/picasso-tabs': patch
+---
+
+- fix horizontal tabs heigh (no top padding and adjusted line height)

--- a/.changeset/friendly-crabs-serve.md
+++ b/.changeset/friendly-crabs-serve.md
@@ -2,4 +2,4 @@
 '@toptal/picasso-tabs': patch
 ---
 
-- fix horizontal tabs heigh (no top padding and adjusted line height)
+- fix spacing in horizontal tabs variant (no top padding and adjusted line height)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -44,7 +44,7 @@ Describe the changes and motivations for the pull request.
 List of available commands:
 
 - `@toptal-bot run package:alpha-release` - Release alpha version
-- `@toptal-anvil ping reviewers` - Ping FX team for review
+- `@toptal-anvil ping reviewers` - Ping for reviews
 
 </details>
 

--- a/packages/base/Tabs/src/Tab/__snapshots__/test.tsx.snap
+++ b/packages/base/Tabs/src/Tab/__snapshots__/test.tsx.snap
@@ -33,7 +33,7 @@ exports[`Tab Tab disabled tab 1`] = `
               class="MuiTab-wrapper PicassoTab-wrapper"
             >
               <div
-                class="m-0 text-sm text-inherit font-semibold"
+                class="m-0 text-sm text-inherit font-semibold leading-[1.1rem]"
               >
                 Tab Label
               </div>
@@ -82,7 +82,7 @@ exports[`Tab Tab renders 1`] = `
               class="MuiTab-wrapper PicassoTab-wrapper"
             >
               <div
-                class="m-0 text-sm text-inherit font-semibold"
+                class="m-0 text-sm text-inherit font-semibold leading-[1.1rem]"
               >
                 Tab Label
               </div>
@@ -134,7 +134,7 @@ exports[`Tab Tab tab with icon 1`] = `
                 id="Icon"
               />
               <div
-                class="m-0 text-sm text-inherit font-semibold"
+                class="m-0 text-sm text-inherit font-semibold leading-[1.1rem]"
               >
                 Tab Label
               </div>

--- a/packages/base/Tabs/src/Tab/styles.ts
+++ b/packages/base/Tabs/src/Tab/styles.ts
@@ -49,6 +49,7 @@ PicassoProvider.override(({ breakpoints, palette }: Theme) => ({
 export default ({ sizes, palette, shadows, transitions }: Theme) =>
   createStyles({
     horizontal: {
+      paddingTop: 0,
       '&:not(:last-child)': {
         marginRight: '2em',
       },

--- a/packages/base/Tabs/src/TabLabel/TabLabel.tsx
+++ b/packages/base/Tabs/src/TabLabel/TabLabel.tsx
@@ -17,6 +17,7 @@ const TabLabel = ({ label, orientation, titleCase }: Props) => {
         weight='semibold'
         color='inherit'
         titleCase={titleCase}
+        className='leading-[1.1rem]'
       >
         {label}
       </Typography>

--- a/packages/base/Tabs/src/Tabs/__snapshots__/test.tsx.snap
+++ b/packages/base/Tabs/src/Tabs/__snapshots__/test.tsx.snap
@@ -33,7 +33,7 @@ exports[`Tabs renders 1`] = `
               class="MuiTab-wrapper PicassoTab-wrapper"
             >
               <div
-                class="m-0 text-sm text-inherit font-semibold"
+                class="m-0 text-sm text-inherit font-semibold leading-[1.1rem]"
               >
                 Tab 1
               </div>
@@ -51,7 +51,7 @@ exports[`Tabs renders 1`] = `
               class="MuiTab-wrapper PicassoTab-wrapper"
             >
               <div
-                class="m-0 text-sm text-inherit font-semibold"
+                class="m-0 text-sm text-inherit font-semibold leading-[1.1rem]"
               >
                 Tab 2
               </div>
@@ -97,7 +97,7 @@ exports[`Tabs renders in full width 1`] = `
               class="MuiTab-wrapper PicassoTab-wrapper"
             >
               <div
-                class="m-0 text-sm text-inherit font-semibold"
+                class="m-0 text-sm text-inherit font-semibold leading-[1.1rem]"
               >
                 Tab 1
               </div>
@@ -115,7 +115,7 @@ exports[`Tabs renders in full width 1`] = `
               class="MuiTab-wrapper PicassoTab-wrapper"
             >
               <div
-                class="m-0 text-sm text-inherit font-semibold"
+                class="m-0 text-sm text-inherit font-semibold leading-[1.1rem]"
               >
                 Tab 2
               </div>
@@ -233,7 +233,7 @@ exports[`Tabs renders with a pre-selected option 1`] = `
               class="MuiTab-wrapper PicassoTab-wrapper"
             >
               <div
-                class="m-0 text-sm text-inherit font-semibold"
+                class="m-0 text-sm text-inherit font-semibold leading-[1.1rem]"
               >
                 Tab 1
               </div>
@@ -251,7 +251,7 @@ exports[`Tabs renders with a pre-selected option 1`] = `
               class="MuiTab-wrapper PicassoTab-wrapper"
             >
               <div
-                class="m-0 text-sm text-inherit font-semibold"
+                class="m-0 text-sm text-inherit font-semibold leading-[1.1rem]"
               >
                 Tab 2
               </div>
@@ -308,7 +308,7 @@ exports[`Tabs renders with a pre-selected option using custom value 1`] = `
               class="MuiTab-wrapper PicassoTab-wrapper"
             >
               <div
-                class="m-0 text-sm text-inherit font-semibold"
+                class="m-0 text-sm text-inherit font-semibold leading-[1.1rem]"
               >
                 Tab 1
               </div>
@@ -326,7 +326,7 @@ exports[`Tabs renders with a pre-selected option using custom value 1`] = `
               class="MuiTab-wrapper PicassoTab-wrapper"
             >
               <div
-                class="m-0 text-sm text-inherit font-semibold"
+                class="m-0 text-sm text-inherit font-semibold leading-[1.1rem]"
               >
                 Tab 2
               </div>


### PR DESCRIPTION
[MP-598]

### Description

Aligns Tabs with [Base design](https://www.figma.com/design/5SCTOPrCDcHuk5We091GBn/Product-Library?node-id=246-11213&t=CFVgzhA9g0px4x9M-0).

### How to test

<!-- The temploy link will be automatically updated when the temploy is deployed -->
- [Temploy](https://picasso.toptal.net/MP-598-tabs-height)
- Check visual changes

### Screenshots

Base

<img width="431" alt="Screenshot 2025-02-04 at 19 43 30" src="https://github.com/user-attachments/assets/0de67c86-9c99-4ea7-8cb2-cbb53189db68" />


Before changes

<img width="423" alt="Screenshot 2025-02-04 at 19 51 20" src="https://github.com/user-attachments/assets/d4643fed-2a00-47c4-90f6-599cce5d709d" />


After changes

<img width="454" alt="Screenshot 2025-02-04 at 19 42 58" src="https://github.com/user-attachments/assets/a377b64c-6234-44e3-a12e-f8b0073a5aec" />


### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Double check if `picasso-tailwind-merge` requires major update (check its `README.md`)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [N/A] Annotate all `props` in component with documentation
- [N/A] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests ([visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md) included)

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping FX team for review

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[MP-598]: https://toptal-core.atlassian.net/browse/MP-598?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ