### PR TITLE
[Tier 1] migrate Note to @base-ui/react + Tailwind

### DIFF
--- a/packages/base/Note/package.json
+++ b/packages/base/Note/package.json
@@ -32,10 +32,9 @@
     "**/styles.js"
   ],
   "peerDependencies": {
-    "@material-ui/core": "4.12.4",
     "@toptal/picasso-tailwind": ">=2.7",
     "@toptal/picasso-tailwind-merge": "^2.0.0",
-    "react": ">=16.12.0 < 19.0.0"
+    "react": ">=16.12.0"
   },
   "exports": {
     ".": "./dist-package/src/index.js"


### PR DESCRIPTION
# Note migration diff

Generated: 2026-05-05 13:52:41 CEST

**Package:** `packages/base/Note`

## Files
_No file additions, deletions, or renames._

## Imports

**Added:**

```
packages/base/Note/dist-package/src/Note/Note.d.ts:import React from 'react';
packages/base/Note/dist-package/src/Note/Note.d.ts:import type { BaseProps } from '@toptal/picasso-shared';
packages/base/Note/dist-package/src/Note/index.d.ts:export { default as Note } from './Note';
packages/base/Note/dist-package/src/Note/index.d.ts:import type { OmitInternalProps } from '@toptal/picasso-shared';
packages/base/Note/dist-package/src/Note/index.d.ts:import type { Props } from './Note';
packages/base/Note/dist-package/src/NoteContent/NoteContent.d.ts:import React from 'react';
packages/base/Note/dist-package/src/NoteContent/NoteContent.d.ts:import type { BaseProps } from '@toptal/picasso-shared';
packages/base/Note/dist-package/src/NoteContent/NoteContent.d.ts:import type { ReactNode } from 'react';
packages/base/Note/dist-package/src/NoteContent/index.d.ts:export { default as NoteContent } from './NoteContent';
packages/base/Note/dist-package/src/NoteSubtitle/NoteSubtitle.d.ts:import React from 'react';
packages/base/Note/dist-package/src/NoteSubtitle/NoteSubtitle.d.ts:import type { BaseProps } from '@toptal/picasso-shared';
packages/base/Note/dist-package/src/NoteSubtitle/NoteSubtitle.d.ts:import type { ReactNode } from 'react';
packages/base/Note/dist-package/src/NoteSubtitle/index.d.ts:export { default as NoteSubtitle } from './NoteSubtitle';
packages/base/Note/dist-package/src/NoteTitle/NoteTitle.d.ts:import React from 'react';
packages/base/Note/dist-package/src/NoteTitle/NoteTitle.d.ts:import type { BaseProps } from '@toptal/picasso-shared';
packages/base/Note/dist-package/src/NoteTitle/index.d.ts:export { default as NoteTitle } from './NoteTitle';
packages/base/Note/dist-package/src/index.d.ts:export * from './Note';
packages/base/Note/dist-package/src/index.d.ts:export * from './NoteCompound';
packages/base/Note/dist-package/src/index.d.ts:export * from './NoteContent';
packages/base/Note/dist-package/src/index.d.ts:export * from './NoteSubtitle';
packages/base/Note/dist-package/src/index.d.ts:export * from './NoteTitle';
```

## MUI v4 / JSS residue check

| Check | Count |
|---|---|
| `@material-ui/*` source imports | 0 |
| JSS calls (makeStyles/createStyles/withStyles) | 0 |
| `@material-ui/core` in package.json | 0
0 |

_Migration is **NOT complete** until all three are 0._

## package.json delta

```diff
@@ -32,10 +32,9 @@
     "**/styles.js"
   ],
   "peerDependencies": {
-    "@material-ui/core": "4.12.4",
     "@toptal/picasso-tailwind": ">=2.7",
     "@toptal/picasso-tailwind-merge": "^2.0.0",
-    "react": ">=16.12.0 < 19.0.0"
+    "react": ">=16.12.0"
   },
   "exports": {
     ".": "./dist-package/src/index.js"
```

## Prop-surface diff
_(no dist-package output to compare — was the package built before snapshot?)_

## Happo
Happo log: `migration-runs/2026-05-05/Note/happo.log` (0
? flagged lines).

_Designer: review screen diffs >0.5% per `docs/migration/migration-plan.md` §6.3._

## React 19 smoke
_Stubbed (pending PF-1994). The real smoke wires up during PF-1994's first migration._
