### PR TITLE
[MP-996] Add size property to TagSelector

### DIFF
--- a/.changeset/lovely-bikes-agree.md
+++ b/.changeset/lovely-bikes-agree.md
@@ -1,0 +1,7 @@
+---
+'@toptal/picasso-tagselector': minor
+---
+
+### TagSelector
+
+- add `size` property to control input size

--- a/packages/base/Tagselector/src/TagSelector/TagSelector.tsx
+++ b/packages/base/Tagselector/src/TagSelector/TagSelector.tsx
@@ -6,7 +6,7 @@ import type {
   FocusEventHandler,
 } from 'react'
 import React, { forwardRef, Fragment } from 'react'
-import type { BaseProps } from '@toptal/picasso-shared'
+import type { BaseProps, SizeType } from '@toptal/picasso-shared'
 import type { PopperOptions } from 'popper.js'
 import { Autocomplete } from '@toptal/picasso-autocomplete'
 import { unsafeErrorLog, noop } from '@toptal/picasso-utils'
@@ -49,7 +49,7 @@ const getItemText = (item: Item | null) =>
 
 export interface Props
   extends BaseProps,
-    Omit<InputHTMLAttributes<HTMLInputElement>, 'onChange' | 'value'> {
+    Omit<InputHTMLAttributes<HTMLInputElement>, 'onChange' | 'value' | 'size'> {
   /** Placeholder for value */
   placeholder?: string
   /** Disables `TagSelector` */
@@ -101,6 +101,8 @@ export interface Props
     onDelete: () => void
     disabled?: boolean
   }) => ReactNode
+  /** Component size */
+  size?: SizeType<'small' | 'medium' | 'large'>
   /** DOM element that wraps the Popper */
   popperContainer?: HTMLElement
   /** Options provided to the popper.js instance */

--- a/packages/base/Tagselector/src/TagSelector/TagSelector.tsx
+++ b/packages/base/Tagselector/src/TagSelector/TagSelector.tsx
@@ -102,7 +102,7 @@ export interface Props
     disabled?: boolean
   }) => ReactNode
   /** Component size */
-  size?: SizeType<'small' | 'medium' | 'large'>
+  size?: SizeType<'medium' | 'large'>
   /** DOM element that wraps the Popper */
   popperContainer?: HTMLElement
   /** Options provided to the popper.js instance */
@@ -280,6 +280,7 @@ TagSelector.defaultProps = {
   placeholder: '',
   showOtherOption: false,
   status: 'default',
+  size: 'medium',
 }
 
 TagSelector.displayName = 'TagSelector'

--- a/packages/base/Tagselector/src/TagSelector/__snapshots__/test.tsx.snap
+++ b/packages/base/Tagselector/src/TagSelector/__snapshots__/test.tsx.snap
@@ -15,7 +15,7 @@ exports[`TagSelector disabled render 1`] = `
         class="flex"
       >
         <div
-          class="base-Input base- base-Input relative gap-y gap-x items-center rounded-sm [font-size:_unset] group text-nowrap p-2 w-[18.75rem] bg-gray after:content-[""] after:inline-block after:absolute after:top-0 after:bottom-0 after:right-0 after:left-0 after:pointer-events after:border-solid after:rounded-sm after:border-gray after:border [&:has(:focus)]:after:shadow-[0_0_0_3px] [&:has(:focus)]:after:shadow-blue text-gray flex flex-wrap h-auto py-1 pl-1 cursor-pointer [&>input]:min-w [&>input]:flex-grow [&>input]:w-0 [&>input]:h-6 [&>input]:pl-1 [&>input]:pr-0 [&>input]:mb-0"
+          class="base-Input base- base-Input relative gap-y gap-x items-center rounded-sm [font-size:_unset] group text-nowrap p-2 w-[18.75rem] bg-gray after:content-[""] after:inline-block after:absolute after:top-0 after:bottom-0 after:right-0 after:left-0 after:pointer-events after:border-solid after:rounded-sm after:border-gray after:border [&:has(:focus)]:after:shadow-[0_0_0_3px] [&:has(:focus)]:after:shadow-blue text-gray flex flex-wrap h-auto cursor-pointer [&>input]:min-w [&>input]:flex-grow [&>input]:w-0 [&>input]:h-6 [&>input]:pl-1 [&>input]:pr-0 [&>input]:mb-0 py-1 pl-1"
         >
           <div
             aria-disabled="true"
@@ -83,7 +83,7 @@ exports[`TagSelector preselected value 1`] = `
           class="flex"
         >
           <div
-            class="base-Input base-Input relative gap-y gap-x items-center rounded-sm [font-size:_unset] group text-nowrap p-2 w-[18.75rem] bg-white after:content-[""] after:inline-block after:absolute after:top-0 after:bottom-0 after:right-0 after:left-0 after:pointer-events after:border-solid after:rounded-sm after:border-gray [&:has(:focus)]:after:border-blue after:border [&:has(:focus)]:after:shadow-[0_0_0_3px] [&:has(:focus)]:after:shadow-blue hover:[&:not(:has(:focus))]:after:border-gray text-black flex flex-wrap h-auto py-1 pl-1 cursor-pointer [&>input]:min-w [&>input]:flex-grow [&>input]:w-0 [&>input]:h-6 [&>input]:pl-1 [&>input]:pr-0 [&>input]:mb-0"
+            class="base-Input base-Input relative gap-y gap-x items-center rounded-sm [font-size:_unset] group text-nowrap p-2 w-[18.75rem] bg-white after:content-[""] after:inline-block after:absolute after:top-0 after:bottom-0 after:right-0 after:left-0 after:pointer-events after:border-solid after:rounded-sm after:border-gray [&:has(:focus)]:after:border-blue after:border [&:has(:focus)]:after:shadow-[0_0_0_3px] [&:has(:focus)]:after:shadow-blue hover:[&:not(:has(:focus))]:after:border-gray text-black flex flex-wrap h-auto cursor-pointer [&>input]:min-w [&>input]:flex-grow [&>input]:w-0 [&>input]:h-6 [&>input]:pl-1 [&>input]:pr-0 [&>input]:mb-0 py-1 pl-1"
           >
             <div
               class="text-lg transition-none border border-solid rounded-[6.25rem] h-6 max-w inline-flex justify-center items-center cursor-default bg-white group align-middle leading-[inherit] text-graphite border-gray"
@@ -149,7 +149,7 @@ exports[`TagSelector renders 1`] = `
         class="flex"
       >
         <div
-          class="base-Input base-Input relative gap-y gap-x items-center rounded-sm [font-size:_unset] group text-nowrap p-2 w-[18.75rem] bg-white after:content-[""] after:inline-block after:absolute after:top-0 after:bottom-0 after:right-0 after:left-0 after:pointer-events after:border-solid after:rounded-sm after:border-gray [&:has(:focus)]:after:border-blue after:border [&:has(:focus)]:after:shadow-[0_0_0_3px] [&:has(:focus)]:after:shadow-blue hover:[&:not(:has(:focus))]:after:border-gray text-black flex flex-wrap h-auto py-1 pl-1 cursor-pointer [&>input]:min-w [&>input]:flex-grow [&>input]:w-0 [&>input]:h-6 [&>input]:pl-1 [&>input]:pr-0 [&>input]:mb-0"
+          class="base-Input base-Input relative gap-y gap-x items-center rounded-sm [font-size:_unset] group text-nowrap p-2 w-[18.75rem] bg-white after:content-[""] after:inline-block after:absolute after:top-0 after:bottom-0 after:right-0 after:left-0 after:pointer-events after:border-solid after:rounded-sm after:border-gray [&:has(:focus)]:after:border-blue after:border [&:has(:focus)]:after:shadow-[0_0_0_3px] [&:has(:focus)]:after:shadow-blue hover:[&:not(:has(:focus))]:after:border-gray text-black flex flex-wrap h-auto cursor-pointer [&>input]:min-w [&>input]:flex-grow [&>input]:w-0 [&>input]:h-6 [&>input]:pl-1 [&>input]:pr-0 [&>input]:mb-0 py-1 pl-1"
         >
           <input
             aria-autocomplete="list"

--- a/packages/base/Tagselector/src/TagSelector/story/Sizes.example.tsx
+++ b/packages/base/Tagselector/src/TagSelector/story/Sizes.example.tsx
@@ -1,0 +1,97 @@
+import React, { useState } from 'react'
+import type { AutocompleteItem, TagSelectorProps } from '@toptal/picasso'
+import { Container, TagSelector, Typography } from '@toptal/picasso'
+import { isSubstring, SPACING_4 } from '@toptal/picasso-utils'
+
+const allOptions = [
+  { value: 'AF', text: 'Afghanistan' },
+  { value: 'AI', text: 'Aland Islands' },
+  { value: 'ALB', text: 'Albania' },
+  { value: 'ALG', text: 'Algeria' },
+  { value: 'BY', text: 'Belarus' },
+  { value: 'HR', text: 'Croatia' },
+  { value: 'LU', text: 'Lithuania' },
+  { value: 'SK', text: 'Slovakia' },
+  { value: 'SP', text: 'Spain' },
+  { value: 'UA', text: 'Ukraine' },
+]
+
+const EMPTY_INPUT_VALUE = ''
+const getDisplayValue = (item: AutocompleteItem | null) =>
+  (item && item.text) || EMPTY_INPUT_VALUE
+
+const filterOptions = (str = '') => {
+  if (str === '') {
+    return allOptions
+  }
+
+  const result = allOptions.filter(option =>
+    isSubstring(str, getDisplayValue(option))
+  )
+
+  return result.length > 0 ? result : null
+}
+
+const TagSelectWithSize = ({
+  size,
+  value,
+  options,
+  inputValue,
+  onChange,
+  onInputChange,
+}: TagSelectorProps) => (
+  <TagSelector
+    size={size}
+    data-testid='component'
+    options={options}
+    placeholder='Start typing...'
+    value={value}
+    inputValue={inputValue}
+    getDisplayValue={getDisplayValue}
+    onChange={onChange}
+    onInputChange={onInputChange}
+  />
+)
+
+const Example = () => {
+  const [options, setOptions] = useState<AutocompleteItem[] | null>(allOptions)
+  const [value, setValue] = useState<AutocompleteItem[]>([
+    allOptions[0],
+    allOptions[1],
+    allOptions[2],
+  ])
+  const [inputValue, setInputValue] = useState(EMPTY_INPUT_VALUE)
+
+  const onChange = selectedValues => {
+    window.console.log('onChange values: ', selectedValues)
+    setValue(selectedValues)
+  }
+
+  const onInputChange = newInputValue => {
+    window.console.log('onInputChange value: ', newInputValue)
+    setInputValue(newInputValue)
+    setOptions(filterOptions(newInputValue))
+  }
+
+  return (
+    <div>
+      {(['small', 'medium', 'large'] as const).map(size => (
+        <Container key={size} bottom={SPACING_4}>
+          <Typography variant='body' titleCase>
+            {size}
+          </Typography>
+          <TagSelectWithSize
+            options={options}
+            size={size}
+            value={value}
+            inputValue={inputValue}
+            onChange={onChange}
+            onInputChange={onInputChange}
+          />
+        </Container>
+      ))}
+    </div>
+  )
+}
+
+export default Example

--- a/packages/base/Tagselector/src/TagSelector/story/Sizes.example.tsx
+++ b/packages/base/Tagselector/src/TagSelector/story/Sizes.example.tsx
@@ -75,7 +75,7 @@ const Example = () => {
 
   return (
     <div>
-      {(['small', 'medium', 'large'] as const).map(size => (
+      {(['medium', 'large'] as const).map(size => (
         <Container key={size} bottom={SPACING_4}>
           <Typography variant='body' titleCase>
             {size}

--- a/packages/base/Tagselector/src/TagSelector/story/index.jsx
+++ b/packages/base/Tagselector/src/TagSelector/story/index.jsx
@@ -91,3 +91,8 @@ page
     'Status',
     'base/Tagselector'
   )
+  .addExample(
+    'TagSelector/story/Sizes.example.tsx',
+    'Sizes',
+    'base/Tagselector'
+  )

--- a/packages/base/Tagselector/src/TagSelectorInput/TagSelectorInput.tsx
+++ b/packages/base/Tagselector/src/TagSelectorInput/TagSelectorInput.tsx
@@ -93,6 +93,7 @@ TagSelectorInput.defaultProps = {
   multiline: false,
   width: 'auto',
   status: 'default',
+  size: 'medium',
 }
 
 TagSelectorInput.displayName = 'TagSelectorInput'

--- a/packages/base/Tagselector/src/TagSelectorInput/TagSelectorInput.tsx
+++ b/packages/base/Tagselector/src/TagSelectorInput/TagSelectorInput.tsx
@@ -53,7 +53,8 @@ export const TagSelectorInput = forwardRef<HTMLInputElement, InputProps>(
           [&>input]:min-w-[3em] [&>input]:flex-grow [&>input]:w-0 [&>input]:h-6 [&>input]:pl-1 [&>input]:pr-0 [&>input]:mb-0`,
           {
             'pr-[2.25em]': Boolean(endAdornment),
-            'pl-1': size === 'small',
+            'py-1 pl-1': size === 'medium',
+            'gap-[12px] px-4': size === 'large',
           }
         )}
         highlight={highlight}

--- a/packages/base/Tagselector/src/TagSelectorInput/TagSelectorInput.tsx
+++ b/packages/base/Tagselector/src/TagSelectorInput/TagSelectorInput.tsx
@@ -32,6 +32,7 @@ export const TagSelectorInput = forwardRef<HTMLInputElement, InputProps>(
       inputProps,
       testIds,
       highlight,
+      size,
       ...rest
     } = props
 
@@ -48,10 +49,11 @@ export const TagSelectorInput = forwardRef<HTMLInputElement, InputProps>(
         inputRef={ref}
         style={style}
         className={cx(
-          `flex flex-wrap h-auto py-1 pl-1 cursor-pointer
+          `flex flex-wrap h-auto cursor-pointer
           [&>input]:min-w-[3em] [&>input]:flex-grow [&>input]:w-0 [&>input]:h-6 [&>input]:pl-1 [&>input]:pr-0 [&>input]:mb-0`,
           {
             'pr-[2.25em]': Boolean(endAdornment),
+            'pl-1': size === 'small',
           }
         )}
         highlight={highlight}
@@ -78,6 +80,7 @@ export const TagSelectorInput = forwardRef<HTMLInputElement, InputProps>(
         endAdornment={usedEndAdornment}
         startAdornment={startAdornment}
         onChange={onChange}
+        size={size}
       >
         {children}
       </OutlinedInput>

--- a/packages/base/Tagselector/src/TagSelectorInput/__snapshots__/test.tsx.snap
+++ b/packages/base/Tagselector/src/TagSelectorInput/__snapshots__/test.tsx.snap
@@ -6,7 +6,7 @@ exports[`TagSelectorInput renders 1`] = `
     class="Picasso-root"
   >
     <div
-      class="base-Input relative gap-y gap-x items-center rounded-sm [font-size:_unset] group text-nowrap p-2 w-[18.75rem] bg-white after:content-[""] after:inline-block after:absolute after:top-0 after:bottom-0 after:right-0 after:left-0 after:pointer-events after:border-solid after:rounded-sm after:border-gray [&:has(:focus)]:after:border-blue after:border [&:has(:focus)]:after:shadow-[0_0_0_3px] [&:has(:focus)]:after:shadow-blue hover:[&:not(:has(:focus))]:after:border-gray text-black flex flex-wrap h-auto py-1 pl-1 cursor-pointer [&>input]:min-w [&>input]:flex-grow [&>input]:w-0 [&>input]:h-6 [&>input]:pl-1 [&>input]:pr-0 [&>input]:mb-0"
+      class="base-Input relative gap-y gap-x items-center rounded-sm [font-size:_unset] group text-nowrap p-2 w-[18.75rem] bg-white after:content-[""] after:inline-block after:absolute after:top-0 after:bottom-0 after:right-0 after:left-0 after:pointer-events after:border-solid after:rounded-sm after:border-gray [&:has(:focus)]:after:border-blue after:border [&:has(:focus)]:after:shadow-[0_0_0_3px] [&:has(:focus)]:after:shadow-blue hover:[&:not(:has(:focus))]:after:border-gray text-black flex flex-wrap h-auto cursor-pointer [&>input]:min-w [&>input]:flex-grow [&>input]:w-0 [&>input]:h-6 [&>input]:pl-1 [&>input]:pr-0 [&>input]:mb-0"
     >
       <input
         aria-invalid="false"

--- a/packages/base/Tagselector/src/TagSelectorInput/__snapshots__/test.tsx.snap
+++ b/packages/base/Tagselector/src/TagSelectorInput/__snapshots__/test.tsx.snap
@@ -6,7 +6,7 @@ exports[`TagSelectorInput renders 1`] = `
     class="Picasso-root"
   >
     <div
-      class="base-Input relative gap-y gap-x items-center rounded-sm [font-size:_unset] group text-nowrap p-2 w-[18.75rem] bg-white after:content-[""] after:inline-block after:absolute after:top-0 after:bottom-0 after:right-0 after:left-0 after:pointer-events after:border-solid after:rounded-sm after:border-gray [&:has(:focus)]:after:border-blue after:border [&:has(:focus)]:after:shadow-[0_0_0_3px] [&:has(:focus)]:after:shadow-blue hover:[&:not(:has(:focus))]:after:border-gray text-black flex flex-wrap h-auto cursor-pointer [&>input]:min-w [&>input]:flex-grow [&>input]:w-0 [&>input]:h-6 [&>input]:pl-1 [&>input]:pr-0 [&>input]:mb-0"
+      class="base-Input relative gap-y gap-x items-center rounded-sm [font-size:_unset] group text-nowrap p-2 w-[18.75rem] bg-white after:content-[""] after:inline-block after:absolute after:top-0 after:bottom-0 after:right-0 after:left-0 after:pointer-events after:border-solid after:rounded-sm after:border-gray [&:has(:focus)]:after:border-blue after:border [&:has(:focus)]:after:shadow-[0_0_0_3px] [&:has(:focus)]:after:shadow-blue hover:[&:not(:has(:focus))]:after:border-gray text-black flex flex-wrap h-auto cursor-pointer [&>input]:min-w [&>input]:flex-grow [&>input]:w-0 [&>input]:h-6 [&>input]:pl-1 [&>input]:pr-0 [&>input]:mb-0 py-1 pl-1"
     >
       <input
         aria-invalid="false"


### PR DESCRIPTION
[MP-996]

### Description

Make TagSelector support `large` size.

<img width="635" alt="Screenshot 2025-02-28 at 15 36 11" src="https://github.com/user-attachments/assets/2f601134-bf2b-427d-aad8-ee5514e2e85f" />

<img width="630" alt="Screenshot 2025-02-28 at 15 36 21" src="https://github.com/user-attachments/assets/2c60a43b-22d1-44b0-a36e-2d5ed2ff371b" />


### How to test

<!-- The temploy link will be automatically updated when the temploy is deployed -->
- [Temploy](https://picasso.toptal.net/MP-965-pass-props)
- Check [TagSelector stories](https://picasso.toptal.net/MP-965-pass-props/?path=/story/forms-tagselector--tagselector) and visual diffs

### Screenshots

<img width="364" alt="Screenshot 2025-02-28 at 16 06 29" src="https://github.com/user-attachments/assets/d9524dd3-1002-4013-b055-f7f60b367301" />


### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Double check if `picasso-tailwind-merge` requires major update (check its `README.md`)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [N/A] Covered with tests ([visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md) included)

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping for reviews

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>



[MP-996]: https://toptal-core.atlassian.net/browse/MP-996?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ