### PR TITLE
[MP-917] Support size in Autocomplete props

### DIFF
--- a/.changeset/honest-pumas-roll.md
+++ b/.changeset/honest-pumas-roll.md
@@ -1,0 +1,7 @@
+---
+'@toptal/picasso-autocomplete': minor
+---
+
+### Autocomplete
+
+- add `size` property to control input size

--- a/packages/base/Autocomplete/src/Autocomplete/Autocomplete.tsx
+++ b/packages/base/Autocomplete/src/Autocomplete/Autocomplete.tsx
@@ -11,7 +11,7 @@ import type {
   Ref,
 } from 'react'
 import React, { forwardRef, useRef } from 'react'
-import type { BaseProps } from '@toptal/picasso-shared'
+import type { BaseProps, SizeType } from '@toptal/picasso-shared'
 import { isForwardRef } from '@toptal/picasso-shared'
 import type { PopperOptions } from 'popper.js'
 import { Input } from '@toptal/picasso-input'
@@ -118,6 +118,8 @@ export interface Props
     disableAutofillInput?: string
   }
   highlight?: 'autofill'
+  /** Component size */
+  size?: SizeType<'medium' | 'large'>
 }
 
 const getItemText = (item: Item | null) =>

--- a/packages/base/Autocomplete/src/Autocomplete/story/LargeSize.example.tsx
+++ b/packages/base/Autocomplete/src/Autocomplete/story/LargeSize.example.tsx
@@ -1,0 +1,23 @@
+import React from 'react'
+import { Autocomplete } from '@toptal/picasso'
+
+const options = [
+  { text: 'Belarus' },
+  { text: 'Croatia' },
+  { text: 'Lithuania' },
+  { text: 'Slovakia' },
+  { text: 'Ukraine' },
+]
+
+const Example = () => (
+  <div>
+    <Autocomplete
+      placeholder='Start typing country...'
+      options={options}
+      value=''
+      size='large'
+    />
+  </div>
+)
+
+export default Example

--- a/packages/base/Autocomplete/src/Autocomplete/story/index.jsx
+++ b/packages/base/Autocomplete/src/Autocomplete/story/index.jsx
@@ -99,6 +99,14 @@ page
     'base/Autocomplete'
   )
   .addExample(
+    'Autocomplete/story/LargeSize.example.tsx',
+    {
+      title: 'Large size',
+      takeScreenshot: false,
+    },
+    'base/Autocomplete'
+  )
+  .addExample(
     'Autocomplete/story/Loading.example.tsx',
     'Loading',
     'base/Autocomplete'


### PR DESCRIPTION
[MP-917]

### Description

Picasso's Autocomplete passes its `...rest` props to the `Input` element, so technically it supports already passing `size='large'`, and it is working.

But `size` was not defined in the `Props` type, so we got a type error. This adds `size` to the `Props` type.

### How to test

- Storybook: http://localhost:9001/?path=/story/forms-autocomplete--autocomplete#large-size

### Screenshots

<img width="434" alt="Bildschirmfoto 2025-03-04 um 12 55 58" src="https://github.com/user-attachments/assets/44178539-9079-4c1a-b545-342dc0ec18ac" />

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Double check if `picasso-tailwind-merge` requires major update (check its `README.md`)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests ([visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md) included)

**Breaking change**

- n/a codemod is created and showcased in the changeset
- [x] test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping for reviews

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[MP-917]: https://toptal-core.atlassian.net/browse/MP-917?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ