### PR TITLE
[PF-1994] Migrate ModalContext to @base-ui/react + Tailwind

### DIFF
--- a/.changeset/migrate-modal-context.md
+++ b/.changeset/migrate-modal-context.md
@@ -1,7 +1,0 @@
----
-'@toptal/picasso-modal-context': patch
----
-
-### ModalContext
-
-- Drop the vestigial `@material-ui/core` peer-dependency (source is a React context provider that imports nothing from MUI) and lift the `react` peer cap to `>=16.12.0`. Public API unchanged; behavioral parity.

--- a/.changeset/migrate-modal-context.md
+++ b/.changeset/migrate-modal-context.md
@@ -1,0 +1,7 @@
+---
+'@toptal/picasso-modal-context': patch
+---
+
+### ModalContext
+
+- Drop the vestigial `@material-ui/core` peer-dependency (source is a React context provider that imports nothing from MUI) and lift the `react` peer cap to `>=16.12.0`. Public API unchanged; behavioral parity.

--- a/.changeset/modal-context-migration.md
+++ b/.changeset/modal-context-migration.md
@@ -1,0 +1,7 @@
+---
+'@toptal/picasso-modal-context': patch
+---
+
+### ModalContext
+
+- Drop the vestigial `@material-ui/core` peer-dependency (source is a React context provider that imports nothing from MUI) and lift the `react` peer cap to `>=16.12.0`. Public API unchanged; behavioral parity.

--- a/packages/base/ModalContext/package.json
+++ b/packages/base/ModalContext/package.json
@@ -29,8 +29,7 @@
     "**/styles.js"
   ],
   "peerDependencies": {
-    "@material-ui/core": "4.12.4",
-    "react": ">=16.12.0 < 19.0.0"
+    "react": ">=16.12.0"
   },
   "exports": {
     ".": "./dist-package/src/index.js"

--- a/packages/base/ModalContext/src/test.tsx
+++ b/packages/base/ModalContext/src/test.tsx
@@ -1,0 +1,31 @@
+import React, { useContext } from 'react'
+import { render } from '@toptal/picasso-test-utils'
+import { describe, expect, it } from '@jest/globals'
+
+import ModalContext from './ModalContext'
+
+const testId = 'modal-context-value'
+
+const ModalContextProbe = () => {
+  const insideModal = useContext(ModalContext)
+
+  return <span data-testid={testId}>{String(insideModal)}</span>
+}
+
+describe('ModalContext', () => {
+  it('defaults to false outside of a provider', () => {
+    const { getByTestId } = render(<ModalContextProbe />)
+
+    expect(getByTestId(testId).textContent).toBe('false')
+  })
+
+  it('exposes the value supplied by its provider', () => {
+    const { getByTestId } = render(
+      <ModalContext.Provider value={true}>
+        <ModalContextProbe />
+      </ModalContext.Provider>
+    )
+
+    expect(getByTestId(testId).textContent).toBe('true')
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1962,9 +1962,6 @@ importers:
 
   packages/base/ModalContext:
     dependencies:
-      '@material-ui/core':
-        specifier: 4.12.4
-        version: 4.12.4(@types/react@17.0.39)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       classnames:
         specifier: ^2.5.1
         version: 2.5.1


### PR DESCRIPTION
## Summary

Migrates `@toptal/picasso-modal-context` off the legacy MUI v4 peer-dependency footprint. The source is a 4-LOC React context provider (`createContext<boolean>(false)`) that imports nothing from `@material-ui/core`, so the migration is a `package.json` delta — drop the vestigial `@material-ui/core` peer-dep and lift the React peer cap — plus a small unit test added so the package has a real test surface.

## Decisions

- **Drop `@material-ui/core` peer-dep**: verified vestigial — `src/ModalContext.ts` and `src/index.ts` import only from `react`; no MUI symbol anywhere in the package. Removing a peer requirement is strictly relaxing for consumers, not breaking.
- **Lift React cap** `>=16.12.0 < 19.0.0` → `>=16.12.0`, the standard Tier 1 peer-cap widening. Widening a peer range is non-breaking.
- **Added `src/test.tsx`**: the package previously had zero tests, so the jest gate failed with "No tests found". Added two assertions on the context's observable contract (default `false`, provider override) rather than a "renders without crashing" stub. Build + types are otherwise the contract for a context-only module.
- **`patch` bump** (matches `manifest.json#versionBump`): public API (the context value shape) unchanged, behavioral parity. The dropped dep was a peer-dep, not a `dependency`, and was unused.
- **`classes` prop**: N/A — ModalContext is context-only, renders no DOM, has no slots.

## Limitations / Out-of-scope

- No visual/Happo/Playwright verification: ModalContext renders no DOM, so there is nothing to screenshot.
- The added test exercises the context default and provider override only — that is the full observable surface of a `createContext` value.

## Verification

- **Local gate stages passed**: `pnpm --filter @toptal/picasso-modal-context build:package` (tsc -b) exits 0; `pnpm davinci-syntax lint code --check packages/base/ModalContext/src` exits 0; `pnpm davinci-qa unit --config=./jest.spec.mjs --testPathPattern packages/base/ModalContext` → 2 passed.
- **Lockfile**: plain `pnpm install`; 3-line diff removing the `@material-ui/core` entry under `packages/base/ModalContext`. No workspace-link expansion.
- **Runtime check (Playwright)**: N/A — context-only, no rendered component.
- **Visual parity**: N/A — no DOM output.

## Diff attribution note (orchestrator action needed)

The PR diff includes `packages/shared/src/utils/{to-react-event,to-react-change-event,test}.ts`, the matching `index.ts` re-exports, and `.changeset/picasso-shared-react-event-helpers.md`. **These are NOT part of the ModalContext migration.** They originate from orchestrator commit `57de385b7` ("Add onChange helper and rules"), which is *not* on the PR target `feature/picasso-modernization-temp` (nor master), so it surfaces in the `base...HEAD` diff per the documented worktree-forking behavior (CLAUDE.md §"Branch hygiene"). ModalContext is a pure `createContext<boolean>(false)` and consumes none of these helpers. They belong to the infrastructure track / the first Tier-0 migration that uses them (Switch). Recommend the orchestrator land/rebase them separately so they drop out of this PR's diff — including the flagged `as unknown as R` cast in `to-react-event.ts:54`, which is that track's code, not editable here without cross-track scope creep.

---

## Mechanical diff evidence

_Auto-generated by `bin/migration-diff.sh report` from pre/post snapshots. The agent's narrative is above; this section is the file-level facts._

# ModalContext migration diff

Generated: 2026-05-31 12:28:47 CEST

**Package:** `packages/base/ModalContext`

## Files
_No file additions, deletions, or renames._

## Imports
_No import changes._

## MUI v4 / JSS residue check

| Check | Count |
|---|---|
| `@material-ui/*` source imports | 0 |
| JSS calls (makeStyles/createStyles/withStyles) | 0 |
| `@material-ui/core` in package.json | 0
0 |

_Migration is **NOT complete** until all three are 0._

## package.json delta

```diff
@@ -29,8 +29,7 @@
     "**/styles.js"
   ],
   "peerDependencies": {
-    "@material-ui/core": "4.12.4",
-    "react": ">=16.12.0 < 19.0.0"
+    "react": ">=16.12.0"
   },
   "exports": {
     ".": "./dist-package/src/index.js"
```

## Prop-surface diff

<details><summary>Click to expand .d.ts diff</summary>

```diff
```

</details>

_Review carefully: any `-` line on a public export is a breaking change. See `docs/migration/rules/api-preservation.md`._

## Happo
Happo log: `migration-runs/2026-05-31/ModalContext/happo.log` (0
? flagged lines).

_Designer: review screen diffs >0.5% per `docs/migration/migration-plan.md` §6.3._

## React 19 smoke
_Stubbed (pending PF-1994). The real smoke wires up during PF-1994's first migration._
