### PR TITLE
[BILL-6530] Move happo secrets to step level of the workflows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -79,7 +79,8 @@ jobs:
     if: ${{ github.event.pull_request.head.ref != 'changeset-release/master' }}
     name: Storybook Visual Tests
     runs-on: ubuntu-latest
-    permissions: write-all
+    permissions:
+      contents: read
     needs: [static-checks]
     steps:
       - name: Checkout
@@ -109,9 +110,7 @@ jobs:
     name: Deploy Picasso docs
     runs-on: ubuntu-latest
     permissions:
-      contents: write
-      id-token: write
-      deployments: write
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/davinci-integration-tests.yml
+++ b/.github/workflows/davinci-integration-tests.yml
@@ -51,8 +51,6 @@ jobs:
     env:
       GROUP_INDEX: ${{ matrix.index }}
       PARALLEL_GROUPS: ${{ strategy.job-total }}
-      HAPPO_API_KEY: ${{ secrets.HAPPO_API_KEY }}
-      HAPPO_API_SECRET: ${{ secrets.HAPPO_API_SECRET }}
     steps:
       - name: Checkout project
         uses: actions/checkout@v4
@@ -72,6 +70,9 @@ jobs:
 
       - name: Run integration tests
         uses: ./.github/actions/integration-tests
+        env:
+          HAPPO_API_KEY: ${{ secrets.HAPPO_API_KEY }}
+          HAPPO_API_SECRET: ${{ secrets.HAPPO_API_SECRET }}
 
   finalize-integration-tests:
     name: Finalize Integration Tests
@@ -80,9 +81,6 @@ jobs:
       contents: read
       id-token: write
     needs: [integration-tests]
-    env:
-      HAPPO_API_KEY: ${{ secrets.HAPPO_API_KEY }}
-      HAPPO_API_SECRET: ${{ secrets.HAPPO_API_SECRET }}
     steps:
       - name: Checkout project
         uses: actions/checkout@v4
@@ -96,3 +94,6 @@ jobs:
 
       - name: Finalize Happo
         run: npx happo-e2e finalize
+        env:
+          HAPPO_API_KEY: ${{ secrets.HAPPO_API_KEY }}
+          HAPPO_API_SECRET: ${{ secrets.HAPPO_API_SECRET }}

--- a/.github/workflows/visual-testing.yml
+++ b/.github/workflows/visual-testing.yml
@@ -20,14 +20,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-      id-token: write
-      actions: write
-      issues: write
-      pull-requests: write
-    env:
-      HAPPO_PROJECT: Picasso/Storybook
-      HAPPO_API_KEY: ${{ secrets.HAPPO_API_KEY }}
-      HAPPO_API_SECRET: ${{ secrets.HAPPO_API_SECRET }}
     steps:
       - name: Checkout project
         uses: actions/checkout@v4
@@ -41,3 +33,7 @@ jobs:
 
       - name: Happo Tests
         run: yarn happo:storybook
+        env:
+          HAPPO_PROJECT: Picasso/Storybook
+          HAPPO_API_KEY: ${{ secrets.HAPPO_API_KEY }}
+          HAPPO_API_SECRET: ${{ secrets.HAPPO_API_SECRET }}


### PR DESCRIPTION
[BILL-6530]

### Description

Move happo secrets to step level of the workflows

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping for reviews

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[BILL-6530]: https://toptal-core.atlassian.net/browse/BILL-6530?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ