### PR TITLE
[PF-1994] Migrate Note to @base-ui/react + Tailwind

### DIFF
--- a/.changeset/note-migration.md
+++ b/.changeset/note-migration.md
@@ -1,0 +1,7 @@
+---
+'@toptal/picasso-note': patch
+---
+
+### Note
+
+- Drop `@material-ui/core` from `peerDependencies`; widen React peer range to `>=16.12.0` (drop `<19.0.0` upper bound). Source already MUI-clean; public API unchanged.

--- a/packages/base/Note/package.json
+++ b/packages/base/Note/package.json
@@ -32,10 +32,9 @@
     "**/styles.js"
   ],
   "peerDependencies": {
-    "@material-ui/core": "4.12.4",
     "@toptal/picasso-tailwind": ">=2.7",
     "@toptal/picasso-tailwind-merge": "^2.0.0",
-    "react": ">=16.12.0 < 19.0.0"
+    "react": ">=16.12.0"
   },
   "exports": {
     ".": "./dist-package/src/index.js"

--- a/packages/picasso-tailwind-merge/tsconfig.json
+++ b/packages/picasso-tailwind-merge/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": { "outDir": "dist-package" },
-  "include": ["src"],
-  "references": [{ "path": "../base/Utils" }]
+  "include": ["src"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1987,9 +1987,6 @@ importers:
 
   packages/base/Note:
     dependencies:
-      '@material-ui/core':
-        specifier: 4.12.4
-        version: 4.12.4(@types/react@17.0.39)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@toptal/picasso-container':
         specifier: 3.1.4
         version: link:../Container


### PR DESCRIPTION
## Summary

Tier 1 already-clean migration: Note's source is already MUI-free (zero `@material-ui/*` imports, zero JSS) and the only Note-specific change is a `package.json` peer-dep cleanup. Drops `@material-ui/core` from `peerDependencies` and widens the React peer range to `>=16.12.0` (removes the `<19.0.0` upper bound). Source unchanged.

A second, surgical infra fix in this PR removes a dead TypeScript project reference from `packages/picasso-tailwind-merge/tsconfig.json` to break a pre-existing cycle that blocked the build/jest/happo gates. The fix has direct precedent (Slider migration `eb216fbaf`, 2026-05-24, applied the identical one-liner).

## Decisions

- **No `classes` action.** Per the per-item plan, Note does not expose a public `classes` prop today; the classes-shim decision matrix is N/A — nothing to drop, narrow, or preserve.
- **`patch` bump for `@toptal/picasso-note`.** Library swap is invisible to consumers: `@material-ui/core` was a `peerDependency` only (Note's source did not import it), and widening the React peer cap is non-breaking. Behavioral parity is mechanically guaranteed because the source did not change.
- **Removed dead `{ "path": "../base/Utils" }` reference from `packages/picasso-tailwind-merge/tsconfig.json`.** Source evidence: `packages/picasso-tailwind-merge/src/*` imports only from `tailwind-merge` (external) and `@toptal/picasso-tailwind` — it does not import from `@toptal/picasso-utils`, so the project reference was dead code. The reference formed a 2-node cycle with `packages/base/Utils/tsconfig.json` (which legitimately references picasso-tailwind-merge because `Utils/src/utils/with-classes.ts` imports `twMerge`). Removing the dead direction breaks the cycle in the correct direction. Precedent: commit `eb216fbaf` (Slider migration, 2026-05-24) applied the identical fix and passed the gate. The cycle was originally introduced in `a8a5af9ea` ("Orchestrator fix #6", 2026-05-07).

## Limitations / Out-of-scope

- The tsconfig fix lives outside Note's package boundary. It is included here because the failure surfaced when running Note's gate stages, and the same fix is already validated on the Slider branch. If the operator prefers to land the infra fix as a separate orchestrator commit, the Note-specific `package.json` peer-dep edit stands on its own.
- Transitive consumers Typography and Container are themselves Tier 1 and run in parallel under `--tier=1`. Snapshot drift through `NoteContent` / `NoteSubtitle` (which render `<Typography>`) is possible once Typography lands, but Note's own source is unaffected.

## Verification

- **Source audit**: `grep '@material-ui\|@mui'` over `packages/base/Note/src` → 0 matches; `grep 'makeStyles\|createStyles\|withStyles\|JssProps'` → 0 matches. Confirms Tier 1 already-clean.
- **Lockfile**: plain `pnpm install` (no `--config.link-workspace-packages=false`); diff is 3 lines — well under the 1000-line STOP threshold.
- **Lint** (`pnpm davinci-syntax lint code --check packages/base/Note/src`): PASS, zero findings.
- **Build** (`pnpm --filter @toptal/picasso-note build:package`): PASS after tsconfig cycle fix.
- **Unit tests** (`pnpm -F @toptal/picasso-note exec davinci-qa unit --runInBand`): PASS — 1 test, 1 snapshot (unchanged).
- **Playwright runtime check**: not attempted — source did not change, so baseline-vs-local parity is mechanically guaranteed. Happo gate will run on the orchestrator's next tick.

---

## Mechanical diff evidence

_Auto-generated by `bin/migration-diff.sh report` from pre/post snapshots. The agent's narrative is above; this section is the file-level facts._

# Note migration diff

Generated: 2026-05-25 23:14:49 CEST

**Package:** `packages/base/Note`

## Files
_No file additions, deletions, or renames._

## Imports
_No import changes._

## MUI v4 / JSS residue check

| Check | Count |
|---|---|
| `@material-ui/*` source imports | 0 |
| JSS calls (makeStyles/createStyles/withStyles) | 0 |
| `@material-ui/core` in package.json | 0
0 |

_Migration is **NOT complete** until all three are 0._

## package.json delta
_No package.json changes._

## Prop-surface diff

<details><summary>Click to expand .d.ts diff</summary>

```diff
```

</details>

_Review carefully: any `-` line on a public export is a breaking change. See `docs/migration/rules/api-preservation.md`._

## Happo
Happo log: `migration-runs/2026-05-25/Note/happo.log` (0
? flagged lines).

_Designer: review screen diffs >0.5% per `docs/migration/migration-plan.md` §6.3._

## React 19 smoke
_Stubbed (pending PF-1994). The real smoke wires up during PF-1994's first migration._
