### PR TITLE
[PF-1994] Migrate Modal fix shades

### DIFF
--- a/.changeset/modal-migration.md
+++ b/.changeset/modal-migration.md
@@ -4,6 +4,7 @@
 
 ### Modal
 
-- Re-implement on `@base-ui/react`'s `Dialog` (`Dialog.Root` + `Dialog.Portal` + `Dialog.Backdrop` + `Dialog.Popup`), replacing `@mui/base/Modal`. Public Props API is unchanged — `open`, `onClose`, `onOpen`, `onBackdropClick`, `disableBackdropClick`, `hideBackdrop`, `container`, `size`, `align`, `transitionProps`, `transitionDuration`, `paperProps`, `testIds` and the narrowed `classes?: { closeButton }` are all preserved, with behavioral parity (custom focus management, page scroll lock, multi-modal coexistence, backdrop-click and escape close).
-- Internally the dim overlay is now a `Dialog.Backdrop` element instead of the composed `@toptal/picasso-backdrop` component, and the open/close fade is driven by `data-starting-style`/`data-ending-style` Tailwind transitions instead of `@toptal/picasso-fade`.
-- `@mui/base`, `@toptal/picasso-backdrop` and `@toptal/picasso-fade` are dropped from dependencies; the `react` peer cap is lifted to `>=16.12.0`.
+- re-implement on `@base-ui/react`'s `Dialog` (`Dialog.Root` + `Dialog.Portal` + `Dialog.Backdrop` + `Dialog.Popup`), replacing `@mui/base/Modal`. Public Props API is unchanged — `open`, `onClose`, `onOpen`, `onBackdropClick`, `disableBackdropClick`, `hideBackdrop`, `container`, `size`, `align`, `transitionProps`, `transitionDuration`, `paperProps`, `testIds` and the narrowed `classes?: { closeButton }` are all preserved, with behavioral parity (custom focus management, page scroll lock, multi-modal coexistence, backdrop-click and escape close).
+- internally the dim overlay is now a `Dialog.Backdrop` element instead of the composed `@toptal/picasso-backdrop` component, and the open/close fade is driven by `data-starting-style`/`data-ending-style` Tailwind transitions instead of `@toptal/picasso-fade`.
+- the `@mui/base`, `@toptal/picasso-backdrop` and `@toptal/picasso-fade` are dropped from dependencies; the `react` peer cap is lifted to `>=16.12.0`.
+- the `ModalContent` scroll shades now fade in and out via CSS opacity (`data-active` + `transition-opacity`) instead of being conditionally mounted; no API change.

--- a/cypress/component/Modal.spec.tsx
+++ b/cypress/component/Modal.spec.tsx
@@ -60,7 +60,7 @@ const TestModalOverflown = (props: Partial<Omit<ModalProps, 'open'>>) => {
   return (
     <Modal {...props} open={isOpen}>
       <Modal.Title>A lot of data</Modal.Title>
-      <Modal.Content>
+      <Modal.Content data-testid='overflown-content'>
         Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
         tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
         veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
@@ -207,6 +207,19 @@ describe('Modal', () => {
   it('renders overflown', () => {
     cy.mount(<TestModalOverflown />)
 
+    // Precondition: the content must actually overflow, otherwise no shade
+    // appears and the opacity wait below would hang. Fail fast with a clear
+    // message if a future fixture change stops it overflowing.
+    cy.get('[data-testid="overflown-content"]').should($el => {
+      const el = $el.get(0)
+
+      expect(el.scrollHeight).to.be.greaterThan(el.clientHeight)
+    })
+
+    // The scroll shades fade in over 300ms; wait for the fade to settle so the
+    // screenshot captures the fully-opaque shade instead of a mid-fade frame.
+    cy.get('[data-active="true"]').should('have.css', 'opacity', '1')
+
     cy.get('body').happoScreenshot({
       component,
       variant: 'overflown',
@@ -226,6 +239,16 @@ describe('Modal', () => {
             cy.mount(
               <TestModalOverflown size={modalSize as ModalProps['size']} />
             )
+
+            // Precondition: content must overflow (see 'renders overflown').
+            cy.get('[data-testid="overflown-content"]').should($el => {
+              const el = $el.get(0)
+
+              expect(el.scrollHeight).to.be.greaterThan(el.clientHeight)
+            })
+
+            // Wait for the scroll-shade fade to settle before screenshotting.
+            cy.get('[data-active="true"]').should('have.css', 'opacity', '1')
 
             cy.get('body').happoScreenshot({
               component,

--- a/cypress/component/Modal.spec.tsx
+++ b/cypress/component/Modal.spec.tsx
@@ -149,16 +149,28 @@ const TestModalOverflown = (props: Partial<Omit<ModalProps, 'open'>>) => {
 
 const component = 'Modal'
 
+// Wait for the modal's open fade (data-starting-style:opacity-0 → 1) to settle
+// before taking the screenshot. Capturing mid-fade composites the bordered
+// secondary (Cancel) button at partial opacity, producing edge artifacts on its
+// border.
+const waitForModalOpen = () =>
+  cy
+    .get('[role="dialog"]')
+    .should('be.visible')
+    .and('not.have.attr', 'data-starting-style')
+
 // The scroll shades fade in over 300ms. When the content overflows, wait for
 // the fade to settle so the screenshot captures the fully-opaque shade instead
 // of a mid-fade frame. When it doesn't overflow (e.g. full-screen / xlarge on a
 // tall viewport) there are no shades, so skip the wait — asserting otherwise
 // would hang.
-const waitForScrollShades = () =>
-  cy
+const waitForScrollShades = () => {
+  // Settle the modal open fade first (same reason as waitForModalOpen), then
+  // gate on the shade fade so the overflown screenshots are fully stable.
+  waitForModalOpen()
+
+  return cy
     .get('[data-testid="overflown-content"]')
-    // Wait for the modal to finish opening so the layout (and therefore the
-    // overflow measurement below) is settled before we read it.
     .should('be.visible')
     .then($el => {
       const el = $el.get(0)
@@ -170,10 +182,13 @@ const waitForScrollShades = () =>
         ? cy.get('[data-active="true"]').should('have.css', 'opacity', '1')
         : cy.wrap(null)
     })
+}
 
 describe('Modal', () => {
   it('renders', () => {
     cy.mount(<TestModalForm />)
+
+    waitForModalOpen()
 
     cy.get('body').happoScreenshot({
       component,
@@ -184,6 +199,8 @@ describe('Modal', () => {
   it('renders aligned to top', () => {
     cy.mount(<TestModalForm align='top' />)
 
+    waitForModalOpen()
+
     cy.get('body').happoScreenshot({
       component,
       variant: 'align-top',
@@ -192,6 +209,8 @@ describe('Modal', () => {
 
   it('renders without backdrop', () => {
     cy.mount(<TestModalForm hideBackdrop />)
+
+    waitForModalOpen()
 
     cy.get('body').happoScreenshot({
       component,
@@ -202,6 +221,8 @@ describe('Modal', () => {
   it('renders small', () => {
     cy.mount(<TestModalForm size='small' />)
 
+    waitForModalOpen()
+
     cy.get('body').happoScreenshot({
       component,
       variant: 'size/small',
@@ -211,6 +232,8 @@ describe('Modal', () => {
   it('renders large', () => {
     cy.mount(<TestModalForm size='large' />)
 
+    waitForModalOpen()
+
     cy.get('body').happoScreenshot({
       component,
       variant: 'size/large',
@@ -219,6 +242,8 @@ describe('Modal', () => {
 
   it('renders full-screen', () => {
     cy.mount(<TestModalForm size='full-screen' />)
+
+    waitForModalOpen()
 
     cy.get('body').happoScreenshot({
       component,

--- a/cypress/component/Modal.spec.tsx
+++ b/cypress/component/Modal.spec.tsx
@@ -149,6 +149,28 @@ const TestModalOverflown = (props: Partial<Omit<ModalProps, 'open'>>) => {
 
 const component = 'Modal'
 
+// The scroll shades fade in over 300ms. When the content overflows, wait for
+// the fade to settle so the screenshot captures the fully-opaque shade instead
+// of a mid-fade frame. When it doesn't overflow (e.g. full-screen / xlarge on a
+// tall viewport) there are no shades, so skip the wait — asserting otherwise
+// would hang.
+const waitForScrollShades = () =>
+  cy
+    .get('[data-testid="overflown-content"]')
+    // Wait for the modal to finish opening so the layout (and therefore the
+    // overflow measurement below) is settled before we read it.
+    .should('be.visible')
+    .then($el => {
+      const el = $el.get(0)
+      const overflows = el.scrollHeight > el.clientHeight
+
+      // No overflow (e.g. full-screen / xlarge on a tall viewport) → no shades
+      // to wait for. Otherwise wait for the fade to finish.
+      return overflows
+        ? cy.get('[data-active="true"]').should('have.css', 'opacity', '1')
+        : cy.wrap(null)
+    })
+
 describe('Modal', () => {
   it('renders', () => {
     cy.mount(<TestModalForm />)
@@ -207,18 +229,7 @@ describe('Modal', () => {
   it('renders overflown', () => {
     cy.mount(<TestModalOverflown />)
 
-    // Precondition: the content must actually overflow, otherwise no shade
-    // appears and the opacity wait below would hang. Fail fast with a clear
-    // message if a future fixture change stops it overflowing.
-    cy.get('[data-testid="overflown-content"]').should($el => {
-      const el = $el.get(0)
-
-      expect(el.scrollHeight).to.be.greaterThan(el.clientHeight)
-    })
-
-    // The scroll shades fade in over 300ms; wait for the fade to settle so the
-    // screenshot captures the fully-opaque shade instead of a mid-fade frame.
-    cy.get('[data-active="true"]').should('have.css', 'opacity', '1')
+    waitForScrollShades()
 
     cy.get('body').happoScreenshot({
       component,
@@ -240,15 +251,7 @@ describe('Modal', () => {
               <TestModalOverflown size={modalSize as ModalProps['size']} />
             )
 
-            // Precondition: content must overflow (see 'renders overflown').
-            cy.get('[data-testid="overflown-content"]').should($el => {
-              const el = $el.get(0)
-
-              expect(el.scrollHeight).to.be.greaterThan(el.clientHeight)
-            })
-
-            // Wait for the scroll-shade fade to settle before screenshotting.
-            cy.get('[data-active="true"]').should('have.css', 'opacity', '1')
+            waitForScrollShades()
 
             cy.get('body').happoScreenshot({
               component,

--- a/cypress/component/PromptModal.spec.tsx
+++ b/cypress/component/PromptModal.spec.tsx
@@ -22,9 +22,22 @@ const TestProptModal = () => {
   )
 }
 
+// Wait for the modal's open fade (data-starting-style:opacity-0 → 1) to settle
+// before taking the screenshot. Capturing mid-fade composites the (only)
+// bordered button — the secondary Cancel — at partial opacity, producing edge
+// artifacts on its border.
+const waitForModalOpen = () =>
+  cy
+    .get('[role="dialog"]')
+    .should('be.visible')
+    .and('not.have.attr', 'data-starting-style')
+
 describe('PromptModal', () => {
   it('renders on desktop and mobile', () => {
     cy.mount(<TestProptModal />)
+
+    waitForModalOpen()
+
     cy.get('body').happoScreenshot({
       component,
       variant: 'default',

--- a/packages/base/Modal/src/Modal/__snapshots__/test.tsx.snap
+++ b/packages/base/Modal/src/Modal/__snapshots__/test.tsx.snap
@@ -73,6 +73,14 @@ exports[`Modal renders 1`] = `
           class="flex relative flex-auto overflow-y"
         >
           <div
+            class="z-[1] absolute pointer-events right-8 left-8 h-[112px] opacity-0 transition-opacity duration-300 data-[active=true]:opacity-100 from-white to-transparent to-100% from-0% via-[2rem] via-white top-0 bg-linear-to"
+            data-active="false"
+          />
+          <div
+            class="z-[1] absolute pointer-events right-8 left-8 h-[112px] opacity-0 transition-opacity duration-300 data-[active=true]:opacity-100 from-white to-transparent to-100% from-0% via-[2rem] via-white bottom-0 bg-linear-to"
+            data-active="false"
+          />
+          <div
             class="pt-6 px-8 pb-8 overflow-auto flex-auto"
           >
             Modal test content

--- a/packages/base/Modal/src/ModalContent/ModalContent.tsx
+++ b/packages/base/Modal/src/ModalContent/ModalContent.tsx
@@ -24,7 +24,7 @@ export const ModalContent = forwardRef<HTMLDivElement, Props>(
     const { top, bottom } = useScrollableShades(modalContentRef)
 
     const shadeClasses =
-      'z-[1] absolute pointer-events-none right-8 left-8 h-[112px]'
+      'z-[1] absolute pointer-events-none right-8 left-8 h-[112px] opacity-0 transition-opacity duration-300 data-[active=true]:opacity-100'
     const gradientClasses =
       'from-white to-transparent to-100% from-0% via-[2rem] via-white'
 
@@ -35,26 +35,26 @@ export const ModalContent = forwardRef<HTMLDivElement, Props>(
           classes?.root
         )}
       >
-        {top && (
-          <div
-            className={twMerge(
-              shadeClasses,
-              gradientClasses,
-              classes?.topShade,
-              'top-0 bg-gradient-to-b'
-            )}
-          />
-        )}
-        {bottom && (
-          <div
-            className={twMerge(
-              shadeClasses,
-              gradientClasses,
-              classes?.bottomShade,
-              'bottom-0 bg-gradient-to-t'
-            )}
-          />
-        )}
+        <div
+          data-active={top}
+          className={twMerge(
+            shadeClasses,
+            gradientClasses,
+            classes?.topShade,
+            'top-0 bg-linear-to-b'
+          )}
+        />
+
+        <div
+          data-active={bottom}
+          className={twMerge(
+            shadeClasses,
+            gradientClasses,
+            classes?.bottomShade,
+            'bottom-0 bg-linear-to-t'
+          )}
+        />
+
         <div
           {...rest}
           style={style}

--- a/packages/base/PromptModal/src/PromptModal/__snapshots__/test.tsx.snap
+++ b/packages/base/PromptModal/src/PromptModal/__snapshots__/test.tsx.snap
@@ -104,6 +104,14 @@ exports[`PromptModal showPrompt opens and closes modal on Submit action 2`] = `
               class="flex relative flex-auto overflow-y"
             >
               <div
+                class="z-[1] absolute pointer-events right-8 left-8 h-[112px] opacity-0 transition-opacity duration-300 data-[active=true]:opacity-100 from-white to-transparent to-100% from-0% via-[2rem] via-white top-0 bg-linear-to"
+                data-active="false"
+              />
+              <div
+                class="z-[1] absolute pointer-events right-8 left-8 h-[112px] opacity-0 transition-opacity duration-300 data-[active=true]:opacity-100 from-white to-transparent to-100% from-0% via-[2rem] via-white bottom-0 bg-linear-to"
+                data-active="false"
+              />
+              <div
                 class="pt-6 px-8 pb-8 overflow-auto flex-auto"
               >
                 <p


### PR DESCRIPTION
[PF-1994]

### Description

`ModalContent` renders top/bottom gradient "shades" that hint at scrollable
overflow. Previously each shade was **conditionally mounted** (`{top && …}` /
`{bottom && …}`), so it popped in and out of the DOM as the user scrolled,
with no transition.

This changes both shades to be **always rendered** and toggled purely in CSS:
visibility is driven from the DOM via a `data-active` attribute, and the fade
is handled by `opacity` + `transition-opacity duration-300`.

Motivations:
- **Smooth fade instead of a hard pop** — the shade now fades in/out over 300ms
  instead of appearing/disappearing instantly.
- **Aligns with the styling doctrine** — state-driven styling should use
  `data-[…]:` variants (read state from the DOM) rather than branching the
  render tree (`AGENTS.md › Styling`).
- **Consistency** — `duration-300` matches the sibling overlay surface
  (`Drawer` uses `transition-opacity duration-300`), and both shades now share
  one class string, fixing a prior mismatch where only the bottom shade carried
  `duration-300`.

Scope:
- No public API change — `Props` and `classes?: { root, topShade, bottomShade }`
  are untouched, so consumers need no migration.
- Scroll detection (`use-scrollable-shades`) is intentionally unchanged; this PR
  only changes how the shades are *displayed*. (A CSS-only detection path —
  `animation-timeline: scroll()` / `scroll-state()` — isn't viable under the
  repo's browserslist, which still targets Safari 13+ and Firefox.)

### How to test

- [Temploy](https://picasso.toptal.net/pf-1994-fix-migrate-modal)
- Open any Modal with content taller than its viewport (e.g. Modal → Dynamic
  Content story).
- Scroll the content down: the **top** shade should fade in; scroll back up:
  it should fade out. Scroll to the very bottom: the **bottom** shade should
  fade out.
- With content that fits (no overflow): neither shade should be visible.

### Screenshots

| Before                                       | After                                        |
| -------------------------------------------- | -------------------------------------------- |
| Shade pops in/out instantly (no transition)  | Shade fades in/out over 300ms                |


https://github.com/user-attachments/assets/52136949-cabd-4119-8fe8-c90a9e0613fb

https://github.com/user-attachments/assets/0048ddb2-17f5-4d4b-954b-a4b892cc983b



[PF-1994]: https://toptal-core.atlassian.net/browse/PF-1994?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ