### PR TITLE
Record Dropdown v2 run state (PR #5008)

### DIFF
--- a/docs/migration/manifest.json
+++ b/docs/migration/manifest.json
@@ -918,7 +918,23 @@
       "worktree": null,
       "iterations": 0,
       "merged_at": null,
-      "notes": "Heavy composite + mixed-state PR. Single PR covers @mui/base portion + @material-ui/core/Grow transition replacement. Replace Grow with CSS data-starting-style/data-ending-style transitions. versionBump=patch: locally narrowed `classes?: { popper, content }` is preserved (2 external callsites — see classes-audit §6). Promote to minor if new functionality is added in the rewrite."
+      "notes": "Heavy composite + mixed-state PR. Single PR covers @mui/base portion + @material-ui/core/Grow transition replacement. Replace Grow with CSS data-starting-style/data-ending-style transitions. versionBump=patch: locally narrowed `classes?: { popper, content }` is preserved (2 external callsites — see classes-audit §6). Promote to minor if new functionality is added in the rewrite.",
+      "variants": {
+        "v2": {
+          "status": "awaiting_review",
+          "pr": "https://github.com/toptal/picasso/pull/5008",
+          "branch": "migrate-Dropdown-v2",
+          "worktree": "migration-runs/2026-06-12/Dropdown-v2/worktree",
+          "iterations": 2,
+          "merged_at": null,
+          "escalation_reason": null,
+          "last_ci_green_at": null,
+          "last_review_seen_at": null,
+          "review_iterations": 0,
+          "session_id": null,
+          "awaiting_ci_since": null
+        }
+      }
     },
     "Page": {
       "tier": 3,


### PR DESCRIPTION
Adds the Dropdown `v2` variant to the orchestrator manifest so a `--review-sweep` from this branch picks up **PR #5008** (`migrate-Dropdown-v2`).

## Manifest (`docs/migration/manifest.json`)
Dropdown had no `variants` block; adds:
- **v2** — `awaiting_review`, PR #5008 (`migrate-Dropdown-v2`), 7-file Dropdown-only diff after the branch was rebased clean onto the migration target.

**Status note:** the local run left v2 stale at `in_progress`; recorded here as `awaiting_review` to match GitHub (OPEN, CI-green, REVIEW_REQUIRED) and make it sweepable.

Refs: PF-1992