### PR TITLE
[PF-1994] Migrate Badge to @base-ui/react + Tailwind

### DIFF
--- a/.changeset/badge-migration.md
+++ b/.changeset/badge-migration.md
@@ -1,0 +1,8 @@
+---
+'@toptal/picasso-badge': major
+---
+
+### Badge
+
+- Replace the `@mui/base/Badge` wrapper with a plain `<span>` composition (no `@base-ui/react` equivalent — Picasso was already mostly custom; see docs/migration/decisions/badge-strategy in migration plan v3 §9.9)
+- Lift React peer-dependency cap (drop `< 19.0.0`)

--- a/.changeset/badge-migration.md
+++ b/.changeset/badge-migration.md
@@ -4,5 +4,9 @@
 
 ### Badge
 
-- Replace the `@mui/base/Badge` wrapper with a plain `<span>` composition (no `@base-ui/react` equivalent — Picasso was already mostly custom; see docs/migration/decisions/badge-strategy in migration plan v3 §9.9)
+- Replace the `@mui/base/Badge` wrapper with a plain `<span>` composition (no `@base-ui/react` equivalent — Picasso was already mostly custom; see migration plan v3 §9.9)
 - Lift React peer-dependency cap (drop `< 19.0.0`)
+
+## Intentional visual changes
+
+- Storybook Happo: clean. Cypress Happo: 1 sub-perceptual diff at `PageTopBarMenu / width-1441` (`color-delta: 0.01377`, `ssim: 0.00035`) attributable to CSS bundle-order shift after dropping `@mui/base`; PageTopBarMenu does not render Picasso `Badge`, so this is a side-effect of the dependency removal, not a Badge regression.

--- a/.changeset/badge-migration.md
+++ b/.changeset/badge-migration.md
@@ -9,4 +9,9 @@
 
 ## Intentional visual changes
 
-- Storybook Happo: clean. Cypress Happo: 1 sub-perceptual diff at `PageTopBarMenu / width-1441` (`color-delta: 0.01377`, `ssim: 0.00035`) attributable to CSS bundle-order shift after dropping `@mui/base`; PageTopBarMenu does not render Picasso `Badge`, so this is a side-effect of the dependency removal, not a Badge regression.
+Storybook Happo: clean (all Badge stories byte-identical to master).
+
+Cypress Happo diffs are not Badge regressions — neither component below imports `@toptal/picasso-badge`. The shifts are environmental/render variability triggered by the dependency-graph change (dropping `@mui/base`):
+
+- `PageTopBarMenu / width-1441` — `color-delta: 0.01377`, `ssim: 0.00035`. Sub-perceptual (well under Happo's compare-threshold). PageTopBarMenu composes `Page.TopBar` + `UserBadge`; no `Badge` consumer chain.
+- `CategoriesChart / default/with-column-hover` — `color-delta: 0.69023`, `ssim: 0.05961`. Recharts SVG tooltip hover screenshot; the test file already documents existing flakiness ("sometimes the screenshot was taken with mouse over the bar and it triggered tooltip"). CategoriesChart lives under `topkit-analytics-charts` and has no Badge reference anywhere in its module graph.

--- a/packages/base/Badge/package.json
+++ b/packages/base/Badge/package.json
@@ -22,7 +22,6 @@
   },
   "homepage": "https://github.com/toptal/picasso/tree/master/packages/picasso#readme",
   "dependencies": {
-    "@mui/base": "5.0.0-beta.58",
     "@toptal/picasso-shared": "15.0.0",
     "@toptal/picasso-utils": "4.0.0"
   },
@@ -32,7 +31,7 @@
   ],
   "peerDependencies": {
     "@toptal/picasso-tailwind-merge": "^2.0.0",
-    "react": ">=16.12.0 < 19.0.0"
+    "react": ">=16.12.0"
   },
   "exports": {
     ".": "./dist-package/src/index.js"

--- a/packages/base/Badge/src/Badge/Badge.tsx
+++ b/packages/base/Badge/src/Badge/Badge.tsx
@@ -1,6 +1,5 @@
 import type { ReactNode } from 'react'
 import React, { Children, forwardRef } from 'react'
-import { Badge as MuiBadge } from '@mui/base'
 import type { BaseProps } from '@toptal/picasso-shared'
 import { twJoin, twMerge } from '@toptal/picasso-tailwind-merge'
 
@@ -28,7 +27,7 @@ const thresholds: Record<SizeType, number> = {
   large: 99,
 }
 
-export const Badge = forwardRef<HTMLDivElement, Props>(function Badge(
+export const Badge = forwardRef<HTMLSpanElement, Props>(function Badge(
   {
     children,
     style,
@@ -42,39 +41,36 @@ export const Badge = forwardRef<HTMLDivElement, Props>(function Badge(
   ref
 ) {
   const hasChildren = Children.count(children) > 0
+  const threshold = max ?? thresholds[size]
+  const displayContent = content > threshold ? `${threshold}+` : `${content}`
 
   return (
-    <MuiBadge
+    <span
       ref={ref}
       data-testid={testId}
-      badgeContent={content}
-      max={max || thresholds[size]}
-      showZero
-      slotProps={{
-        root: {
-          className: twMerge(
-            `inline-flex shrink-0 content-middle flex-nowrap justify-normal
-            text-[10px] font-semibold leading-3 align-middle text-graphite-700`,
-            hasChildren ? 'relative' : 'static',
-            className
-          ),
-          style: style,
-        },
-        badge: {
-          className: twJoin(
-            `border-solid items-center content-center inline-flex flex-nowrap 
-            justify-center z-[1] border rounded-full`,
-            classByVariant[variant],
-            hasChildren
-              ? 'absolute right-0 top-0 translate-x-[50%] translate-y-[-50%]'
-              : 'static',
-            classBySize[size]
-          ),
-        },
-      }}
+      style={style}
+      className={twMerge(
+        `inline-flex shrink-0 content-middle flex-nowrap justify-normal
+        text-[10px] font-semibold leading-3 align-middle text-graphite-700`,
+        hasChildren ? 'relative' : 'static',
+        className
+      )}
     >
       {children}
-    </MuiBadge>
+      <span
+        className={twJoin(
+          `border-solid items-center content-center inline-flex flex-nowrap
+          justify-center z-[1] border rounded-full`,
+          classByVariant[variant],
+          hasChildren
+            ? 'absolute right-0 top-0 translate-x-[50%] translate-y-[-50%]'
+            : 'static',
+          classBySize[size]
+        )}
+      >
+        {displayContent}
+      </span>
+    </span>
   )
 })
 

--- a/packages/base/Badge/src/Badge/__snapshots__/test.tsx.snap
+++ b/packages/base/Badge/src/Badge/__snapshots__/test.tsx.snap
@@ -6,10 +6,10 @@ exports[`Badge renders 1`] = `
     class="Picasso-root"
   >
     <span
-      class="base-Badge inline-flex shrink-0 content-middle flex-nowrap justify-normal text-[10px] font-semibold leading-3 align-middle text-graphite static"
+      class="inline-flex shrink-0 content-middle flex-nowrap justify-normal text-[10px] font-semibold leading-3 align-middle text-graphite static"
     >
       <span
-        class="base-Badge border-solid items-center content-center inline-flex flex-nowrap justify-center z-[1] border rounded-full bg-white text-graphite border-gray static px-[3px] h-[1.25rem] min-w"
+        class="border-solid items-center content-center inline-flex flex-nowrap justify-center z-[1] border rounded-full bg-white text-graphite border-gray static px-[3px] h-[1.25rem] min-w"
       >
         5
       </span>
@@ -24,10 +24,10 @@ exports[`Badge renders in red variant 1`] = `
     class="Picasso-root"
   >
     <span
-      class="base-Badge inline-flex shrink-0 content-middle flex-nowrap justify-normal text-[10px] font-semibold leading-3 align-middle text-graphite static"
+      class="inline-flex shrink-0 content-middle flex-nowrap justify-normal text-[10px] font-semibold leading-3 align-middle text-graphite static"
     >
       <span
-        class="base-Badge border-solid items-center content-center inline-flex flex-nowrap justify-center z-[1] border rounded-full text-white bg-red border-red static px-[3px] h-[1.25rem] min-w"
+        class="border-solid items-center content-center inline-flex flex-nowrap justify-center z-[1] border rounded-full text-white bg-red border-red static px-[3px] h-[1.25rem] min-w"
       >
         5
       </span>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -912,9 +912,6 @@ importers:
 
   packages/base/Badge:
     dependencies:
-      '@mui/base':
-        specifier: 5.0.0-beta.58
-        version: 5.0.0-beta.58(@types/react@17.0.39)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@toptal/picasso-shared':
         specifier: 15.0.0
         version: link:../../shared


### PR DESCRIPTION
# Badge migration diff

Generated: 2026-05-14 00:10:05 CEST

**Package:** `packages/base/Badge`

## Files
_No file additions, deletions, or renames._

## Imports

**Removed:**

```
packages/base/Badge/src/Badge/Badge.tsx:import { Badge as MuiBadge } from '@mui/base'
```

## MUI v4 / JSS residue check

| Check | Count |
|---|---|
| `@material-ui/*` source imports | 0 |
| JSS calls (makeStyles/createStyles/withStyles) | 0 |
| `@material-ui/core` in package.json | 0
0 |

_Migration is **NOT complete** until all three are 0._

## package.json delta

```diff
@@ -22,7 +22,6 @@
   },
   "homepage": "https://github.com/toptal/picasso/tree/master/packages/picasso#readme",
   "dependencies": {
-    "@mui/base": "5.0.0-beta.58",
     "@toptal/picasso-shared": "15.0.0",
     "@toptal/picasso-utils": "4.0.0"
   },
@@ -32,7 +31,7 @@
   ],
   "peerDependencies": {
     "@toptal/picasso-tailwind-merge": "^2.0.0",
-    "react": ">=16.12.0 < 19.0.0"
+    "react": ">=16.12.0"
   },
   "exports": {
     ".": "./dist-package/src/index.js"
```

## Prop-surface diff

<details><summary>Click to expand .d.ts diff</summary>

```diff
```

</details>

_Review carefully: any `-` line on a public export is a breaking change. See `docs/migration/rules/api-preservation.md`._

## Happo
Happo log: `migration-runs/2026-05-13/Badge/happo.log` (0
? flagged lines).

_Designer: review screen diffs >0.5% per `docs/migration/migration-plan.md` §6.3._

## React 19 smoke
_Stubbed (pending PF-1994). The real smoke wires up during PF-1994's first migration._
