### PR TITLE
[PF-1994] Migrate Form to @base-ui/react + Tailwind

### DIFF
--- a/.changeset/form-migration.md
+++ b/.changeset/form-migration.md
@@ -1,0 +1,7 @@
+---
+'@toptal/picasso-form': patch
+---
+
+### Form
+
+- Drop `@material-ui/core` from `peerDependencies`; widen React peer range to `>=16.12.0` (drop `<19.0.0` upper bound). Source already MUI-clean; public API unchanged.

--- a/packages/base/Form/package.json
+++ b/packages/base/Form/package.json
@@ -41,11 +41,10 @@
     "**/styles.js"
   ],
   "peerDependencies": {
-    "@material-ui/core": "4.12.4",
     "@toptal/picasso-provider": "*",
     "@toptal/picasso-tailwind": ">=2.7",
     "@toptal/picasso-tailwind-merge": "^2.0.0",
-    "react": ">=16.12.0 < 19.0.0"
+    "react": ">=16.12.0"
   },
   "exports": {
     ".": "./dist-package/src/index.js"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1480,9 +1480,6 @@ importers:
 
   packages/base/Form:
     dependencies:
-      '@material-ui/core':
-        specifier: 4.12.4
-        version: 4.12.4(@types/react@17.0.39)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@toptal/picasso-alert':
         specifier: 4.0.0
         version: link:../Alert


### PR DESCRIPTION
## Summary

Tier 1 already-clean migration: Form's source is already MUI-free (zero `@material-ui/*` imports, zero JSS) so the only change is a `package.json` peer-dep cleanup. Drops `@material-ui/core` from `peerDependencies` and widens the React peer range to `>=16.12.0` (removes the `<19.0.0` upper bound). Source unchanged across all 11 subcomponents.

## Decisions

- **No `classes` action.** Per the per-item plan and the cross-tier audit, Form does not currently expose a public `classes` prop in any of its 11 subcomponents (Form, FormField, FormError, FormHint, FormWarning, FormLevelError, FormLevelWarning, FormCompound, FormAutoSaveIndicator, FormActionsContainer, FieldRequirements). The classes-shim decision matrix is N/A — nothing to drop, narrow, or preserve.
- **`patch` bump for `@toptal/picasso-form`.** Library swap is invisible to consumers: `@material-ui/core` was a `peerDependency` only (Form's source did not import it), and widening the React peer cap is non-breaking per `references/code-standards.md` §"Changeset conventions". Behavioral parity is mechanically guaranteed because source did not change.
- **Inline `style={{ ...style, ...labelWidthStyles }}` retained** in `FormActionsContainer.tsx` and `FormField.tsx`. These are dynamic computed styles driven by the `labelWidth` form-layout context (responsive grid-column-width); they cannot be expressed as static Tailwind classes. Pre-existing pattern, out of scope for a library-swap migration.

## Limitations / Out-of-scope

- The `@typescript-eslint/no-non-null-assertion` warning at `FormField/styles.ts:36` is pre-existing and unrelated to the migration; preserved per the existing-violations carve-out (`references/design-patterns-addendum.md` §1).
- Sibling-package transitive snapshot drift: FormError / FormHint / FormWarning render `<Typography>` and FormLabel passes through `<FormLabel>`. Both are Tier 1 and migrate in parallel under `--tier=1`; Form's own source is unaffected.
- Cypress component spec `cypress/component/Form.spec.tsx` imports from `@toptal/picasso-forms` (the picasso-forms wrapper package), not from `@toptal/picasso-form` directly — out of scope for this PR.

## Verification

- **Source audit**: `grep '@material-ui\|@mui'` over `packages/base/Form/src` → 0 matches; `grep 'makeStyles\|createStyles\|withStyles\|JssProps'` → 0 matches. Confirms Tier 1 already-clean.
- **Lockfile**: plain `pnpm install` (no `--config.link-workspace-packages=false`); diff is 3 lines — well under the 1000-line STOP threshold.
- **Lint** (`pnpm davinci-syntax lint code --check packages/base/Form/src`): PASS, 0 errors, 1 pre-existing warning (unchanged).
- **Build** (`pnpm -F @toptal/picasso-form build:package`): PASS.
- **Unit tests** (`pnpm -F @toptal/picasso-form exec davinci-qa unit --runInBand`): PASS — 7 suites, 12 tests, 10 snapshots (unchanged).
- **Playwright runtime check**: not attempted — source did not change, so baseline-vs-local parity is mechanically guaranteed. Happo gate will run on the orchestrator's next tick.

---

## Mechanical diff evidence

_Auto-generated by `bin/migration-diff.sh report` from pre/post snapshots. The agent's narrative is above; this section is the file-level facts._

# Form migration diff

Generated: 2026-05-27 00:09:17 CEST

**Package:** `packages/base/Form`

## Files
_No file additions, deletions, or renames._

## Imports
_No import changes._

## MUI v4 / JSS residue check

| Check | Count |
|---|---|
| `@material-ui/*` source imports | 0 |
| JSS calls (makeStyles/createStyles/withStyles) | 0 |
| `@material-ui/core` in package.json | 0
0 |

_Migration is **NOT complete** until all three are 0._

## package.json delta

```diff
@@ -41,11 +41,10 @@
     "**/styles.js"
   ],
   "peerDependencies": {
-    "@material-ui/core": "4.12.4",
     "@toptal/picasso-provider": "*",
     "@toptal/picasso-tailwind": ">=2.7",
     "@toptal/picasso-tailwind-merge": "^2.0.0",
-    "react": ">=16.12.0 < 19.0.0"
+    "react": ">=16.12.0"
   },
   "exports": {
     ".": "./dist-package/src/index.js"
```

## Prop-surface diff

<details><summary>Click to expand .d.ts diff</summary>

```diff
```

</details>

_Review carefully: any `-` line on a public export is a breaking change. See `docs/migration/rules/api-preservation.md`._

## Happo
Happo log: `migration-runs/2026-05-26/Form/happo.log` (0
? flagged lines).

_Designer: review screen diffs >0.5% per `docs/migration/migration-plan.md` §6.3._

## React 19 smoke
_Stubbed (pending PF-1994). The real smoke wires up during PF-1994's first migration._
