### PR TITLE
Fix performance issues of Select component

### DIFF
--- a/.changeset/grumpy-clouds-mate.md
+++ b/.changeset/grumpy-clouds-mate.md
@@ -4,4 +4,6 @@
 
 ---
 
+### Select
+
 - fix performance issue of the Select component

--- a/.changeset/grumpy-clouds-mate.md
+++ b/.changeset/grumpy-clouds-mate.md
@@ -1,0 +1,7 @@
+---
+'@toptal/picasso-select': patch
+---
+
+---
+
+- fix performance issue of the Select component

--- a/packages/base/Select/src/NonNativeSelectOption/NonNativeSelectOption.tsx
+++ b/packages/base/Select/src/NonNativeSelectOption/NonNativeSelectOption.tsx
@@ -12,30 +12,42 @@ export interface Props<T extends ValueType> extends ItemProps {
   option: Option<T>
 }
 
+const NonNativeSelectOptionComponent = <T extends ValueType>({
+  option,
+  selected,
+  highlighted,
+  description,
+  children,
+  ...itemProps
+}: Props<T>) => {
+  return (
+    <MenuItem
+      value={option.value}
+      selected={highlighted}
+      checkmarked={selected}
+      titleCase={false}
+      description={description}
+      role='option'
+      aria-selected={selected}
+      data-highlighted={highlighted}
+      disabled={option.disabled}
+      {...itemProps}
+    >
+      {children}
+    </MenuItem>
+  )
+}
+
 const NonNativeSelectOption = React.memo(
-  <T extends ValueType>({
-    option,
-    selected,
-    highlighted,
-    description,
-    children,
-    ...itemProps
-  }: Props<T>) => {
+  NonNativeSelectOptionComponent,
+  (prevProps, nextProps) => {
     return (
-      <MenuItem
-        value={option.value}
-        selected={highlighted}
-        checkmarked={selected}
-        titleCase={false}
-        description={description}
-        role='option'
-        aria-selected={selected}
-        data-highlighted={highlighted}
-        disabled={option.disabled}
-        {...itemProps}
-      >
-        {children}
-      </MenuItem>
+      prevProps.selected === nextProps.selected &&
+      prevProps.highlighted === nextProps.highlighted &&
+      prevProps.option === nextProps.option &&
+      prevProps.option.disabled === nextProps.option.disabled &&
+      prevProps.description === nextProps.description &&
+      prevProps.children === nextProps.children
     )
   }
 )


### PR DESCRIPTION
### Description

Fix constant re-renders of the Select dropdown menu. Now does not re-render on change of the highlight item in the menu

### Screenshots

https://github.com/user-attachments/assets/a495326e-fd67-4deb-b374-216d5c41d2bd

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Double check if `picasso-tailwind-merge` requires major update (check its `README.md`)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests ([visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md) included)

**Breaking change**

- [x] codemod is created and showcased in the changeset
- [x] test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping for reviews

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>
