### PR TITLE
Fix Table paddings for last column

### DIFF
--- a/.changeset/lazy-radios-train.md
+++ b/.changeset/lazy-radios-train.md
@@ -4,4 +4,4 @@
 
 ---
 
-- make padding of the last Table Cell smalle and equal to the left padding of the first cell/column.
+- make padding of the last Table Cell smaller and equal to the left padding of the first cell/column.

--- a/.changeset/lazy-radios-train.md
+++ b/.changeset/lazy-radios-train.md
@@ -1,0 +1,7 @@
+---
+'@toptal/picasso-table': patch
+---
+
+---
+
+- make padding of the last Table Cell smalle and equal to the left padding of the first cell/column.

--- a/packages/base/Table/src/Table/__snapshots__/test.tsx.snap
+++ b/packages/base/Table/src/Table/__snapshots__/test.tsx.snap
@@ -15,7 +15,7 @@ exports[`Table renders 1`] = `
           class="border-0 border-solid border-b border-gray"
         >
           <th
-            class="h-10 py-2 border-none last:pr-6 px-4 text-left"
+            class="h-10 py-2 border-none px-4 text-left"
           >
             <div
               class="m-0 text-xxs text-graphite font-semibold text-align"
@@ -30,7 +30,7 @@ exports[`Table renders 1`] = `
           class="border-0 border-solid border-b border-gray"
         >
           <td
-            class="h-10 py-2 border-none last:pr-6 px-4"
+            class="h-10 py-2 border-none px-4"
           >
             <div
               class="m-0 text-sm text-graphite font-inherit text-align"
@@ -47,7 +47,7 @@ exports[`Table renders 1`] = `
           class="border-0 border-solid border-b border-gray"
         >
           <td
-            class="h-10 py-2 border-none last:pr-6 px-4"
+            class="h-10 py-2 border-none px-4"
           >
             <div
               class="m-0 text-sm text-black font-semibold text-align"

--- a/packages/base/Table/src/TableBody/__snapshots__/test.tsx.snap
+++ b/packages/base/Table/src/TableBody/__snapshots__/test.tsx.snap
@@ -13,7 +13,7 @@ exports[`TableCell renders 1`] = `
           class="border-0 border-solid border-b border-gray"
         >
           <td
-            class="h-10 py-2 border-none last:pr-6 px-4"
+            class="h-10 py-2 border-none px-4"
           >
             <div
               class="m-0 text-sm text-graphite font-inherit text-align"

--- a/packages/base/Table/src/TableCell/TableCell.tsx
+++ b/packages/base/Table/src/TableCell/TableCell.tsx
@@ -92,7 +92,7 @@ export const TableCell = forwardRef<HTMLTableCellElement, Props>(
     const spacingClasses = {
       narrow: '',
       regular: 'px-4',
-      compact: 'h-6 py-[1px] last:pr-3',
+      compact: 'h-6 py-[1px]',
     }
 
     return (
@@ -100,7 +100,7 @@ export const TableCell = forwardRef<HTMLTableCellElement, Props>(
         {...rest}
         ref={ref}
         className={twMerge(
-          'h-10 px-2 py-2 border-none last:pr-4',
+          'h-10 px-2 py-2 border-none',
           spacingClasses[spacing],
           isHead && 'text-left',
           className

--- a/packages/base/Table/src/TableCell/TableCell.tsx
+++ b/packages/base/Table/src/TableCell/TableCell.tsx
@@ -100,7 +100,7 @@ export const TableCell = forwardRef<HTMLTableCellElement, Props>(
         {...rest}
         ref={ref}
         className={twMerge(
-          'h-10 px-2 py-2 border-none last:pr-6',
+          'h-10 px-2 py-2 border-none last:pr-4',
           spacingClasses[spacing],
           isHead && 'text-left',
           className

--- a/packages/base/Table/src/TableCell/__snapshots__/test.tsx.snap
+++ b/packages/base/Table/src/TableCell/__snapshots__/test.tsx.snap
@@ -13,7 +13,7 @@ exports[`TableCell renders 1`] = `
           class="border-0 border-solid border-b border-gray"
         >
           <td
-            class="h-10 py-2 border-none last:pr-6 px-4"
+            class="h-10 py-2 border-none px-4"
           >
             <div
               class="m-0 text-sm text-graphite font-inherit text-align"
@@ -41,7 +41,7 @@ exports[`TableCell renders compact 1`] = `
           class="border-0 border-solid border-b border-gray"
         >
           <td
-            class="h-10 py-2 border-none last:pr-6 px-4"
+            class="h-10 py-2 border-none px-4"
           >
             <div
               class="m-0 text-sm text-graphite font-inherit text-align"
@@ -69,7 +69,7 @@ exports[`TableCell renders narrow 1`] = `
           class="border-0 border-solid border-b border-gray"
         >
           <td
-            class="h-10 py-2 border-none last:pr-6 px-4"
+            class="h-10 py-2 border-none px-4"
           >
             <div
               class="m-0 text-sm text-graphite font-inherit text-align"

--- a/packages/base/Table/src/TableFooter/__snapshots__/test.tsx.snap
+++ b/packages/base/Table/src/TableFooter/__snapshots__/test.tsx.snap
@@ -15,7 +15,7 @@ exports[`TableFooter renders 1`] = `
           class="border-0 border-solid border-b border-gray"
         >
           <td
-            class="h-10 py-2 border-none last:pr-6 px-4"
+            class="h-10 py-2 border-none px-4"
           >
             <div
               class="m-0 text-sm text-black font-semibold text-align"

--- a/packages/base/Table/src/TableHead/__snapshots__/test.tsx.snap
+++ b/packages/base/Table/src/TableHead/__snapshots__/test.tsx.snap
@@ -15,7 +15,7 @@ exports[`TableHead renders 1`] = `
           class="border-0 border-solid border-b border-gray"
         >
           <th
-            class="h-10 py-2 border-none last:pr-6 px-4 text-left"
+            class="h-10 py-2 border-none px-4 text-left"
           >
             <div
               class="m-0 text-xxs text-graphite font-semibold text-align"

--- a/packages/base/Table/src/TableRow/__snapshots__/test.tsx.snap
+++ b/packages/base/Table/src/TableRow/__snapshots__/test.tsx.snap
@@ -13,7 +13,7 @@ exports[`TableRow renders 1`] = `
           class="border-0 border-solid border-b border-gray"
         >
           <td
-            class="h-10 py-2 border-none last:pr-6 px-4"
+            class="h-10 py-2 border-none px-4"
           >
             <div
               class="m-0 text-sm text-graphite font-inherit text-align"

--- a/packages/base/Table/src/TableSectionHead/__snapshots__/test.tsx.snap
+++ b/packages/base/Table/src/TableSectionHead/__snapshots__/test.tsx.snap
@@ -13,7 +13,7 @@ exports[`TableSectionHead renders 1`] = `
           class="border-0 min-h border-y border-solid border-gray"
         >
           <th
-            class="h-10 py-2 border-none last:pr-6 px-4 text-left"
+            class="h-10 py-2 border-none px-4 text-left"
             colspan="100"
           >
             <div

--- a/packages/base/Table/src/TableSortableCell/__snapshots__/test.tsx.snap
+++ b/packages/base/Table/src/TableSortableCell/__snapshots__/test.tsx.snap
@@ -9,7 +9,7 @@ exports[`TableCell sort direction is asc renders with a sort button in the right
       <tbody>
         <tr>
           <td
-            class="h-10 py-2 border-none last:pr-6 px-4 group hover:bg-gray"
+            class="h-10 py-2 border-none px-4 group hover:bg-gray"
           >
             <div
               class="flex items-center"
@@ -59,7 +59,7 @@ exports[`TableCell sort direction is desc renders with a sort button in the righ
       <tbody>
         <tr>
           <td
-            class="h-10 py-2 border-none last:pr-6 px-4 group hover:bg-gray"
+            class="h-10 py-2 border-none px-4 group hover:bg-gray"
           >
             <div
               class="flex items-center"


### PR DESCRIPTION
### Description

By some reason now we have the last cell having custom extra padding. After discussion with Milos and checking Figma - https://www.figma.com/design/q2nvjiyO2CLqBv4DeJnU3i/Product-Library-Documentation?node-id=476-9897&t=ywR92i2wXfDtSkiq-4. We agreed that there should be no extra padding and the left padding for the first cell/column should be the same as the right padding for the last column.

<img width="2296" alt="Screenshot 2025-02-24 at 12 40 58" src="https://github.com/user-attachments/assets/b0de1e83-5c0e-47f3-b58e-f04f4bba7af8" />

### How to test

Check padding for Table component in storybook.

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Double check if `picasso-tailwind-merge` requires major update (check its `README.md`)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests ([visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md) included)

**Breaking change**

- [x] codemod is created and showcased in the changeset
- [x] test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping for reviews

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>
