### PR TITLE
[MP-1619] Support warning status on form fields

### DIFF
--- a/.changeset/forty-wombats-check.md
+++ b/.changeset/forty-wombats-check.md
@@ -1,0 +1,18 @@
+---
+'@toptal/picasso-rich-text-editor': minor
+'@toptal/picasso-outlined-input': minor
+'@toptal/picasso-password-input': minor
+'@toptal/picasso-autocomplete': minor
+'@toptal/picasso-number-input': minor
+'@toptal/picasso-tagselector': minor
+'@toptal/picasso-date-picker': minor
+'@toptal/picasso-timepicker': minor
+'@toptal/picasso-forms': minor
+'@toptal/picasso-select': minor
+'@toptal/picasso-input': minor
+'@toptal/picasso-form': minor
+---
+
+### Changes
+
+- added support for warning status on form fields

--- a/packages/base/Autocomplete/src/Autocomplete/story/Status.example.tsx
+++ b/packages/base/Autocomplete/src/Autocomplete/story/Status.example.tsx
@@ -13,6 +13,10 @@ const Example = () => {
         <Autocomplete value='Ukraine' status='error' />
       </Form.Field>
       <Form.Field>
+        <Form.Label>Warning</Form.Label>
+        <Autocomplete value='Ukraine' status='warning' />
+      </Form.Field>
+      <Form.Field>
         <Form.Label>Success</Form.Label>
         <Autocomplete value='Ukraine' status='success' />
       </Form.Field>

--- a/packages/base/DatePicker/src/DatePicker/story/Status.example.tsx
+++ b/packages/base/DatePicker/src/DatePicker/story/Status.example.tsx
@@ -28,6 +28,16 @@ const Example = () => {
         />
       </Form.Field>
       <Form.Field>
+        <Form.Label>Warning</Form.Label>
+        <DatePicker
+          value={datepickerValue}
+          onChange={date => {
+            setDatepickerValue(date)
+          }}
+          status='warning'
+        />
+      </Form.Field>
+      <Form.Field>
         <Form.Label>Success</Form.Label>
         <DatePicker
           value={datepickerValue}

--- a/packages/base/Form/src/Form/story/index.jsx
+++ b/packages/base/Form/src/Form/story/index.jsx
@@ -4,6 +4,7 @@ import { Form } from '../Form'
 import formFieldStory from '../../FormField/story'
 import formHintStory from '../../FormHint/story'
 import formErrorStory from '../../FormError/story'
+import formWarningStory from '../../FormWarning/story'
 import PicassoBook from '~/.storybook/components/PicassoBook'
 
 const page = PicassoBook.section('Forms').createPage(
@@ -25,6 +26,7 @@ page
   .addComponentDocs(formHintStory.componentDocs)
   .addComponentDocs(formLabelStory.componentDocs)
   .addComponentDocs(formErrorStory.componentDocs)
+  .addComponentDocs(formWarningStory.componentDocs)
 
 page.createChapter().addExample(
   'Form/story/Error.example.tsx',

--- a/packages/base/Form/src/FormCompound/index.ts
+++ b/packages/base/Form/src/FormCompound/index.ts
@@ -4,10 +4,12 @@ import { Form } from '../Form'
 import { FormError } from '../FormError'
 import { FormField } from '../FormField'
 import { FormHint } from '../FormHint'
+import { FormWarning } from '../FormWarning'
 
 export const FormCompound = Object.assign(Form, {
   Field: FormField,
   Hint: FormHint,
   Error: FormError,
   Label: FormLabel,
+  Warning: FormWarning,
 })

--- a/packages/base/Form/src/FormField/FormField.tsx
+++ b/packages/base/Form/src/FormField/FormField.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable complexity */
 import type { ReactNode, HTMLAttributes } from 'react'
 import React, { forwardRef, Children } from 'react'
 import type { BaseProps } from '@toptal/picasso-shared'
@@ -8,12 +9,15 @@ import { useFieldsLayoutContext } from '@toptal/picasso-form-layout'
 import { FormHint } from '../FormHint'
 import { FormError } from '../FormError'
 import { createLabelWidthStyles, horizontalLayoutClasses } from './styles'
+import { FormWarning } from '../FormWarning'
 
 export interface Props extends BaseProps, HTMLAttributes<HTMLDivElement> {
   /** The text of the hint */
-  hint?: string
+  hint?: string | ReactNode
   /** The text of the error */
-  error?: string
+  error?: string | ReactNode
+  /** The text of the warning */
+  warning?: string | ReactNode
   /** The content of the Form.Field */
   children: ReactNode
   /** Field requirements for this specific field */
@@ -79,6 +83,7 @@ export const FormField = forwardRef<HTMLDivElement, Props>(function FormField(
     hint,
     children,
     error,
+    warning,
     fieldRequirements,
     hasMultilineCounter,
     ...rest
@@ -108,8 +113,13 @@ export const FormField = forwardRef<HTMLDivElement, Props>(function FormField(
         hasMultilineCounter={hasMultilineCounter}
       >
         {error && <FormError>{error}</FormError>}
+        {warning && (
+          <FormWarning className={twJoin(error && hint && 'mt-0')}>
+            {warning}
+          </FormWarning>
+        )}
         {hint && (
-          <FormHint className={twJoin(error && hint && 'mt-0')}>
+          <FormHint className={twJoin((error || warning) && hint && 'mt-0')}>
             {hint}
           </FormHint>
         )}

--- a/packages/base/Form/src/FormField/story/ErrorAndWarning.example.tsx
+++ b/packages/base/Form/src/FormField/story/ErrorAndWarning.example.tsx
@@ -5,23 +5,16 @@ const Example = () => (
   <Grid>
     <Grid.Item sm={5}>
       <Form>
-        <Form.Field error='This field is required'>
+        <Form.Field
+          error='This should not contain any special characters'
+          warning='This might be too long'
+        >
           <Form.Label htmlFor='district'>District</Form.Label>
           <Input
             status='error'
             id='district'
             width='full'
             placeholder='e.g., Sant Marti'
-          />
-        </Form.Field>
-
-        <Form.Field error={<span>This field is required</span>}>
-          <Form.Label htmlFor='region'>Region</Form.Label>
-          <Input
-            status='error'
-            id='region'
-            width='full'
-            placeholder='e.g., Catalonia'
           />
         </Form.Field>
       </Form>

--- a/packages/base/Form/src/FormField/story/Warning.example.tsx
+++ b/packages/base/Form/src/FormField/story/Warning.example.tsx
@@ -5,23 +5,13 @@ const Example = () => (
   <Grid>
     <Grid.Item sm={5}>
       <Form>
-        <Form.Field error='This field is required'>
+        <Form.Field warning='This field is required'>
           <Form.Label htmlFor='district'>District</Form.Label>
           <Input
-            status='error'
+            status='warning'
             id='district'
             width='full'
             placeholder='e.g., Sant Marti'
-          />
-        </Form.Field>
-
-        <Form.Field error={<span>This field is required</span>}>
-          <Form.Label htmlFor='region'>Region</Form.Label>
-          <Input
-            status='error'
-            id='region'
-            width='full'
-            placeholder='e.g., Catalonia'
           />
         </Form.Field>
       </Form>

--- a/packages/base/Form/src/FormField/story/index.jsx
+++ b/packages/base/Form/src/FormField/story/index.jsx
@@ -12,6 +12,12 @@ const chapter = PicassoBook.connectToPage(page =>
     .addExample('FormField/story/Default.example.tsx', 'Default', 'base/Form')
     .addExample('FormField/story/Required.example.tsx', 'Required', 'base/Form')
     .addExample('FormField/story/Error.example.tsx', 'Error', 'base/Form')
+    .addExample('FormField/story/Warning.example.tsx', 'Warning', 'base/Form')
+    .addExample(
+      'FormField/story/ErrorAndWarning.example.tsx',
+      'Error and Warning',
+      'base/Form'
+    )
     .addExample('FormField/story/Hint.example.tsx', 'Hint', 'base/Form')
     .addExample(
       'FormField/story/HintAndError.example.tsx',

--- a/packages/base/Form/src/FormWarning/FormWarning.tsx
+++ b/packages/base/Form/src/FormWarning/FormWarning.tsx
@@ -1,0 +1,33 @@
+import type { ReactNode, HTMLAttributes } from 'react'
+import React, { forwardRef } from 'react'
+import type { BaseProps } from '@toptal/picasso-shared'
+import { Typography } from '@toptal/picasso-typography'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
+
+export interface Props extends BaseProps, HTMLAttributes<HTMLDivElement> {
+  /** The text of the error */
+  children: ReactNode
+}
+
+export const FormWarning = forwardRef<HTMLDivElement, Props>(
+  function FormWarning(props, ref) {
+    const { children, className, style, ...rest } = props
+
+    return (
+      <div
+        {...rest}
+        ref={ref}
+        className={twMerge('mt-1', className)}
+        style={style}
+      >
+        <Typography color='yellow' size='xxsmall' className='cursor-default'>
+          {children}
+        </Typography>
+      </div>
+    )
+  }
+)
+
+FormWarning.displayName = 'FormWarning'
+
+export default FormWarning

--- a/packages/base/Form/src/FormWarning/__snapshots__/test.tsx.snap
+++ b/packages/base/Form/src/FormWarning/__snapshots__/test.tsx.snap
@@ -1,0 +1,57 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`FormWarning renders 1`] = `
+<div>
+  <div
+    class="Picasso-root"
+  >
+    <form
+      class=""
+    >
+      <div
+        class="text-[1rem] [&+&]:mt-4"
+        data-field-has-error="false"
+      >
+        <label
+          class="block leading-[1em] mb-[0.5em] text-graphite"
+        >
+          <span
+            class="text-[0.875rem]"
+          >
+            Label:
+          </span>
+        </label>
+        <div
+          class="base-Input base-Input base-Input relative inline-flex gap-y gap-x items-center rounded-sm [font-size:_unset] group text-nowrap p-2 h-8 w-[18.75rem] bg-white after:content-[""] after:inline-block after:absolute after:top-0 after:bottom-0 after:right-0 after:left-0 after:pointer-events after:border-solid after:rounded-sm after:border-gray [&:has(:focus)]:after:border-blue after:border [&:has(:focus)]:after:shadow-[0_0_0_3px] [&:has(:focus)]:after:shadow-blue hover:[&:not(:has(:focus))]:after:border-gray text-black cursor-[inherit]"
+        >
+          <input
+            aria-invalid="false"
+            autocomplete="none"
+            class="base-Input [&::-webkit-calendar-picker-indicator]:bg bg-transparent border-none box-border cursor-[inherit] h-full outline-none p-0 peer resize-none w-full text-md leading-4 text-black [&::placeholder]:text-gray [&::placeholder]:opacity-100"
+            type="text"
+            value=""
+          />
+        </div>
+        <div
+          class="mt-1"
+        >
+          <p
+            class="m-0 text-2xs text-yellow font-regular cursor-default"
+          >
+            My Warning
+          </p>
+        </div>
+        <div
+          class="mt-1"
+        >
+          <p
+            class="m-0 text-2xs text-graphite font-regular"
+          >
+            This is a hint
+          </p>
+        </div>
+      </div>
+    </form>
+  </div>
+</div>
+`;

--- a/packages/base/Form/src/FormWarning/index.ts
+++ b/packages/base/Form/src/FormWarning/index.ts
@@ -1,0 +1,6 @@
+import type { OmitInternalProps } from '@toptal/picasso-shared'
+
+import type { Props } from './FormWarning'
+
+export { default as FormWarning } from './FormWarning'
+export type FormWarningProps = OmitInternalProps<Props>

--- a/packages/base/Form/src/FormWarning/story/index.jsx
+++ b/packages/base/Form/src/FormWarning/story/index.jsx
@@ -1,0 +1,9 @@
+import { FormWarning } from '../FormWarning'
+import PicassoBook from '~/.storybook/components/PicassoBook'
+
+const componentDocs = PicassoBook.createComponentDocs(
+  FormWarning,
+  'Form.Warning'
+)
+
+export default { componentDocs }

--- a/packages/base/Form/src/FormWarning/test.tsx
+++ b/packages/base/Form/src/FormWarning/test.tsx
@@ -1,0 +1,34 @@
+import React from 'react'
+import type { RenderResult } from '@toptal/picasso-test-utils'
+import { render } from '@toptal/picasso-test-utils'
+import type { OmitInternalProps } from '@toptal/picasso-shared'
+import { Input } from '@toptal/picasso-input'
+
+import type { Props } from './FormWarning'
+import { FormCompound as Form } from '../FormCompound'
+
+const TestFormError = ({ children }: OmitInternalProps<Props>) => {
+  return (
+    <Form>
+      <Form.Field>
+        <Form.Label>Label:</Form.Label>
+        <Input />
+        <Form.Warning>{children}</Form.Warning>
+        <Form.Hint>This is a hint</Form.Hint>
+      </Form.Field>
+    </Form>
+  )
+}
+
+describe('FormWarning', () => {
+  let api: RenderResult
+
+  beforeEach(() => {
+    api = render(<TestFormError>My Warning</TestFormError>)
+  })
+  it('renders', () => {
+    const { container } = api
+
+    expect(container).toMatchSnapshot()
+  })
+})

--- a/packages/base/Form/src/index.ts
+++ b/packages/base/Form/src/index.ts
@@ -2,6 +2,7 @@ export * from './FormCompound'
 export * from './Form'
 export * from './FormError'
 export * from './FormHint'
+export * from './FormWarning'
 export * from './FormField'
 export type {
   FieldsLayoutContextProviderProps,

--- a/packages/base/Input/src/Input/story/Status.example.tsx
+++ b/packages/base/Input/src/Input/story/Status.example.tsx
@@ -13,6 +13,10 @@ const Example = () => {
         <Input value='Ukraine' status='error' />
       </Form.Field>
       <Form.Field>
+        <Form.Label>Warning</Form.Label>
+        <Input value='Ukraine' status='warning' />
+      </Form.Field>
+      <Form.Field>
         <Form.Label>Success</Form.Label>
         <Input value='Ukraine' status='success' />
       </Form.Field>

--- a/packages/base/NumberInput/src/NumberInput/story/Status.example.tsx
+++ b/packages/base/NumberInput/src/NumberInput/story/Status.example.tsx
@@ -13,6 +13,10 @@ const Example = () => {
         <NumberInput value='100' status='error' />
       </Form.Field>
       <Form.Field>
+        <Form.Label>Warning</Form.Label>
+        <NumberInput value='100' status='warning' />
+      </Form.Field>
+      <Form.Field>
         <Form.Label>Success</Form.Label>
         <NumberInput value='100' status='success' />
       </Form.Field>

--- a/packages/base/OutlinedInput/src/OutlinedInput/OutlinedInput.tsx
+++ b/packages/base/OutlinedInput/src/OutlinedInput/OutlinedInput.tsx
@@ -129,6 +129,7 @@ const OutlinedInput = forwardRef<HTMLElement, Props>(function OutlinedInput(
   useImperativeHandle(ref, () => divRef.current as HTMLElement, [])
 
   const isError = Boolean(status === 'error')
+  const isWarning = Boolean(status === 'warning')
 
   const inputClassName = getInputClassName({
     size,
@@ -152,6 +153,7 @@ const OutlinedInput = forwardRef<HTMLElement, Props>(function OutlinedInput(
     className,
     classes,
     isError,
+    isWarning,
   })
 
   const multilineProps = multiline

--- a/packages/base/OutlinedInput/src/OutlinedInput/stylesRoot.test.ts
+++ b/packages/base/OutlinedInput/src/OutlinedInput/stylesRoot.test.ts
@@ -17,6 +17,7 @@ describe('getRootClassName', () => {
     isDark: false,
     layout: 'vertical' as FieldLayout,
     isError: false,
+    isWarning: false,
     size: 'medium' as Size,
     width: 'auto' as WidthType,
   }

--- a/packages/base/OutlinedInput/src/OutlinedInput/stylesRoot.ts
+++ b/packages/base/OutlinedInput/src/OutlinedInput/stylesRoot.ts
@@ -65,6 +65,10 @@ export const borderPseudoClassesByState = {
     default: ['after:border-gray-400', '[&:has(:focus)]:after:border-blue-500'],
     disabled: 'after:border-gray-400',
     error: ['after:border-red-500', '[&:has(:focus)]:after:border-red-500'],
+    warning: [
+      'after:border-yellow-500',
+      '[&:has(:focus)]:after:border-yellow-500',
+    ],
     hoverWithoutFocus: 'hover:[&:not(:has(:focus))]:after:border-gray-600',
   },
   border: {
@@ -72,6 +76,7 @@ export const borderPseudoClassesByState = {
     default: 'after:border',
     disabled: '',
     error: '',
+    warning: '',
   },
   shadow: {
     dark: '[&:has(:focus)]:after:shadow-0',
@@ -83,6 +88,10 @@ export const borderPseudoClassesByState = {
     error: [
       '[&:has(:focus)]:after:shadow-[0_0_0_3px]',
       '[&:has(:focus)]:after:shadow-red-500/[.48]',
+    ],
+    warning: [
+      '[&:has(:focus)]:after:shadow-[0_0_0_3px]',
+      '[&:has(:focus)]:after:shadow-yellow-500/[.48]',
     ],
   },
 }
@@ -146,10 +155,11 @@ const getTextColorClass = (disabled: boolean | undefined) =>
 const getCursorClass = (disabled: boolean | undefined) =>
   disabled ? cursorClass.disabled : cursorClass.default
 
-type State = 'default' | 'disabled' | 'error' | 'dark'
+type State = 'default' | 'disabled' | 'error' | 'dark' | 'warning'
 type StateConditions = Partial<Record<State, boolean>> & {
   isDark: boolean
   isError: boolean
+  isWarning: boolean
 }
 
 const getClassForState = (
@@ -164,7 +174,7 @@ const getClassForState = (
 }
 
 const borderPseudoElement = (conditions: StateConditions) => {
-  const { disabled, isDark, isError } = conditions
+  const { disabled, isDark, isError, isWarning } = conditions
   const { borderColor } = borderPseudoClassesByState
   const primaryState = isError
     ? 'error'
@@ -172,9 +182,12 @@ const borderPseudoElement = (conditions: StateConditions) => {
     ? 'disabled'
     : isDark
     ? 'dark'
+    : isWarning
+    ? 'warning'
     : 'default'
 
-  const hoverClass = !disabled && !isError ? borderColor.hoverWithoutFocus : ''
+  const hoverClass =
+    !disabled && !isError && !isWarning ? borderColor.hoverWithoutFocus : ''
 
   return [
     borderPseudoCoreClasses,
@@ -193,19 +206,21 @@ export const getRootClassName = ({
   highlight,
   disabled,
   isError,
+  isWarning,
 }: Partial<Props> & {
   isDark: boolean
   layout: FieldLayout
   isError: boolean
   size: Size
   width: WidthType
+  isWarning: boolean
 }) => [
   rootBasicClasses,
   spacingBySize[size],
   getHeightClasses({ size, multiline }),
   getWidthClasses({ width, layout }),
   getBackgroundColorClasses({ isDark, disabled, highlight }),
-  borderPseudoElement({ isDark, disabled, isError }),
+  borderPseudoElement({ isDark, disabled, isError, isWarning }),
   getTextColorClass(disabled),
   getCursorClass(disabled),
   type === 'hidden' && 'hidden',

--- a/packages/base/OutlinedInput/src/OutlinedInput/types.ts
+++ b/packages/base/OutlinedInput/src/OutlinedInput/types.ts
@@ -20,7 +20,7 @@ export type ValueType =
   | boolean
   | object
 
-export type Status = 'error' | 'success' | 'default'
+export type Status = 'error' | 'success' | 'warning' | 'default'
 
 export type BaseInputProps = InputBaseComponentProps & {
   variant?: 'dark' | 'light'

--- a/packages/base/PasswordInput/src/PasswordInput/story/Status.example.tsx
+++ b/packages/base/PasswordInput/src/PasswordInput/story/Status.example.tsx
@@ -13,6 +13,10 @@ const Example = () => {
         <PasswordInput value='asd' status='error' />
       </Form.Field>
       <Form.Field>
+        <Form.Label>Warning</Form.Label>
+        <PasswordInput value='asd' status='warning' />
+      </Form.Field>
+      <Form.Field>
         <Form.Label>Success</Form.Label>
         <PasswordInput value='asd' status='success' />
       </Form.Field>

--- a/packages/base/Select/src/Select/story/Status.example.tsx
+++ b/packages/base/Select/src/Select/story/Status.example.tsx
@@ -12,6 +12,10 @@ const Example = () => {
         <Form.Label>Error</Form.Label>
         <Select options={[]} status='error' width='auto' />
       </Form.Field>
+      <Form.Field>
+        <Form.Label>Warning</Form.Label>
+        <Select options={[]} status='warning' width='auto' />
+      </Form.Field>
     </Form>
   )
 }

--- a/packages/base/Select/src/SelectBase/types.ts
+++ b/packages/base/Select/src/SelectBase/types.ts
@@ -31,8 +31,8 @@ export interface SelectProps<
   disabled?: boolean
   /** Whether to render select options in portal. Should be disabled in Modals */
   disablePortal?: boolean
-  /** Indicate whether `Select` is in `error` or `default` state */
-  status?: Extract<Status, 'error' | 'default'>
+  /** Indicate whether `Select` is in `error`, `warning` or `default` state */
+  status?: Extract<Status, 'error' | 'warning' | 'default'>
   /** Component ID */
   id?: string
   /** Width of the component */

--- a/packages/base/Tagselector/src/TagSelector/story/Status.example.tsx
+++ b/packages/base/Tagselector/src/TagSelector/story/Status.example.tsx
@@ -30,6 +30,10 @@ const Example = () => {
         </Container>
       </Container>
       <Container padded={SPACING_4}>
+        <Typography>Warning</Typography>
+        <TagSelector placeholder='warning' status='warning' value={value} />
+      </Container>
+      <Container padded={SPACING_4}>
         <Typography>Success with long placeholder</Typography>
         <TagSelector placeholder='Very long placeholder' status='success' />
       </Container>

--- a/packages/base/Timepicker/src/TimePicker/TimePicker.tsx
+++ b/packages/base/Timepicker/src/TimePicker/TimePicker.tsx
@@ -34,8 +34,8 @@ export interface Props
     > {
   /** Time value that will be selected in TimePicker */
   value?: string
-  /** Indicate whether `TimePicker` is in `error` or `default` state */
-  status?: Extract<Status, 'error' | 'default'>
+  /** Indicate whether `TimePicker` is in `error`, `warning` or `default` state */
+  status?: Extract<Status, 'error' | 'warning' | 'default'>
   /** Called on input change */
   onChange?: (value: string) => void
 }

--- a/packages/base/Timepicker/src/TimePicker/story/Status.example.tsx
+++ b/packages/base/Timepicker/src/TimePicker/story/Status.example.tsx
@@ -12,6 +12,10 @@ const Example = () => {
         <Form.Label>Error</Form.Label>
         <TimePicker status='error' />
       </Form.Field>
+      <Form.Field>
+        <Form.Label>Warning</Form.Label>
+        <TimePicker status='warning' />
+      </Form.Field>
     </Form>
   )
 }

--- a/packages/picasso-forms/src/FieldWrapper/FieldWrapper.tsx
+++ b/packages/picasso-forms/src/FieldWrapper/FieldWrapper.tsx
@@ -6,10 +6,10 @@ import type { Props as FieldLabelProps } from '../FieldLabel'
 import FieldLabel from '../FieldLabel'
 import InputField from '../InputField'
 
-export type Props<TWrappedComponentProps, TInputValue> = Omit<
-  FieldProps<TWrappedComponentProps, TInputValue>,
-  'label'
-> &
+export type Props<
+  TWrappedComponentProps extends IFormComponentProps,
+  TInputValue
+> = Omit<FieldProps<TWrappedComponentProps, TInputValue>, 'label'> &
   Omit<FieldLabelProps, 'name'>
 
 const FieldWrapper = <

--- a/packages/picasso-forms/src/FieldWrapper/story/index.jsx
+++ b/packages/picasso-forms/src/FieldWrapper/story/index.jsx
@@ -108,7 +108,7 @@ const componentDocs = PicassoBook.createComponentDocs(
       name: 'status',
       type: {
         name: 'OutlinedFieldStatus',
-        description: '"default" | "error" | "success"',
+        description: '"default" | "error" | "warning" | "success"',
       },
       description:
         'The status of the field to be used by the OutlinedInput component',

--- a/packages/picasso-rich-text-editor/src/RichTextEditor/RichTextEditor.tsx
+++ b/packages/picasso-rich-text-editor/src/RichTextEditor/RichTextEditor.tsx
@@ -30,8 +30,8 @@ export interface Props extends BaseProps {
   disabled?: boolean
   /** unique identifier */
   id: string
-  /** Indicate `RichTextEditor` is in `error` or `default` state */
-  status?: Extract<OutlinedInputStatus, 'error' | 'default'>
+  /** Indicate `RichTextEditor` is in `error`, `warning` or `default` state */
+  status?: Extract<OutlinedInputStatus, 'error' | 'warning' | 'default'>
   /** Used inside Form with combination of Label to enable forHtml functionality */
   hiddenInputId?: string
   /**
@@ -150,6 +150,7 @@ export const RichTextEditor = forwardRef<HTMLDivElement, Props>(
               [classes.disabled]: disabled,
               [classes.focused]: hasFocus,
               [classes.error]: status === 'error',
+              [classes.warning]: status === 'warning',
               [classes.highlightAutofill]: highlight === 'autofill',
             },
             className

--- a/packages/picasso-rich-text-editor/src/RichTextEditor/story/Status.example.tsx
+++ b/packages/picasso-rich-text-editor/src/RichTextEditor/story/Status.example.tsx
@@ -17,6 +17,13 @@ const Example = () => {
         status='error'
         name='error'
       />
+      <RichTextEditor
+        label='Warning'
+        id='editor-warning'
+        placeholder='Write some cool rich text'
+        status='warning'
+        name='warning'
+      />
     </FormNonCompound>
   )
 }

--- a/packages/picasso-rich-text-editor/src/RichTextEditor/styles.ts
+++ b/packages/picasso-rich-text-editor/src/RichTextEditor/styles.ts
@@ -31,6 +31,14 @@ export default (theme: Theme) => {
       },
     },
 
+    warning: {
+      borderColor: palette.yellow.main,
+      '&$focused': {
+        borderColor: palette.yellow.main,
+        ...outline(palette.yellow.main),
+      },
+    },
+
     focused: {
       borderColor: palette.grey.main2,
       ...outline(palette.primary.main),


### PR DESCRIPTION
[MP-1619] 

### Description

In this PR, two API improvements are presented:
* Adding `status="warning"` to form fields. This includes Input, Select etc.. and a form wrapper that can now render warnings and errors at the same time.
* Errors, hints and warnings can be passed as `ReactNode`, not only as a `string` from now on.

This change makes it possible to create forms like this (particularly required to complete [this ticket](https://toptal-core.atlassian.net/browse/MP-1619))

<img width="470" alt="image" src="https://github.com/user-attachments/assets/13e83284-e460-411e-a38a-d0b653185da2" />


### How to test

<!-- The temploy link will be automatically updated when the temploy is deployed -->
- [Temploy](https://picasso.toptal.net/MP-1619-form-warning-state-and-error-as-react-node)
- Go over each field from form and those that support "status" prop should also support new variant - "warning"
- Also open https://picasso.toptal.net/MP-1619-form-warning-state-and-error-as-react-node/?path=/story/forms-form--form and check that we can render warnings & errors at the same time as well as we can render both errors as string and react node.
- OR you can check happo tests https://happo.io/a/675/p/1189/compare/3b51fc99efd90453833875cc4c660c356d4b4a24/9fc8c8e0317c9cd344b43d340d6daf31b11450f6

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| Insert screenshots or screen recordings | Insert screenshots or screen recordings |

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Double check if `picasso-tailwind-merge` requires major update (check its `README.md`)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests ([visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md) included)

**Breaking change**

- [x] codemod is created and showcased in the changeset
- [x] test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping for reviews

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[MP-1619]: https://toptal-core.atlassian.net/browse/MP-1619?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ