### PR TITLE
[BILL-5992] Remove mui v4 import for MenuItem props

### DIFF
--- a/.changeset/quick-cheetahs-compete.md
+++ b/.changeset/quick-cheetahs-compete.md
@@ -1,0 +1,7 @@
+---
+'@toptal/picasso-page': patch
+---
+
+---
+
+- replace type from mui v4 for the `as` prop with the MenuItemProps from picasso-menu package

--- a/packages/base/Page/src/SidebarItem/types.ts
+++ b/packages/base/Page/src/SidebarItem/types.ts
@@ -1,8 +1,7 @@
 import type { ElementType, ReactElement } from 'react'
 import type React from 'react'
 import type { BaseProps, TextLabelProps } from '@toptal/picasso-shared'
-import type { MenuItemProps } from '@material-ui/core/MenuItem'
-import type { MenuItemAttributes } from '@toptal/picasso-menu'
+import type { MenuItemAttributes, MenuItemProps } from '@toptal/picasso-menu'
 
 import type { VariantType } from '../PageSidebar/types'
 import type {

--- a/packages/base/Page/src/TopBarItem/TopBarItem.tsx
+++ b/packages/base/Page/src/TopBarItem/TopBarItem.tsx
@@ -5,7 +5,7 @@ import type {
 } from '@toptal/picasso-shared'
 import type { ElementType, ReactElement } from 'react'
 import React, { forwardRef, memo } from 'react'
-import type { MenuItemProps } from '@material-ui/core/MenuItem'
+import type { MenuItemProps } from '@toptal/picasso-menu'
 import { twMerge } from '@toptal/picasso-tailwind-merge'
 import { noop } from '@toptal/picasso-utils'
 


### PR DESCRIPTION
[BILL-5992]

### Description

Remove mui v4 import for MenuItem props, replacing them with the types defined in MenuItem component in the `@topta/picasso-menu` package.

### How to test

Try alpha package in various portals.

### Screenshots

No changes.

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Double check if `picasso-tailwind-merge` requires major update (check its `README.md`)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests ([visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md) included)

**Breaking change**

- [x] codemod is created and showcased in the changeset
- [x] test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping for reviews

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[BILL-5992]: https://toptal-core.atlassian.net/browse/BILL-5992?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ