### PR TITLE
Add Hero component

### DIFF
--- a/packages/base/Hero/package.json
+++ b/packages/base/Hero/package.json
@@ -1,0 +1,49 @@
+{
+  "name": "@toptal/picasso-hero",
+  "version": "0.1.0",
+  "description": "Toptal UI components library - Hero",
+  "publishConfig": {
+    "access": "public"
+  },
+  "main": "./dist-package/src/index.js",
+  "module": "./dist-package/src/index.js",
+  "scripts": {
+    "build:package": "tsc -b tsconfig.json",
+    "prepublishOnly": "pnpm build:package"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/toptal/picasso.git"
+  },
+  "author": "Toptal",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/toptal/picasso/issues"
+  },
+  "homepage": "https://github.com/toptal/picasso/tree/master/packages/picasso#readme",
+  "dependencies": {
+    "@toptal/picasso-tailwind-merge": "2.0.4",
+    "classnames": "^2.5.1"
+  },
+  "sideEffects": [
+    "**/styles.ts",
+    "**/styles.js"
+  ],
+  "peerDependencies": {
+    "@material-ui/core": "4.12.4",
+    "@toptal/picasso-tailwind": ">=2.7",
+    "@toptal/picasso-tailwind-merge": "^2.0.0",
+    "react": ">=16.12.0 < 19.0.0"
+  },
+  "exports": {
+    ".": "./dist-package/src/index.js"
+  },
+  "devDependencies": {
+    "@toptal/picasso-test-utils": "2.0.0"
+  },
+  "files": [
+    "dist-package/**",
+    "!dist-package/tsconfig.tsbuildinfo",
+    "src"
+  ]
+}

--- a/packages/base/Hero/src/Hero/Hero.tsx
+++ b/packages/base/Hero/src/Hero/Hero.tsx
@@ -2,22 +2,49 @@ import React, { forwardRef } from 'react'
 import type { BaseProps } from '@toptal/picasso-shared'
 import { twMerge } from '@toptal/picasso-tailwind-merge'
 
+type Variant = 'filled' | 'outlined' | 'subtle'
+type Color = 'blue' | 'green'
+
 export interface Props extends BaseProps {
   children: React.ReactNode
+  variant?: Variant
+  color?: Color
   as?: 'section' | 'header' | 'div'
 }
 
+const baseStyles =
+  'flex flex-col items-start gap-4 px-8 py-16 rounded-lg border border-solid'
+
+const styles: Record<Variant, Record<Color, string>> = {
+  filled: {
+    blue: 'bg-blue-500 border-blue-500 text-white',
+    green: 'bg-green-500 border-green-500 text-white',
+  },
+  outlined: {
+    blue: 'bg-white border-blue-500 text-blue-700',
+    green: 'bg-white border-green-500 text-green-700',
+  },
+  subtle: {
+    blue: 'bg-blue-50 border-blue-100 text-blue-900',
+    green: 'bg-green-50 border-green-100 text-green-900',
+  },
+}
+
 export const Hero = forwardRef<HTMLElement, Props>(function Hero(
-  { children, className, as: Component = 'section', ...rest },
+  {
+    children,
+    className,
+    variant = 'filled',
+    color = 'blue',
+    as: Component = 'section',
+    ...rest
+  },
   ref
 ) {
   return (
     <Component
       ref={ref as React.Ref<HTMLDivElement>}
-      className={twMerge(
-        'flex flex-col items-start gap-4 px-8 py-16 bg-white rounded-lg',
-        className
-      )}
+      className={twMerge(baseStyles, styles[variant][color], className)}
       {...rest}
     >
       {children}

--- a/packages/base/Hero/src/Hero/Hero.tsx
+++ b/packages/base/Hero/src/Hero/Hero.tsx
@@ -1,0 +1,30 @@
+import React, { forwardRef } from 'react'
+import type { BaseProps } from '@toptal/picasso-shared'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
+
+export interface Props extends BaseProps {
+  children: React.ReactNode
+  as?: 'section' | 'header' | 'div'
+}
+
+export const Hero = forwardRef<HTMLElement, Props>(function Hero(
+  { children, className, as: Component = 'section', ...rest },
+  ref
+) {
+  return (
+    <Component
+      ref={ref as React.Ref<HTMLDivElement>}
+      className={twMerge(
+        'flex flex-col items-start gap-4 px-8 py-16 bg-white rounded-lg',
+        className
+      )}
+      {...rest}
+    >
+      {children}
+    </Component>
+  )
+})
+
+Hero.displayName = 'Hero'
+
+export default Hero

--- a/packages/base/Hero/src/Hero/Hero.tsx
+++ b/packages/base/Hero/src/Hero/Hero.tsx
@@ -11,11 +11,16 @@ export interface Props extends BaseProps {
   variant?: Variant
   color?: Color
   orientation?: Orientation
+  isCompact?: boolean
   as?: 'section' | 'header' | 'div'
 }
 
-const baseStyles =
-  'flex items-center gap-8 px-8 py-16 rounded-lg border border-solid'
+const baseStyles = 'flex items-center gap-8 rounded-lg border border-solid'
+
+const sizeStyles = {
+  compact: 'px-4 py-8',
+  regular: 'px-8 py-16',
+}
 
 const orientationStyles: Record<Orientation, string> = {
   'image-right': 'flex-row',
@@ -44,6 +49,7 @@ export const Hero = forwardRef<HTMLElement, Props>(function Hero(
     variant = 'filled',
     color = 'blue',
     orientation = 'image-right',
+    isCompact = false,
     as: Component = 'section',
     ...rest
   },
@@ -54,6 +60,7 @@ export const Hero = forwardRef<HTMLElement, Props>(function Hero(
       ref={ref as React.Ref<HTMLDivElement>}
       className={twMerge(
         baseStyles,
+        isCompact ? sizeStyles.compact : sizeStyles.regular,
         orientationStyles[orientation],
         styles[variant][color],
         className

--- a/packages/base/Hero/src/Hero/Hero.tsx
+++ b/packages/base/Hero/src/Hero/Hero.tsx
@@ -4,16 +4,23 @@ import { twMerge } from '@toptal/picasso-tailwind-merge'
 
 type Variant = 'filled' | 'outlined' | 'subtle'
 type Color = 'blue' | 'green'
+type Orientation = 'image-right' | 'image-left'
 
 export interface Props extends BaseProps {
   children: React.ReactNode
   variant?: Variant
   color?: Color
+  orientation?: Orientation
   as?: 'section' | 'header' | 'div'
 }
 
 const baseStyles =
-  'flex flex-col items-start gap-4 px-8 py-16 rounded-lg border border-solid'
+  'flex items-center gap-8 px-8 py-16 rounded-lg border border-solid'
+
+const orientationStyles: Record<Orientation, string> = {
+  'image-right': 'flex-row',
+  'image-left': 'flex-row-reverse',
+}
 
 const styles: Record<Variant, Record<Color, string>> = {
   filled: {
@@ -36,6 +43,7 @@ export const Hero = forwardRef<HTMLElement, Props>(function Hero(
     className,
     variant = 'filled',
     color = 'blue',
+    orientation = 'image-right',
     as: Component = 'section',
     ...rest
   },
@@ -44,7 +52,12 @@ export const Hero = forwardRef<HTMLElement, Props>(function Hero(
   return (
     <Component
       ref={ref as React.Ref<HTMLDivElement>}
-      className={twMerge(baseStyles, styles[variant][color], className)}
+      className={twMerge(
+        baseStyles,
+        orientationStyles[orientation],
+        styles[variant][color],
+        className
+      )}
       {...rest}
     >
       {children}

--- a/packages/base/Hero/src/Hero/index.ts
+++ b/packages/base/Hero/src/Hero/index.ts
@@ -1,0 +1,6 @@
+import type { OmitInternalProps } from '@toptal/picasso-shared'
+
+import type { Props } from './Hero'
+
+export { default as Hero } from './Hero'
+export type HeroProps = OmitInternalProps<Props>

--- a/packages/base/Hero/src/HeroCompound/index.ts
+++ b/packages/base/Hero/src/HeroCompound/index.ts
@@ -1,0 +1,8 @@
+import { Hero } from '../Hero'
+import { HeroContent } from '../HeroContent'
+import { HeroImage } from '../HeroImage'
+
+export const HeroCompound = Object.assign(Hero, {
+  Content: HeroContent,
+  Image: HeroImage,
+})

--- a/packages/base/Hero/src/HeroContent/HeroContent.tsx
+++ b/packages/base/Hero/src/HeroContent/HeroContent.tsx
@@ -1,0 +1,25 @@
+import React, { forwardRef } from 'react'
+import type { BaseProps } from '@toptal/picasso-shared'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
+
+export interface Props extends BaseProps {
+  children: React.ReactNode
+}
+
+export const HeroContent = forwardRef<HTMLDivElement, Props>(
+  function HeroContent({ children, className, ...rest }, ref) {
+    return (
+      <div
+        ref={ref}
+        className={twMerge('flex flex-col gap-4 flex-1 min-w-0', className)}
+        {...rest}
+      >
+        {children}
+      </div>
+    )
+  }
+)
+
+HeroContent.displayName = 'HeroContent'
+
+export default HeroContent

--- a/packages/base/Hero/src/HeroContent/index.ts
+++ b/packages/base/Hero/src/HeroContent/index.ts
@@ -1,0 +1,6 @@
+import type { OmitInternalProps } from '@toptal/picasso-shared'
+
+import type { Props } from './HeroContent'
+
+export { default as HeroContent } from './HeroContent'
+export type HeroContentProps = OmitInternalProps<Props>

--- a/packages/base/Hero/src/HeroImage/HeroImage.tsx
+++ b/packages/base/Hero/src/HeroImage/HeroImage.tsx
@@ -4,20 +4,23 @@ import { twMerge } from '@toptal/picasso-tailwind-merge'
 
 export interface Props
   extends BaseProps,
-    Omit<React.ImgHTMLAttributes<HTMLImageElement>, 'className' | 'style'> {
+    Omit<
+      React.ImgHTMLAttributes<HTMLImageElement>,
+      'className' | 'style' | 'alt'
+    > {
   src: string
-  alt: string
+  imageAlt: string
 }
 
 export const HeroImage = forwardRef<HTMLImageElement, Props>(function HeroImage(
-  { className, src, alt, ...rest },
+  { className, src, imageAlt, ...rest },
   ref
 ) {
   return (
     <img
       ref={ref}
       src={src}
-      alt={alt}
+      alt={imageAlt}
       className={twMerge(
         'flex-1 min-w-0 max-w-[50%] h-auto object-cover rounded-lg',
         className

--- a/packages/base/Hero/src/HeroImage/HeroImage.tsx
+++ b/packages/base/Hero/src/HeroImage/HeroImage.tsx
@@ -1,0 +1,32 @@
+import React, { forwardRef } from 'react'
+import type { BaseProps } from '@toptal/picasso-shared'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
+
+export interface Props
+  extends BaseProps,
+    Omit<React.ImgHTMLAttributes<HTMLImageElement>, 'className' | 'style'> {
+  src: string
+  alt: string
+}
+
+export const HeroImage = forwardRef<HTMLImageElement, Props>(function HeroImage(
+  { className, src, alt, ...rest },
+  ref
+) {
+  return (
+    <img
+      ref={ref}
+      src={src}
+      alt={alt}
+      className={twMerge(
+        'flex-1 min-w-0 max-w-[50%] h-auto object-cover rounded-lg',
+        className
+      )}
+      {...rest}
+    />
+  )
+})
+
+HeroImage.displayName = 'HeroImage'
+
+export default HeroImage

--- a/packages/base/Hero/src/HeroImage/index.ts
+++ b/packages/base/Hero/src/HeroImage/index.ts
@@ -1,0 +1,6 @@
+import type { OmitInternalProps } from '@toptal/picasso-shared'
+
+import type { Props } from './HeroImage'
+
+export { default as HeroImage } from './HeroImage'
+export type HeroImageProps = OmitInternalProps<Props>

--- a/packages/base/Hero/src/index.ts
+++ b/packages/base/Hero/src/index.ts
@@ -1,0 +1,1 @@
+export * from './Hero'

--- a/packages/base/Hero/src/index.ts
+++ b/packages/base/Hero/src/index.ts
@@ -1,1 +1,4 @@
 export * from './Hero'
+export * from './HeroContent'
+export * from './HeroImage'
+export * from './HeroCompound'

--- a/packages/base/Hero/tsconfig.json
+++ b/packages/base/Hero/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "compilerOptions": { "outDir": "dist-package" },
+  "include": ["src"],
+  "references": [
+    { "path": "../../picasso-tailwind" },
+    { "path": "../../picasso-tailwind-merge" }
+  ]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1646,6 +1646,28 @@ importers:
         specifier: 2.0.0
         version: link:../Test-Utils
 
+  packages/base/Hero:
+    dependencies:
+      '@material-ui/core':
+        specifier: 4.12.4
+        version: 4.12.4(@types/react@17.0.39)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@toptal/picasso-tailwind':
+        specifier: '>=2.7'
+        version: link:../../picasso-tailwind
+      '@toptal/picasso-tailwind-merge':
+        specifier: 2.0.4
+        version: link:../../picasso-tailwind-merge
+      classnames:
+        specifier: ^2.5.1
+        version: 2.5.1
+      react:
+        specifier: ^18.2.0
+        version: 18.2.0
+    devDependencies:
+      '@toptal/picasso-test-utils':
+        specifier: 2.0.0
+        version: link:../Test-Utils
+
   packages/base/Icons:
     dependencies:
       '@toptal/picasso-tailwind':

--- a/tsconfig.pkgsrc.json
+++ b/tsconfig.pkgsrc.json
@@ -46,6 +46,7 @@
     { "path": "packages/base/FormLayout" },
     { "path": "packages/base/Grid" },
     { "path": "packages/base/Helpbox" },
+    { "path": "packages/base/Hero" },
     { "path": "packages/base/Icons" },
     { "path": "packages/base/Image" },
     { "path": "packages/base/Input" },


### PR DESCRIPTION
## Summary
- Adds a new `Hero` component package (`@toptal/picasso-hero`) under `packages/base/Hero`
- Minimal API: accepts `children`, supports `className`/`style`, and an `as` prop (`section` | `header` | `div`)
- Follows existing Picasso component patterns (forwardRef, `BaseProps`, `twMerge`)

## Test plan
- [ ] `pnpm build:package` in `packages/base/Hero`
- [ ] Import `Hero` from `@toptal/picasso-hero` in a consumer and verify render

🤖 Generated with [Claude Code](https://claude.com/claude-code)