### PR TITLE
[PF-1994] Migrate Grid to @base-ui/react + Tailwind

### DIFF
--- a/.changeset/grid-migration.md
+++ b/.changeset/grid-migration.md
@@ -1,0 +1,8 @@
+---
+'@toptal/picasso-grid': patch
+---
+
+### Grid
+
+- Replace the MUI v4 `GridSize` type re-export with the Picasso-native `GridSize` union; public API unchanged, behavioral parity preserved.
+- Drop `@material-ui/core` peer dependency and widen the React peer range to `>=16.12.0`.

--- a/.changeset/migrate-grid-base-ui.md
+++ b/.changeset/migrate-grid-base-ui.md
@@ -1,0 +1,4 @@
+---
+---
+
+Superseded by grid-migration.md (empty changeset — no release).

--- a/.changeset/migrate-grid-base-ui.md
+++ b/.changeset/migrate-grid-base-ui.md
@@ -1,4 +1,0 @@
----
----
-
-Superseded by grid-migration.md (empty changeset — no release).

--- a/packages/base/Grid/package.json
+++ b/packages/base/Grid/package.json
@@ -32,11 +32,10 @@
   ],
   "peerDependencies": {
     "@toptal/picasso-tailwind-merge": "^2.0.0",
-    "@material-ui/core": "4.12.4",
     "@toptal/picasso-provider": "*",
     "@toptal/picasso-shared": "15.0.0",
     "@toptal/picasso-tailwind": ">=2.1.0",
-    "react": ">=16.12.0 < 19.0.0"
+    "react": ">=16.12.0"
   },
   "exports": {
     ".": "./dist-package/src/index.js"

--- a/packages/base/Grid/src/Grid/index.ts
+++ b/packages/base/Grid/src/Grid/index.ts
@@ -4,4 +4,4 @@ import type { Props } from './Grid'
 
 export { default as Grid } from './Grid'
 export type GridProps = OmitInternalProps<Props>
-export type { GridSize } from '@material-ui/core/Grid'
+export type { GridSize } from '../types'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1594,9 +1594,6 @@ importers:
 
   packages/base/Grid:
     dependencies:
-      '@material-ui/core':
-        specifier: 4.12.4
-        version: 4.12.4(@types/react@17.0.39)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@toptal/picasso-icons':
         specifier: 1.15.2
         version: link:../Icons


### PR DESCRIPTION
## Summary

Migrates `@toptal/picasso-grid` off MUI v4. Grid stays a custom CSS-Grid + Tailwind layout primitive (no `@base-ui/react` Grid analog exists), so this is a Tier 1 type-only fix: the last `@material-ui/core` reference — a `GridSize` type re-export in `src/Grid/index.ts` — is repointed to the already-existing Picasso-native `GridSize` union in `src/types.ts`, and the `@material-ui/core` peer dependency is dropped. No runtime, JSS, or render-output change.

## Decisions

- **`GridSize` source**: re-export the local `src/types.ts` `GridSize` (`true | 'auto' | 1..12`) instead of MUI's (`'auto' | 1..12`). It's already the in-use Picasso-native definition (driving the `size === true` branch in `get-class-names-for-breakpoint.ts`), so this consolidates to a single source of truth. The local union is a non-breaking superset of MUI's — every prior value still type-checks; `boolean` in `GridSizes` (`xs?: boolean | GridSize`) already covered `true`/`false` at the prop level.
- **Peer deps**: removed `@material-ui/core` from `peerDependencies` and widened `react` from `>=16.12.0 < 19.0.0` to `>=16.12.0`, per the standard migration peer-cap lift. No `tsconfig.json` `references` change needed — MUI was an external npm dep, not a workspace ref.
- **Bump = patch**: pure library-reference removal with identical public API (manifest `versionBump: patch`).

## Limitations / Out-of-scope

- Grid is not re-implemented on `@base-ui/react` — there is no Grid primitive there; it remains custom by design (`target_path: none`).
- No `classes`-prop work: Grid never exposed `classes`, so nothing to drop or shim.

## Verification

- **Local gate stages passed**: `build:package` (tsc -b, exit 0), `davinci-syntax lint code --check packages/base/Grid/src` (0 errors; 6 pre-existing warnings in untouched files), full unit suite (308 suites / 1304 tests / 274 snapshots, all pass — no snapshot drift, confirming zero render change).
- **Runtime check (Playwright)**: N/A — a type-only re-export + peer-dep cleanup produces no DOM or render-output change, so there is nothing visually verifiable. No `.tsx` render path was touched.
- **Visual parity (Happo)**: N/A for the same reason; snapshots are byte-identical.

---

## Mechanical diff evidence

_Auto-generated by `bin/migration-diff.sh report` from pre/post snapshots. The agent's narrative is above; this section is the file-level facts._

# Grid migration diff

Generated: 2026-05-30 14:50:43 CEST

**Package:** `packages/base/Grid`

## Files
_No file additions, deletions, or renames._

## Imports

**Removed:**

```
packages/base/Grid/dist-package/src/Grid/index.d.ts:export type { GridSize } from '@material-ui/core/Grid';
packages/base/Grid/src/Grid/index.ts:export type { GridSize } from '@material-ui/core/Grid'
```

**Added:**

```
packages/base/Grid/dist-package/src/Grid/index.d.ts:export type { GridSize } from '../types';
packages/base/Grid/src/Grid/index.ts:export type { GridSize } from '../types'
```

## MUI v4 / JSS residue check

| Check | Count |
|---|---|
| `@material-ui/*` source imports | 0 |
| JSS calls (makeStyles/createStyles/withStyles) | 0 |
| `@material-ui/core` in package.json | 0
0 |

_Migration is **NOT complete** until all three are 0._

## package.json delta

```diff
@@ -32,11 +32,10 @@
   ],
   "peerDependencies": {
     "@toptal/picasso-tailwind-merge": "^2.0.0",
-    "@material-ui/core": "4.12.4",
     "@toptal/picasso-provider": "*",
     "@toptal/picasso-shared": "15.0.0",
     "@toptal/picasso-tailwind": ">=2.1.0",
-    "react": ">=16.12.0 < 19.0.0"
+    "react": ">=16.12.0"
   },
   "exports": {
     ".": "./dist-package/src/index.js"
```

## Prop-surface diff

<details><summary>Click to expand .d.ts diff</summary>

```diff
```

</details>

_Review carefully: any `-` line on a public export is a breaking change. See `docs/migration/rules/api-preservation.md`._

## Happo
Happo log: `migration-runs/2026-05-30/Grid/happo.log` (0
? flagged lines).

_Designer: review screen diffs >0.5% per `docs/migration/migration-plan.md` §6.3._

## React 19 smoke
_Stubbed (pending PF-1994). The real smoke wires up during PF-1994's first migration._
