### PR TITLE
[BILL-6575] Fix slack messages in the CI workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,34 +105,33 @@ jobs:
               })
             }
 
-      # - name: Send a Slack notification on failure
-      #   if: ${{ failure() }}
-      #   uses: slackapi/slack-github-action@v1.27.0
-      #   env:
-      #     SLACK_BOT_TOKEN: ${{ env.SLACK_BOT_TOKEN }}
-      #     FAILURE_URL: ${{ steps.trigger-deploy.outputs.jenkins_job_url || steps.trigger-build.outputs.jenkins_job_url }}
-      #     FALLBACK_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}?check_suite_focus=true
-      #   with:
-      #     channel-id: 'frontend-notifications'
-      #     slack-message: ':x: <!here> Current master version of Picasso is <${{ env.FAILURE_URL || env.FALLBACK_URL }}|broken>.'
+      - name: Send a Slack notification on failure
+        if: ${{ failure() }}
+        uses: slackapi/slack-github-action@v2.1.1
+        env:
+          # FAILURE_URL: ${{ steps.trigger-deploy.outputs.jenkins_job_url || steps.trigger-build.outputs.jenkins_job_url }}
+          FALLBACK_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}?check_suite_focus=true
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          # slack-message: ':x: <!here> Current master version of Picasso is <${{ env.FAILURE_URL || env.FALLBACK_URL }}|broken>.'
+          payload: |
+            text: ':x: <!here> Current master version of Picasso is <${{ env.FALLBACK_URL }}|broken>.'
 
-      # - name: Send a Slack notification on success release
-      #   if: ${{ success() && steps.changesets.outputs.published == 'true' }}
-      #   uses: slackapi/slack-github-action@v1.27.0
-      #   with:
-      #     channel-id: 'frontend-notifications'
-      #     slack-message: 'Current master version of Picasso successfully released :green_heart:'
-      #   env:
-      #     SLACK_BOT_TOKEN: ${{ env.SLACK_BOT_TOKEN }}
+      - name: Send a Slack notification on success release
+        if: ${{ success() && steps.changesets.outputs.published == 'true' }}
+        uses: slackapi/slack-github-action@v2.1.1
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          payload: |
+            text: 'Current master version of Picasso successfully released :green_heart:'
 
-      # - name: Send a Slack notification on success PR merge
-      #   if: ${{ success() && steps.changesets.outputs.published != 'true'}}
-      #   uses: slackapi/slack-github-action@v1.27.0
-      #   with:
-      #     channel-id: 'frontend-notifications'
-      #     slack-message: 'A new PR was merged to Picasso :parrotspin:'
-      #   env:
-      #     SLACK_BOT_TOKEN: ${{ env.SLACK_BOT_TOKEN }}
+      - name: Send a Slack notification on success PR merge
+        if: ${{ success() && steps.changesets.outputs.published != 'true'}}
+        uses: slackapi/slack-github-action@v2.1.1
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
+          payload: |
+            text: 'A new PR was merged to Picasso :parrotspin:'
 
       # Implement Storybook deployment here
 


### PR DESCRIPTION
[BILL-6575]

### Description

Fix slack messages in the CI workflows.
I've added a new secret `SLACK_WEBHOOK_URL` to the repo. It can send messages to a single channel with notifications.

### How to test

<!-- The temploy link will be automatically updated when the temploy is deployed -->

Run release pipeline and see the slack message appears.

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Double check if `picasso-tailwind-merge` requires major update (check its `README.md`)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests ([visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md) included)

**Breaking change**

- [x] codemod is created and showcased in the changeset
- [x] test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>PR commands</summary>
<br />

List of available commands:

- `@toptal-bot run package:alpha-release` - Release alpha version
- `@toptal-anvil ping reviewers` - Ping for reviews

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[BILL-6575]: https://toptal-core.atlassian.net/browse/BILL-6575?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ