### PR TITLE
[BILL-💵] Allow specific days to be disabled on the date picker

### DIFF
--- a/.changeset/khaki-bottles-nail.md
+++ b/.changeset/khaki-bottles-nail.md
@@ -1,0 +1,6 @@
+---
+'@toptal/picasso-date-picker': minor
+'@toptal/picasso-calendar': minor
+---
+
+- allow to disable specific days on date picker

--- a/cypress/component/DatePicker.spec.tsx
+++ b/cypress/component/DatePicker.spec.tsx
@@ -97,6 +97,23 @@ describe('DatePicker', () => {
     })
   })
 
+  it('prevents selection of disabled days', () => {
+    cy.mount(
+      <TestDatePicker
+        autoFocus
+        minDate={new Date('2015-12-01')}
+        maxDate={new Date('2015-12-30')}
+        value={new Date('2015-12-10')}
+        disableDays={{ dayOfWeek: [0, 2] }}
+      />
+    )
+
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'disabled-days',
+    })
+  })
+
   it('renders a customized footer', () => {
     cy.mount(
       <TestDatePicker

--- a/packages/base/Calendar/src/Calendar/Calendar.tsx
+++ b/packages/base/Calendar/src/Calendar/Calendar.tsx
@@ -56,6 +56,8 @@ export interface Props
   renderMonthHeader?: RenderMonthHeader
   /** Custom day renderer */
   renderDay?: RenderDay
+  /** Days to disable. e.g. Disable Sundays and Saturdays {dayOfWeek: [0, 6]} */
+  disableDays?: { dayOfWeek: number[] }
   /** Intervals that should be indicated as disabled */
   disabledIntervals?: CalendarDateRange[]
   /** Intervals that should be indicated with orange dots */
@@ -100,6 +102,7 @@ export const Calendar = forwardRef<HTMLDivElement, Props>(function Calendar(
     renderRoot,
     numberOfMonths = 1,
     dropdownNavigation = false,
+    disableDays,
     ...rest
   } = props
 
@@ -237,7 +240,7 @@ export const Calendar = forwardRef<HTMLDivElement, Props>(function Calendar(
             onMonthChange={month => setNavigationMonth(month)}
             toDate={maxDate}
             numberOfMonths={shouldRenderMultipleMonths ? numberOfMonths : 1}
-            disabled={disabledIntervalsFormatted}
+            disabled={disabledIntervalsFormatted || disableDays}
             weekStartsOn={weekStartsOn}
             formatters={{ formatWeekdayName: date => format(date, 'EEE') }}
             modifiers={modifiers}

--- a/packages/base/Calendar/src/Calendar/test.tsx
+++ b/packages/base/Calendar/src/Calendar/test.tsx
@@ -91,4 +91,28 @@ describe('Calendar', () => {
       })
     })
   })
+
+  describe('when disableDays is set', () => {
+    it('disables specified days', () => {
+      const minDate = new Date('2015-12-01')
+      const maxDate = new Date('2015-12-30')
+      const value = new Date('2015-12-10')
+      const onChange = jest.fn()
+
+      const { getByTestId } = render(
+        <Calendar
+          minDate={minDate}
+          maxDate={maxDate}
+          value={value}
+          onChange={onChange}
+          disableDays={{ dayOfWeek: [0, 6] }}
+        />
+      )
+
+      const disabledButton = getByTestId('day-button-12')
+
+      fireEvent.click(disabledButton)
+      expect(onChange).not.toHaveBeenCalled()
+    })
+  })
 })

--- a/packages/base/DatePicker/src/DatePicker/DatePicker.tsx
+++ b/packages/base/DatePicker/src/DatePicker/DatePicker.tsx
@@ -68,6 +68,8 @@ export interface Props
   hideOnSelect?: boolean
   /** Date format that user will see in the input */
   displayDateFormat?: string
+  /** Days to disable. e.g. Disable Sundays and Saturdays {dayOfWeek: [0, 6]} */
+  disableDays?: { dayOfWeek: number[] }
   /** Date range where selection is not allowed */
   disabledIntervals?: CalendarDateRange[]
   /** Date format that user will see during manual input */
@@ -122,6 +124,7 @@ export const DatePicker = (props: Props) => {
     icon,
     minDate,
     maxDate,
+    disableDays,
     disabledIntervals,
     popperContainer,
     renderDay,
@@ -442,6 +445,7 @@ export const DatePicker = (props: Props) => {
                 weekStartsOn={weekStartsOn}
                 numberOfMonths={numberOfMonths}
                 dropdownNavigation={dropdownNavigation}
+                disableDays={disableDays}
               />
               {footer && (
                 <div

--- a/packages/base/DatePicker/src/DatePicker/story/WithDisabledDays.example.tsx
+++ b/packages/base/DatePicker/src/DatePicker/story/WithDisabledDays.example.tsx
@@ -1,0 +1,27 @@
+import React, { useState } from 'react'
+import { DatePicker, Search16 } from '@toptal/picasso'
+
+const WithDisabledDaysExample = () => {
+  const [value, setValue] = useState(new Date('2015-12-10'))
+  const minDate = new Date('2015-12-01')
+  const maxDate = new Date('2015-12-30')
+
+  return (
+    <div style={{ height: '50vh', width: '100%' }}>
+      <DatePicker
+        value={value}
+        minDate={minDate}
+        maxDate={maxDate}
+        icon={<Search16 />}
+        iconPosition='end'
+        placeholder='Please select date...'
+        disableDays={{ dayOfWeek: [0, 2] }}
+        onChange={date => {
+          setValue(date as Date)
+        }}
+      />
+    </div>
+  )
+}
+
+export default WithDisabledDaysExample

--- a/packages/base/DatePicker/src/DatePicker/story/index.jsx
+++ b/packages/base/DatePicker/src/DatePicker/story/index.jsx
@@ -111,6 +111,14 @@ page
     'base/DatePicker'
   )
   .addExample(
+    'DatePicker/story/WithDisabledDays.example.tsx',
+    {
+      title: 'With Disabled Days',
+      takeScreenshot: false,
+    },
+    'base/DatePicker'
+  )
+  .addExample(
     'DatePicker/story/WithCustomDayRendering.example.tsx',
     {
       title: 'With Custom Day rendering',


### PR DESCRIPTION
[BILL-💵]

### Description

It's not possible to disable specific days on the date picker, i.e. Monday, Tuesday etc... This PR allows this which is supported from our underlying component https://daypicker.dev/v8/advanced-guides/custom-modifiers#disabling-days

### How to test

<!-- The temploy link will be automatically updated when the temploy is deployed -->
- Open storybook and `With Disabled Days` story
- The `disabledIntervals` prop should take precedence and work as before

### Screenshots

<img width="514" alt="10048" src="https://github.com/user-attachments/assets/e661d369-ab4d-4983-a6f9-d6c0f148721b" />



### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Double check if `picasso-tailwind-merge` requires major update (check its `README.md`)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests ([visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md) included)

**Breaking change**

- [x] codemod is created and showcased in the changeset
- [x] test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping for reviews

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>
