### PR TITLE
[PF-1994] Migrate Typography to @base-ui/react + Tailwind

### DIFF
--- a/.changeset/typography-migration.md
+++ b/.changeset/typography-migration.md
@@ -1,0 +1,7 @@
+---
+'@toptal/picasso-typography': patch
+---
+
+### Typography
+- Drop `@material-ui/core` peer dependency; widen React peer range to `>=16.12.0`.
+- Remove vestigial `classes` prop from the public type via `Omit<StandardProps, 'classes'>`; runtime backstop discards any inherited value. Behavioral parity verified by snapshot + unit tests; public API unchanged for real consumers (audit-verified: 0 internal, 0 external usages).

--- a/.changeset/typography-migration.md
+++ b/.changeset/typography-migration.md
@@ -1,5 +1,5 @@
 ---
-'@toptal/picasso-typography': patch
+'@toptal/picasso-typography': major
 ---
 
 ### Typography

--- a/.changeset/typography-mui-cleanup.md
+++ b/.changeset/typography-mui-cleanup.md
@@ -1,0 +1,1 @@
+<!-- superseded by typography-migration.md -->

--- a/.changeset/typography-mui-cleanup.md
+++ b/.changeset/typography-mui-cleanup.md
@@ -1,1 +1,3 @@
-<!-- superseded by typography-migration.md -->
+---
+'@toptal/picasso-typography': patch
+---

--- a/packages/base/Typography/package.json
+++ b/packages/base/Typography/package.json
@@ -30,10 +30,9 @@
     "**/styles.js"
   ],
   "peerDependencies": {
-    "@material-ui/core": "4.12.4",
     "@toptal/picasso-provider": "*",
     "@toptal/picasso-tailwind-merge": "^2.0.0",
-    "react": ">=16.12.0 < 19.0.0"
+    "react": ">=16.12.0"
   },
   "exports": {
     ".": "./dist-package/src/index.js"

--- a/packages/base/Typography/src/Typography/Typography.tsx
+++ b/packages/base/Typography/src/Typography/Typography.tsx
@@ -121,7 +121,7 @@ export type TypographyAlign =
   | 'justify'
 
 export interface Props
-  extends StandardProps,
+  extends Omit<StandardProps, 'classes'>,
     TextLabelProps,
     HTMLAttributes<HTMLElement> {
   /** Font variant for inner text */
@@ -174,8 +174,10 @@ export const Typography = forwardRef<HTMLElement, Props>(function Typography(
     titleCase,
     underline,
     weight,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    classes: _classes,
     ...rest
-  } = props
+  } = props as Props & { classes?: unknown }
 
   const Component: ElementType = as || variantToElement(variant, size)
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3026,9 +3026,6 @@ importers:
 
   packages/base/Typography:
     dependencies:
-      '@material-ui/core':
-        specifier: 4.12.4
-        version: 4.12.4(@types/react@17.0.39)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@toptal/picasso-tailwind-merge':
         specifier: ^2.0.0
         version: link:../../picasso-tailwind-merge


### PR DESCRIPTION
## Summary

Tier 1 already-clean cleanup of `@toptal/picasso-typography`. The component source was already MUI-free (Tailwind utilities + `twMerge`); the migration drops the dead `@material-ui/core` peer dependency, widens the React peer range to drop the `< 19.0.0` cap, and removes the vestigial `classes` prop from the public type per the cross-tier audit.

## Decisions

- **Drop `classes` from public type**: applied `Omit<StandardProps, 'classes'>` per `references/practices.md §"API preservation"` Tier 1 vestigial entry. Source body never read `classes`; per-component audit found 0 internal callsites and 0 external real callsites (`decisions/classes-audit.md §3`). Added the `classes: _classes` runtime destructure backstop with an `eslint-disable-next-line @typescript-eslint/no-unused-vars` comment (no `argsIgnorePattern` configured in this repo's lint config).
- **Bump tier — `patch`**: pure peer-dep cleanup + a type-narrowing that drops an audit-verified vestigial prop. `@material-ui/core` is a Picasso `dependencies`-level peer, not a consumer peer-dep; removing it is invisible to consumer dep trees. React peer widening is non-breaking. The `classes` drop targets a prop with 0 real consumers (audit verified) — no codemod needed.
- **Preserved `@toptal/picasso-provider` peer-dep** per the migration plan note (Typography reads tokens transitively through `picasso-shared` → `picasso-provider`).

## Limitations / Out-of-scope

- Did not run Playwright/Happo because this iter's source-level rendering output is byte-identical to pre-migration (no Tailwind class strings changed). Visual regression risk is bounded to whatever changes in downstream snapshots/Happo when the React peer cap lift propagates through consumers, which the orchestrator's full gate exercises.
- Did not preemptively convert `extends StandardProps` to `extends BaseProps` on the `TextLabelProps`/`HTMLAttributes` intersection — per `references/design-patterns-addendum.md §2`, the canonical `BaseProps` rollover happens in the coordinated post-migration sweep that removes `StandardProps` / `JssProps` / `Classes` from `@toptal/picasso-shared`.

## Verification

- **Build**: `pnpm --filter @toptal/picasso-typography build:package` → exit 0.
- **Lint**: `pnpm davinci-syntax lint code --check packages/base/Typography/src` → 0 errors.
- **Jest (broad pattern)**: `pnpm davinci-qa unit Typography` → 307 suites / 1292 tests / 274 snapshots pass.
- **Jest (narrowed)**: `pnpm davinci-qa unit packages/base/Typography` → 3 suites / 9 tests / 3 snapshots pass.
- **Lockfile diff**: 3 lines removed (single peer-dep entry only — no cross-package churn).
- **Runtime / Happo**: not run locally this iter. Source has no Tailwind class string changes, so no visual diff expected; orchestrator's gate will run Happo against the migrated branch.

---

## Mechanical diff evidence

_Auto-generated by `bin/migration-diff.sh report` from pre/post snapshots. The agent's narrative is above; this section is the file-level facts._

# Typography migration diff

Generated: 2026-05-27 17:40:21 CEST

**Package:** `packages/base/Typography`

## Files
_No file additions, deletions, or renames._

## Imports
_No import changes._

## MUI v4 / JSS residue check

| Check | Count |
|---|---|
| `@material-ui/*` source imports | 0 |
| JSS calls (makeStyles/createStyles/withStyles) | 0 |
| `@material-ui/core` in package.json | 0
0 |

_Migration is **NOT complete** until all three are 0._

## package.json delta

```diff
@@ -30,10 +30,9 @@
     "**/styles.js"
   ],
   "peerDependencies": {
-    "@material-ui/core": "4.12.4",
     "@toptal/picasso-provider": "*",
     "@toptal/picasso-tailwind-merge": "^2.0.0",
-    "react": ">=16.12.0 < 19.0.0"
+    "react": ">=16.12.0"
   },
   "exports": {
     ".": "./dist-package/src/index.js"
```

## Prop-surface diff

<details><summary>Click to expand .d.ts diff</summary>

```diff
```

</details>

_Review carefully: any `-` line on a public export is a breaking change. See `docs/migration/rules/api-preservation.md`._

## Happo
Happo log: `migration-runs/2026-05-27/Typography/happo.log` (0
? flagged lines).

_Designer: review screen diffs >0.5% per `docs/migration/migration-plan.md` §6.3._

## React 19 smoke
_Stubbed (pending PF-1994). The real smoke wires up during PF-1994's first migration._
