### PR TITLE
[ER-45674] Allow not providing totalCount for compact Pagination

### DIFF
--- a/.changeset/calm-insects-run.md
+++ b/.changeset/calm-insects-run.md
@@ -1,0 +1,6 @@
+---
+'@toptal/picasso-pagination': patch
+---
+
+- allow `variant=compact` without `totalCount`
+- add `nextDisabled` for pagination control

--- a/packages/base/Pagination/src/Pagination/Pagination.tsx
+++ b/packages/base/Pagination/src/Pagination/Pagination.tsx
@@ -9,27 +9,38 @@ import { Typography } from '@toptal/picasso-typography'
 import { getRange, ELLIPSIS } from './utils'
 import { PaginationButton } from '../PaginationButton'
 
-export interface Props extends BaseProps, HTMLAttributes<HTMLDivElement> {
+interface CommonProps extends BaseProps, HTMLAttributes<HTMLDivElement> {
   /** Value of the current highlighted page */
   activePage: number
   /** Shows `Pagination` in disabled state when pages are not changeable */
   disabled?: boolean
   /** Callback invoked when any page number is clicked */
   onPageChange: (page: number) => void
-  /** Value of total pages of the data set used for calculation of page buttons.
-   *  When not provided:
-   *  - An error will be raised unless `variant=compact`
-   *  - Last page can't be detected, so next button will always be enabled.
-   *    Use `nextDisabled=true` to disable it when rendering the last page.
-   * */
-  totalPages?: number
   /** Number of the active page siblings  */
   siblingCount?: number
-  /** Variant of the pagination representation  */
-  variant?: 'default' | 'compact'
   /** Shows the next button as disabled. */
   nextDisabled?: boolean
 }
+
+interface DefaultVariantProps {
+  /** Variant of the pagination representation  */
+  variant?: 'default'
+  /** Value of total pages of the data set used for calculation of page buttons. */
+  totalPages: number
+}
+
+interface CompactVariantProps {
+  /** Variant of the pagination representation  */
+  variant: 'compact'
+  /** Value of total pages of the data set used for calculation of page buttons.
+   *  Only optional for the `compact` variant.
+   *  When not provided the last page can't be detected, so next button will always be enabled.
+   *  Use `nextDisabled=true` to disable it when rendering the last page.
+   * */
+  totalPages?: number
+}
+
+export type Props = CommonProps & (DefaultVariantProps | CompactVariantProps)
 
 export const Pagination = forwardRef<HTMLDivElement, Props>(function Pagination(
   props,
@@ -46,19 +57,13 @@ export const Pagination = forwardRef<HTMLDivElement, Props>(function Pagination(
     ...rest
   } = props
 
-  if (totalPages == null && variant !== 'compact') {
-    throw new Error('Pagination requires totalPages for non compact variants')
-  }
-
   const pages = useMemo(
     () =>
-      totalPages != null
-        ? getRange({ activePage, totalPages, siblingCount })
-        : [],
+      totalPages ? getRange({ activePage, totalPages, siblingCount }) : [],
     [activePage, totalPages, siblingCount]
   )
 
-  if (totalPages != null && totalPages <= 1) {
+  if (totalPages !== undefined && totalPages <= 1) {
     return null
   }
 

--- a/packages/base/Pagination/src/Pagination/__snapshots__/test.tsx.snap
+++ b/packages/base/Pagination/src/Pagination/__snapshots__/test.tsx.snap
@@ -164,6 +164,47 @@ exports[`Pagination renders 1`] = `
 </div>
 `;
 
+exports[`Pagination renders compact without totalPages 1`] = `
+<div>
+  <div
+    class="Picasso-root"
+  >
+    <div
+      class="items-center inline-flex"
+    >
+      <button
+        aria-disabled="false"
+        class="base-Button text-lg inline-flex items-center justify-center select-none appearance-none m-0 relative normal-case align-middle transition-colors duration-350 ease-out shrink-0 outline-none [[data-component-type="button"]+&]:ml cursor-pointer no-underline hover:no-underline rounded-sm shadow-none focus-visible:shadow-[0_0_0_3px_rgba(32,78,207,0.48)] focus-within:shadow-[0_0_0_3px_rgba(32,78,207,0.48)] border border-solid text-black hover:border-black visited:text-black active:bg-gray active:border-black bg-white border-gray min-w h-6 py-0 px-3 [&+&]:!ml-2"
+        data-component-type="button"
+        role="button"
+        tabindex="0"
+        type="button"
+      >
+        <span
+          class="items-center inline-flex font-semibold whitespace-nowrap text-button"
+        >
+          Prev
+        </span>
+      </button>
+      <button
+        aria-disabled="false"
+        class="base-Button text-lg inline-flex items-center justify-center select-none appearance-none m-0 relative normal-case align-middle transition-colors duration-350 ease-out shrink-0 outline-none [[data-component-type="button"]+&]:ml cursor-pointer no-underline hover:no-underline rounded-sm shadow-none focus-visible:shadow-[0_0_0_3px_rgba(32,78,207,0.48)] focus-within:shadow-[0_0_0_3px_rgba(32,78,207,0.48)] border border-solid text-black hover:border-black visited:text-black active:bg-gray active:border-black bg-white border-gray min-w h-6 py-0 px-3 [&+&]:!ml-2"
+        data-component-type="button"
+        role="button"
+        tabindex="0"
+        type="button"
+      >
+        <span
+          class="items-center inline-flex font-semibold whitespace-nowrap text-button"
+        >
+          Next
+        </span>
+      </button>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Pagination renders disabled 1`] = `
 <div>
   <div
@@ -350,5 +391,47 @@ exports[`Pagination renders nothing for 1 page 1`] = `
   <div
     class="Picasso-root"
   />
+</div>
+`;
+
+exports[`Pagination renders with next disabled 1`] = `
+<div>
+  <div
+    class="Picasso-root"
+  >
+    <div
+      class="items-center inline-flex"
+    >
+      <button
+        aria-disabled="false"
+        class="base-Button text-lg inline-flex items-center justify-center select-none appearance-none m-0 relative normal-case align-middle transition-colors duration-350 ease-out shrink-0 outline-none [[data-component-type="button"]+&]:ml cursor-pointer no-underline hover:no-underline rounded-sm shadow-none focus-visible:shadow-[0_0_0_3px_rgba(32,78,207,0.48)] focus-within:shadow-[0_0_0_3px_rgba(32,78,207,0.48)] border border-solid text-black hover:border-black visited:text-black active:bg-gray active:border-black bg-white border-gray min-w h-6 py-0 px-3 [&+&]:!ml-2"
+        data-component-type="button"
+        role="button"
+        tabindex="0"
+        type="button"
+      >
+        <span
+          class="items-center inline-flex font-semibold whitespace-nowrap text-button"
+        >
+          Prev
+        </span>
+      </button>
+      <button
+        aria-disabled="true"
+        class="base-Button base- text-lg inline-flex items-center justify-center select-none appearance-none m-0 relative normal-case align-middle transition-colors duration-350 ease-out shrink-0 outline-none [[data-component-type="button"]+&]:ml cursor-default pointer-events no-underline hover:no-underline rounded-sm shadow-none border border-solid text-gray visited:text-gray border-gray bg-white min-w h-6 py-0 px-3 [&+&]:!ml-2"
+        data-component-type="button"
+        disabled=""
+        role="button"
+        tabindex="-1"
+        type="button"
+      >
+        <span
+          class="items-center inline-flex font-semibold whitespace-nowrap text-button"
+        >
+          Next
+        </span>
+      </button>
+    </div>
+  </div>
 </div>
 `;

--- a/packages/base/Pagination/src/Pagination/story/Disabled.example.tsx
+++ b/packages/base/Pagination/src/Pagination/story/Disabled.example.tsx
@@ -1,15 +1,37 @@
 import React from 'react'
-import { Pagination } from '@toptal/picasso'
+import { Pagination, Container, Typography } from '@toptal/picasso'
+import { SPACING_2, SPACING_4 } from '@toptal/picasso-utils'
 
 const Example = () => (
-  <div>
-    <Pagination
-      activePage={4}
-      disabled
-      onPageChange={handlePageChange}
-      totalPages={10}
-    />
-  </div>
+  <Container flex direction='column' justifyContent='space-between'>
+    <Container bottom={SPACING_2}>
+      <Typography variant='heading' size='small'>
+        Disabled
+      </Typography>
+    </Container>
+    <Container bottom={SPACING_4}>
+      <Pagination
+        activePage={4}
+        disabled
+        onPageChange={handlePageChange}
+        totalPages={10}
+      />
+    </Container>
+
+    <Container bottom={SPACING_2}>
+      <Typography variant='heading' size='small'>
+        Next disabled
+      </Typography>
+    </Container>
+    <Container>
+      <Pagination
+        activePage={4}
+        nextDisabled
+        onPageChange={handlePageChange}
+        totalPages={10}
+      />
+    </Container>
+  </Container>
 )
 
 const handlePageChange = () => {}

--- a/packages/base/Pagination/src/Pagination/story/Variants.example.tsx
+++ b/packages/base/Pagination/src/Pagination/story/Variants.example.tsx
@@ -26,7 +26,6 @@ const Example = () => (
       <Pagination
         activePage={3}
         onPageChange={handlePageChange}
-        totalPages={5}
         variant='compact'
       />
     </Container>

--- a/packages/base/Pagination/src/Pagination/test.tsx
+++ b/packages/base/Pagination/src/Pagination/test.tsx
@@ -48,16 +48,6 @@ describe('Pagination', () => {
     expect(container).toMatchSnapshot()
   })
 
-  it('throws an error when using default variant and no totalPages', () => {
-    expect(() =>
-      renderPagination({
-        activePage: 5,
-        totalPages: null,
-        onPageChange: () => {},
-      })
-    ).toThrow('Pagination requires totalPages for non compact variants')
-  })
-
   it('renders disabled', () => {
     const { container } = renderPagination({
       activePage: 5,

--- a/packages/base/Pagination/src/Pagination/test.tsx
+++ b/packages/base/Pagination/src/Pagination/test.tsx
@@ -6,7 +6,14 @@ import type { Props } from './Pagination'
 import { Pagination } from './Pagination'
 
 const renderPagination = (props: OmitInternalProps<Props>) => {
-  const { activePage, disabled, onPageChange, totalPages } = props
+  const {
+    activePage,
+    disabled,
+    onPageChange,
+    totalPages,
+    nextDisabled,
+    variant,
+  } = props
 
   return render(
     <Pagination
@@ -14,6 +21,8 @@ const renderPagination = (props: OmitInternalProps<Props>) => {
       disabled={disabled}
       onPageChange={onPageChange}
       totalPages={totalPages}
+      nextDisabled={nextDisabled}
+      variant={variant}
     />
   )
 }
@@ -29,11 +38,42 @@ describe('Pagination', () => {
     expect(container).toMatchSnapshot()
   })
 
+  it('renders compact without totalPages', () => {
+    const { container } = renderPagination({
+      activePage: 5,
+      variant: 'compact',
+      onPageChange: () => {},
+    })
+
+    expect(container).toMatchSnapshot()
+  })
+
+  it('throws an error when using default variant and no totalPages', () => {
+    expect(() =>
+      renderPagination({
+        activePage: 5,
+        totalPages: null,
+        onPageChange: () => {},
+      })
+    ).toThrow('Pagination requires totalPages for non compact variants')
+  })
+
   it('renders disabled', () => {
     const { container } = renderPagination({
       activePage: 5,
       totalPages: 20,
       disabled: true,
+      onPageChange: () => {},
+    })
+
+    expect(container).toMatchSnapshot()
+  })
+
+  it('renders with next disabled', () => {
+    const { container } = renderPagination({
+      activePage: 5,
+      variant: 'compact',
+      nextDisabled: true,
       onPageChange: () => {},
     })
 


### PR DESCRIPTION
[ER-45674]

### Description

Sometimes the backend doesn't have the total number results for a query (for example because getting the total count is expensive)

`<Pagination variant="compact">` UX works well for this use case, but the component expects `totalPages`. This removes the requirement.

When we don't have the `totalPages` we can't know in which page we are, so we can't know if we're in the last page to show the button disabled (we can know when we are on the first one though). To fix, this also adds a `nextDisabled` prop.

### How to test

<!-- The temploy link will be automatically updated when the temploy is deployed -->
- [Temploy](https://picasso.toptal.net/er-45674-pagination-without-totals)
- FIXME: Add the steps describing how to verify your changes
- See https://github.com/toptal/staff-portal/pull/14195

### Screenshots

See storybook

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Double check if `picasso-tailwind-merge` requires major update (check its `README.md`)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests ([visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md) included)

**Breaking change**

- [x] codemod is created and showcased in the changeset
- [x] test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping for reviews

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[ER-45674]: https://toptal-core.atlassian.net/browse/ER-45674?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ