### PR TITLE
[PF-1993] Improve Dockerfile pnpm install caching

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,7 @@
 # syntax=docker/dockerfile:1
 ARG NODE_VERSION=22.20.0
-ARG PNPM_VERSION=10.32.1
 
 FROM node:${NODE_VERSION}-alpine
-
-ARG PNPM_VERSION
 
 ENV PATH="${PATH}:/app/node_modules/.bin" \
   # Installs Chromium (77) package.
@@ -28,7 +25,8 @@ RUN apk add --no-cache \
 # so when we will be running container from CI it would have
 # all necessary rights for npm/pnpm publish
 RUN groupmod -g 469 node && usermod -u 469 -g 469 node
-RUN corepack enable && corepack prepare pnpm@${PNPM_VERSION} --activate
+# Corepack reads the pnpm version from package.json#packageManager.
+RUN corepack enable
 
 WORKDIR /app
 
@@ -38,13 +36,103 @@ RUN chown -R node /app
 USER node
 
 # Enables layer caching: copy lockfile + workspace manifests first,
-# install, then copy the rest of the source.
+# install, then copy the rest of the source. Each manifest is copied
+# explicitly so the install layer's cache key depends only on the
+# manifests + lockfile, not on application source.
+# When a workspace package is added/removed, update the list below.
 COPY --chown=node:node package.json pnpm-lock.yaml pnpm-workspace.yaml .npmrc lerna.json ./
-COPY --chown=node:node packages packages
 
-# Prune to manifests so dependency installation stays cache-friendly.
-RUN find packages -mindepth 2 -maxdepth 2 \! -name "package.json" -print | xargs rm -rf
-RUN find packages/base -mindepth 2 -maxdepth 2 \! -name "package.json" -print | xargs rm -rf
+COPY --chown=node:node packages/base-tailwind/package.json ./packages/base-tailwind/package.json
+COPY --chown=node:node packages/picasso/package.json ./packages/picasso/package.json
+COPY --chown=node:node packages/picasso-charts/package.json ./packages/picasso-charts/package.json
+COPY --chown=node:node packages/picasso-codemod/package.json ./packages/picasso-codemod/package.json
+COPY --chown=node:node packages/picasso-forms/package.json ./packages/picasso-forms/package.json
+COPY --chown=node:node packages/picasso-pictograms/package.json ./packages/picasso-pictograms/package.json
+COPY --chown=node:node packages/picasso-provider/package.json ./packages/picasso-provider/package.json
+COPY --chown=node:node packages/picasso-query-builder/package.json ./packages/picasso-query-builder/package.json
+COPY --chown=node:node packages/picasso-rich-text-editor/package.json ./packages/picasso-rich-text-editor/package.json
+COPY --chown=node:node packages/picasso-tailwind/package.json ./packages/picasso-tailwind/package.json
+COPY --chown=node:node packages/picasso-tailwind-merge/package.json ./packages/picasso-tailwind-merge/package.json
+COPY --chown=node:node packages/shared/package.json ./packages/shared/package.json
+COPY --chown=node:node packages/topkit-analytics-charts/package.json ./packages/topkit-analytics-charts/package.json
+
+COPY --chown=node:node packages/base/Accordion/package.json ./packages/base/Accordion/package.json
+COPY --chown=node:node packages/base/AccountSelect/package.json ./packages/base/AccountSelect/package.json
+COPY --chown=node:node packages/base/Alert/package.json ./packages/base/Alert/package.json
+COPY --chown=node:node packages/base/Amount/package.json ./packages/base/Amount/package.json
+COPY --chown=node:node packages/base/ApplicationUpdateNotification/package.json ./packages/base/ApplicationUpdateNotification/package.json
+COPY --chown=node:node packages/base/Autocomplete/package.json ./packages/base/Autocomplete/package.json
+COPY --chown=node:node packages/base/Avatar/package.json ./packages/base/Avatar/package.json
+COPY --chown=node:node packages/base/AvatarUpload/package.json ./packages/base/AvatarUpload/package.json
+COPY --chown=node:node packages/base/Backdrop/package.json ./packages/base/Backdrop/package.json
+COPY --chown=node:node packages/base/Badge/package.json ./packages/base/Badge/package.json
+COPY --chown=node:node packages/base/Breadcrumbs/package.json ./packages/base/Breadcrumbs/package.json
+COPY --chown=node:node packages/base/Button/package.json ./packages/base/Button/package.json
+COPY --chown=node:node packages/base/Calendar/package.json ./packages/base/Calendar/package.json
+COPY --chown=node:node packages/base/Carousel/package.json ./packages/base/Carousel/package.json
+COPY --chown=node:node packages/base/Checkbox/package.json ./packages/base/Checkbox/package.json
+COPY --chown=node:node packages/base/Collapse/package.json ./packages/base/Collapse/package.json
+COPY --chown=node:node packages/base/Container/package.json ./packages/base/Container/package.json
+COPY --chown=node:node packages/base/DatePicker/package.json ./packages/base/DatePicker/package.json
+COPY --chown=node:node packages/base/DateSelect/package.json ./packages/base/DateSelect/package.json
+COPY --chown=node:node packages/base/Drawer/package.json ./packages/base/Drawer/package.json
+COPY --chown=node:node packages/base/Dropdown/package.json ./packages/base/Dropdown/package.json
+COPY --chown=node:node packages/base/Dropzone/package.json ./packages/base/Dropzone/package.json
+COPY --chown=node:node packages/base/EmptyState/package.json ./packages/base/EmptyState/package.json
+COPY --chown=node:node packages/base/EnvironmentBanner/package.json ./packages/base/EnvironmentBanner/package.json
+COPY --chown=node:node packages/base/Fade/package.json ./packages/base/Fade/package.json
+COPY --chown=node:node packages/base/FileInput/package.json ./packages/base/FileInput/package.json
+COPY --chown=node:node packages/base/Form/package.json ./packages/base/Form/package.json
+COPY --chown=node:node packages/base/FormLabel/package.json ./packages/base/FormLabel/package.json
+COPY --chown=node:node packages/base/FormLayout/package.json ./packages/base/FormLayout/package.json
+COPY --chown=node:node packages/base/Grid/package.json ./packages/base/Grid/package.json
+COPY --chown=node:node packages/base/Helpbox/package.json ./packages/base/Helpbox/package.json
+COPY --chown=node:node packages/base/Icons/package.json ./packages/base/Icons/package.json
+COPY --chown=node:node packages/base/Image/package.json ./packages/base/Image/package.json
+COPY --chown=node:node packages/base/Input/package.json ./packages/base/Input/package.json
+COPY --chown=node:node packages/base/InputAdornment/package.json ./packages/base/InputAdornment/package.json
+COPY --chown=node:node packages/base/Link/package.json ./packages/base/Link/package.json
+COPY --chown=node:node packages/base/List/package.json ./packages/base/List/package.json
+COPY --chown=node:node packages/base/Loader/package.json ./packages/base/Loader/package.json
+COPY --chown=node:node packages/base/Logo/package.json ./packages/base/Logo/package.json
+COPY --chown=node:node packages/base/Menu/package.json ./packages/base/Menu/package.json
+COPY --chown=node:node packages/base/Modal/package.json ./packages/base/Modal/package.json
+COPY --chown=node:node packages/base/ModalContext/package.json ./packages/base/ModalContext/package.json
+COPY --chown=node:node packages/base/Note/package.json ./packages/base/Note/package.json
+COPY --chown=node:node packages/base/Notification/package.json ./packages/base/Notification/package.json
+COPY --chown=node:node packages/base/NumberInput/package.json ./packages/base/NumberInput/package.json
+COPY --chown=node:node packages/base/OutlinedInput/package.json ./packages/base/OutlinedInput/package.json
+COPY --chown=node:node packages/base/OverviewBlock/package.json ./packages/base/OverviewBlock/package.json
+COPY --chown=node:node packages/base/Page/package.json ./packages/base/Page/package.json
+COPY --chown=node:node packages/base/Pagination/package.json ./packages/base/Pagination/package.json
+COPY --chown=node:node packages/base/Paper/package.json ./packages/base/Paper/package.json
+COPY --chown=node:node packages/base/PasswordInput/package.json ./packages/base/PasswordInput/package.json
+COPY --chown=node:node packages/base/Popper/package.json ./packages/base/Popper/package.json
+COPY --chown=node:node packages/base/PromptModal/package.json ./packages/base/PromptModal/package.json
+COPY --chown=node:node packages/base/Quote/package.json ./packages/base/Quote/package.json
+COPY --chown=node:node packages/base/Radio/package.json ./packages/base/Radio/package.json
+COPY --chown=node:node packages/base/Rating/package.json ./packages/base/Rating/package.json
+COPY --chown=node:node packages/base/Section/package.json ./packages/base/Section/package.json
+COPY --chown=node:node packages/base/Select/package.json ./packages/base/Select/package.json
+COPY --chown=node:node packages/base/ShowMore/package.json ./packages/base/ShowMore/package.json
+COPY --chown=node:node packages/base/SkeletonLoader/package.json ./packages/base/SkeletonLoader/package.json
+COPY --chown=node:node packages/base/Slide/package.json ./packages/base/Slide/package.json
+COPY --chown=node:node packages/base/Slider/package.json ./packages/base/Slider/package.json
+COPY --chown=node:node packages/base/Step/package.json ./packages/base/Step/package.json
+COPY --chown=node:node packages/base/Switch/package.json ./packages/base/Switch/package.json
+COPY --chown=node:node packages/base/Table/package.json ./packages/base/Table/package.json
+COPY --chown=node:node packages/base/Tabs/package.json ./packages/base/Tabs/package.json
+COPY --chown=node:node packages/base/Tag/package.json ./packages/base/Tag/package.json
+COPY --chown=node:node packages/base/Tagselector/package.json ./packages/base/Tagselector/package.json
+COPY --chown=node:node packages/base/Test-Utils/package.json ./packages/base/Test-Utils/package.json
+COPY --chown=node:node packages/base/Timeline/package.json ./packages/base/Timeline/package.json
+COPY --chown=node:node packages/base/Timepicker/package.json ./packages/base/Timepicker/package.json
+COPY --chown=node:node packages/base/Tooltip/package.json ./packages/base/Tooltip/package.json
+COPY --chown=node:node packages/base/TreeView/package.json ./packages/base/TreeView/package.json
+COPY --chown=node:node packages/base/Typography/package.json ./packages/base/Typography/package.json
+COPY --chown=node:node packages/base/TypographyOverflow/package.json ./packages/base/TypographyOverflow/package.json
+COPY --chown=node:node packages/base/UserBadge/package.json ./packages/base/UserBadge/package.json
+COPY --chown=node:node packages/base/Utils/package.json ./packages/base/Utils/package.json
 
 RUN pnpm install --frozen-lockfile
 


### PR DESCRIPTION
## Summary

Follow-up to #4920. Addresses three points raised in code review:

- **Drop `ARG PNPM_VERSION`.** Corepack reads the version from `package.json#packageManager` (`pnpm@10.32.1`), so the duplicate constant in the Dockerfile is unnecessary and risks drift.
- **Fix the manifest prune.** The previous `find packages -mindepth 2 -maxdepth 2 ! -name "package.json" | xargs rm -rf` matches `packages/base/<name>` directories at depth 2 and removes them along with their `package.json` files. The follow-up `find packages/base ...` pass then runs against an empty directory. Once exercised in CI, `pnpm install --frozen-lockfile` would fail for the 70+ workspace packages under `packages/base/*`.
- **Make the install layer cacheable on manifests only.** `COPY packages packages` includes every source file in the layer's hash, so editing component code invalidates `node_modules`. Switching to explicit per-manifest `COPY` commands ties the install cache key to lockfile + workspace manifests only.

## Test plan

- [x] CI green on this branch
- [x] `docker build` against this Dockerfile produces a valid image with `node_modules` populated under `packages/base/<name>` workspaces
- [x] Editing a source file under `packages/<x>/src` does not invalidate the `pnpm install` layer in the next build