### PR TITLE
Remove cypress screenshots upload step from integration tests WF

### DIFF
--- a/.github/workflows/davinci-integration-tests.yml
+++ b/.github/workflows/davinci-integration-tests.yml
@@ -126,13 +126,6 @@ jobs:
       - name: Run integration tests
         uses: toptal/davinci-github-actions/integration-tests@v16.0.4
 
-      - name: Upload screenshots
-        uses: actions/upload-artifact@v4
-        if: failure()
-        with:
-          name: cypress-screenshots
-          path: cypress/screenshots
-
   finalize-integration-tests:
     name: Finalize Integration Tests
     runs-on: ubuntu-latest


### PR DESCRIPTION
`toptal/davinci-github-actions/integration-tests` does upload screenshots automatically. An attempt to upload them once again results in a failure https://github.com/toptal/picasso/actions/runs/15922756856/job/44913457950#step:10:32 

![image](https://github.com/user-attachments/assets/c439e5d0-550d-492c-9d5b-ce78af65b4d9)

### How to test

<!-- The temploy link will be automatically updated when the temploy is deployed -->
- [Temploy](https://picasso.toptal.net/fix-integration-tests)
- CI is green

### Development checks

- [n/a] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [n/a] Double check if `picasso-tailwind-merge` requires major update (check its `README.md`)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [n/a] Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [n/a] Annotate all `props` in component with documentation
- [n/a] Create `examples` for component
- [n/a] Ensure that deployed demo has expected results and good examples
- [n/a] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [n/a] Covered with tests ([visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md) included)

**Breaking change**

- [n/a] codemod is created and showcased in the changeset
- [n/a] test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping for reviews

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>
