### PR TITLE
Replace overflow `hidden` by `clip` in Popper

### DIFF
--- a/.changeset/real-eyes-kiss.md
+++ b/.changeset/real-eyes-kiss.md
@@ -1,0 +1,7 @@
+---
+'@toptal/picasso-popper': minor
+'@toptal/picasso-modal': minor
+'@toptal/picasso-utils': minor
+---
+
+- replace overflow hidden by overflow clip in Popper

--- a/packages/base/Modal/src/Modal/test.tsx
+++ b/packages/base/Modal/src/Modal/test.tsx
@@ -208,7 +208,7 @@ describe('Modal', () => {
     it('drops scroll lock when initially open modal is mounted', () => {
       render(<Modal open={true}>Hello from modal!</Modal>)
 
-      expect(getHtmlElement(document).style.overflow).toBe('hidden')
+      expect(getHtmlElement(document).style.overflow).toBe('clip')
     })
 
     it('does not drop scroll lock when closed modal is mounted', () => {
@@ -243,7 +243,7 @@ describe('Modal', () => {
         expect(getHtmlElement(document).style.overflow).toBe('')
 
         fireEvent.click(screen.getByTestId('open-first'))
-        expect(getHtmlElement(document).style.overflow).toBe('hidden')
+        expect(getHtmlElement(document).style.overflow).toBe('clip')
 
         fireEvent.click(screen.getByTestId('close-first'))
         expect(getHtmlElement(document).style.overflow).toBe('')
@@ -275,7 +275,7 @@ describe('Modal', () => {
         expect(getHtmlElement(document).style.overflow).toBe('')
 
         fireEvent.click(screen.getByTestId('open-first'))
-        expect(getHtmlElement(document).style.overflow).toBe('hidden')
+        expect(getHtmlElement(document).style.overflow).toBe('clip')
 
         fireEvent.click(screen.getByTestId('close-first'))
         expect(getHtmlElement(document).style.overflow).toBe('')
@@ -308,7 +308,7 @@ describe('Modal', () => {
         expect(getHtmlElement(document).style.overflow).toBe('visible')
 
         fireEvent.click(screen.getByTestId('open-first'))
-        expect(getHtmlElement(document).style.overflow).toBe('hidden')
+        expect(getHtmlElement(document).style.overflow).toBe('clip')
 
         fireEvent.click(screen.getByTestId('close-first'))
         expect(getHtmlElement(document).style.overflow).toBe('visible')
@@ -352,13 +352,13 @@ describe('Modal', () => {
         expect(getHtmlElement(document).style.overflow).toBe('')
 
         fireEvent.click(screen.getByTestId('open-first'))
-        expect(getHtmlElement(document).style.overflow).toBe('hidden')
+        expect(getHtmlElement(document).style.overflow).toBe('clip')
 
         fireEvent.click(screen.getByTestId('open-second'))
-        expect(getHtmlElement(document).style.overflow).toBe('hidden')
+        expect(getHtmlElement(document).style.overflow).toBe('clip')
 
         fireEvent.click(screen.getByTestId('close-first'))
-        expect(getHtmlElement(document).style.overflow).toBe('hidden')
+        expect(getHtmlElement(document).style.overflow).toBe('clip')
 
         fireEvent.click(screen.getByTestId('close-second'))
         expect(getHtmlElement(document).style.overflow).toBe('')
@@ -404,10 +404,10 @@ describe('Modal', () => {
         expect(getHtmlElement(document).style.overflow).toBe('')
 
         fireEvent.click(screen.getByTestId('open-first'))
-        expect(getHtmlElement(document).style.overflow).toBe('hidden')
+        expect(getHtmlElement(document).style.overflow).toBe('clip')
 
         fireEvent.click(screen.getByTestId('mount-second'))
-        expect(getHtmlElement(document).style.overflow).toBe('hidden')
+        expect(getHtmlElement(document).style.overflow).toBe('clip')
 
         fireEvent.click(screen.getByTestId('close-first'))
         expect(getHtmlElement(document).style.overflow).toBe('')

--- a/packages/base/Popper/src/Popper/Popper.tsx
+++ b/packages/base/Popper/src/Popper/Popper.tsx
@@ -145,10 +145,10 @@ export const Popper = forwardRef<PopperJs, Props>(function Popper(props, ref) {
   const anchorElWidthStyle = !isCompactLayout && widthStyle
 
   useIsomorphicLayoutEffect(() => {
-    if (isCompactLayout && open && document.body.style.overflow !== 'hidden') {
+    if (isCompactLayout && open && document.body.style.overflow !== 'clip') {
       const prev = document.body.style.overflow
 
-      document.body.style.overflow = 'hidden'
+      document.body.style.overflow = 'clip'
 
       return () => {
         document.body.style.overflow = prev

--- a/packages/base/Utils/src/utils/__tests__/use-page-scroll-lock.test.tsx
+++ b/packages/base/Utils/src/utils/__tests__/use-page-scroll-lock.test.tsx
@@ -21,14 +21,14 @@ describe('usePageScrollLock', () => {
     it('drops scroll lock when mounted with true', () => {
       renderHook(() => usePageScrollLock(true))
 
-      expect(getHtmlElement(document).style.overflow).toBe('hidden')
+      expect(getHtmlElement(document).style.overflow).toBe('clip')
     })
 
     describe('lifts scroll lock', () => {
       it('when unmounted', () => {
         const { unmount } = renderHook(() => usePageScrollLock(true))
 
-        expect(getHtmlElement(document).style.overflow).toBe('hidden')
+        expect(getHtmlElement(document).style.overflow).toBe('clip')
 
         unmount()
 
@@ -41,7 +41,7 @@ describe('usePageScrollLock', () => {
           { initialProps: true }
         )
 
-        expect(getHtmlElement(document).style.overflow).toBe('hidden')
+        expect(getHtmlElement(document).style.overflow).toBe('clip')
 
         rerender(false)
 
@@ -53,7 +53,7 @@ describe('usePageScrollLock', () => {
 
         const { unmount } = renderHook(() => usePageScrollLock(true))
 
-        expect(getHtmlElement(document).style.overflow).toBe('hidden')
+        expect(getHtmlElement(document).style.overflow).toBe('clip')
 
         unmount()
 
@@ -78,12 +78,12 @@ describe('usePageScrollLock', () => {
 
       hook1.rerender(true)
 
-      expect(getHtmlElement(document).style.overflow).toBe('hidden')
+      expect(getHtmlElement(document).style.overflow).toBe('clip')
 
       hook2.rerender(true)
       hook3.rerender(true)
 
-      expect(getHtmlElement(document).style.overflow).toBe('hidden')
+      expect(getHtmlElement(document).style.overflow).toBe('clip')
     })
 
     it('lifts scroll lock once no hook with isLocked=true left mounted', () => {
@@ -99,15 +99,15 @@ describe('usePageScrollLock', () => {
         initialProps: true,
       })
 
-      expect(getHtmlElement(document).style.overflow).toBe('hidden')
+      expect(getHtmlElement(document).style.overflow).toBe('clip')
 
       hook3.unmount()
 
-      expect(getHtmlElement(document).style.overflow).toBe('hidden')
+      expect(getHtmlElement(document).style.overflow).toBe('clip')
 
       hook2.rerender(false)
 
-      expect(getHtmlElement(document).style.overflow).toBe('hidden')
+      expect(getHtmlElement(document).style.overflow).toBe('clip')
 
       hook1.rerender(false)
 

--- a/packages/base/Utils/src/utils/use-page-scroll-lock.ts
+++ b/packages/base/Utils/src/utils/use-page-scroll-lock.ts
@@ -47,7 +47,7 @@ const addPageScrollLock = () => {
     scrollLock = {
       prevHtmlOverflow: document.getElementsByTagName('html')[0].style.overflow,
     }
-    document.getElementsByTagName('html')[0].style.overflow = 'hidden'
+    document.getElementsByTagName('html')[0].style.overflow = 'clip'
   }
 }
 


### PR DESCRIPTION
### Description

When overlay elements that are based no Popper are shown, the body overflow is set to `hidden` to small - medium screens. This style breaks with any sticky element that may be visible – it immediately loses the "stickyness" while body overflow is hidden, causing an undesired visual behavior.

This PR changes that to overflow `clip` instead. Overflow `clip` behaves similar to `hidden`, but it doesn't a new scrolling area and sticky elements keep sticky. [See for context](https://toptal-core.slack.com/archives/CHK8E5JEN/p1745591412604209?thread_ts=1745431550.717609&cid=CHK8E5JEN)

https://github.com/user-attachments/assets/5593a5b2-bdee-4d93-80e5-84ba0d0158a4

### How to test

<!-- The temploy link will be automatically updated when the temploy is deployed -->
- [Temploy](https://picasso.toptal.net/ff-x-replace-overflow-hidden-by-clip-popper)
- You can check it in action in this PR https://github.com/toptal/client-portal/pull/10730

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Double check if `picasso-tailwind-merge` requires major update (check its `README.md`)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests ([visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md) included)

**Breaking change**

- [x] codemod is created and showcased in the changeset
- [x] test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping for reviews

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>
