### PR TITLE
[CPS-1596] Add Picasso Black PageTopBar Variant

### DIFF
--- a/.changeset/honest-toes-fail.md
+++ b/.changeset/honest-toes-fail.md
@@ -1,0 +1,11 @@
+---
+'@toptal/picasso-page': minor
+---
+
+---
+
+### PageTopBar
+
+---
+
+- add black variation for the PageTopBar

--- a/packages/base/Page/src/PageTopBar/PageTopBar.tsx
+++ b/packages/base/Page/src/PageTopBar/PageTopBar.tsx
@@ -27,7 +27,7 @@ import styles from './styles'
 
 const SMALL_SCREEN_WIDTH = 1280
 
-type VariantType = 'dark' | 'light' | 'grey'
+type VariantType = 'dark' | 'light' | 'grey' | 'black'
 
 export interface Props extends BaseProps, HTMLAttributes<HTMLElement> {
   /** Title which is displayed along the `Logo` */
@@ -109,7 +109,7 @@ export const PageTopBar = forwardRef<HTMLElement, Props>(function PageTopBar(
     return () => setHasPageHamburger(false)
   }, [setHasPageHamburger, showHamburger])
 
-  const isDark = ['dark', 'grey'].includes(variant)
+  const isDark = ['dark', 'grey', 'black'].includes(variant)
   const logoVariant = isDark ? 'white' : 'default'
   const logoDefault = (
     <>

--- a/packages/base/Page/src/PageTopBar/story/Variants.example.tsx
+++ b/packages/base/Page/src/PageTopBar/story/Variants.example.tsx
@@ -51,6 +51,30 @@ const Example = () => (
     </Container>
 
     <Container style={{ position: 'relative', height: '6rem' }}>
+      <Page.TopBar
+        variant='black'
+        title='Black'
+        actionItems={
+          <Container right={SPACING_6}>
+            <Button.Circular variant='transparent' icon={<Bell16 />} />
+          </Container>
+        }
+        rightContent={
+          <Page.TopBarMenu
+            name='Jacqueline Roque'
+            meta='Developer'
+            avatar='./jacqueline-with-flowers-1954-square.jpg'
+          >
+            <Menu>
+              <Menu.Item>My Account</Menu.Item>
+              <Menu.Item>Log Out</Menu.Item>
+            </Menu>
+          </Page.TopBarMenu>
+        }
+      />
+    </Container>
+
+    <Container style={{ position: 'relative', height: '6rem' }}>
       <Page hamburgerId='hamburger-default-example'>
         <Page.TopBar
           variant='light'

--- a/packages/base/Page/src/PageTopBar/styles.ts
+++ b/packages/base/Page/src/PageTopBar/styles.ts
@@ -25,7 +25,7 @@ export default ({ palette, layout, zIndex, screens }: Theme) =>
       backgroundColor: palette.grey.darker,
     },
     black: {
-      backgroundColor: 'black',
+      backgroundColor: palette.common.black,
     },
     content: {
       boxSizing: 'border-box',

--- a/packages/base/Page/src/PageTopBar/styles.ts
+++ b/packages/base/Page/src/PageTopBar/styles.ts
@@ -24,6 +24,9 @@ export default ({ palette, layout, zIndex, screens }: Theme) =>
     grey: {
       backgroundColor: palette.grey.darker,
     },
+    black: {
+      backgroundColor: 'black',
+    },
     content: {
       boxSizing: 'border-box',
       display: 'flex',


### PR DESCRIPTION
[CPS-1596]

### Description

Add Picasso Black TopBar Variation

### How to test

<!-- The temploy link will be automatically updated when the temploy is deployed -->
- Check the storybook

### Screenshots

<img width="1417" alt="Screenshot 2025-03-14 at 10 18 53" src="https://github.com/user-attachments/assets/94ebf591-3388-4651-8c8e-21ddeb860fe2" />


### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Double check if `picasso-tailwind-merge` requires major update (check its `README.md`)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests ([visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md) included)

**Breaking change**

- [x] codemod is created and showcased in the changeset
- [x] test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping for reviews

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[CPS-1596]: https://toptal-core.atlassian.net/browse/CPS-1596?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ