### PR TITLE
Add JSDoc for Button `as` prop

### DIFF
--- a/.changeset/button-as-prop-jsdoc.md
+++ b/.changeset/button-as-prop-jsdoc.md
@@ -1,0 +1,6 @@
+---
+'@toptal/picasso-button': patch
+'@toptal/picasso': patch
+---
+
+- add JSDoc description for the `Button` `as` prop so it surfaces in generated docs and IDE tooltips alongside the other props

--- a/packages/base/Button/src/Button/Button.tsx
+++ b/packages/base/Button/src/Button/Button.tsx
@@ -40,6 +40,7 @@ export interface Props
     ButtonOrAnchorProps {
   /** Show button in the active state (left mouse button down) */
   active?: boolean
+  /** The component used for the root node. Either a string to use a HTML element or a component */
   as?: ElementType
   /** Disables button */
   disabled?: boolean


### PR DESCRIPTION
## Summary
A test change to try if alpha packages built correctly.
