### PR TITLE
[PF-2133] Move pnpm config to pnpm-workspace.yaml

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,57 +82,6 @@
       "json"
     ]
   },
-  "pnpm": {
-    "overrides": {
-      "@types/node-fetch>form-data": "3.0.4",
-      "@cypress/request>form-data": "2.5.5",
-      "@swc/plugin-styled-components": "9.1.0",
-      "axios": "1.12.0",
-      "npm": "11.6.0",
-      "webpack-dev-middleware": "5.3.4",
-      "@storybook/core-server>ip": "npm:@toptal/davinci-ip@2.0.3",
-      "@types/unist": "3.0.0",
-      "meow>trim-newlines": "^3",
-      "find-babel-config>json5": "1",
-      "marksy>marked": "^0.7.0",
-      "@storybook/react": "^6.5.15",
-      "ansi-regex": "^5.0.1",
-      "glob-parent": "^6.0.2",
-      "lodash": "^4.17.21",
-      "minimist": "^1.2.6",
-      "node-fetch": "^2.6.7",
-      "postcss": "^8.4.32",
-      "prettier": "^2.5.1",
-      "prismjs": "^1.30.0",
-      "react": "^18.2.0",
-      "react-dom": "^18.2.0",
-      "react-test-renderer": "^19.2.0",
-      "semver-regex": "^3.1.3",
-      "trim": "^0.0.3",
-      "unset-value": "^2.0.1",
-      "webpack": "^5.0.0",
-      "yaml": "2",
-      "micromatch": "^4.0.8",
-      "nx": "22.7.5",
-      "@nx/js": "22.7.5",
-      "@types/react": "17",
-      "js-yaml": "^3.13.1"
-    },
-    "onlyBuiltDependencies": [
-      "@sentry/cli",
-      "@swc/core",
-      "core-js",
-      "core-js-pure",
-      "cypress",
-      "esbuild",
-      "highlight.js",
-      "nx",
-      "styled-components"
-    ],
-    "patchedDependencies": {
-      "@storybook/react-docgen-typescript-plugin@1.0.2-canary.6.9d540b91e815f8fc2f8829189deb00553559ff63.0": "patches/@storybook__react-docgen-typescript-plugin@1.0.2-canary.6.9d540b91e815f8fc2f8829189deb00553559ff63.0.patch"
-    }
-  },
   "devDependencies": {
     "@actions/core": "^1.10.0",
     "@actions/github": "^6.0.0",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -16,3 +16,52 @@ minimumReleaseAge: 10080
 minimumReleaseAgeExclude:
   - '@toptal/*'
   - '@topkit/*'
+
+overrides:
+  '@types/node-fetch>form-data': '3.0.4'
+  '@cypress/request>form-data': '2.5.5'
+  '@swc/plugin-styled-components': '9.1.0'
+  axios: '1.12.0'
+  npm: '11.6.0'
+  webpack-dev-middleware: '5.3.4'
+  '@storybook/core-server>ip': 'npm:@toptal/davinci-ip@2.0.3'
+  '@types/unist': '3.0.0'
+  'meow>trim-newlines': '^3'
+  'find-babel-config>json5': '1'
+  'marksy>marked': '^0.7.0'
+  '@storybook/react': '^6.5.15'
+  ansi-regex: '^5.0.1'
+  glob-parent: '^6.0.2'
+  lodash: '^4.17.21'
+  minimist: '^1.2.6'
+  node-fetch: '^2.6.7'
+  postcss: '^8.4.32'
+  prettier: '^2.5.1'
+  prismjs: '^1.30.0'
+  react: '^18.2.0'
+  react-dom: '^18.2.0'
+  react-test-renderer: '^19.2.0'
+  semver-regex: '^3.1.3'
+  trim: '^0.0.3'
+  unset-value: '^2.0.1'
+  webpack: '^5.0.0'
+  yaml: '2'
+  micromatch: '^4.0.8'
+  nx: '22.7.5'
+  '@nx/js': '22.7.5'
+  '@types/react': '17'
+  js-yaml: '^3.13.1'
+
+onlyBuiltDependencies:
+  - '@sentry/cli'
+  - '@swc/core'
+  - core-js
+  - core-js-pure
+  - cypress
+  - esbuild
+  - highlight.js
+  - nx
+  - styled-components
+
+patchedDependencies:
+  '@storybook/react-docgen-typescript-plugin@1.0.2-canary.6.9d540b91e815f8fc2f8829189deb00553559ff63.0': 'patches/@storybook__react-docgen-typescript-plugin@1.0.2-canary.6.9d540b91e815f8fc2f8829189deb00553559ff63.0.patch'


### PR DESCRIPTION
[PF-2133] Move pnpm config from package.json to pnpm-workspace.yaml

### Description

pnpm 10 (this repo is pinned to `pnpm@10.32.1` via `packageManager`) no
longer reads the `pnpm` field in `package.json`. On install it warns:

> The "pnpm" field in package.json is no longer read by pnpm. The
> following keys were ignored: "pnpm.overrides",
> "pnpm.onlyBuiltDependencies", "pnpm.patchedDependencies"

So all three blocks were being **silently ignored**, which is a
correctness/supply-chain risk:

- **`overrides`** — pinned versions (incl. security pins: `axios@1.12.0`,
  `form-data@3.0.4`/`2.5.5`, `lodash`, `postcss`, `prismjs`,
  `react`/`@types/react`) were no longer enforced on the transitive tree.
- **`onlyBuiltDependencies`** — the build-script allowlist (`cypress`,
  `esbuild`, `@swc/core`, `core-js`, `nx`, `styled-components`, …) was no
  longer honored.
- **`patchedDependencies`** — the
  `@storybook/react-docgen-typescript-plugin` patch was not applied,
  regressing Storybook prop-table docgen.

pnpm 10 reads these keys only from `pnpm-workspace.yaml`. This PR moves
the three blocks there as top-level keys (`overrides`,
`onlyBuiltDependencies`, `patchedDependencies`) **verbatim** and deletes
the `pnpm` field from the root `package.json`. No version values change —
config is only relocated to where pnpm 10 reads it.

Ref: https://pnpm.io/settings

### How to test

- Run `pnpm install` on a clean checkout of this branch.
  - No `"pnpm" field … ignored` warning is emitted.
  - No `patch … not applied` warning is emitted.
  - `pnpm-lock.yaml` is unchanged by the install (overrides still resolve
    to the same versions).
- `cypress`/`esbuild`/`@swc/core` postinstall build scripts still run
  (allowlist preserved).
- CI green: static-checks (syncpack, circularity, lint, typecheck, jest).

### Development checks

- [x] Self reviewed

[PF-1994]: https://toptal-core.atlassian.net/browse/PF-1994?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[PF-2133]: https://toptal-core.atlassian.net/browse/PF-2133?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ