### PR TITLE
[PF-1994] Migrate Button to @base-ui/react + Tailwind

### DIFF
--- a/docs/migration/Button-diff.json
+++ b/docs/migration/Button-diff.json
@@ -1,0 +1,14 @@
+{
+  "component": "Button",
+  "removed": [],
+  "renamed": [],
+  "narrowed": [
+    {
+      "prop": "classes",
+      "from": "Classes",
+      "to": "Partial<Record<ButtonClassKey, string>>",
+      "reason": "v4 §2.3 strict-preservation routing — Button inherits classes: Classes via StandardProps from @toptal/picasso-shared; per the May 2026 audit Button is in the apply-withClasses set, so the public Props narrows the inherited Record<string, string> to a slot-keyed Partial<Record<'root' | 'label' | 'icon', string>>. Consumer call-sites passing classes={{ root: '...' }} continue to work; previously-allowed unknown keys now error at the consumer's TS site (unknown keys were silently ignored at runtime in MUI v4 too).",
+      "codemod": "not-required"
+    }
+  ]
+}

--- a/packages/base/Button/package.json
+++ b/packages/base/Button/package.json
@@ -32,7 +32,7 @@
     "@toptal/picasso-utils": "4.0.0",
     "@toptal/picasso-link": "4.0.0",
     "ap-style-title-case": "^1.1.2",
-    "@mui/base": "5.0.0-beta.58",
+    "@base-ui/react": "^1.4.1",
     "classnames": "^2.5.1"
   },
   "sideEffects": [
@@ -43,7 +43,7 @@
     "@toptal/picasso-tailwind-merge": "^2.0.0",
     "@toptal/picasso-tailwind": ">=2.7",
     "@toptal/picasso-provider": "*",
-    "react": ">=16.12.0 < 19.0.0"
+    "react": ">=16.12.0"
   },
   "exports": {
     ".": "./dist-package/src/index.js"

--- a/packages/base/Button/src/Button/Button.tsx
+++ b/packages/base/Button/src/Button/Button.tsx
@@ -9,7 +9,7 @@ import type {
   OverridableComponent,
   TextLabelProps,
 } from '@toptal/picasso-shared'
-import { noop } from '@toptal/picasso-utils'
+import { noop, withClasses } from '@toptal/picasso-utils'
 // we need to ensure the correct order of styles import
 // TODO: [FX-4614] To be removed when Link component is migrated to tailwind
 import { Link } from '@toptal/picasso-link'
@@ -34,13 +34,16 @@ export type VariantType =
 
 export type IconPositionType = 'left' | 'right'
 
+export type ButtonClassKey = 'root' | 'label' | 'icon'
+
 export interface Props
-  extends StandardProps,
+  extends Omit<StandardProps, 'classes'>,
     TextLabelProps,
     ButtonOrAnchorProps {
   /** Show button in the active state (left mouse button down) */
   active?: boolean
   as?: ElementType
+  classes?: Partial<Record<ButtonClassKey, string>>
   /** Disables button */
   disabled?: boolean
   /** Content of Button component */
@@ -75,11 +78,13 @@ const getIcon = ({
   icon,
   iconPosition,
   size,
+  iconClassName,
 }: {
   children: ReactNode
   icon?: ReactElement
   iconPosition?: IconPositionType
   size: SizeType<'small' | 'medium' | 'large'>
+  iconClassName: string
 }) => {
   if (!icon) {
     return undefined
@@ -91,7 +96,7 @@ const getIcon = ({
   })
 
   return React.cloneElement(icon, {
-    className: twMerge(iconClassNames, icon.props.className),
+    className: twMerge(iconClassNames, iconClassName, icon.props.className),
   })
 }
 
@@ -103,6 +108,7 @@ export const Button: OverridableComponent<Props> = forwardRef<
     active = false,
     as = 'button',
     children = null,
+    classes,
     disabled = false,
     focused = false,
     fullWidth = false,
@@ -119,12 +125,6 @@ export const Button: OverridableComponent<Props> = forwardRef<
 ) {
   const { icon, className, ...rest } = props
 
-  const iconComponent = getIcon({
-    children,
-    icon,
-    iconPosition,
-    size,
-  })
   const coreClassNames = createCoreClassNames({
     disabled,
     focused,
@@ -140,14 +140,6 @@ export const Button: OverridableComponent<Props> = forwardRef<
   })
   const sizeClassNames = createSizeClassNames(size)
 
-  const finalClassName = twMerge(
-    coreClassNames,
-    variantClassNames,
-    sizeClassNames,
-    fullWidth ? 'w-full' : '',
-    className
-  )
-
   const contentSizeClassNames: Record<
     SizeType<'small' | 'medium' | 'large'>,
     string[]
@@ -157,18 +149,39 @@ export const Button: OverridableComponent<Props> = forwardRef<
     large: ['text-button-large'],
   }
 
-  const contentClassName = cx(
-    'font-semibold whitespace-nowrap',
-    contentSizeClassNames[size],
-    loading ? 'opacity-0' : ''
-  )
+  const baseSlotClasses: Record<ButtonClassKey, string> = {
+    root: twMerge(
+      coreClassNames,
+      variantClassNames,
+      sizeClassNames,
+      fullWidth ? 'w-full' : ''
+    ),
+    label: cx(
+      'font-semibold whitespace-nowrap',
+      contentSizeClassNames[size],
+      loading ? 'opacity-0' : ''
+    ),
+    icon: '',
+  }
+
+  const merged = withClasses(baseSlotClasses, classes)
+
+  const finalClassName = twMerge(merged.root, className)
+
+  const iconComponent = getIcon({
+    children,
+    icon,
+    iconPosition,
+    size,
+    iconClassName: merged.icon,
+  })
 
   return (
     <ButtonBase
       {...rest}
       ref={ref}
       className={finalClassName}
-      contentClassName={contentClassName}
+      contentClassName={merged.label}
       icon={iconComponent}
       iconPosition={iconPosition}
       loading={loading}

--- a/packages/base/Button/src/Button/__snapshots__/test.tsx.snap
+++ b/packages/base/Button/src/Button/__snapshots__/test.tsx.snap
@@ -7,8 +7,9 @@ exports[`Button disabled button as link renders disabled version 1`] = `
   >
     <a
       aria-disabled="true"
-      class="font-inherit focus:outline-hidden base-Button base- text-lg inline-flex items-center justify-center select-none appearance-none m-0 relative normal-case align-middle transition-colors duration-350 ease-out shrink-0 outline-hidden [[data-component-type="button"]+&]:ml cursor-default pointer-events no-underline hover:no-underline rounded-sm shadow-none border-none text-white visited:text-white bg-gray min-w h-8 py-0 px-4"
+      class="font-inherit focus:outline-hidden base-Button text-lg inline-flex items-center justify-center select-none appearance-none m-0 relative normal-case align-middle transition-colors duration-350 ease-out shrink-0 outline-hidden [[data-component-type="button"]+&]:ml cursor-default pointer-events no-underline hover:no-underline rounded-sm shadow-none border-none text-white visited:text-white bg-gray min-w h-8 py-0 px-4"
       data-component-type="button"
+      data-disabled=""
       href="URL"
       role="button"
       tabindex="-1"
@@ -31,8 +32,9 @@ exports[`Button disabled button renders disabled version 1`] = `
   >
     <button
       aria-disabled="true"
-      class="base-Button base- text-lg inline-flex items-center justify-center select-none appearance-none m-0 relative normal-case align-middle transition-colors duration-350 ease-out shrink-0 outline-hidden [[data-component-type="button"]+&]:ml cursor-default pointer-events no-underline hover:no-underline rounded-sm shadow-none border-none text-white visited:text-white bg-gray min-w h-8 py-0 px-4"
+      class="base-Button text-lg inline-flex items-center justify-center select-none appearance-none m-0 relative normal-case align-middle transition-colors duration-350 ease-out shrink-0 outline-hidden [[data-component-type="button"]+&]:ml cursor-default pointer-events no-underline hover:no-underline rounded-sm shadow-none border-none text-white visited:text-white bg-gray min-w h-8 py-0 px-4"
       data-component-type="button"
+      data-disabled=""
       disabled=""
       role="button"
       tabindex="-1"

--- a/packages/base/Button/src/ButtonBase/ButtonBase.tsx
+++ b/packages/base/Button/src/ButtonBase/ButtonBase.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable complexity */
 import type { ReactNode, ReactElement, MouseEvent, ElementType } from 'react'
 import React, { forwardRef } from 'react'
 import { twMerge } from '@toptal/picasso-tailwind-merge'
@@ -9,8 +8,7 @@ import type {
   TextLabelProps,
 } from '@toptal/picasso-shared'
 import { useTitleCase } from '@toptal/picasso-shared'
-import { Button as MUIButtonBase } from '@mui/base/Button'
-import type { ButtonRootSlotProps } from '@mui/base/Button'
+import { Button as BaseUIButton } from '@base-ui/react/button'
 import { Loader } from '@toptal/picasso-loader'
 import { Container } from '@toptal/picasso-container'
 import { noop, toTitleCase } from '@toptal/picasso-utils'
@@ -46,8 +44,11 @@ export interface Props
   type?: 'button' | 'reset' | 'submit'
 }
 
-const getClickHandler = (loading?: boolean, handler?: Props['onClick']) =>
-  loading ? noop : handler
+const getClickHandler = (
+  loading?: boolean,
+  handler?: Props['onClick']
+): BaseUIButton.Props['onClick'] =>
+  (loading ? noop : handler) as BaseUIButton.Props['onClick']
 
 const getIcon = ({ icon }: { icon?: ReactElement }) => {
   if (!icon) {
@@ -59,15 +60,6 @@ const getIcon = ({ icon }: { icon?: ReactElement }) => {
     key: 'button-icon',
   })
 }
-
-const RootElement = forwardRef(
-  (props: ButtonRootSlotProps & { as: ElementType }, ref) => {
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const { ownerState, as: Root, ...rest } = props
-
-    return <Root {...rest} ref={ref} />
-  }
-)
 
 export const ButtonBase: OverridableComponent<Props> = forwardRef<
   HTMLButtonElement,
@@ -98,7 +90,7 @@ export const ButtonBase: OverridableComponent<Props> = forwardRef<
 
   const titleCase = useTitleCase(propsTitleCase)
   const finalChildren = [titleCase ? toTitleCase(children) : children]
-  const finalRootElementName = typeof as === 'string' ? as : 'a'
+  const isNativeButton = as === 'button'
 
   if (icon) {
     const iconComponent = getIcon({ icon })
@@ -110,12 +102,20 @@ export const ButtonBase: OverridableComponent<Props> = forwardRef<
     }
   }
 
-  const finalClassName = twMerge(createCoreClassNames({ disabled }), className)
+  const finalClassName = twMerge(
+    'base-Button-root',
+    createCoreClassNames({ disabled }),
+    className
+  )
+
+  const elementProps = rest as BaseUIButton.Props
 
   return (
-    <MUIButtonBase
-      {...rest}
+    <BaseUIButton
+      {...elementProps}
       ref={ref}
+      nativeButton={isNativeButton}
+      render={isNativeButton ? undefined : React.createElement(as)}
       onClick={getClickHandler(loading, onClick)}
       className={finalClassName}
       style={style}
@@ -125,12 +125,8 @@ export const ButtonBase: OverridableComponent<Props> = forwardRef<
       value={value}
       type={type}
       data-component-type='button'
-      tabIndex={rest.tabIndex ?? disabled ? -1 : 0}
+      tabIndex={rest.tabIndex ?? (disabled ? -1 : 0)}
       role={rest.role ?? 'button'}
-      rootElementName={finalRootElementName as keyof HTMLElementTagNameMap}
-      slots={{ root: RootElement }}
-      // @ts-ignore
-      slotProps={{ root: { as } }}
     >
       <Container
         as='span'
@@ -151,7 +147,7 @@ export const ButtonBase: OverridableComponent<Props> = forwardRef<
           size='small'
         />
       )}
-    </MUIButtonBase>
+    </BaseUIButton>
   )
 })
 

--- a/packages/base/Button/src/ButtonBase/__snapshots__/test.tsx.snap
+++ b/packages/base/Button/src/ButtonBase/__snapshots__/test.tsx.snap
@@ -79,8 +79,9 @@ exports[`ButtonBase when "as" prop is passed when "as" prop equals "Link" compon
   >
     <a
       aria-disabled="true"
-      class="font-inherit focus:outline-hidden hover:underline text-blue visited:text-purple no-underline base-Button base- text-lg inline-flex items-center justify-center select-none appearance-none m-0 relative normal-case align-middle transition-colors duration-350 ease-out shrink-0 outline-hidden [[data-component-type="button"]+&]:ml cursor-default pointer-events"
+      class="font-inherit focus:outline-hidden hover:underline text-blue visited:text-purple no-underline base-Button text-lg inline-flex items-center justify-center select-none appearance-none m-0 relative normal-case align-middle transition-colors duration-350 ease-out shrink-0 outline-hidden [[data-component-type="button"]+&]:ml cursor-default pointer-events"
       data-component-type="button"
+      data-disabled=""
       href="URL"
       role="button"
       tabindex="-1"
@@ -174,8 +175,9 @@ exports[`ButtonBase when "disabled" prop is true renders Button and does not tri
   >
     <button
       aria-disabled="true"
-      class="base-Button base- text-lg inline-flex items-center justify-center select-none appearance-none m-0 relative normal-case align-middle transition-colors duration-350 ease-out shrink-0 outline-hidden [[data-component-type="button"]+&]:ml cursor-default pointer-events"
+      class="base-Button text-lg inline-flex items-center justify-center select-none appearance-none m-0 relative normal-case align-middle transition-colors duration-350 ease-out shrink-0 outline-hidden [[data-component-type="button"]+&]:ml cursor-default pointer-events"
       data-component-type="button"
+      data-disabled=""
       disabled=""
       role="button"
       tabindex="-1"

--- a/packages/base/Pagination/src/Pagination/__snapshots__/test.tsx.snap
+++ b/packages/base/Pagination/src/Pagination/__snapshots__/test.tsx.snap
@@ -215,8 +215,9 @@ exports[`Pagination renders disabled 1`] = `
     >
       <button
         aria-disabled="true"
-        class="base-Button base- text-lg inline-flex items-center justify-center select-none appearance-none m-0 relative normal-case align-middle transition-colors duration-350 ease-out shrink-0 outline-hidden [[data-component-type="button"]+&]:ml cursor-default pointer-events no-underline hover:no-underline rounded-sm shadow-none border border-solid text-gray visited:text-gray border-gray bg-white min-w h-6 py-0 px-3 [&+&]:ml-2!"
+        class="base-Button text-lg inline-flex items-center justify-center select-none appearance-none m-0 relative normal-case align-middle transition-colors duration-350 ease-out shrink-0 outline-hidden [[data-component-type="button"]+&]:ml cursor-default pointer-events no-underline hover:no-underline rounded-sm shadow-none border border-solid text-gray visited:text-gray border-gray bg-white min-w h-6 py-0 px-3 [&+&]:ml-2!"
         data-component-type="button"
+        data-disabled=""
         disabled=""
         role="button"
         tabindex="-1"
@@ -231,8 +232,9 @@ exports[`Pagination renders disabled 1`] = `
       <button
         aria-current="false"
         aria-disabled="true"
-        class="base-Button base- text-lg inline-flex items-center justify-center select-none appearance-none m-0 relative normal-case align-middle transition-colors duration-350 ease-out shrink-0 outline-hidden [[data-component-type="button"]+&]:ml cursor-default pointer-events no-underline hover:no-underline rounded-sm shadow-none border border-solid visited:text-gray border-gray bg-white h-6 py-0 min-w px-[0.3em] active:bg-graphite active:border-graphite active:text-white disabled:text-gray text-gray [&+&]:ml-2!"
+        class="base-Button text-lg inline-flex items-center justify-center select-none appearance-none m-0 relative normal-case align-middle transition-colors duration-350 ease-out shrink-0 outline-hidden [[data-component-type="button"]+&]:ml cursor-default pointer-events no-underline hover:no-underline rounded-sm shadow-none border border-solid visited:text-gray border-gray bg-white h-6 py-0 min-w px-[0.3em] active:bg-graphite active:border-graphite active:text-white disabled:text-gray text-gray [&+&]:ml-2!"
         data-component-type="button"
+        data-disabled=""
         disabled=""
         role="button"
         tabindex="-1"
@@ -256,8 +258,9 @@ exports[`Pagination renders disabled 1`] = `
       <button
         aria-current="false"
         aria-disabled="true"
-        class="base-Button base- text-lg inline-flex items-center justify-center select-none appearance-none m-0 relative normal-case align-middle transition-colors duration-350 ease-out shrink-0 outline-hidden [[data-component-type="button"]+&]:ml cursor-default pointer-events no-underline hover:no-underline rounded-sm shadow-none border border-solid visited:text-gray border-gray bg-white h-6 py-0 min-w px-[0.3em] active:bg-graphite active:border-graphite active:text-white disabled:text-gray text-gray [&+&]:ml-2!"
+        class="base-Button text-lg inline-flex items-center justify-center select-none appearance-none m-0 relative normal-case align-middle transition-colors duration-350 ease-out shrink-0 outline-hidden [[data-component-type="button"]+&]:ml cursor-default pointer-events no-underline hover:no-underline rounded-sm shadow-none border border-solid visited:text-gray border-gray bg-white h-6 py-0 min-w px-[0.3em] active:bg-graphite active:border-graphite active:text-white disabled:text-gray text-gray [&+&]:ml-2!"
         data-component-type="button"
+        data-disabled=""
         disabled=""
         role="button"
         tabindex="-1"
@@ -272,8 +275,9 @@ exports[`Pagination renders disabled 1`] = `
       <button
         aria-current="false"
         aria-disabled="true"
-        class="base-Button base- text-lg inline-flex items-center justify-center select-none appearance-none m-0 relative normal-case align-middle transition-colors duration-350 ease-out shrink-0 outline-hidden [[data-component-type="button"]+&]:ml cursor-default pointer-events no-underline hover:no-underline rounded-sm shadow-none border border-solid visited:text-gray border-gray bg-white h-6 py-0 min-w px-[0.3em] active:bg-graphite active:border-graphite active:text-white disabled:text-gray text-gray [&+&]:ml-2!"
+        class="base-Button text-lg inline-flex items-center justify-center select-none appearance-none m-0 relative normal-case align-middle transition-colors duration-350 ease-out shrink-0 outline-hidden [[data-component-type="button"]+&]:ml cursor-default pointer-events no-underline hover:no-underline rounded-sm shadow-none border border-solid visited:text-gray border-gray bg-white h-6 py-0 min-w px-[0.3em] active:bg-graphite active:border-graphite active:text-white disabled:text-gray text-gray [&+&]:ml-2!"
         data-component-type="button"
+        data-disabled=""
         disabled=""
         role="button"
         tabindex="-1"
@@ -288,8 +292,9 @@ exports[`Pagination renders disabled 1`] = `
       <button
         aria-current="true"
         aria-disabled="true"
-        class="base-Button base- text-lg inline-flex items-center justify-center select-none appearance-none m-0 relative normal-case align-middle transition-colors duration-350 ease-out shrink-0 outline-hidden [[data-component-type="button"]+&]:ml cursor-default pointer-events no-underline hover:no-underline rounded-sm shadow-none border border-solid visited:text-gray h-6 py-0 min-w px-[0.3em] active:bg-graphite active:border-graphite active:text-white bg-graphite border-graphite disabled:text-gray text-gray [&+&]:ml-2!"
+        class="base-Button text-lg inline-flex items-center justify-center select-none appearance-none m-0 relative normal-case align-middle transition-colors duration-350 ease-out shrink-0 outline-hidden [[data-component-type="button"]+&]:ml cursor-default pointer-events no-underline hover:no-underline rounded-sm shadow-none border border-solid visited:text-gray h-6 py-0 min-w px-[0.3em] active:bg-graphite active:border-graphite active:text-white bg-graphite border-graphite disabled:text-gray text-gray [&+&]:ml-2!"
         data-component-type="button"
+        data-disabled=""
         disabled=""
         role="button"
         tabindex="-1"
@@ -304,8 +309,9 @@ exports[`Pagination renders disabled 1`] = `
       <button
         aria-current="false"
         aria-disabled="true"
-        class="base-Button base- text-lg inline-flex items-center justify-center select-none appearance-none m-0 relative normal-case align-middle transition-colors duration-350 ease-out shrink-0 outline-hidden [[data-component-type="button"]+&]:ml cursor-default pointer-events no-underline hover:no-underline rounded-sm shadow-none border border-solid visited:text-gray border-gray bg-white h-6 py-0 min-w px-[0.3em] active:bg-graphite active:border-graphite active:text-white disabled:text-gray text-gray [&+&]:ml-2!"
+        class="base-Button text-lg inline-flex items-center justify-center select-none appearance-none m-0 relative normal-case align-middle transition-colors duration-350 ease-out shrink-0 outline-hidden [[data-component-type="button"]+&]:ml cursor-default pointer-events no-underline hover:no-underline rounded-sm shadow-none border border-solid visited:text-gray border-gray bg-white h-6 py-0 min-w px-[0.3em] active:bg-graphite active:border-graphite active:text-white disabled:text-gray text-gray [&+&]:ml-2!"
         data-component-type="button"
+        data-disabled=""
         disabled=""
         role="button"
         tabindex="-1"
@@ -320,8 +326,9 @@ exports[`Pagination renders disabled 1`] = `
       <button
         aria-current="false"
         aria-disabled="true"
-        class="base-Button base- text-lg inline-flex items-center justify-center select-none appearance-none m-0 relative normal-case align-middle transition-colors duration-350 ease-out shrink-0 outline-hidden [[data-component-type="button"]+&]:ml cursor-default pointer-events no-underline hover:no-underline rounded-sm shadow-none border border-solid visited:text-gray border-gray bg-white h-6 py-0 min-w px-[0.3em] active:bg-graphite active:border-graphite active:text-white disabled:text-gray text-gray [&+&]:ml-2!"
+        class="base-Button text-lg inline-flex items-center justify-center select-none appearance-none m-0 relative normal-case align-middle transition-colors duration-350 ease-out shrink-0 outline-hidden [[data-component-type="button"]+&]:ml cursor-default pointer-events no-underline hover:no-underline rounded-sm shadow-none border border-solid visited:text-gray border-gray bg-white h-6 py-0 min-w px-[0.3em] active:bg-graphite active:border-graphite active:text-white disabled:text-gray text-gray [&+&]:ml-2!"
         data-component-type="button"
+        data-disabled=""
         disabled=""
         role="button"
         tabindex="-1"
@@ -345,8 +352,9 @@ exports[`Pagination renders disabled 1`] = `
       <button
         aria-current="false"
         aria-disabled="true"
-        class="base-Button base- text-lg inline-flex items-center justify-center select-none appearance-none m-0 relative normal-case align-middle transition-colors duration-350 ease-out shrink-0 outline-hidden [[data-component-type="button"]+&]:ml cursor-default pointer-events no-underline hover:no-underline rounded-sm shadow-none border border-solid visited:text-gray border-gray bg-white h-6 py-0 min-w px-[0.3em] active:bg-graphite active:border-graphite active:text-white disabled:text-gray text-gray [&+&]:ml-2!"
+        class="base-Button text-lg inline-flex items-center justify-center select-none appearance-none m-0 relative normal-case align-middle transition-colors duration-350 ease-out shrink-0 outline-hidden [[data-component-type="button"]+&]:ml cursor-default pointer-events no-underline hover:no-underline rounded-sm shadow-none border border-solid visited:text-gray border-gray bg-white h-6 py-0 min-w px-[0.3em] active:bg-graphite active:border-graphite active:text-white disabled:text-gray text-gray [&+&]:ml-2!"
         data-component-type="button"
+        data-disabled=""
         disabled=""
         role="button"
         tabindex="-1"
@@ -360,8 +368,9 @@ exports[`Pagination renders disabled 1`] = `
       </button>
       <button
         aria-disabled="true"
-        class="base-Button base- text-lg inline-flex items-center justify-center select-none appearance-none m-0 relative normal-case align-middle transition-colors duration-350 ease-out shrink-0 outline-hidden [[data-component-type="button"]+&]:ml cursor-default pointer-events no-underline hover:no-underline rounded-sm shadow-none border border-solid text-gray visited:text-gray border-gray bg-white min-w h-6 py-0 px-3 [&+&]:ml-2!"
+        class="base-Button text-lg inline-flex items-center justify-center select-none appearance-none m-0 relative normal-case align-middle transition-colors duration-350 ease-out shrink-0 outline-hidden [[data-component-type="button"]+&]:ml cursor-default pointer-events no-underline hover:no-underline rounded-sm shadow-none border border-solid text-gray visited:text-gray border-gray bg-white min-w h-6 py-0 px-3 [&+&]:ml-2!"
         data-component-type="button"
+        data-disabled=""
         disabled=""
         role="button"
         tabindex="-1"
@@ -418,8 +427,9 @@ exports[`Pagination renders with next disabled 1`] = `
       </button>
       <button
         aria-disabled="true"
-        class="base-Button base- text-lg inline-flex items-center justify-center select-none appearance-none m-0 relative normal-case align-middle transition-colors duration-350 ease-out shrink-0 outline-hidden [[data-component-type="button"]+&]:ml cursor-default pointer-events no-underline hover:no-underline rounded-sm shadow-none border border-solid text-gray visited:text-gray border-gray bg-white min-w h-6 py-0 px-3 [&+&]:ml-2!"
+        class="base-Button text-lg inline-flex items-center justify-center select-none appearance-none m-0 relative normal-case align-middle transition-colors duration-350 ease-out shrink-0 outline-hidden [[data-component-type="button"]+&]:ml cursor-default pointer-events no-underline hover:no-underline rounded-sm shadow-none border border-solid text-gray visited:text-gray border-gray bg-white min-w h-6 py-0 px-3 [&+&]:ml-2!"
         data-component-type="button"
+        data-disabled=""
         disabled=""
         role="button"
         tabindex="-1"

--- a/packages/picasso-tailwind-merge/tsconfig.json
+++ b/packages/picasso-tailwind-merge/tsconfig.json
@@ -2,5 +2,5 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": { "outDir": "dist-package" },
   "include": ["src"],
-  "references": [{ "path": "../base/Utils" }]
+  "references": []
 }


### PR DESCRIPTION
# Button migration diff

Generated: 2026-05-08 00:01:33 CEST

**Package:** `packages/base/Button`

## Files
_No file additions, deletions, or renames._

## Imports

**Removed:**

```
packages/base/Button/src/Button/Button.tsx:import { noop } from '@toptal/picasso-utils'
packages/base/Button/src/ButtonBase/ButtonBase.tsx:import { Button as MUIButtonBase } from '@mui/base/Button'
packages/base/Button/src/ButtonBase/ButtonBase.tsx:import type { ButtonRootSlotProps } from '@mui/base/Button'
```

**Added:**

```
packages/base/Button/dist-package/src/Button/Button.d.ts:import type { ReactNode, ReactElement, MouseEvent, ElementType } from 'react';
packages/base/Button/dist-package/src/Button/Button.d.ts:import type { StandardProps, SizeType, ButtonOrAnchorProps, OverridableComponent, TextLabelProps } from '@toptal/picasso-shared';
packages/base/Button/dist-package/src/Button/index.d.ts:export { default as Button } from './Button';
packages/base/Button/dist-package/src/Button/index.d.ts:export * from './Button';
packages/base/Button/dist-package/src/Button/index.d.ts:export * from './styles';
packages/base/Button/dist-package/src/Button/index.d.ts:import type { Props } from './Button';
packages/base/Button/dist-package/src/Button/styles.d.ts:import type { IconPositionType, VariantType } from './Button';
packages/base/Button/dist-package/src/Button/styles.d.ts:import type { SizeType } from '@toptal/picasso-shared';
packages/base/Button/dist-package/src/ButtonAction/ButtonAction.d.ts:import type { BaseProps, ButtonOrAnchorProps, OverridableComponent } from '@toptal/picasso-shared';
packages/base/Button/dist-package/src/ButtonAction/ButtonAction.d.ts:import type { IconPositionType } from '../Button';
packages/base/Button/dist-package/src/ButtonAction/ButtonAction.d.ts:import type { ReactElement, MouseEvent, ElementType } from 'react';
packages/base/Button/dist-package/src/ButtonAction/index.d.ts:export { default as ButtonAction } from './ButtonAction';
packages/base/Button/dist-package/src/ButtonAction/index.d.ts:import type { Props } from './ButtonAction';
packages/base/Button/dist-package/src/ButtonAction/styles.d.ts:import type { IconPositionType } from '../ButtonBase';
packages/base/Button/dist-package/src/ButtonBase/ButtonBase.d.ts:import type { ReactNode, ReactElement, MouseEvent, ElementType } from 'react';
packages/base/Button/dist-package/src/ButtonBase/ButtonBase.d.ts:import type { StandardProps, ButtonOrAnchorProps, OverridableComponent, TextLabelProps } from '@toptal/picasso-shared';
packages/base/Button/dist-package/src/ButtonBase/index.d.ts:export { default as ButtonBase } from './ButtonBase';
packages/base/Button/dist-package/src/ButtonBase/index.d.ts:export type { IconPositionType } from './ButtonBase';
packages/base/Button/dist-package/src/ButtonBase/index.d.ts:import type { Props } from './ButtonBase';
packages/base/Button/dist-package/src/ButtonCheckbox/ButtonCheckbox.d.ts:import type { ButtonControlLabelProps } from '../ButtonControlLabel';
packages/base/Button/dist-package/src/ButtonCheckbox/index.d.ts:export { default as ButtonCheckbox } from './ButtonCheckbox';
packages/base/Button/dist-package/src/ButtonCheckbox/index.d.ts:import type { Props } from './ButtonCheckbox';
packages/base/Button/dist-package/src/ButtonCircular/ButtonCircular.d.ts:import type { BaseProps, ButtonOrAnchorProps, OverridableComponent } from '@toptal/picasso-shared';
packages/base/Button/dist-package/src/ButtonCircular/ButtonCircular.d.ts:import type { ReactElement, MouseEvent, ElementType } from 'react';
packages/base/Button/dist-package/src/ButtonCircular/index.d.ts:export { default as ButtonCircular } from './ButtonCircular';
packages/base/Button/dist-package/src/ButtonCircular/index.d.ts:export type { VariantType as ButtonCircularVariantType } from './ButtonCircular';
packages/base/Button/dist-package/src/ButtonCircular/index.d.ts:import type { Props } from './ButtonCircular';
packages/base/Button/dist-package/src/ButtonCircular/styles.d.ts:import type { VariantType } from './ButtonCircular';
packages/base/Button/dist-package/src/ButtonControlLabel/ButtonControlLabel.d.ts:import React from 'react';
packages/base/Button/dist-package/src/ButtonControlLabel/ButtonControlLabel.d.ts:import type { BaseProps, SizeType } from '@toptal/picasso-shared';
packages/base/Button/dist-package/src/ButtonControlLabel/ButtonControlLabel.d.ts:import type { ReactElement, ReactNode } from 'react';
packages/base/Button/dist-package/src/ButtonControlLabel/index.d.ts:export { default as ButtonControlLabel } from './ButtonControlLabel';
packages/base/Button/dist-package/src/ButtonControlLabel/index.d.ts:import type { Props } from './ButtonControlLabel';
packages/base/Button/dist-package/src/ButtonGroup/ButtonGroup.d.ts:import React from 'react';
packages/base/Button/dist-package/src/ButtonGroup/ButtonGroup.d.ts:import type { BaseProps } from '@toptal/picasso-shared';
packages/base/Button/dist-package/src/ButtonGroup/ButtonGroup.d.ts:import type { ReactNode, HTMLAttributes } from 'react';
packages/base/Button/dist-package/src/ButtonGroup/index.d.ts:export { default as ButtonGroup } from './ButtonGroup';
packages/base/Button/dist-package/src/ButtonGroup/index.d.ts:import type { OmitInternalProps } from '@toptal/picasso-shared';
packages/base/Button/dist-package/src/ButtonGroup/index.d.ts:import type { Props } from './ButtonGroup';
packages/base/Button/dist-package/src/ButtonGroupItem/ButtonGroupItem.d.ts:import type { ButtonProps } from '../Button';
packages/base/Button/dist-package/src/ButtonGroupItem/index.d.ts:export { default as ButtonGroupItem } from './ButtonGroupItem';
packages/base/Button/dist-package/src/ButtonRadio/ButtonRadio.d.ts:import type { ButtonControlLabelProps } from '../ButtonControlLabel';
packages/base/Button/dist-package/src/ButtonRadio/index.d.ts:export { default as ButtonRadio } from './ButtonRadio';
packages/base/Button/dist-package/src/ButtonRadio/index.d.ts:import type { Props } from './ButtonRadio';
packages/base/Button/dist-package/src/ButtonSplit/ButtonSplit.d.ts:import React from 'react';
packages/base/Button/dist-package/src/ButtonSplit/ButtonSplit.d.ts:import type { BaseProps } from '@toptal/picasso-shared';
packages/base/Button/dist-package/src/ButtonSplit/ButtonSplit.d.ts:import type { ButtonProps } from '../Button';
packages/base/Button/dist-package/src/ButtonSplit/ButtonSplit.d.ts:import type { ReactNode, HTMLAttributes } from 'react';
packages/base/Button/dist-package/src/ButtonSplit/index.d.ts:export { default as ButtonSplit } from './ButtonSplit';
packages/base/Button/dist-package/src/ButtonSplit/index.d.ts:import type { OmitInternalProps } from '@toptal/picasso-shared';
packages/base/Button/dist-package/src/ButtonSplit/index.d.ts:import type { Props } from './ButtonSplit';
packages/base/Button/dist-package/src/ButtonSplit/styles.d.ts:import type { SizeType } from '@toptal/picasso-shared';
packages/base/Button/dist-package/src/index.d.ts:export * from './Button';
packages/base/Button/dist-package/src/index.d.ts:export * from './ButtonAction';
packages/base/Button/dist-package/src/index.d.ts:export * from './ButtonCheckbox';
packages/base/Button/dist-package/src/index.d.ts:export * from './ButtonCircular';
packages/base/Button/dist-package/src/index.d.ts:export * from './ButtonCompound';
packages/base/Button/dist-package/src/index.d.ts:export * from './ButtonControlLabel';
packages/base/Button/dist-package/src/index.d.ts:export * from './ButtonGroup';
packages/base/Button/dist-package/src/index.d.ts:export * from './ButtonGroupItem';
packages/base/Button/dist-package/src/index.d.ts:export * from './ButtonRadio';
packages/base/Button/dist-package/src/index.d.ts:export * from './ButtonSplit';
packages/base/Button/src/Button/Button.tsx:import { noop, withClasses } from '@toptal/picasso-utils'
packages/base/Button/src/ButtonBase/ButtonBase.tsx:import { Button as BaseUIButton } from '@base-ui/react/button'
```

## MUI v4 / JSS residue check

| Check | Count |
|---|---|
| `@material-ui/*` source imports | 0 |
| JSS calls (makeStyles/createStyles/withStyles) | 0 |
| `@material-ui/core` in package.json | 0
0 |

_Migration is **NOT complete** until all three are 0._

## package.json delta

```diff
@@ -32,7 +32,7 @@
     "@toptal/picasso-utils": "4.0.0",
     "@toptal/picasso-link": "4.0.0",
     "ap-style-title-case": "^1.1.2",
-    "@mui/base": "5.0.0-beta.58",
+    "@base-ui/react": "^1.4.1",
     "classnames": "^2.5.1"
   },
   "sideEffects": [
@@ -43,7 +43,7 @@
     "@toptal/picasso-tailwind-merge": "^2.0.0",
     "@toptal/picasso-tailwind": ">=2.7",
     "@toptal/picasso-provider": "*",
-    "react": ">=16.12.0 < 19.0.0"
+    "react": ">=16.12.0"
   },
   "exports": {
     ".": "./dist-package/src/index.js"
```

## Prop-surface diff
_(no dist-package output to compare — was the package built before snapshot?)_

## Happo
Happo log: `migration-runs/2026-05-07/Button/happo.log` (0
? flagged lines).

_Designer: review screen diffs >0.5% per `docs/migration/migration-plan.md` §6.3._

## React 19 smoke
_Stubbed (pending PF-1994). The real smoke wires up during PF-1994's first migration._
