### PR TITLE
Make loading disabled buttons colorful

### DIFF
--- a/.changeset/nice-games-beg.md
+++ b/.changeset/nice-games-beg.md
@@ -1,0 +1,9 @@
+---
+'@toptal/picasso-button': patch
+---
+
+---
+
+### Button
+
+- use the button's variant color when displaying the loading indicator in a disabled button, instead of the default grey

--- a/packages/base/Button/src/Button/Button.tsx
+++ b/packages/base/Button/src/Button/Button.tsx
@@ -131,6 +131,7 @@ export const Button: OverridableComponent<Props> = forwardRef<
     focused,
     hovered,
     active,
+    loading,
   })
   const sizeClassNames = createSizeClassNames(size)
 

--- a/packages/base/Button/src/Button/styles.ts
+++ b/packages/base/Button/src/Button/styles.ts
@@ -24,11 +24,13 @@ export const createVariantClassNames = (
     focused,
     hovered,
     active,
+    loading,
   }: {
     disabled?: boolean
     focused?: boolean
     hovered?: boolean
     active?: boolean
+    loading?: boolean
   }
 ): string[] => {
   const variantClassNames = []
@@ -39,7 +41,7 @@ export const createVariantClassNames = (
       variantClassNames.push('text-white')
       variantClassNames.push('visited:text-white')
 
-      if (disabled) {
+      if (disabled && !loading) {
         variantClassNames.push('bg-gray-400')
       } else {
         variantClassNames.push('hover:bg-[#4269D6]')
@@ -60,7 +62,7 @@ export const createVariantClassNames = (
       variantClassNames.push('text-white')
       variantClassNames.push('visited:text-white')
 
-      if (disabled) {
+      if (disabled && !loading) {
         variantClassNames.push('bg-gray-400')
       } else {
         variantClassNames.push('hover:bg-[#DB466B]')
@@ -80,7 +82,7 @@ export const createVariantClassNames = (
       variantClassNames.push('text-white')
       variantClassNames.push('visited:text-white')
 
-      if (disabled) {
+      if (disabled && !loading) {
         variantClassNames.push('bg-gray-400')
       } else {
         variantClassNames.push('hover:bg-[#27D496]')
@@ -98,7 +100,7 @@ export const createVariantClassNames = (
     case 'secondary':
       variantClassNames.push('border border-solid')
 
-      if (disabled) {
+      if (disabled && !loading) {
         variantClassNames.push('text-gray-500')
         variantClassNames.push('visited:text-gray-500')
         variantClassNames.push('border-gray-500')
@@ -127,7 +129,7 @@ export const createVariantClassNames = (
       break
     case 'transparent':
       variantClassNames.push('border border-solid')
-      if (disabled) {
+      if (disabled && !loading) {
         variantClassNames.push('text-white/[0.32]')
         variantClassNames.push('border-white/[0.32]')
         variantClassNames.push('bg-transparent')

--- a/packages/base/Button/src/ButtonCircular/ButtonCircular.tsx
+++ b/packages/base/Button/src/ButtonCircular/ButtonCircular.tsx
@@ -57,6 +57,7 @@ export const ButtonCircular: OverridableComponent<Props> = forwardRef<
     focused,
     hovered,
     active,
+    loading,
   })
 
   const finalClassName = cx(

--- a/packages/base/Button/src/ButtonCircular/styles.ts
+++ b/packages/base/Button/src/ButtonCircular/styles.ts
@@ -28,11 +28,13 @@ export const createVariantClassNames = (
     focused,
     hovered,
     active,
+    loading,
   }: {
     disabled?: boolean
     focused?: boolean
     hovered?: boolean
     active?: boolean
+    loading?: boolean
   }
 ): string[] => {
   const variantClassNames = []
@@ -43,7 +45,7 @@ export const createVariantClassNames = (
       variantClassNames.push('text-white')
       variantClassNames.push('visited:text-white')
 
-      if (disabled) {
+      if (disabled && !loading) {
         variantClassNames.push('bg-gray-400')
       } else {
         variantClassNames.push('hover:bg-[#4269D6]')
@@ -69,7 +71,7 @@ export const createVariantClassNames = (
       variantClassNames.push('border-none')
       variantClassNames.push('text-graphite-700')
 
-      if (disabled) {
+      if (disabled && !loading) {
         variantClassNames.push('text-graphite-700')
         variantClassNames.push('opacity-[0.48]')
         variantClassNames.push('bg-transparent')
@@ -97,7 +99,7 @@ export const createVariantClassNames = (
       variantClassNames.push('border-none')
       variantClassNames.push('text-white')
 
-      if (disabled) {
+      if (disabled && !loading) {
         variantClassNames.push('text-white/[0.48]')
         variantClassNames.push('bg-transparent')
       } else {


### PR DESCRIPTION
### Description

After discussion with Milos it appeared that the buttons in loading state, even if they are disabled should look like normal buttons, instead of becoming grey. So, here is the change.

Let's make them colorful!

![giphy](https://github.com/user-attachments/assets/8cddf318-4b4c-4933-a314-99c44ec626be)


### How to test

- Open storybook and check Button with both `loading` and `disabled` at the same time.
- It should be disabled, but having color of the variant

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| <img width="94" alt="Screenshot 2025-02-12 at 16 58 33" src="https://github.com/user-attachments/assets/98409dc9-e594-46f0-9a21-043b3151c02d" /> | <img width="95" alt="Screenshot 2025-02-12 at 16 58 39" src="https://github.com/user-attachments/assets/b153e100-c7ef-463f-888e-896f6cb84aa9" /> |

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Double check if `picasso-tailwind-merge` requires major update (check its `README.md`)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests ([visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md) included)

**Breaking change**

- [x] codemod is created and showcased in the changeset
- [x] test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping for reviews

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>
