### PR TITLE
feat(Paper): add borderRadius prop

### DIFF
--- a/.changeset/paper-border-radius-prop.md
+++ b/.changeset/paper-border-radius-prop.md
@@ -1,0 +1,6 @@
+---
+'@toptal/picasso-paper': minor
+'@toptal/picasso': minor
+---
+
+Add `borderRadius` prop to `Paper` component. Accepts `'none' | 'sm' | 'md' | 'full'` and maps to Picasso's Tailwind border-radius scale. Defaults to no border radius (backward compatible).

--- a/packages/base/Paper/src/Paper/Paper.tsx
+++ b/packages/base/Paper/src/Paper/Paper.tsx
@@ -3,9 +3,13 @@ import React, { forwardRef } from 'react'
 import type { BaseProps } from '@toptal/picasso-shared'
 import { twMerge } from '@toptal/picasso-tailwind-merge'
 
+export type PaperBorderRadius = 'none' | 'sm' | 'md' | 'full'
+
 export interface Props extends BaseProps, HTMLAttributes<HTMLDivElement> {
   /** Paper elevation shadow */
   elevation?: number
+  /** Border radius of the Paper surface */
+  borderRadius?: PaperBorderRadius
   children: ReactNode
 }
 
@@ -38,8 +42,15 @@ const shadowsMapping: Record<number, string> = {
   24: 'shadow-24',
 }
 
+const borderRadiusMapping: Record<PaperBorderRadius, string> = {
+  none: 'rounded-none',
+  sm: 'rounded-sm',
+  md: 'rounded-md',
+  full: 'rounded-full',
+}
+
 export const Paper = forwardRef<HTMLDivElement, Props>(function Paper(
-  { elevation = 1, ...props },
+  { elevation = 1, borderRadius, ...props },
   ref
 ) {
   const { className, style, children, ...rest } = props
@@ -51,6 +62,7 @@ export const Paper = forwardRef<HTMLDivElement, Props>(function Paper(
         'bg-white',
         shadowsMapping[elevation],
         'transition-shadow duration-300 delay-0',
+        borderRadius !== undefined ? borderRadiusMapping[borderRadius] : undefined,
         className
       )}
       style={style}

--- a/packages/base/Paper/src/Paper/test.tsx
+++ b/packages/base/Paper/src/Paper/test.tsx
@@ -20,4 +20,26 @@ describe('Paper', () => {
 
     expect(container).toMatchSnapshot()
   })
+
+  describe('borderRadius', () => {
+    it.each(['none', 'sm', 'md', 'full'] as const)(
+      'applies %s border radius class',
+      borderRadius => {
+        const { container } = render(
+          <Paper borderRadius={borderRadius}>Content</Paper>
+        )
+
+        expect(container.firstChild).toMatchSnapshot()
+      }
+    )
+
+    it('applies no border radius class when borderRadius is not set', () => {
+      const { container } = render(<Paper>Content</Paper>)
+
+      expect(container.firstChild).not.toHaveClass('rounded-none')
+      expect(container.firstChild).not.toHaveClass('rounded-sm')
+      expect(container.firstChild).not.toHaveClass('rounded-md')
+      expect(container.firstChild).not.toHaveClass('rounded-full')
+    })
+  })
 })


### PR DESCRIPTION
## Summary

Adds a `borderRadius` prop to the `Paper` component so consumers can use Picasso's design-system border-radius scale without resorting to inline `style` overrides.

- Accepts `'none' | 'sm' | 'md' | 'full'` — maps to Tailwind classes `rounded-none`, `rounded-sm` (4px), `rounded-md` (8px), `rounded-full`
- Defaults to `undefined` (no border radius applied — fully backward compatible)
- Exports `PaperBorderRadius` type

## Motivation

Without this prop, consumers who need rounded Paper surfaces (e.g. stat/metric cards) fall back to `style={{ borderRadius: Npx }}` with arbitrary pixel values outside the design system's scale. This was observed in downstream tooling where a `style={{ borderRadius: 6 }}` workaround was documented as a convention — a signal that the prop belongs in the component itself.

## Usage

```tsx
// Rounded stat card
<Paper borderRadius="sm">
  <Container padded={SPACING_6}>
    <Typography variant="heading" size="xlarge">{value}</Typography>
  </Container>
</Paper>
```

## Test plan

- [ ] Existing snapshot test passes unchanged (no default border radius added)
- [ ] New parameterised tests verify each `borderRadius` value applies the correct Tailwind class
- [ ] New test verifies no radius class is present when prop is omitted