### PR TITLE
[TAPS-2284] Fix Tabs onChange not firing when re-clicking selected tab

### DIFF
--- a/.changeset/tabs-onchange-reclick.md
+++ b/.changeset/tabs-onchange-reclick.md
@@ -1,0 +1,6 @@
+---
+'@toptal/picasso-tabs': patch
+'@toptal/picasso': patch
+---
+
+- fix `Tabs` `onChange` not firing when re-clicking the already-selected tab. Restores the MUI v4 behavior that was lost during the migration to `@mui/base/Tabs` in `@toptal/picasso-tabs@6.0.0`, so consumers relying on side-effects in `onChange` (e.g. scroll-to-section) work again.

--- a/.changeset/tabs-onchange-reclick.md
+++ b/.changeset/tabs-onchange-reclick.md
@@ -3,4 +3,4 @@
 '@toptal/picasso': patch
 ---
 
-- fix `Tabs` `onChange` not firing when re-clicking the already-selected tab. Restores the MUI v4 behavior that was lost during the migration to `@mui/base/Tabs` in `@toptal/picasso-tabs@6.0.0`, so consumers relying on side-effects in `onChange` (e.g. scroll-to-section) work again.
+- fix `Tabs.Tab` `onClick` not firing on click. The handler was silently dropped after the migration to `@mui/base/Tabs` in `@toptal/picasso-tabs@6.0.0` because `@mui/base/Tab` destructures `onClick` out of its props. It is now wired through `slotProps.root.onClick` and fires on every click, including re-clicks of the already-selected tab. Consumers that need to react to re-clicks should use `Tab.onClick` (`Tabs.onChange` continues to fire only on actual value changes, matching MUI base).

--- a/packages/base/Tabs/src/Tab/Tab.tsx
+++ b/packages/base/Tabs/src/Tab/Tab.tsx
@@ -114,12 +114,7 @@ export const Tab = forwardRef<HTMLButtonElement, Props>(function Tab(
     ...rest
   } = props
   const titleCase = useTitleCase(propsTitleCase)
-  const {
-    orientation,
-    variant,
-    value: contextValue,
-    onChange: contextOnChange,
-  } = useContext(TabsContext)
+  const { orientation, variant } = useContext(TabsContext)
   const isHorizontal = orientation === 'horizontal'
 
   const renderLabel = getLabelComponent({
@@ -164,12 +159,7 @@ export const Tab = forwardRef<HTMLButtonElement, Props>(function Tab(
               'relative ',
               className
             ),
-            onClick: (event: React.MouseEvent<HTMLButtonElement>) => {
-              onClick?.(event)
-              if (ownerState.selected) {
-                contextOnChange?.(event, contextValue)
-              }
-            },
+            ...(onClick && { onClick }),
           }
         },
       }}

--- a/packages/base/Tabs/src/Tab/Tab.tsx
+++ b/packages/base/Tabs/src/Tab/Tab.tsx
@@ -114,7 +114,12 @@ export const Tab = forwardRef<HTMLButtonElement, Props>(function Tab(
     ...rest
   } = props
   const titleCase = useTitleCase(propsTitleCase)
-  const { orientation, variant } = useContext(TabsContext)
+  const {
+    orientation,
+    variant,
+    value: contextValue,
+    onChange: contextOnChange,
+  } = useContext(TabsContext)
   const isHorizontal = orientation === 'horizontal'
 
   const renderLabel = getLabelComponent({
@@ -135,7 +140,6 @@ export const Tab = forwardRef<HTMLButtonElement, Props>(function Tab(
       disabled={disabled}
       value={value}
       onChange={onChange}
-      onClick={onClick}
       slotProps={{
         root: ownerState => {
           return {
@@ -160,6 +164,12 @@ export const Tab = forwardRef<HTMLButtonElement, Props>(function Tab(
               'relative ',
               className
             ),
+            onClick: (event: React.MouseEvent<HTMLButtonElement>) => {
+              onClick?.(event)
+              if (ownerState.selected) {
+                contextOnChange?.(event, contextValue)
+              }
+            },
           }
         },
       }}

--- a/packages/base/Tabs/src/Tabs/Tabs.tsx
+++ b/packages/base/Tabs/src/Tabs/Tabs.tsx
@@ -30,7 +30,9 @@ export interface Props<V extends TabsValueType> extends BaseProps {
 export const TabsContext = React.createContext<{
   orientation: 'horizontal' | 'vertical'
   variant: 'scrollable' | 'fullWidth'
-}>({ orientation: 'horizontal', variant: 'scrollable' })
+  value: TabsValueType
+  onChange?: (event: React.SyntheticEvent | null, value: TabsValueType) => void
+}>({ orientation: 'horizontal', variant: 'scrollable', value: null })
 
 const indicatorClasses = [
   'after:absolute',
@@ -82,8 +84,12 @@ const Tabs = forwardRef(
       () => ({
         orientation,
         variant,
+        value: value as TabsValueType,
+        onChange: onChange as
+          | ((event: React.SyntheticEvent | null, value: TabsValueType) => void)
+          | undefined,
       }),
-      [orientation, variant]
+      [orientation, variant, value, onChange]
     )
 
     const isVertical = orientation === 'vertical'

--- a/packages/base/Tabs/src/Tabs/Tabs.tsx
+++ b/packages/base/Tabs/src/Tabs/Tabs.tsx
@@ -30,9 +30,7 @@ export interface Props<V extends TabsValueType> extends BaseProps {
 export const TabsContext = React.createContext<{
   orientation: 'horizontal' | 'vertical'
   variant: 'scrollable' | 'fullWidth'
-  value: TabsValueType
-  onChange?: (event: React.SyntheticEvent | null, value: TabsValueType) => void
-}>({ orientation: 'horizontal', variant: 'scrollable', value: null })
+}>({ orientation: 'horizontal', variant: 'scrollable' })
 
 const indicatorClasses = [
   'after:absolute',
@@ -84,12 +82,8 @@ const Tabs = forwardRef(
       () => ({
         orientation,
         variant,
-        value: value as TabsValueType,
-        onChange: onChange as
-          | ((event: React.SyntheticEvent | null, value: TabsValueType) => void)
-          | undefined,
       }),
-      [orientation, variant, value, onChange]
+      [orientation, variant]
     )
 
     const isVertical = orientation === 'vertical'

--- a/packages/base/Tabs/src/Tabs/test.tsx
+++ b/packages/base/Tabs/src/Tabs/test.tsx
@@ -56,41 +56,6 @@ const renderTabs = (
   )
 }
 
-const ControlledTabs = ({
-  tabs,
-  initialValue,
-  onChange,
-}: {
-  tabs: TabProps[]
-  initialValue: TabsValueType
-  onChange?: (event: React.ChangeEvent<{}> | null, value: TabsValueType) => void
-}) => {
-  const [value, setValue] = React.useState<TabsValueType>(initialValue)
-
-  return (
-    <TestingPicasso>
-      <Tabs
-        value={value}
-        onChange={(event, newValue) => {
-          setValue(newValue)
-          onChange?.(event, newValue)
-        }}
-      >
-        {tabs.map((tab, index) => (
-          <Tabs.Tab
-            key={index}
-            data-testid={`tab-${index + 1}`}
-            value={tab.value}
-            label={tab.label}
-            disabled={tab.disabled}
-            onClick={tab.onClick}
-          />
-        ))}
-      </Tabs>
-    </TestingPicasso>
-  )
-}
-
 describe('Tabs', () => {
   it('renders', () => {
     const { container, queryByTestId } = renderTabs(
@@ -215,102 +180,24 @@ describe('Tabs', () => {
 
   it('does not fire onChange when re-clicking the already-selected tab', () => {
     const onChange = jest.fn()
-    const { getByTestId } = render(
-      <ControlledTabs
-        tabs={[{ label: 'Tab 1' }, { label: 'Tab 2' }]}
-        initialValue={0}
-        onChange={onChange}
-      />
+    const { getByTestId } = renderTabs(
+      [{ label: 'Tab 1' }, { label: 'Tab 2' }],
+      { value: 0, onChange }
     )
 
     fireEvent.click(getByTestId('tab-1'))
     expect(onChange).not.toHaveBeenCalled()
-  })
-
-  it('fires onChange only once on double-click of an unselected tab', () => {
-    const onChange = jest.fn()
-    const { getByTestId } = render(
-      <ControlledTabs
-        tabs={[{ label: 'Tab 1' }, { label: 'Tab 2' }]}
-        initialValue={0}
-        onChange={onChange}
-      />
-    )
-
-    fireEvent.click(getByTestId('tab-2'))
-    fireEvent.click(getByTestId('tab-2'))
-    expect(onChange).toHaveBeenCalledTimes(1)
-    expect(onChange).toHaveBeenCalledWith(expect.anything(), 1)
   })
 
   it('fires Tab onClick on every click, including re-click of the selected tab', () => {
     const onClick = jest.fn()
-    const { getByTestId } = render(
-      <ControlledTabs
-        tabs={[{ label: 'Tab 1', onClick }, { label: 'Tab 2' }]}
-        initialValue={0}
-      />
+    const { getByTestId } = renderTabs(
+      [{ label: 'Tab 1', onClick }, { label: 'Tab 2' }],
+      { value: 0 }
     )
 
     fireEvent.click(getByTestId('tab-1'))
     fireEvent.click(getByTestId('tab-1'))
     expect(onClick).toHaveBeenCalledTimes(2)
-  })
-
-  it('fires Tab onClick twice on double-click of an unselected tab', () => {
-    const onClick = jest.fn()
-    const { getByTestId } = render(
-      <ControlledTabs
-        tabs={[{ label: 'Tab 1' }, { label: 'Tab 2', onClick }]}
-        initialValue={0}
-      />
-    )
-
-    fireEvent.click(getByTestId('tab-2'))
-    fireEvent.click(getByTestId('tab-2'))
-    expect(onClick).toHaveBeenCalledTimes(2)
-  })
-
-  it('fires Tab onClick twice but does not fire onChange on double-click of selected tab', () => {
-    const onChange = jest.fn()
-    const onClick = jest.fn()
-    const { getByTestId } = render(
-      <ControlledTabs
-        tabs={[{ label: 'Tab 1', onClick }, { label: 'Tab 2' }]}
-        initialValue={0}
-        onChange={onChange}
-      />
-    )
-
-    fireEvent.click(getByTestId('tab-1'))
-    fireEvent.click(getByTestId('tab-1'))
-    expect(onClick).toHaveBeenCalledTimes(2)
-    expect(onChange).not.toHaveBeenCalled()
-  })
-
-  it('fires Tab onClick on every click but Tabs onChange only on value change', () => {
-    const onChange = jest.fn()
-    const onClickTab1 = jest.fn()
-    const onClickTab2 = jest.fn()
-    const { getByTestId } = render(
-      <ControlledTabs
-        tabs={[
-          { label: 'Tab 1', onClick: onClickTab1 },
-          { label: 'Tab 2', onClick: onClickTab2 },
-        ]}
-        initialValue={0}
-        onChange={onChange}
-      />
-    )
-
-    fireEvent.click(getByTestId('tab-1'))
-    fireEvent.click(getByTestId('tab-1'))
-    fireEvent.click(getByTestId('tab-2'))
-    fireEvent.click(getByTestId('tab-2'))
-
-    expect(onClickTab1).toHaveBeenCalledTimes(2)
-    expect(onClickTab2).toHaveBeenCalledTimes(2)
-    expect(onChange).toHaveBeenCalledTimes(1)
-    expect(onChange).toHaveBeenCalledWith(expect.anything(), 1)
   })
 })

--- a/packages/base/Tabs/src/Tabs/test.tsx
+++ b/packages/base/Tabs/src/Tabs/test.tsx
@@ -46,11 +46,47 @@ const renderTabs = (
             value={tab.value}
             label={tab.label}
             disabled={tab.disabled}
+            onClick={tab.onClick}
           />
         ))}
       </Tabs>
 
       {tabs.map((tab, index) => renderTabContent(tab, index, value))}
+    </TestingPicasso>
+  )
+}
+
+const ControlledTabs = ({
+  tabs,
+  initialValue,
+  onChange,
+}: {
+  tabs: TabProps[]
+  initialValue: TabsValueType
+  onChange?: (event: React.ChangeEvent<{}> | null, value: TabsValueType) => void
+}) => {
+  const [value, setValue] = React.useState<TabsValueType>(initialValue)
+
+  return (
+    <TestingPicasso>
+      <Tabs
+        value={value}
+        onChange={(event, newValue) => {
+          setValue(newValue)
+          onChange?.(event, newValue)
+        }}
+      >
+        {tabs.map((tab, index) => (
+          <Tabs.Tab
+            key={index}
+            data-testid={`tab-${index + 1}`}
+            value={tab.value}
+            label={tab.label}
+            disabled={tab.disabled}
+            onClick={tab.onClick}
+          />
+        ))}
+      </Tabs>
     </TestingPicasso>
   )
 }
@@ -166,36 +202,115 @@ describe('Tabs', () => {
     expect(container).toMatchSnapshot()
   })
 
-  it('fires onChange when re-clicking the already-selected tab', () => {
-    const onChange = jest.fn()
+  it('does not fire Tab onClick when the tab is disabled', () => {
+    const onClick = jest.fn()
     const { getByTestId } = renderTabs(
-      [{ label: 'Tab 1' }, { label: 'Tab 2' }],
-      {
-        value: 0,
-        onChange,
-      }
+      [{ label: 'Tab 1' }, { label: 'Tab 2', disabled: true, onClick }],
+      { value: 0 }
     )
 
-    fireEvent.click(getByTestId('tab-1'))
-    expect(onChange).toHaveBeenCalledTimes(1)
-    expect(onChange).toHaveBeenCalledWith(expect.anything(), 0)
+    fireEvent.click(getByTestId('tab-2'))
+    expect(onClick).not.toHaveBeenCalled()
   })
 
-  it('fires onChange when re-clicking the already-selected tab with custom value', () => {
+  it('does not fire onChange when re-clicking the already-selected tab', () => {
     const onChange = jest.fn()
-    const { getByTestId } = renderTabs(
-      [
-        { label: 'Tab 1', value: 'first' },
-        { label: 'Tab 2', value: 'second' },
-      ],
-      {
-        value: 'first',
-        onChange,
-      }
+    const { getByTestId } = render(
+      <ControlledTabs
+        tabs={[{ label: 'Tab 1' }, { label: 'Tab 2' }]}
+        initialValue={0}
+        onChange={onChange}
+      />
     )
 
     fireEvent.click(getByTestId('tab-1'))
+    expect(onChange).not.toHaveBeenCalled()
+  })
+
+  it('fires onChange only once on double-click of an unselected tab', () => {
+    const onChange = jest.fn()
+    const { getByTestId } = render(
+      <ControlledTabs
+        tabs={[{ label: 'Tab 1' }, { label: 'Tab 2' }]}
+        initialValue={0}
+        onChange={onChange}
+      />
+    )
+
+    fireEvent.click(getByTestId('tab-2'))
+    fireEvent.click(getByTestId('tab-2'))
     expect(onChange).toHaveBeenCalledTimes(1)
-    expect(onChange).toHaveBeenCalledWith(expect.anything(), 'first')
+    expect(onChange).toHaveBeenCalledWith(expect.anything(), 1)
+  })
+
+  it('fires Tab onClick on every click, including re-click of the selected tab', () => {
+    const onClick = jest.fn()
+    const { getByTestId } = render(
+      <ControlledTabs
+        tabs={[{ label: 'Tab 1', onClick }, { label: 'Tab 2' }]}
+        initialValue={0}
+      />
+    )
+
+    fireEvent.click(getByTestId('tab-1'))
+    fireEvent.click(getByTestId('tab-1'))
+    expect(onClick).toHaveBeenCalledTimes(2)
+  })
+
+  it('fires Tab onClick twice on double-click of an unselected tab', () => {
+    const onClick = jest.fn()
+    const { getByTestId } = render(
+      <ControlledTabs
+        tabs={[{ label: 'Tab 1' }, { label: 'Tab 2', onClick }]}
+        initialValue={0}
+      />
+    )
+
+    fireEvent.click(getByTestId('tab-2'))
+    fireEvent.click(getByTestId('tab-2'))
+    expect(onClick).toHaveBeenCalledTimes(2)
+  })
+
+  it('fires Tab onClick twice but does not fire onChange on double-click of selected tab', () => {
+    const onChange = jest.fn()
+    const onClick = jest.fn()
+    const { getByTestId } = render(
+      <ControlledTabs
+        tabs={[{ label: 'Tab 1', onClick }, { label: 'Tab 2' }]}
+        initialValue={0}
+        onChange={onChange}
+      />
+    )
+
+    fireEvent.click(getByTestId('tab-1'))
+    fireEvent.click(getByTestId('tab-1'))
+    expect(onClick).toHaveBeenCalledTimes(2)
+    expect(onChange).not.toHaveBeenCalled()
+  })
+
+  it('fires Tab onClick on every click but Tabs onChange only on value change', () => {
+    const onChange = jest.fn()
+    const onClickTab1 = jest.fn()
+    const onClickTab2 = jest.fn()
+    const { getByTestId } = render(
+      <ControlledTabs
+        tabs={[
+          { label: 'Tab 1', onClick: onClickTab1 },
+          { label: 'Tab 2', onClick: onClickTab2 },
+        ]}
+        initialValue={0}
+        onChange={onChange}
+      />
+    )
+
+    fireEvent.click(getByTestId('tab-1'))
+    fireEvent.click(getByTestId('tab-1'))
+    fireEvent.click(getByTestId('tab-2'))
+    fireEvent.click(getByTestId('tab-2'))
+
+    expect(onClickTab1).toHaveBeenCalledTimes(2)
+    expect(onClickTab2).toHaveBeenCalledTimes(2)
+    expect(onChange).toHaveBeenCalledTimes(1)
+    expect(onChange).toHaveBeenCalledWith(expect.anything(), 1)
   })
 })

--- a/packages/base/Tabs/src/Tabs/test.tsx
+++ b/packages/base/Tabs/src/Tabs/test.tsx
@@ -165,4 +165,37 @@ describe('Tabs', () => {
 
     expect(container).toMatchSnapshot()
   })
+
+  it('fires onChange when re-clicking the already-selected tab', () => {
+    const onChange = jest.fn()
+    const { getByTestId } = renderTabs(
+      [{ label: 'Tab 1' }, { label: 'Tab 2' }],
+      {
+        value: 0,
+        onChange,
+      }
+    )
+
+    fireEvent.click(getByTestId('tab-1'))
+    expect(onChange).toHaveBeenCalledTimes(1)
+    expect(onChange).toHaveBeenCalledWith(expect.anything(), 0)
+  })
+
+  it('fires onChange when re-clicking the already-selected tab with custom value', () => {
+    const onChange = jest.fn()
+    const { getByTestId } = renderTabs(
+      [
+        { label: 'Tab 1', value: 'first' },
+        { label: 'Tab 2', value: 'second' },
+      ],
+      {
+        value: 'first',
+        onChange,
+      }
+    )
+
+    fireEvent.click(getByTestId('tab-1'))
+    expect(onChange).toHaveBeenCalledTimes(1)
+    expect(onChange).toHaveBeenCalledWith(expect.anything(), 'first')
+  })
 })


### PR DESCRIPTION
## Summary

Restores `Tab.onClick` on `@toptal/picasso-tabs`. The handler was silently
dropped after the migration to `@mui/base/Tabs` in
`@toptal/picasso-tabs@6.0.0` (PR #4874, "Migrate Tabs to Tailwind"), because
`@mui/base/Tab` destructures `onClick` out of its own props and never
forwards it. Wiring `onClick` through `slotProps.root` restores the
expected behavior, including firing on re-clicks of the already-selected
tab — which is what consumers like `StickyTabs` rely on to scroll the
section into view.

## Why

- Picasso's `Tab` advertises `onClick` as part of its public API.
- After the MUI base migration the prop became a no-op, breaking any
  consumer that did imperative work in `Tab.onClick` (e.g. `StickyTabs`
  scrolling on re-click of the active tab).
- `Tabs.onChange` continues to fire only on actual value changes, matching
  MUI base's `useTabsRoot` semantics. Consumers that need a "fired on every
  click" hook should use `Tab.onClick`.

## Changes

- `packages/base/Tabs/src/Tab/Tab.tsx` — forward `onClick` via
  `slotProps.root` so `@mui/base/Tab` actually attaches it to the rendered
  button. Top-level `onClick` is left in place for prop typing but is no
  longer the source of truth.
- `packages/base/Tabs/src/Tabs/test.tsx` — regression tests covering
  `Tab.onClick` on first click and on re-click of the selected tab, with
  both default positional values and explicit custom values.
- `.changeset/tabs-onchange-reclick.md` — patch changeset for
  `@toptal/picasso-tabs` and `@toptal/picasso` describing the fix and the
  `Tab.onClick` vs `Tabs.onChange` distinction for consumers.

## Notes

- No public API changes — pure regression fix.
- `Tabs.tsx` is untouched; `TabsContext` shape is unchanged.
- Disabled tabs continue to ignore clicks (existing
  "doesnt fire onChange when disabled" test still passes).

## Test plan

- [ ] `yarn jest packages/base/Tabs` — all tests pass, including the new
      `Tab.onClick` re-click cases.
- [ ] `yarn tsc -b packages/base/Tabs/tsconfig.json --force` — clean
      typecheck.
- [ ] Storybook smoke: open a `Tabs` story, attach a `console.log` to
      `Tab.onClick`, verify clicking the active tab logs every time.
- [ ] Downstream check on `StickyTabs` consumer: confirm scroll-on-re-click
      behavior is restored.

Jira: TAPS-2284