### PR TITLE
Regenerate lockfile in Version Packages PR

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "symlink:off": "cross-env ./bin/symlink --unlink",
     "syncpack": "pnpm syncpack:list & pnpm syncpack:fix",
     "syncpack:fix": "syncpack fix-mismatches",
+    "version": "changeset version && pnpm install --lockfile-only",
     "syncpack:list": "syncpack list-mismatches",
     "test": "NODE_OPTIONS='--no-experimental-require-module' pnpm test:unit && pnpm test:integration",
     "test:combine": "pnpm exec istanbul-merge --out coverage/combined/report.json coverage/cypress/coverage-final.json coverage/jest/coverage-final.json && nyc report --temp-dir coverage/combined --report-dir coverage/combined --reporter html",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1595,7 +1595,7 @@ importers:
         specifier: workspace:*
         version: link:../Icons
       '@toptal/picasso-shared':
-        specifier: 15.0.0
+        specifier: 16.0.0
         version: link:../../shared
       '@toptal/picasso-tailwind':
         specifier: '>=2.1.0'
@@ -3080,7 +3080,7 @@ importers:
         specifier: '>=2.7'
         version: link:../../picasso-tailwind
       '@toptal/picasso-tailwind-merge':
-        specifier: 2.0.4
+        specifier: 2.0.5
         version: link:../../picasso-tailwind-merge
       '@toptal/picasso-typography':
         specifier: workspace:*
@@ -3458,7 +3458,7 @@ importers:
         specifier: 4.12.4
         version: 4.12.4(@types/react@17.0.39)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@toptal/picasso-shared':
-        specifier: ^15.0.0
+        specifier: ^16.0.0
         version: link:../shared
       '@toptal/picasso-utils':
         specifier: workspace:*
@@ -3577,7 +3577,7 @@ importers:
         specifier: workspace:*
         version: link:../base/Select
       '@toptal/picasso-shared':
-        specifier: ^15.0.0
+        specifier: ^16.0.0
         version: link:../shared
       '@toptal/picasso-switch':
         specifier: workspace:*
@@ -3647,7 +3647,7 @@ importers:
   packages/picasso-pictograms:
     dependencies:
       '@toptal/picasso-shared':
-        specifier: ^15.0.0
+        specifier: ^16.0.0
         version: link:../shared
       '@toptal/picasso-utils':
         specifier: workspace:*
@@ -3869,7 +3869,7 @@ importers:
         specifier: workspace:*
         version: link:../base/Select
       '@toptal/picasso-shared':
-        specifier: ^15.0.0
+        specifier: ^16.0.0
         version: link:../shared
       '@toptal/picasso-tailwind':
         specifier: '>=2.7'


### PR DESCRIPTION
## Problem

`pnpm install --frozen-lockfile` is **failing on master** (Release + Integration Tests workflows):

```
ERR_PNPM_OUTDATED_LOCKFILE  Cannot install with "frozen-lockfile" because
pnpm-lock.yaml is not up to date with packages/picasso-charts/package.json
  specifiers in the lockfile don't match specifiers in package.json:
  - @toptal/picasso-shared (lockfile: ^15.0.0, manifest: ^16.0.0)
```

### Root cause

The changesets "Version Packages" PR (#4973) bumped `picasso-shared` `15 → 16` (major). `picasso-shared` is a `peerDependency` of most packages as `^15.0.0`; a major pushes it out of that range, so changesets rewrote those peers to `^16.0.0` in the manifests. But plain `changeset version` updates `package.json`s and **never refreshes `pnpm-lock.yaml`**, so the lockfile kept `^15.0.0` and the frozen install fails.

#### Why the lockfile cares about a peer range (and why yarn never did)

This isn't pnpm being vaguely "stricter" — it's a specific, configured behavior. Verified against both lockfiles:

- **yarn v1 never tracked internal packages.** The last yarn-era `yarn.lock` had **0** `@toptal/picasso*` entries (but did lock `react`). Workspace cross-references resolved through the workspace, so an internal range change couldn't desync `yarn.lock`. yarn also didn't auto-install peers.
- **pnpm locks the peer.** In `picasso-charts`, `picasso-shared` is *only* a `peerDependency`, yet the lockfile records it under the importer's `dependencies` with its specifier:
  ```
  packages/picasso-charts:
    dependencies:
      '@toptal/picasso-shared':
        specifier: ^15.0.0
        version: link:../shared
  ```
  A peer resolved as a `link:` dependency is the signature of **`autoInstallPeers: true`** (set in `pnpm-workspace.yaml`), which makes pnpm resolve and lock peers with their specifier string. `--frozen-lockfile` then enforces that recorded specifier against the manifest.

So the failure needs all three: pnpm locking workspace packages + `autoInstallPeers` locking the peer's range + `--frozen-lockfile` enforcing it. The pnpm migration (#4920) introduced all three; PF-2031 is the first release to exercise them.

#### When this recurs

Any release that **majors a package referenced via a caret/tilde peer range** (today: `picasso-shared`, `picasso-tailwind-merge`). Patch/minor releases don't (the range still covers the new version), open-ended peer ranges like `>=2.7`/`*` don't (still satisfied), and the `workspace:*` deps from #4972 don't (wildcard specifier never changes).

## Fix

1. **Add a root `version` script** so the Version Packages PR regenerates the lockfile in the same commit:
   ```json
   "version": "changeset version && pnpm install --lockfile-only"
   ```
   The changesets action runs a `version` script when present; the repo had none, so the lockfile was never refreshed. This closes the gap permanently.
2. **Regenerate the currently-stale lockfile** to match the already-bumped manifests on master (6 specifier lines: `picasso-shared ^15 → ^16`, `picasso-tailwind-merge 2.0.4 → 2.0.5`).

## Verification

- `pnpm install --frozen-lockfile` — **passes** (the exact check failing in CI).
- `pnpm syncpack:list` — 0 mismatches (workspace-protocol setup from #4972 still consistent).
- Diff is `package.json` (one script line) + `pnpm-lock.yaml` (6 specifier lines).
