### PR TITLE
[HG-985] Allow variant=primary for the PromptModal

### DIFF
--- a/.changeset/friendly-papayas-clean.md
+++ b/.changeset/friendly-papayas-clean.md
@@ -1,0 +1,6 @@
+---
+'@toptal/picasso-prompt-modal': minor
+'@toptal/picasso': minor
+---
+
+- Allowed variant=primary for the PromptModal 

--- a/packages/base/PromptModal/src/PromptModal/PromptModal.tsx
+++ b/packages/base/PromptModal/src/PromptModal/PromptModal.tsx
@@ -8,7 +8,10 @@ import type { Props as ModalProps } from '@toptal/picasso-modal'
 import { ModalCompound as Modal } from '@toptal/picasso-modal'
 import type { VariantType as ButtonVariantType } from '@toptal/picasso-button'
 
-export type VariantType = 'positive' | 'negative'
+export type VariantType = Extract<
+  ButtonVariantType,
+  'positive' | 'negative' | 'primary'
+>
 
 export type PromptOptions = {
   setResult: (newResult: unknown) => void
@@ -133,7 +136,7 @@ export const PromptModal = forwardRef<HTMLDivElement, Props>(
           <Button
             loading={loading}
             onClick={handleSubmit}
-            variant={`${variant}` as ButtonVariantType}
+            variant={variant}
             data-testid={testIds?.submitButton}
           >
             {submitText}

--- a/packages/base/PromptModal/src/PromptModal/story/Variants.example.tsx
+++ b/packages/base/PromptModal/src/PromptModal/story/Variants.example.tsx
@@ -16,6 +16,12 @@ const PromptModalDefaultExample = () => {
     isOpen: isOpenNegative,
   } = useModal()
 
+  const {
+    showModal: showModalPrimary,
+    hideModal: hideModalPrimary,
+    isOpen: isOpenPrimary,
+  } = useModal()
+
   const { showInfo } = useNotifications()
 
   return (
@@ -39,6 +45,16 @@ const PromptModalDefaultExample = () => {
           message='This is negative variant.'
           onSubmit={async () => showInfo('Submitted')}
           onClose={hideModalNegative}
+        />
+
+        <Button onClick={showModalPrimary}>Open primary</Button>
+        <PromptModal
+          variant='primary'
+          open={isOpenPrimary}
+          title='Primary variant'
+          message='This is primary variant.'
+          onSubmit={async () => showInfo('Submitted')}
+          onClose={hideModalPrimary}
         />
       </Container>
     </>


### PR DESCRIPTION
[HG-985]

### Description

Describe the changes and motivations for the pull request.

### How to test

<!-- The temploy link will be automatically updated when the temploy is deployed -->
- Go to [temploy](https://picasso.toptal.net/HG-985-prompt-modal-variant-primary/?path=/story/overlays-promptmodal--promptmodal#variants)
- Click "Open primary" button
- Modal that appears should have blue "Submit" button

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| Insert screenshots or screen recordings | ![image](https://github.com/user-attachments/assets/ffdcf781-b282-440f-87df-b86f2013161f) |

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Double check if `picasso-tailwind-merge` requires major update (check its `README.md`)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [n/a] Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [n/a] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests ([visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md) included)

**Breaking change**

- [n/a] codemod is created and showcased in the changeset
- [n/a] test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping for reviews

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[HG-985]: https://toptal-core.atlassian.net/browse/HG-985?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ