### PR TITLE
[TEMP] Pre-pnpm baseline for nx cycle reproduction (do not merge)

### DIFF
--- a/.changeset/test-pre-pnpm-cycle-check.md
+++ b/.changeset/test-pre-pnpm-cycle-check.md
@@ -1,0 +1,5 @@
+---
+'@toptal/picasso-provider': patch
+---
+
+[TEST] temporary changeset to dispatch alpha publish on pre-pnpm baseline for nx cycle reproduction. will be reverted.

--- a/.changeset/test-pre-pnpm-cycle-check.md
+++ b/.changeset/test-pre-pnpm-cycle-check.md
@@ -1,5 +1,5 @@
 ---
-'@toptal/picasso-provider': patch
+'@toptal/picasso-provider': major
 ---
 
 [TEST] temporary changeset to dispatch alpha publish on pre-pnpm baseline for nx cycle reproduction. will be reverted.

--- a/packages/picasso-provider/package.json
+++ b/packages/picasso-provider/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "@material-ui/core": "4.12.4",
     "@material-ui/utils": "4.11.3",
-    "classnames": "^2.5.1",
+    "classnames": "~2.5.1",
     "lodash": "^4.17.21",
     "notistack": "3.0.1",
     "react-helmet-async": "2.0.3"

--- a/packages/picasso-provider/package.json
+++ b/packages/picasso-provider/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@toptal/picasso-provider",
   "version": "5.0.2",
-  "description": "Picasso provider",
+  "description": "Picasso provider (temp test edit)",
   "author": "Toptal",
   "license": "MIT",
   "main": "dist-package/src/index.js",

--- a/packages/picasso-provider/package.json
+++ b/packages/picasso-provider/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@toptal/picasso-provider",
   "version": "5.0.2",
-  "description": "Picasso provider (temp test edit)",
+  "description": "Picasso provider",
   "author": "Toptal",
   "license": "MIT",
   "main": "dist-package/src/index.js",
@@ -25,7 +25,7 @@
   },
   "peerDependencies": {
     "react": ">=16.12.0 < 19.0.0",
-    "typescript": "~4.7.0"
+    "typescript": "^5.5.0"
   },
   "dependencies": {
     "@material-ui/core": "4.12.4",

--- a/packages/picasso-provider/package.json
+++ b/packages/picasso-provider/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "@material-ui/core": "4.12.4",
     "@material-ui/utils": "4.11.3",
-    "classnames": "~2.5.1",
+    "classnames": "^2.5.1",
     "lodash": "^4.17.21",
     "notistack": "3.0.1",
     "react-helmet-async": "2.0.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9220,7 +9220,7 @@ cjs-module-lexer@^1.0.0:
   resolved "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.2.tgz"
   integrity sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA==
 
-classnames@*, classnames@^2.5.1:
+classnames@*, classnames@^2.5.1, classnames@~2.5.1:
   version "2.5.1"
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.5.1.tgz#ba774c614be0f016da105c858e7159eae8e7687b"
   integrity sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==
@@ -16201,14 +16201,14 @@ json-stringify-safe@^5.0.1, json-stringify-safe@~5.0.1:
   resolved "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
   integrity sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==
 
-json5@1, json5@^1.0.1, json5@^1.0.2:
+json5@1, json5@^1.0.1, json5@^1.0.2, json5@^2.1.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/json5/-/json5-1.0.2.tgz#63d98d60f21b313b77c4d6da18bfa69d80e1d593"
   integrity sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==
   dependencies:
     minimist "^1.2.0"
 
-json5@^2.1.1, json5@^2.1.2, json5@^2.2.0, json5@^2.2.2, json5@^2.2.3, json5@^2.x:
+json5@^2.1.2, json5@^2.2.0, json5@^2.2.2, json5@^2.2.3, json5@^2.x:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.3.tgz#78cd6f1a19bdc12b73db5ad0c61efd66c1e29283"
   integrity sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -9220,7 +9220,7 @@ cjs-module-lexer@^1.0.0:
   resolved "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.2.tgz"
   integrity sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA==
 
-classnames@*, classnames@^2.5.1, classnames@~2.5.1:
+classnames@*, classnames@^2.5.1:
   version "2.5.1"
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.5.1.tgz#ba774c614be0f016da105c858e7159eae8e7687b"
   integrity sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==
@@ -16201,14 +16201,14 @@ json-stringify-safe@^5.0.1, json-stringify-safe@~5.0.1:
   resolved "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
   integrity sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==
 
-json5@1, json5@^1.0.1, json5@^1.0.2, json5@^2.1.1:
+json5@1, json5@^1.0.1, json5@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/json5/-/json5-1.0.2.tgz#63d98d60f21b313b77c4d6da18bfa69d80e1d593"
   integrity sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==
   dependencies:
     minimist "^1.2.0"
 
-json5@^2.1.2, json5@^2.2.0, json5@^2.2.2, json5@^2.2.3, json5@^2.x:
+json5@^2.1.1, json5@^2.1.2, json5@^2.2.0, json5@^2.2.2, json5@^2.2.3, json5@^2.x:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.3.tgz#78cd6f1a19bdc12b73db5ad0c61efd66c1e29283"
   integrity sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -16201,14 +16201,14 @@ json-stringify-safe@^5.0.1, json-stringify-safe@~5.0.1:
   resolved "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
   integrity sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==
 
-json5@1, json5@^1.0.1, json5@^1.0.2:
+json5@1, json5@^1.0.1, json5@^1.0.2, json5@^2.1.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/json5/-/json5-1.0.2.tgz#63d98d60f21b313b77c4d6da18bfa69d80e1d593"
   integrity sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==
   dependencies:
     minimist "^1.2.0"
 
-json5@^2.1.1, json5@^2.1.2, json5@^2.2.0, json5@^2.2.2, json5@^2.2.3, json5@^2.x:
+json5@^2.1.2, json5@^2.2.0, json5@^2.2.2, json5@^2.2.3, json5@^2.x:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.3.tgz#78cd6f1a19bdc12b73db5ad0c61efd66c1e29283"
   integrity sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==


### PR DESCRIPTION
**Temporary test PR — do not merge. Will be closed after the experiment.**

Goal: dispatch alpha publish workflow against the pre-pnpm master state (parent of #4920) to determine whether the nx project-graph circular dependency was reported by nx-release-publish before the pnpm migration removed picasso-provider's \`!@toptal/picasso-test-utils\` implicit-dependencies hint.

Branch base: \`d857c0ce5\` (parent of #4920, "Migrate from Yarn 1 to pnpm 10").

Per Daniel's suggestion in the alpha publishing thread. Self-contained, will not be merged into master.