### PR TITLE
[ER-49165] Fix focus recursion between Drawer and Modal

### DIFF
--- a/.changeset/drawer-modal-focus-recursion.md
+++ b/.changeset/drawer-modal-focus-recursion.md
@@ -1,0 +1,8 @@
+---
+'@toptal/picasso-drawer': patch
+'@toptal/picasso-modal': patch
+'@toptal/picasso-utils': minor
+'@toptal/picasso': patch
+---
+
+- fix `Maximum call stack size exceeded` when a `Drawer` is opened from inside an open `Modal` and then the `Modal` is closed (ER-49165). `Modal` uses a custom document-level focus listener (with `disableEnforceFocus` on MUI's Modal) while `Drawer` relies on MUI's built-in `FocusTrap`; with both active the two focus mechanisms recursed on `Element.focus()`. `Drawer` now registers with the same shared `ModalManager` singleton that `Modal` uses, so when a `Drawer` is on top the underlying `Modal` correctly identifies itself as no longer the topmost overlay and bails out of its focus listener.

--- a/.changeset/drawer-modal-focus-recursion.md
+++ b/.changeset/drawer-modal-focus-recursion.md
@@ -5,4 +5,4 @@
 '@toptal/picasso': patch
 ---
 
-- fix `Maximum call stack size exceeded` when a `Drawer` is opened from inside an open `Modal` and then the `Modal` is closed (ER-49165). `Modal` uses a custom document-level focus listener (with `disableEnforceFocus` on MUI's Modal) while `Drawer` relies on MUI's built-in `FocusTrap`; with both active the two focus mechanisms recursed on `Element.focus()`. `Drawer` now registers with the same shared `ModalManager` singleton that `Modal` uses, so when a `Drawer` is on top the underlying `Modal` correctly identifies itself as no longer the topmost overlay and bails out of its focus listener.
+- fix `Maximum call stack size exceeded` when a `Drawer` is opened inside an open `Modal`. `Modal` opts out of MUI's `FocusTrap` and uses its own document-level focus listener while `Drawer` keeps MUI's, so the two mechanisms recurse on `Element.focus()`. `Drawer` now registers with the shared `ModalManager` singleton, letting the underlying `Modal` bail out of its focus listener when a `Drawer` is on top.

--- a/packages/base/Drawer/package.json
+++ b/packages/base/Drawer/package.json
@@ -47,8 +47,10 @@
     ".": "./dist-package/src/index.js"
   },
   "devDependencies": {
+    "@toptal/picasso-modal": "4.0.0",
     "@toptal/picasso-provider": "5.0.2",
-    "@toptal/picasso-tailwind-merge": "2.0.4"
+    "@toptal/picasso-tailwind-merge": "2.0.4",
+    "@toptal/picasso-test-utils": "2.0.0"
   },
   "files": [
     "dist-package/**",

--- a/packages/base/Drawer/src/Drawer/Drawer.tsx
+++ b/packages/base/Drawer/src/Drawer/Drawer.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react'
+import React, { useEffect, useRef } from 'react'
 import { Modal } from '@mui/base/Modal'
 import type { BaseProps, TransitionProps } from '@toptal/picasso-shared'
 import { useDrawer, usePicassoRoot } from '@toptal/picasso-provider'
@@ -9,6 +9,8 @@ import { Slide } from '@toptal/picasso-slide'
 import { Backdrop } from '@toptal/picasso-backdrop'
 import { Container } from '@toptal/picasso-container'
 import {
+  defaultModalManager,
+  generateModalId,
   useIsomorphicLayoutEffect,
   usePageScrollLock,
 } from '@toptal/picasso-utils'
@@ -81,6 +83,7 @@ export const Drawer = ({
   const { setHasDrawer } = useDrawer()
   const container = usePicassoRoot()
   const ref = useRef<HTMLDivElement>(null)
+  const drawerId = useRef(generateModalId())
 
   usePageScrollLock(Boolean(maintainBodyScrollLock && open))
 
@@ -93,6 +96,20 @@ export const Drawer = ({
 
     return cleanup
   }, [open, setHasDrawer])
+
+  // Register with the shared overlay manager so a Picasso Modal below
+  // yields focus enforcement to this Drawer (see ER-49165).
+  useEffect(() => {
+    const id = drawerId.current
+
+    if (open) {
+      defaultModalManager.add(id)
+    }
+
+    return () => {
+      defaultModalManager.remove(id)
+    }
+  }, [open])
 
   const handleOnClose = () => {
     if (onClose) {

--- a/packages/base/Drawer/src/Drawer/test.tsx
+++ b/packages/base/Drawer/src/Drawer/test.tsx
@@ -1,0 +1,147 @@
+import React from 'react'
+import { afterEach, describe, expect, it, jest } from '@jest/globals'
+import { render, cleanup } from '@toptal/picasso-test-utils'
+import { Modal } from '@toptal/picasso-modal'
+import { defaultModalManager } from '@toptal/picasso-utils'
+
+import Drawer from './Drawer'
+
+describe('Drawer', () => {
+  afterEach(() => {
+    cleanup()
+    defaultModalManager.reset()
+  })
+
+  it('renders without crashing', () => {
+    const { baseElement } = render(<Drawer open>content</Drawer>)
+
+    expect(baseElement).toBeInTheDocument()
+  })
+
+  describe('overlay registration', () => {
+    it('registers with defaultModalManager when open', () => {
+      render(<Drawer open>content</Drawer>)
+      expect(defaultModalManager.modals).toHaveLength(1)
+    })
+
+    it('does not register when closed', () => {
+      render(<Drawer open={false}>content</Drawer>)
+      expect(defaultModalManager.modals).toHaveLength(0)
+    })
+
+    it('removes itself from defaultModalManager on unmount', () => {
+      const { unmount } = render(<Drawer open>content</Drawer>)
+
+      expect(defaultModalManager.modals).toHaveLength(1)
+      unmount()
+      expect(defaultModalManager.modals).toHaveLength(0)
+    })
+
+    it('updates registration when open prop toggles', () => {
+      const { rerender } = render(<Drawer open>content</Drawer>)
+
+      expect(defaultModalManager.modals).toHaveLength(1)
+
+      rerender(<Drawer open={false}>content</Drawer>)
+      expect(defaultModalManager.modals).toHaveLength(0)
+
+      rerender(<Drawer open>content</Drawer>)
+      expect(defaultModalManager.modals).toHaveLength(1)
+    })
+  })
+
+  // ER-49165: Picasso Modal uses a custom document focus listener (because it
+  // sets disableEnforceFocus on MUI's Modal) while Drawer relies on MUI's
+  // FocusTrap. With both active, the two focus mechanisms recursed on
+  // Element.focus() and raised "Maximum call stack size exceeded".
+  describe('when nested inside a Picasso Modal (ER-49165)', () => {
+    it('takes over as topmost overlay in the shared manager', () => {
+      // Mount Modal first so its id is unambiguous in the manager — relying
+      // on the stack position after a simultaneous mount of both would be
+      // fragile against MUI's internal mount lifecycle.
+      const { rerender } = render(<Modal open>modal content</Modal>)
+      const modalId = defaultModalManager.modals[0]
+
+      expect(defaultModalManager.isTopModal(modalId)).toBe(true)
+
+      rerender(
+        <Modal open>
+          <Drawer open>drawer content</Drawer>
+        </Modal>
+      )
+
+      // Modal stayed mounted, only Drawer fired its add, so the stack is
+      // [modalId, drawerId] with the Drawer on top.
+      expect(defaultModalManager.modals).toHaveLength(2)
+      expect(defaultModalManager.modals[0]).toBe(modalId)
+      const drawerId = defaultModalManager.modals[1]
+
+      expect(defaultModalManager.isTopModal(drawerId)).toBe(true)
+      expect(defaultModalManager.isTopModal(modalId)).toBe(false)
+    })
+
+    it('makes the Modal listener bail out on document focus events', () => {
+      const focusSpy = jest.spyOn(HTMLElement.prototype, 'focus')
+      // Spying on isTopModal lets us prove the Modal listener actually ran —
+      // without this, a harness regression (e.g. the listener not attached or
+      // the synthetic event not reaching it) would silently pass the
+      // negative .focus() assertion below.
+      const isTopModalSpy = jest.spyOn(defaultModalManager, 'isTopModal')
+
+      render(
+        <Modal open>
+          <input data-testid='modal-input' />
+          <Drawer open>
+            <input data-testid='drawer-input' />
+          </Drawer>
+        </Modal>
+      )
+
+      // Discard focus calls fired during mount (auto-focus, MUI FocusTrap).
+      focusSpy.mockClear()
+      isTopModalSpy.mockClear()
+
+      // Re-fire the document focus listener path that previously recursed.
+      document.dispatchEvent(new FocusEvent('focus', { bubbles: true }))
+
+      // Proof the Modal listener actually fired and queried the manager.
+      // isTopModal is only called from inside Modal's focus handler, so a
+      // call here means the handler ran end-to-end up to the bailout check.
+      expect(isTopModalSpy).toHaveBeenCalled()
+      // And at least one of those calls returned false (the Modal's own id,
+      // since Drawer is on top), exercising the bailout branch.
+      expect(isTopModalSpy.mock.results.map(result => result.value)).toContain(
+        false
+      )
+
+      // With the bailout taken, Modal's handler does not invoke
+      // focusFirstFocusableElement, so no .focus() calls originate from it.
+      expect(focusSpy).not.toHaveBeenCalled()
+
+      focusSpy.mockRestore()
+      isTopModalSpy.mockRestore()
+    })
+
+    it('restores Modal as topmost when the Drawer closes', () => {
+      const { rerender } = render(<Modal open>modal content</Modal>)
+      const modalId = defaultModalManager.modals[0]
+
+      rerender(
+        <Modal open>
+          <Drawer open>drawer content</Drawer>
+        </Modal>
+      )
+
+      expect(defaultModalManager.isTopModal(modalId)).toBe(false)
+
+      rerender(
+        <Modal open>
+          <Drawer open={false}>drawer content</Drawer>
+        </Modal>
+      )
+
+      expect(defaultModalManager.modals).toHaveLength(1)
+      expect(defaultModalManager.isTopModal(modalId)).toBe(true)
+    })
+  })
+})

--- a/packages/base/Modal/src/Modal/Modal.tsx
+++ b/packages/base/Modal/src/Modal/Modal.tsx
@@ -16,7 +16,8 @@ import { usePicassoRoot, RootContext } from '@toptal/picasso-provider'
 import { CloseMinor16 } from '@toptal/picasso-icons'
 import {
   useCombinedRefs,
-  ModalManager,
+  defaultModalManager,
+  generateModalId,
   usePageScrollLock,
 } from '@toptal/picasso-utils'
 import { ButtonCircular } from '@toptal/picasso-button'
@@ -66,8 +67,6 @@ export interface Props extends BaseProps, HTMLAttributes<HTMLDivElement> {
   }
 }
 
-const defaultManager = new ModalManager()
-
 // https://github.com/udacity/ud891/blob/gh-pages/lesson2-focus/07-modals-and-keyboard-traps/solution/modal.js#L25
 // found in https://developers.google.com/web/fundamentals/accessibility/focus/using-tabindex
 const focusableElementsString =
@@ -112,12 +111,6 @@ const isFocusInsideTooltip = () => {
   return false
 }
 
-const generateKey = (() => {
-  let count = 0
-
-  return () => ++count
-})()
-
 // eslint-disable-next-line react/display-name
 export const Modal = forwardRef<HTMLDivElement, Props>(function Modal(
   {
@@ -150,7 +143,7 @@ export const Modal = forwardRef<HTMLDivElement, Props>(function Modal(
     ref,
     useRef<HTMLDivElement>(null)
   )
-  const modalId = useRef(generateKey())
+  const modalId = useRef(generateModalId())
   const { rootRef } = useContext(RootContext)
 
   useEffect(() => {
@@ -161,7 +154,7 @@ export const Modal = forwardRef<HTMLDivElement, Props>(function Modal(
         )
       }
 
-      if (!defaultManager.isTopModal(modalId.current)) {
+      if (!defaultModalManager.isTopModal(modalId.current)) {
         return
       }
 
@@ -195,11 +188,11 @@ export const Modal = forwardRef<HTMLDivElement, Props>(function Modal(
     const currentModalId = modalId.current
 
     if (open) {
-      defaultManager.add(currentModalId)
+      defaultModalManager.add(currentModalId)
     }
 
     return () => {
-      defaultManager.remove(currentModalId)
+      defaultModalManager.remove(currentModalId)
     }
   }, [open])
 

--- a/packages/base/Utils/src/utils/Modal/index.ts
+++ b/packages/base/Utils/src/utils/Modal/index.ts
@@ -1,2 +1,6 @@
-export { ModalManager } from './modal-manager'
+export {
+  ModalManager,
+  defaultModalManager,
+  generateModalId,
+} from './modal-manager'
 export { useModal } from './use-modal'

--- a/packages/base/Utils/src/utils/Modal/modal-manager.ts
+++ b/packages/base/Utils/src/utils/Modal/modal-manager.ts
@@ -24,4 +24,18 @@ export class ModalManager {
       this.modals.length > 0 && this.modals[this.modals.length - 1] === modalId
     )
   }
+
+  /** @internal Test-only helper to reset state between specs. */
+  reset() {
+    this.modals.length = 0
+  }
 }
+
+// Shared across Picasso overlay components (Modal, Drawer) so the topmost
+// overlay's focus mechanism wins and nested overlays don't fight each other.
+// See: https://toptal-core.atlassian.net/browse/ER-49165
+export const defaultModalManager = new ModalManager()
+
+let modalIdCounter = 0
+
+export const generateModalId = () => ++modalIdCounter

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1269,12 +1269,18 @@ importers:
         specifier: ^18.2.0
         version: 18.2.0
     devDependencies:
+      '@toptal/picasso-modal':
+        specifier: 4.0.0
+        version: link:../Modal
       '@toptal/picasso-provider':
         specifier: 5.0.2
         version: link:../../picasso-provider
       '@toptal/picasso-tailwind-merge':
         specifier: 2.0.4
         version: link:../../picasso-tailwind-merge
+      '@toptal/picasso-test-utils':
+        specifier: 2.0.0
+        version: link:../Test-Utils
 
   packages/base/Dropdown:
     dependencies:


### PR DESCRIPTION
[ER-49165]

### Description

When a `Drawer` is opened from inside an open `Modal` and the `Modal` is later closed, the browser console fills with `RangeError: Maximum call stack size exceeded` or `too much recursion`. `Modal` opts out of MUI's `FocusTrap` and uses its own document-level focus listener; `Drawer` keeps MUI's `FocusTrap` active. With both open, the two focus mechanisms recurse on `.focus()` indefinitely.

This PR lifts `Modal`'s private `ModalManager` singleton into `picasso-utils` (as `defaultModalManager`) and has `Drawer` register with it on open. `Modal`'s focus listener already bails when it isn't the topmost overlay; now that `Drawer` registers above it, the bailout actually fires and the recursion is broken.

### How to test

1. Open the Drawer story Default example in Storybook: https://picasso.toptal.net/?path=/story/components-drawer--drawer#default
2. Click "Edit code" and paste the reproduction snippet from [ER-49165] (a Modal that opens a Drawer).
3. Click `1. Show Modal` → `2. Open Drawer` → `3. Close Modal`.
4. Browser console should stay clean

### Screenshots

| Before                                  | After                                   |
| --------------------------------------- | --------------------------------------- |
| <img width="1894" height="1035" alt="image" src="https://github.com/user-attachments/assets/d7f136fe-ba40-415b-bd0a-81a8bd9edf66" /> | <img width="1916" height="1036" alt="image" src="https://github.com/user-attachments/assets/42a27ee9-f574-4fc2-a338-f9b8efef7c9e" />|

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Double check if `picasso-tailwind-merge` requires major update (check its `README.md`)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests ([visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md) included)

**Breaking change**

- N/A codemod is created and showcased in the changeset
- N/A test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>Alpha packages</summary>
<br />

Manually trigger the [publish.yml](https://github.com/toptal/picasso/actions/workflows/publish.yml) workflow to publish alpha packages. Specify pull request number as a parameter (only digits, e.g. `123`).

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>

[ER-49165]: https://toptal-core.atlassian.net/browse/ER-49165
