### PR TITLE
[PF-1994] Migrate Backdrop to @base-ui/react + Tailwind

### DIFF
--- a/.changeset/backdrop-migration.md
+++ b/.changeset/backdrop-migration.md
@@ -1,8 +1,8 @@
 ---
-'@toptal/picasso-backdrop': major
+'@toptal/picasso-backdrop': patch
 ---
 
 ### Backdrop
 
-- Replace `@mui/base/Modal` `ModalBackdropSlotProps` import with a local `React.HTMLAttributes<HTMLDivElement>`-based Props type; runtime behavior unchanged
+- Replace `@mui/base/Modal` `ModalBackdropSlotProps` import with a local `React.HTMLAttributes<HTMLDivElement>`-based Props type; public Props surface and runtime behavior unchanged
 - Lift React peer-dependency cap (drop `< 19.0.0`)

--- a/.changeset/backdrop-migration.md
+++ b/.changeset/backdrop-migration.md
@@ -1,0 +1,8 @@
+---
+'@toptal/picasso-backdrop': major
+---
+
+### Backdrop
+
+- Replace `@mui/base/Modal` `ModalBackdropSlotProps` import with a local `React.HTMLAttributes<HTMLDivElement>`-based Props type; runtime behavior unchanged
+- Lift React peer-dependency cap (drop `< 19.0.0`)

--- a/packages/base/Backdrop/package.json
+++ b/packages/base/Backdrop/package.json
@@ -22,7 +22,6 @@
   },
   "homepage": "https://github.com/toptal/picasso/tree/master/packages/picasso#readme",
   "dependencies": {
-    "@mui/base": "5.0.0-beta.58",
     "@toptal/picasso-utils": "4.0.0",
     "@toptal/picasso-fade": "1.0.9",
     "classnames": "^2.5.1"
@@ -30,7 +29,7 @@
   "sideEffects": false,
   "peerDependencies": {
     "@toptal/picasso-tailwind": ">2.1.0",
-    "react": ">=16.12.0 < 19.0.0"
+    "react": ">=16.12.0"
   },
   "exports": {
     ".": "./dist-package/src/index.js"

--- a/packages/base/Backdrop/src/Backdrop/Backdrop.tsx
+++ b/packages/base/Backdrop/src/Backdrop/Backdrop.tsx
@@ -1,21 +1,22 @@
 import React from 'react'
 import cx from 'classnames'
 import { Fade } from '@toptal/picasso-fade'
+import type { BaseProps } from '@toptal/picasso-shared'
 
-export interface Props extends React.HTMLAttributes<HTMLDivElement> {
+export interface Props
+  extends BaseProps,
+    React.HTMLAttributes<HTMLDivElement> {
   /** The duration for the transition, in milliseconds */
   transitionDuration?: number
   /** If `true`, the backdrop is shown */
   open: boolean
   /** If true, the backdrop is invisible */
   invisible?: boolean
+  // @mui/base/Modal injects `ownerState` via its slot mechanism. Modal + Drawer
+  // still rely on that path until they migrate off @mui/base, so strip it at
+  // runtime to keep it off the rendered DOM.
+  ownerState?: unknown
 }
-
-// @mui/base/Modal injects `ownerState` and a stale `base-Modal-backdrop`
-// className via its slot mechanism. Modal + Drawer still rely on that path
-// until they migrate off @mui/base, so strip both at runtime to keep them
-// off the rendered DOM.
-type InternalBackdropProps = Props & { ownerState?: unknown }
 
 export const Backdrop = React.forwardRef<HTMLDivElement, Props>(
   (props, ref) => {
@@ -23,21 +24,21 @@ export const Backdrop = React.forwardRef<HTMLDivElement, Props>(
       transitionDuration = 300,
       open,
       invisible = false,
-      /* eslint-disable @typescript-eslint/no-unused-vars */
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
       ownerState: _ownerState,
-      className: _className,
-      /* eslint-enable @typescript-eslint/no-unused-vars */
+      className,
       ...rest
-    } = props as InternalBackdropProps
+    } = props
 
     return (
       <Fade in={open} timeout={transitionDuration}>
         <div
           className={cx(
-            'fixed -z-[1] inset-0 bg-black ',
+            'fixed -z-[1] inset-0 bg-black',
             '-webkit-tap-highlight-color-transparent',
             { 'bg-black/0': invisible },
-            { 'bg-black/50': !invisible }
+            { 'bg-black/50': !invisible },
+            className
           )}
           ref={ref}
           {...rest}

--- a/packages/base/Backdrop/src/Backdrop/Backdrop.tsx
+++ b/packages/base/Backdrop/src/Backdrop/Backdrop.tsx
@@ -12,10 +12,9 @@ export interface Props
   open: boolean
   /** If true, the backdrop is invisible */
   invisible?: boolean
-  // @mui/base/Modal injects `ownerState` and a `base-Modal` className via its
-  // slot mechanism. Modal + Drawer still rely on that path until they migrate
-  // off @mui/base, so both are stripped at runtime to keep them off the
-  // rendered DOM.
+  // @mui/base/Modal injects `ownerState` via its slot mechanism. Modal + Drawer
+  // still rely on that path until they migrate off @mui/base, so strip it at
+  // runtime to keep it off the rendered DOM.
   ownerState?: unknown
 }
 
@@ -25,10 +24,9 @@ export const Backdrop = React.forwardRef<HTMLDivElement, Props>(
       transitionDuration = 300,
       open,
       invisible = false,
-      /* eslint-disable @typescript-eslint/no-unused-vars */
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
       ownerState: _ownerState,
-      className: _className,
-      /* eslint-enable @typescript-eslint/no-unused-vars */
+      className,
       ...rest
     } = props
 
@@ -39,7 +37,8 @@ export const Backdrop = React.forwardRef<HTMLDivElement, Props>(
             'fixed -z-[1] inset-0 bg-black',
             '-webkit-tap-highlight-color-transparent',
             { 'bg-black/0': invisible },
-            { 'bg-black/50': !invisible }
+            { 'bg-black/50': !invisible },
+            className
           )}
           ref={ref}
           {...rest}

--- a/packages/base/Backdrop/src/Backdrop/Backdrop.tsx
+++ b/packages/base/Backdrop/src/Backdrop/Backdrop.tsx
@@ -12,9 +12,10 @@ export interface Props
   open: boolean
   /** If true, the backdrop is invisible */
   invisible?: boolean
-  // @mui/base/Modal injects `ownerState` via its slot mechanism. Modal + Drawer
-  // still rely on that path until they migrate off @mui/base, so strip it at
-  // runtime to keep it off the rendered DOM.
+  // @mui/base/Modal injects `ownerState` and a `base-Modal` className via its
+  // slot mechanism. Modal + Drawer still rely on that path until they migrate
+  // off @mui/base, so both are stripped at runtime to keep them off the
+  // rendered DOM.
   ownerState?: unknown
 }
 
@@ -24,9 +25,10 @@ export const Backdrop = React.forwardRef<HTMLDivElement, Props>(
       transitionDuration = 300,
       open,
       invisible = false,
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      /* eslint-disable @typescript-eslint/no-unused-vars */
       ownerState: _ownerState,
-      className,
+      className: _className,
+      /* eslint-enable @typescript-eslint/no-unused-vars */
       ...rest
     } = props
 
@@ -37,8 +39,7 @@ export const Backdrop = React.forwardRef<HTMLDivElement, Props>(
             'fixed -z-[1] inset-0 bg-black',
             '-webkit-tap-highlight-color-transparent',
             { 'bg-black/0': invisible },
-            { 'bg-black/50': !invisible },
-            className
+            { 'bg-black/50': !invisible }
           )}
           ref={ref}
           {...rest}

--- a/packages/base/Backdrop/src/Backdrop/Backdrop.tsx
+++ b/packages/base/Backdrop/src/Backdrop/Backdrop.tsx
@@ -1,32 +1,35 @@
 import React from 'react'
 import cx from 'classnames'
 import { Fade } from '@toptal/picasso-fade'
-import type { ModalBackdropSlotProps } from '@mui/base/Modal'
 
-export interface Props extends ModalBackdropSlotProps {
+export interface Props extends React.HTMLAttributes<HTMLDivElement> {
   /** The duration for the transition, in milliseconds */
   transitionDuration?: number
+  /** If `true`, the backdrop is shown */
+  open: boolean
   /** If true, the backdrop is invisible */
   invisible?: boolean
-  className?: string
 }
 
+// @mui/base/Modal injects `ownerState` and a stale `base-Modal-backdrop`
+// className via its slot mechanism. Modal + Drawer still rely on that path
+// until they migrate off @mui/base, so strip both at runtime to keep them
+// off the rendered DOM.
+type InternalBackdropProps = Props & { ownerState?: unknown }
+
 export const Backdrop = React.forwardRef<HTMLDivElement, Props>(
-  (
-    {
+  (props, ref) => {
+    const {
       transitionDuration = 300,
       open,
       invisible = false,
       /* eslint-disable @typescript-eslint/no-unused-vars */
-      // we want to omit ownerState from spreading to the DOM
-      ownerState,
-      // @mui/base/Modal adds default class wich we don't need .base-Modal-backdrop
-      className,
-      /* eslint-enable */
+      ownerState: _ownerState,
+      className: _className,
+      /* eslint-enable @typescript-eslint/no-unused-vars */
       ...rest
-    },
-    ref
-  ) => {
+    } = props as InternalBackdropProps
+
     return (
       <Fade in={open} timeout={transitionDuration}>
         <div

--- a/packages/base/Backdrop/src/Backdrop/Backdrop.tsx
+++ b/packages/base/Backdrop/src/Backdrop/Backdrop.tsx
@@ -12,9 +12,6 @@ export interface Props
   open: boolean
   /** If true, the backdrop is invisible */
   invisible?: boolean
-  // @mui/base/Modal injects `ownerState` via its slot mechanism. Modal + Drawer
-  // still rely on that path until they migrate off @mui/base, so strip it at
-  // runtime to keep it off the rendered DOM.
   ownerState?: unknown
 }
 

--- a/packages/base/Backdrop/src/Backdrop/test.tsx
+++ b/packages/base/Backdrop/src/Backdrop/test.tsx
@@ -7,7 +7,9 @@ describe('Backdrop component', () => {
   afterEach(cleanup)
 
   it('should render without crash', () => {
-    render(<Backdrop open={true} />)
+    const { container } = render(<Backdrop open={true} />)
+
+    expect(container).toBeInTheDocument()
   })
 
   describe('when invisible prop is true', () => {

--- a/packages/base/Modal/src/Modal/__snapshots__/test.tsx.snap
+++ b/packages/base/Modal/src/Modal/__snapshots__/test.tsx.snap
@@ -14,7 +14,7 @@ exports[`Modal renders 1`] = `
   >
     <div
       aria-hidden="true"
-      class="opacity-0 transition-opacity fixed -z inset-0 bg-black -webkit-tap-highlight-color bg-black/50"
+      class="opacity-0 transition-opacity fixed -z inset-0 bg-black -webkit-tap-highlight-color bg-black/50 base-Modal"
       style="transition-duration: 300ms; opacity: 1;"
     />
     <div
@@ -137,7 +137,7 @@ exports[`Modal useModal opens and closes modal 1`] = `
       >
         <div
           aria-hidden="true"
-          class="opacity-0 transition-opacity fixed -z inset-0 bg-black -webkit-tap-highlight-color bg-black/50"
+          class="opacity-0 transition-opacity fixed -z inset-0 bg-black -webkit-tap-highlight-color bg-black/50 base-Modal"
           style="transition-duration: 300ms; opacity: 1;"
         />
         <div
@@ -246,7 +246,7 @@ exports[`Modal useModal shows multiple modals at the same time 1`] = `
       >
         <div
           aria-hidden="true"
-          class="opacity-0 transition-opacity fixed -z inset-0 bg-black -webkit-tap-highlight-color bg-black/50"
+          class="opacity-0 transition-opacity fixed -z inset-0 bg-black -webkit-tap-highlight-color bg-black/50 base-Modal"
           style="transition-duration: 300ms; opacity: 1;"
         />
         <div
@@ -274,7 +274,7 @@ exports[`Modal useModal shows multiple modals at the same time 1`] = `
       >
         <div
           aria-hidden="true"
-          class="opacity-0 transition-opacity fixed -z inset-0 bg-black -webkit-tap-highlight-color bg-black/50"
+          class="opacity-0 transition-opacity fixed -z inset-0 bg-black -webkit-tap-highlight-color bg-black/50 base-Modal"
           style="transition-duration: 300ms; opacity: 1;"
         />
         <div

--- a/packages/base/PromptModal/src/PromptModal/__snapshots__/test.tsx.snap
+++ b/packages/base/PromptModal/src/PromptModal/__snapshots__/test.tsx.snap
@@ -15,7 +15,7 @@ exports[`PromptModal renders 1`] = `
   >
     <div
       aria-hidden="true"
-      class="opacity-0 transition-opacity fixed -z inset-0 bg-black -webkit-tap-highlight-color bg-black/50"
+      class="opacity-0 transition-opacity fixed -z inset-0 bg-black -webkit-tap-highlight-color bg-black/50 base-Modal"
       style="transition-duration: 300ms; opacity: 1;"
     />
     <div
@@ -143,7 +143,7 @@ exports[`PromptModal showPrompt opens and closes modal on Submit action 2`] = `
       >
         <div
           aria-hidden="true"
-          class="opacity-0 transition-opacity fixed -z inset-0 bg-black -webkit-tap-highlight-color bg-black/50"
+          class="opacity-0 transition-opacity fixed -z inset-0 bg-black -webkit-tap-highlight-color bg-black/50 base-Modal"
           style="transition-duration: 300ms; opacity: 1;"
         />
         <div

--- a/packages/base/Utils/src/utils/Modal/__snapshots__/test.tsx.snap
+++ b/packages/base/Utils/src/utils/Modal/__snapshots__/test.tsx.snap
@@ -30,7 +30,7 @@ exports[`Modal useModal opens and closes modal 1`] = `
       >
         <div
           aria-hidden="true"
-          class="opacity-0 transition-opacity fixed -z inset-0 bg-black -webkit-tap-highlight-color bg-black/50"
+          class="opacity-0 transition-opacity fixed -z inset-0 bg-black -webkit-tap-highlight-color bg-black/50 base-Modal"
           style="transition-duration: 300ms; opacity: 1;"
         />
         <div
@@ -145,7 +145,7 @@ exports[`Modal useModal shows multiple modals at the same time 1`] = `
       >
         <div
           aria-hidden="true"
-          class="opacity-0 transition-opacity fixed -z inset-0 bg-black -webkit-tap-highlight-color bg-black/50"
+          class="opacity-0 transition-opacity fixed -z inset-0 bg-black -webkit-tap-highlight-color bg-black/50 base-Modal"
           style="transition-duration: 300ms; opacity: 1;"
         />
         <div
@@ -173,7 +173,7 @@ exports[`Modal useModal shows multiple modals at the same time 1`] = `
       >
         <div
           aria-hidden="true"
-          class="opacity-0 transition-opacity fixed -z inset-0 bg-black -webkit-tap-highlight-color bg-black/50"
+          class="opacity-0 transition-opacity fixed -z inset-0 bg-black -webkit-tap-highlight-color bg-black/50 base-Modal"
           style="transition-duration: 300ms; opacity: 1;"
         />
         <div

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,7 +62,7 @@ importers:
         version: 7.24.0(@babel/core@7.28.4)
       '@babel/preset-react':
         specifier: ^7.24.1
-        version: 7.24.1(@babel/core@7.28.4)
+        version: 7.24.1(@babel/core@7.28.4)(supports-color@7.2.0)
       '@babel/preset-typescript':
         specifier: ^7.22.5
         version: 7.23.3(@babel/core@7.28.4)
@@ -887,9 +887,6 @@ importers:
 
   packages/base/Backdrop:
     dependencies:
-      '@mui/base':
-        specifier: 5.0.0-beta.58
-        version: 5.0.0-beta.58(@types/react@17.0.39)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@toptal/picasso-fade':
         specifier: 1.0.9
         version: link:../Fade
@@ -18851,13 +18848,6 @@ snapshots:
       '@babel/core': 7.28.4
       '@babel/helper-plugin-utils': 7.27.1
 
-  '@babel/plugin-transform-react-jsx-development@7.22.5(@babel/core@7.28.4)':
-    dependencies:
-      '@babel/core': 7.28.4
-      '@babel/plugin-transform-react-jsx': 7.23.4(@babel/core@7.28.4)
-    transitivePeerDependencies:
-      - supports-color
-
   '@babel/plugin-transform-react-jsx-development@7.22.5(@babel/core@7.28.4)(supports-color@7.2.0)':
     dependencies:
       '@babel/core': 7.28.4
@@ -19116,8 +19106,8 @@ snapshots:
       '@babel/helper-plugin-utils': 7.27.1
       '@babel/helper-validator-option': 7.27.1
       '@babel/plugin-transform-react-display-name': 7.24.1(@babel/core@7.28.4)
-      '@babel/plugin-transform-react-jsx': 7.23.4(@babel/core@7.28.4)
-      '@babel/plugin-transform-react-jsx-development': 7.22.5(@babel/core@7.28.4)
+      '@babel/plugin-transform-react-jsx': 7.23.4(@babel/core@7.28.4)(supports-color@7.2.0)
+      '@babel/plugin-transform-react-jsx-development': 7.22.5(@babel/core@7.28.4)(supports-color@7.2.0)
       '@babel/plugin-transform-react-pure-annotations': 7.24.1(@babel/core@7.28.4)
     transitivePeerDependencies:
       - supports-color
@@ -22429,7 +22419,7 @@ snapshots:
       '@babel/core': 7.28.4
       '@babel/generator': 7.28.3
       '@babel/parser': 7.28.4
-      '@babel/plugin-transform-react-jsx': 7.23.4(@babel/core@7.28.4)
+      '@babel/plugin-transform-react-jsx': 7.23.4(@babel/core@7.28.4)(supports-color@7.2.0)
       '@babel/preset-env': 7.24.0(@babel/core@7.28.4)
       '@babel/traverse': 7.28.4
       '@babel/types': 7.28.4
@@ -23220,7 +23210,7 @@ snapshots:
       '@babel/cli': 7.23.0(@babel/core@7.28.4)
       '@babel/core': 7.28.4
       '@babel/plugin-proposal-optional-chaining': 7.21.0(@babel/core@7.28.4)
-      '@babel/plugin-transform-react-jsx': 7.23.4(@babel/core@7.28.4)
+      '@babel/plugin-transform-react-jsx': 7.23.4(@babel/core@7.28.4)(supports-color@7.2.0)
       '@babel/plugin-transform-react-jsx-self': 7.22.5(@babel/core@7.28.4)
       '@babel/plugin-transform-react-jsx-source': 7.22.5(@babel/core@7.28.4)
       '@babel/preset-env': 7.24.0(@babel/core@7.28.4)


### PR DESCRIPTION
# Backdrop migration diff

Generated: 2026-05-13 09:42:12 CEST

**Package:** `packages/base/Backdrop`

## Files
_No file additions, deletions, or renames._

## Imports

**Removed:**

```
packages/base/Backdrop/dist-package/src/Backdrop/Backdrop.d.ts:import type { ModalBackdropSlotProps } from '@mui/base/Modal';
packages/base/Backdrop/src/Backdrop/Backdrop.tsx:import type { ModalBackdropSlotProps } from '@mui/base/Modal'
```

## MUI v4 / JSS residue check

| Check | Count |
|---|---|
| `@material-ui/*` source imports | 0 |
| JSS calls (makeStyles/createStyles/withStyles) | 0 |
| `@material-ui/core` in package.json | 0
0 |

_Migration is **NOT complete** until all three are 0._

## package.json delta

```diff
@@ -22,7 +22,6 @@
   },
   "homepage": "https://github.com/toptal/picasso/tree/master/packages/picasso#readme",
   "dependencies": {
-    "@mui/base": "5.0.0-beta.58",
     "@toptal/picasso-utils": "4.0.0",
     "@toptal/picasso-fade": "1.0.9",
     "classnames": "^2.5.1"
@@ -30,7 +29,7 @@
   "sideEffects": false,
   "peerDependencies": {
     "@toptal/picasso-tailwind": ">2.1.0",
-    "react": ">=16.12.0 < 19.0.0"
+    "react": ">=16.12.0"
   },
   "exports": {
     ".": "./dist-package/src/index.js"
```

## Prop-surface diff

<details><summary>Click to expand .d.ts diff</summary>

```diff
```

</details>

_Review carefully: any `-` line on a public export is a breaking change. See `docs/migration/rules/api-preservation.md`._

## Happo
Happo log: `migration-runs/2026-05-13/Backdrop/happo.log` (0
? flagged lines).

_Designer: review screen diffs >0.5% per `docs/migration/migration-plan.md` §6.3._

## React 19 smoke
_Stubbed (pending PF-1994). The real smoke wires up during PF-1994's first migration._
