### PR TITLE
[MP-955] Fix abrupt animation on Section when expanded and collapsed

### DIFF
--- a/.changeset/hungry-berries-march.md
+++ b/.changeset/hungry-berries-march.md
@@ -1,0 +1,7 @@
+---
+'@toptal/picasso-section': patch
+---
+
+### Section
+
+- fix abrupt animation on Section component when expanded and collapsed

--- a/packages/base/Section/src/Section/Section.tsx
+++ b/packages/base/Section/src/Section/Section.tsx
@@ -40,18 +40,6 @@ export interface Props extends BaseProps {
   titleSize?: SizeType<'small' | 'medium'>
 }
 
-const defaultChildMargin = '[&>:last-child:not(:first-child)]:mt-6'
-
-const classesByVariant: Record<VariantType, string | string[]> = {
-  default: defaultChildMargin,
-  bordered: [
-    defaultChildMargin,
-    'border rounded-md border-solid border-gray-300',
-    'p-8 [&>:last-child]:pb-0',
-  ],
-  withHeaderBar: 'p-0 rounded-md border border-solid border-gray-400',
-}
-
 const headerBarClasses = [
   'pt-3 pb-3 pl-4 pr-4',
   'rounded-tl-md rounded-tr-md rounded-br-0 rounded-bl-0',
@@ -63,6 +51,41 @@ const classesByCollapsedHeader: Record<VariantType, string | string[]> = {
   default: 'pb-0',
   bordered: 'pb-0',
   withHeaderBar: ['border-b-0 rounded-md', 'transition delay-300'],
+}
+
+const getVariantClasses = (
+  variant: VariantType,
+  collapsible: boolean,
+  className: string | undefined
+) => {
+  const defaultChildMargin = collapsible
+    ? ''
+    : '[&>:last-child:not(:first-child)]:mt-6'
+
+  const classesByVariant: Record<VariantType, string | string[]> = {
+    default: defaultChildMargin,
+    bordered: [
+      defaultChildMargin,
+      'border rounded-md border-solid border-gray-300',
+      'p-8 [&>:last-child]:pb-0',
+    ],
+    withHeaderBar: 'p-0 rounded-md border border-solid border-gray-400',
+  }
+
+  return twMerge(
+    'pt-8',
+    classesByVariant[variant],
+    collapsible && variant === 'bordered' && 'p-6',
+    className
+  )
+}
+
+const getHeaderClasses = (variant: VariantType, isCollapsed: boolean) => {
+  return twJoin(
+    'flex items-center',
+    variant === 'withHeaderBar' && headerBarClasses,
+    isCollapsed && classesByCollapsedHeader[variant]
+  )
 }
 
 export const Section = forwardRef<HTMLDivElement, Props>(function Section(
@@ -166,22 +189,12 @@ export const Section = forwardRef<HTMLDivElement, Props>(function Section(
       }
       style={style}
       {...rest}
-      className={twMerge(
-        'pt-8',
-        classesByVariant[variant],
-        variant === 'default' && isCollapsed && 'pb-8',
-        collapsible && variant === 'bordered' && 'p-6',
-        className
-      )}
+      className={getVariantClasses(variant, collapsible, className)}
     >
       {hasHeader && (
         <Container
           data-testid={testIds?.header}
-          className={twJoin(
-            'flex items-center',
-            variant === 'withHeaderBar' && headerBarClasses,
-            isCollapsed && classesByCollapsedHeader[variant]
-          )}
+          className={getHeaderClasses(variant, isCollapsed)}
         >
           {renderTitle()}
           {renderSubtitle()}
@@ -189,7 +202,11 @@ export const Section = forwardRef<HTMLDivElement, Props>(function Section(
         </Container>
       )}
       <Collapse in={!isCollapsed} unmountOnExit>
-        <Container className={variant === 'withHeaderBar' ? 'p-6' : ''}>
+        <Container
+          className={
+            variant === 'withHeaderBar' ? 'p-6' : collapsible ? 'mt-6' : ''
+          }
+        >
           {children}
         </Container>
       </Collapse>

--- a/packages/base/Section/src/Section/__snapshots__/test.tsx.snap
+++ b/packages/base/Section/src/Section/__snapshots__/test.tsx.snap
@@ -6,7 +6,7 @@ exports[`Section renders collapsible initially collapsed 1`] = `
     class="Picasso-root"
   >
     <div
-      class="pt-8 [&>:last-child:not(:first-child)]:mt-6 pb-8"
+      class="pt-8"
     >
       <div
         class="flex items-center pb-0"
@@ -52,7 +52,7 @@ exports[`Section renders collapsible initially expanded 1`] = `
     class="Picasso-root"
   >
     <div
-      class="pt-8 [&>:last-child:not(:first-child)]:mt-6"
+      class="pt-8"
     >
       <div
         class="flex items-center"
@@ -98,7 +98,7 @@ exports[`Section renders collapsible initially expanded 1`] = `
             class="w-full"
           >
             <div
-              class=""
+              class="mt-6"
             >
               <div
                 data-testid="content"


### PR DESCRIPTION
[MP-955]

### Description

The expand/collapse transitions for some of the `Section` variations were a bit "jumpy". This PR fixes them.

### How to test

<!-- The temploy link will be automatically updated when the temploy is deployed -->
- Start storybook locally with `yarn start`
- Go to the Section component
- Expand and collapse all the different stories

### Screenshots

#### Before 

https://github.com/user-attachments/assets/32012b9b-2a07-4ff9-b6ec-ded2abaa3369


#### After


https://github.com/user-attachments/assets/bcc7c7b7-9eee-4cda-9e82-e03f7678e7aa


### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Double check if `picasso-tailwind-merge` requires major update (check its `README.md`)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests ([visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md) included)

**Breaking change**

- N/A codemod is created and showcased in the changeset
- N/A test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping for reviews

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[MP-955]: https://toptal-core.atlassian.net/browse/MP-955?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ