### PR TITLE
[Tier 0] migrate Button to @base-ui/react + Tailwind

### DIFF
--- a/packages/base/Button/package.json
+++ b/packages/base/Button/package.json
@@ -32,7 +32,7 @@
     "@toptal/picasso-utils": "4.0.0",
     "@toptal/picasso-link": "4.0.0",
     "ap-style-title-case": "^1.1.2",
-    "@mui/base": "5.0.0-beta.58",
+    "@base-ui/react": "^1.4.1",
     "classnames": "^2.5.1"
   },
   "sideEffects": [
@@ -43,7 +43,7 @@
     "@toptal/picasso-tailwind-merge": "^2.0.0",
     "@toptal/picasso-tailwind": ">=2.7",
     "@toptal/picasso-provider": "*",
-    "react": ">=16.12.0 < 19.0.0"
+    "react": ">=16.12.0"
   },
   "exports": {
     ".": "./dist-package/src/index.js"

--- a/packages/base/Button/src/Button/__snapshots__/test.tsx.snap
+++ b/packages/base/Button/src/Button/__snapshots__/test.tsx.snap
@@ -7,8 +7,9 @@ exports[`Button disabled button as link renders disabled version 1`] = `
   >
     <a
       aria-disabled="true"
-      class="font-inherit focus:outline-hidden base-Button base- text-lg inline-flex items-center justify-center select-none appearance-none m-0 relative normal-case align-middle transition-colors duration-350 ease-out shrink-0 outline-hidden [[data-component-type="button"]+&]:ml cursor-default pointer-events no-underline hover:no-underline rounded-sm shadow-none border-none text-white visited:text-white bg-gray min-w h-8 py-0 px-4"
+      class="font-inherit focus:outline-hidden base-Button text-lg inline-flex items-center justify-center select-none appearance-none m-0 relative normal-case align-middle transition-colors duration-350 ease-out shrink-0 outline-hidden [[data-component-type="button"]+&]:ml cursor-default pointer-events no-underline hover:no-underline rounded-sm shadow-none border-none text-white visited:text-white bg-gray min-w h-8 py-0 px-4"
       data-component-type="button"
+      data-disabled=""
       href="URL"
       role="button"
       tabindex="-1"
@@ -31,8 +32,9 @@ exports[`Button disabled button renders disabled version 1`] = `
   >
     <button
       aria-disabled="true"
-      class="base-Button base- text-lg inline-flex items-center justify-center select-none appearance-none m-0 relative normal-case align-middle transition-colors duration-350 ease-out shrink-0 outline-hidden [[data-component-type="button"]+&]:ml cursor-default pointer-events no-underline hover:no-underline rounded-sm shadow-none border-none text-white visited:text-white bg-gray min-w h-8 py-0 px-4"
+      class="base-Button text-lg inline-flex items-center justify-center select-none appearance-none m-0 relative normal-case align-middle transition-colors duration-350 ease-out shrink-0 outline-hidden [[data-component-type="button"]+&]:ml cursor-default pointer-events no-underline hover:no-underline rounded-sm shadow-none border-none text-white visited:text-white bg-gray min-w h-8 py-0 px-4"
       data-component-type="button"
+      data-disabled=""
       disabled=""
       role="button"
       tabindex="-1"

--- a/packages/base/Button/src/ButtonBase/ButtonBase.tsx
+++ b/packages/base/Button/src/ButtonBase/ButtonBase.tsx
@@ -9,8 +9,7 @@ import type {
   TextLabelProps,
 } from '@toptal/picasso-shared'
 import { useTitleCase } from '@toptal/picasso-shared'
-import { Button as MUIButtonBase } from '@mui/base/Button'
-import type { ButtonRootSlotProps } from '@mui/base/Button'
+import { Button as BaseUIButton } from '@base-ui/react/button'
 import { Loader } from '@toptal/picasso-loader'
 import { Container } from '@toptal/picasso-container'
 import { noop, toTitleCase } from '@toptal/picasso-utils'
@@ -60,14 +59,15 @@ const getIcon = ({ icon }: { icon?: ReactElement }) => {
   })
 }
 
-const RootElement = forwardRef(
-  (props: ButtonRootSlotProps & { as: ElementType }, ref) => {
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const { ownerState, as: Root, ...rest } = props
+const isValidAs = (value: Props['as']) => {
+  const valueType = typeof value
 
-    return <Root {...rest} ref={ref} />
-  }
-)
+  return (
+    valueType === 'string' ||
+    valueType === 'function' ||
+    (valueType === 'object' && value !== null)
+  )
+}
 
 export const ButtonBase: OverridableComponent<Props> = forwardRef<
   HTMLButtonElement,
@@ -98,7 +98,8 @@ export const ButtonBase: OverridableComponent<Props> = forwardRef<
 
   const titleCase = useTitleCase(propsTitleCase)
   const finalChildren = [titleCase ? toTitleCase(children) : children]
-  const finalRootElementName = typeof as === 'string' ? as : 'a'
+  const finalAs: ElementType = isValidAs(as) ? as : 'a'
+  const isNativeButton = finalAs === 'button'
 
   if (icon) {
     const iconComponent = getIcon({ icon })
@@ -110,13 +111,17 @@ export const ButtonBase: OverridableComponent<Props> = forwardRef<
     }
   }
 
-  const finalClassName = twMerge(createCoreClassNames({ disabled }), className)
+  const finalClassName = twMerge(
+    'base-Button-root',
+    createCoreClassNames({ disabled }),
+    className
+  )
 
   return (
-    <MUIButtonBase
+    <BaseUIButton
       {...rest}
-      ref={ref}
-      onClick={getClickHandler(loading, onClick)}
+      ref={ref as React.Ref<HTMLElement>}
+      onClick={getClickHandler(loading, onClick) as BaseUIButton.Props['onClick']}
       className={finalClassName}
       style={style}
       aria-disabled={disabled}
@@ -125,12 +130,10 @@ export const ButtonBase: OverridableComponent<Props> = forwardRef<
       value={value}
       type={type}
       data-component-type='button'
-      tabIndex={rest.tabIndex ?? disabled ? -1 : 0}
+      tabIndex={rest.tabIndex ?? (disabled ? -1 : 0)}
       role={rest.role ?? 'button'}
-      rootElementName={finalRootElementName as keyof HTMLElementTagNameMap}
-      slots={{ root: RootElement }}
-      // @ts-ignore
-      slotProps={{ root: { as } }}
+      nativeButton={isNativeButton}
+      render={isNativeButton ? undefined : React.createElement(finalAs)}
     >
       <Container
         as='span'
@@ -151,7 +154,7 @@ export const ButtonBase: OverridableComponent<Props> = forwardRef<
           size='small'
         />
       )}
-    </MUIButtonBase>
+    </BaseUIButton>
   )
 })
 

--- a/packages/base/Button/src/ButtonBase/__snapshots__/test.tsx.snap
+++ b/packages/base/Button/src/ButtonBase/__snapshots__/test.tsx.snap
@@ -79,8 +79,9 @@ exports[`ButtonBase when "as" prop is passed when "as" prop equals "Link" compon
   >
     <a
       aria-disabled="true"
-      class="font-inherit focus:outline-hidden hover:underline text-blue visited:text-purple no-underline base-Button base- text-lg inline-flex items-center justify-center select-none appearance-none m-0 relative normal-case align-middle transition-colors duration-350 ease-out shrink-0 outline-hidden [[data-component-type="button"]+&]:ml cursor-default pointer-events"
+      class="font-inherit focus:outline-hidden hover:underline text-blue visited:text-purple no-underline base-Button text-lg inline-flex items-center justify-center select-none appearance-none m-0 relative normal-case align-middle transition-colors duration-350 ease-out shrink-0 outline-hidden [[data-component-type="button"]+&]:ml cursor-default pointer-events"
       data-component-type="button"
+      data-disabled=""
       href="URL"
       role="button"
       tabindex="-1"
@@ -174,8 +175,9 @@ exports[`ButtonBase when "disabled" prop is true renders Button and does not tri
   >
     <button
       aria-disabled="true"
-      class="base-Button base- text-lg inline-flex items-center justify-center select-none appearance-none m-0 relative normal-case align-middle transition-colors duration-350 ease-out shrink-0 outline-hidden [[data-component-type="button"]+&]:ml cursor-default pointer-events"
+      class="base-Button text-lg inline-flex items-center justify-center select-none appearance-none m-0 relative normal-case align-middle transition-colors duration-350 ease-out shrink-0 outline-hidden [[data-component-type="button"]+&]:ml cursor-default pointer-events"
       data-component-type="button"
+      data-disabled=""
       disabled=""
       role="button"
       tabindex="-1"


### PR DESCRIPTION
# Button migration diff

Generated: 2026-05-05 20:12:20 CEST

**Package:** `packages/base/Button`

## Files
_No file additions, deletions, or renames._

## Imports

**Removed:**

```
packages/base/Button/src/ButtonBase/ButtonBase.tsx:import type { ButtonRootSlotProps } from '@mui/base/Button'
packages/base/Button/src/ButtonBase/ButtonBase.tsx:import { Button as MUIButtonBase } from '@mui/base/Button'
```

**Added:**

```
packages/base/Button/dist-package/src/Button/Button.d.ts:import type { ReactNode, ReactElement, MouseEvent, ElementType } from 'react';
packages/base/Button/dist-package/src/Button/Button.d.ts:import type { StandardProps, SizeType, ButtonOrAnchorProps, OverridableComponent, TextLabelProps } from '@toptal/picasso-shared';
packages/base/Button/dist-package/src/Button/index.d.ts:export * from './Button';
packages/base/Button/dist-package/src/Button/index.d.ts:export * from './styles';
packages/base/Button/dist-package/src/Button/index.d.ts:export { default as Button } from './Button';
packages/base/Button/dist-package/src/Button/index.d.ts:import type { Props } from './Button';
packages/base/Button/dist-package/src/Button/styles.d.ts:import type { IconPositionType, VariantType } from './Button';
packages/base/Button/dist-package/src/Button/styles.d.ts:import type { SizeType } from '@toptal/picasso-shared';
packages/base/Button/dist-package/src/ButtonAction/ButtonAction.d.ts:import type { BaseProps, ButtonOrAnchorProps, OverridableComponent } from '@toptal/picasso-shared';
packages/base/Button/dist-package/src/ButtonAction/ButtonAction.d.ts:import type { IconPositionType } from '../Button';
packages/base/Button/dist-package/src/ButtonAction/ButtonAction.d.ts:import type { ReactElement, MouseEvent, ElementType } from 'react';
packages/base/Button/dist-package/src/ButtonAction/index.d.ts:export { default as ButtonAction } from './ButtonAction';
packages/base/Button/dist-package/src/ButtonAction/index.d.ts:import type { Props } from './ButtonAction';
packages/base/Button/dist-package/src/ButtonAction/styles.d.ts:import type { IconPositionType } from '../ButtonBase';
packages/base/Button/dist-package/src/ButtonBase/ButtonBase.d.ts:import type { ReactNode, ReactElement, MouseEvent, ElementType } from 'react';
packages/base/Button/dist-package/src/ButtonBase/ButtonBase.d.ts:import type { StandardProps, ButtonOrAnchorProps, OverridableComponent, TextLabelProps } from '@toptal/picasso-shared';
packages/base/Button/dist-package/src/ButtonBase/index.d.ts:export type { IconPositionType } from './ButtonBase';
packages/base/Button/dist-package/src/ButtonBase/index.d.ts:export { default as ButtonBase } from './ButtonBase';
packages/base/Button/dist-package/src/ButtonBase/index.d.ts:import type { Props } from './ButtonBase';
packages/base/Button/dist-package/src/ButtonCheckbox/ButtonCheckbox.d.ts:import type { ButtonControlLabelProps } from '../ButtonControlLabel';
packages/base/Button/dist-package/src/ButtonCheckbox/index.d.ts:export { default as ButtonCheckbox } from './ButtonCheckbox';
packages/base/Button/dist-package/src/ButtonCheckbox/index.d.ts:import type { Props } from './ButtonCheckbox';
packages/base/Button/dist-package/src/ButtonCircular/ButtonCircular.d.ts:import type { BaseProps, ButtonOrAnchorProps, OverridableComponent } from '@toptal/picasso-shared';
packages/base/Button/dist-package/src/ButtonCircular/ButtonCircular.d.ts:import type { ReactElement, MouseEvent, ElementType } from 'react';
packages/base/Button/dist-package/src/ButtonCircular/index.d.ts:export type { VariantType as ButtonCircularVariantType } from './ButtonCircular';
packages/base/Button/dist-package/src/ButtonCircular/index.d.ts:export { default as ButtonCircular } from './ButtonCircular';
packages/base/Button/dist-package/src/ButtonCircular/index.d.ts:import type { Props } from './ButtonCircular';
packages/base/Button/dist-package/src/ButtonCircular/styles.d.ts:import type { VariantType } from './ButtonCircular';
packages/base/Button/dist-package/src/ButtonControlLabel/ButtonControlLabel.d.ts:import React from 'react';
packages/base/Button/dist-package/src/ButtonControlLabel/ButtonControlLabel.d.ts:import type { BaseProps, SizeType } from '@toptal/picasso-shared';
packages/base/Button/dist-package/src/ButtonControlLabel/ButtonControlLabel.d.ts:import type { ReactElement, ReactNode } from 'react';
packages/base/Button/dist-package/src/ButtonControlLabel/index.d.ts:export { default as ButtonControlLabel } from './ButtonControlLabel';
packages/base/Button/dist-package/src/ButtonControlLabel/index.d.ts:import type { Props } from './ButtonControlLabel';
packages/base/Button/dist-package/src/ButtonGroup/ButtonGroup.d.ts:import React from 'react';
packages/base/Button/dist-package/src/ButtonGroup/ButtonGroup.d.ts:import type { BaseProps } from '@toptal/picasso-shared';
packages/base/Button/dist-package/src/ButtonGroup/ButtonGroup.d.ts:import type { ReactNode, HTMLAttributes } from 'react';
packages/base/Button/dist-package/src/ButtonGroup/index.d.ts:export { default as ButtonGroup } from './ButtonGroup';
packages/base/Button/dist-package/src/ButtonGroup/index.d.ts:import type { OmitInternalProps } from '@toptal/picasso-shared';
packages/base/Button/dist-package/src/ButtonGroup/index.d.ts:import type { Props } from './ButtonGroup';
packages/base/Button/dist-package/src/ButtonGroupItem/ButtonGroupItem.d.ts:import type { ButtonProps } from '../Button';
packages/base/Button/dist-package/src/ButtonGroupItem/index.d.ts:export { default as ButtonGroupItem } from './ButtonGroupItem';
packages/base/Button/dist-package/src/ButtonRadio/ButtonRadio.d.ts:import type { ButtonControlLabelProps } from '../ButtonControlLabel';
packages/base/Button/dist-package/src/ButtonRadio/index.d.ts:export { default as ButtonRadio } from './ButtonRadio';
packages/base/Button/dist-package/src/ButtonRadio/index.d.ts:import type { Props } from './ButtonRadio';
packages/base/Button/dist-package/src/ButtonSplit/ButtonSplit.d.ts:import React from 'react';
packages/base/Button/dist-package/src/ButtonSplit/ButtonSplit.d.ts:import type { BaseProps } from '@toptal/picasso-shared';
packages/base/Button/dist-package/src/ButtonSplit/ButtonSplit.d.ts:import type { ButtonProps } from '../Button';
packages/base/Button/dist-package/src/ButtonSplit/ButtonSplit.d.ts:import type { ReactNode, HTMLAttributes } from 'react';
packages/base/Button/dist-package/src/ButtonSplit/index.d.ts:export { default as ButtonSplit } from './ButtonSplit';
packages/base/Button/dist-package/src/ButtonSplit/index.d.ts:import type { OmitInternalProps } from '@toptal/picasso-shared';
packages/base/Button/dist-package/src/ButtonSplit/index.d.ts:import type { Props } from './ButtonSplit';
packages/base/Button/dist-package/src/ButtonSplit/styles.d.ts:import type { SizeType } from '@toptal/picasso-shared';
packages/base/Button/dist-package/src/index.d.ts:export * from './Button';
packages/base/Button/dist-package/src/index.d.ts:export * from './ButtonAction';
packages/base/Button/dist-package/src/index.d.ts:export * from './ButtonCheckbox';
packages/base/Button/dist-package/src/index.d.ts:export * from './ButtonCircular';
packages/base/Button/dist-package/src/index.d.ts:export * from './ButtonCompound';
packages/base/Button/dist-package/src/index.d.ts:export * from './ButtonControlLabel';
packages/base/Button/dist-package/src/index.d.ts:export * from './ButtonGroup';
packages/base/Button/dist-package/src/index.d.ts:export * from './ButtonGroupItem';
packages/base/Button/dist-package/src/index.d.ts:export * from './ButtonRadio';
packages/base/Button/dist-package/src/index.d.ts:export * from './ButtonSplit';
packages/base/Button/src/ButtonBase/ButtonBase.tsx:import { Button as BaseUIButton } from '@base-ui/react/button'
```

## MUI v4 / JSS residue check

| Check | Count |
|---|---|
| `@material-ui/*` source imports | 0 |
| JSS calls (makeStyles/createStyles/withStyles) | 0 |
| `@material-ui/core` in package.json | 0
0 |

_Migration is **NOT complete** until all three are 0._

## package.json delta

```diff
@@ -32,7 +32,7 @@
     "@toptal/picasso-utils": "4.0.0",
     "@toptal/picasso-link": "4.0.0",
     "ap-style-title-case": "^1.1.2",
-    "@mui/base": "5.0.0-beta.58",
+    "@base-ui/react": "^1.4.1",
     "classnames": "^2.5.1"
   },
   "sideEffects": [
@@ -43,7 +43,7 @@
     "@toptal/picasso-tailwind-merge": "^2.0.0",
     "@toptal/picasso-tailwind": ">=2.7",
     "@toptal/picasso-provider": "*",
-    "react": ">=16.12.0 < 19.0.0"
+    "react": ">=16.12.0"
   },
   "exports": {
     ".": "./dist-package/src/index.js"
```

## Prop-surface diff
_(no dist-package output to compare — was the package built before snapshot?)_

## Happo
Happo log: `migration-runs/2026-05-05/Button/happo.log` (0
? flagged lines).

_Designer: review screen diffs >0.5% per `docs/migration/migration-plan.md` §6.3._

## React 19 smoke
_Stubbed (pending PF-1994). The real smoke wires up during PF-1994's first migration._
