### PR TITLE
[PF-2096] Toggle input reset visibility

### DIFF
--- a/.changeset/cruel-ends-sneeze.md
+++ b/.changeset/cruel-ends-sneeze.md
@@ -1,0 +1,6 @@
+---
+'@toptal/picasso-outlined-input': minor
+'@toptal/picasso-input': minor
+---
+
+- add `resetVisibility?: 'hover' | 'always'` prop (default `'hover'`) to control reset-button visibility.

--- a/packages/base/Input/src/Input/Input.tsx
+++ b/packages/base/Input/src/Input/Input.tsx
@@ -78,6 +78,8 @@ export interface Props
   size?: SizeType<'small' | 'medium' | 'large'>
   /** Whether to render reset icon when there is a value in the input */
   enableReset?: boolean
+  /** Controls when the reset button is visible. `hover` shows it only on hover/focus when the input has a value; `always` keeps it visible regardless of hover or content. Only applies when `enableReset` is true. */
+  resetVisibility?: 'hover' | 'always'
   /** Callback invoked when reset button was clicked */
   onResetClick?: (
     event: MouseEvent<HTMLButtonElement & HTMLAnchorElement>
@@ -268,6 +270,7 @@ export const Input = forwardRef<HTMLInputElement, Props>(function Input(
     endAdornment,
     limit,
     enableReset,
+    resetVisibility,
     outlineRef,
     testIds,
     setHasMultilineCounter,
@@ -338,6 +341,7 @@ export const Input = forwardRef<HTMLInputElement, Props>(function Input(
         }
         onChange={onChange}
         enableReset={enableReset}
+        resetVisibility={resetVisibility}
         onResetClick={onResetClick}
         testIds={testIds}
       >

--- a/packages/base/Input/src/Input/story/ResetButtonVisibility.example.tsx
+++ b/packages/base/Input/src/Input/story/ResetButtonVisibility.example.tsx
@@ -1,0 +1,31 @@
+import React, { useState } from 'react'
+import { Input } from '@toptal/picasso'
+
+const ResetButtonVisibilityExample = () => {
+  const [value, setValue] = useState('Text')
+
+  const handleChange = (
+    event: React.ChangeEvent<
+      HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement
+    >
+  ) => {
+    setValue(event.target.value)
+  }
+
+  const handleResetClick = () => {
+    setValue('')
+  }
+
+  return (
+    <Input
+      enableReset
+      resetVisibility='always'
+      onResetClick={handleResetClick}
+      value={value}
+      placeholder='Placeholder'
+      onChange={handleChange}
+    />
+  )
+}
+
+export default ResetButtonVisibilityExample

--- a/packages/base/Input/src/Input/story/index.jsx
+++ b/packages/base/Input/src/Input/story/index.jsx
@@ -65,6 +65,14 @@ page
     'base/Input'
   )
   .addExample(
+    'Input/story/ResetButtonVisibility.example.tsx',
+    {
+      title: 'With reset button always visible',
+      takeScreenshot: false,
+    },
+    'base/Input'
+  )
+  .addExample(
     'Input/story/Refs.example.tsx',
     {
       title: 'Refs',

--- a/packages/base/Input/src/Input/test.tsx
+++ b/packages/base/Input/src/Input/test.tsx
@@ -101,6 +101,49 @@ describe('Input', () => {
     expect(container).toMatchSnapshot()
   })
 
+  describe('reset button visibility', () => {
+    it('defaults to hover visibility (hidden until hover/focus)', () => {
+      const { getByTestId } = renderInput({
+        enableReset: true,
+        value: 'Some value',
+        testIds: { resetButton: testIds.resetButton },
+      })
+
+      const resetAdornment = getByTestId(testIds.resetButton)
+
+      expect(resetAdornment).toHaveClass('invisible')
+      expect(resetAdornment).not.toHaveClass('visible')
+    })
+
+    it('stays visible when resetVisibility is "always", even without a value', () => {
+      const { getByTestId } = renderInput({
+        enableReset: true,
+        resetVisibility: 'always',
+        value: '',
+        testIds: { resetButton: testIds.resetButton },
+      })
+
+      const resetAdornment = getByTestId(testIds.resetButton)
+
+      expect(resetAdornment).toHaveClass('visible')
+      expect(resetAdornment).not.toHaveClass('invisible')
+    })
+
+    it('matches hover behavior when resetVisibility is "hover"', () => {
+      const { getByTestId } = renderInput({
+        enableReset: true,
+        resetVisibility: 'hover',
+        value: 'Some value',
+        testIds: { resetButton: testIds.resetButton },
+      })
+
+      const resetAdornment = getByTestId(testIds.resetButton)
+
+      expect(resetAdornment).toHaveClass('invisible')
+      expect(resetAdornment).toHaveClass('group-hover:visible')
+    })
+  })
+
   it('should show manual resize handler', () => {
     const { container } = renderInput({
       multiline: true,

--- a/packages/base/OutlinedInput/src/OutlinedInput/OutlinedInput.tsx
+++ b/packages/base/OutlinedInput/src/OutlinedInput/OutlinedInput.tsx
@@ -20,22 +20,35 @@ import { getInputClassName } from './stylesInput'
 import { getRows } from './utils'
 import type { Props } from './types'
 
+const getResetButtonClassName = (
+  visibility: 'hover' | 'always',
+  hasValue: boolean
+) => {
+  if (visibility === 'always') {
+    return 'visible'
+  }
+
+  return twJoin(
+    'invisible',
+    hasValue && 'peer-focus:visible peer-active:visible group-hover:visible'
+  )
+}
+
 const ResetButton = ({
   hasValue,
+  visibility = 'hover',
   onClick,
   testIds,
 }: {
   hasValue: boolean
+  visibility?: 'hover' | 'always'
   onClick: (event: MouseEvent<HTMLButtonElement & HTMLAnchorElement>) => void
   testIds?: Props['testIds']
 }) => (
   <InputAdornment
     data-testid={testIds?.resetButton}
     position='end'
-    className={twJoin(
-      'invisible',
-      hasValue && 'peer-focus:visible peer-active:visible group-hover:visible'
-    )}
+    className={getResetButtonClassName(visibility, hasValue)}
   >
     <ButtonCircular
       tabIndex={-1}
@@ -96,6 +109,7 @@ const OutlinedInput = forwardRef<HTMLElement, Props>(function OutlinedInput(
     endAdornment: userDefinedEndAdornment,
     onChange,
     enableReset,
+    resetVisibility,
     disabled,
     inputRef,
     testIds,
@@ -113,6 +127,7 @@ const OutlinedInput = forwardRef<HTMLElement, Props>(function OutlinedInput(
       {shouldShowReset && (
         <ResetButton
           hasValue={Boolean(value)}
+          visibility={resetVisibility}
           onClick={onResetClick}
           testIds={testIds}
         />

--- a/packages/base/OutlinedInput/src/OutlinedInput/types.ts
+++ b/packages/base/OutlinedInput/src/OutlinedInput/types.ts
@@ -68,6 +68,8 @@ export interface Props
   size?: Size
   /** Whether to render reset icon when there is a value in the input */
   enableReset?: boolean
+  /** Controls when the reset button is visible. `hover` shows it only on hover/focus when the input has a value; `always` keeps it visible regardless of hover or content. Only applies when `enableReset` is true. */
+  resetVisibility?: 'hover' | 'always'
   /** Callback invoked when reset button was clicked */
   onResetClick?: (
     event: MouseEvent<HTMLButtonElement & HTMLAnchorElement>


### PR DESCRIPTION
[PF-2096]

### Description

It has been requested to allow for the reset button to be visible even if there is content or it is not hovered, so that users could always see that there is a way to clear the text input. This pull request adds a prop to the input to control the visiblity (`always` or `hover`) of the reset button on the input component.=

### How to test

<!-- The temploy link will be automatically updated when the temploy is deployed -->
- [Temploy](https://picasso.toptal.net/pf-2096-input-persistent-reset)
- FIXME: Add the steps describing how to verify your changes

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| Insert screenshots or screen recordings | Insert screenshots or screen recordings |

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Double check if `picasso-tailwind-merge` requires major update (check its `README.md`)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests ([visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md) included)

**Breaking change**

- [ ] codemod is created and showcased in the changeset
- [ ] test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>Alpha packages</summary>
<br />

Manually trigger the [publish.yml](https://github.com/toptal/picasso/actions/workflows/publish.yml) workflow to publish alpha packages. Specify pull request number as a parameter (only digits, e.g. `123`).

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[PF-2096]: https://toptal-core.atlassian.net/browse/PF-2096?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ