### PR TITLE
[FF-125] Restore generic typing for OverridableComponent

### DIFF
--- a/.changeset/ff-125-overridable-component-generic.md
+++ b/.changeset/ff-125-overridable-component-generic.md
@@ -1,0 +1,19 @@
+---
+'@toptal/picasso-shared': major
+'@toptal/picasso': major
+'@toptal/picasso-button': major
+'@toptal/picasso-link': major
+'@toptal/picasso-menu': major
+'@toptal/picasso-breadcrumbs': major
+'@toptal/picasso-overview-block': major
+'@toptal/picasso-page': major
+---
+
+### OverridableComponent
+
+- restore generic, inferring typing for the polymorphic `as` prop. The `as` target's props are again type-checked at the call site, so `<Link as={RouterLink} to="/x" />` validates `to` against the target component (FF-125). This reverts the permissive `P & { [key: string]: any }` shape introduced for the TypeScript 5.5 upgrade.
+- add the `overridableForwardRef` helper, used internally by components whose props have required fields (`Page.Article`, `Breadcrumbs.Item`, `OverviewBlock`), which TypeScript 5.5 will not assign to the generic call signature directly.
+
+This is a type-level breaking change for every polymorphic component (`Link`, `Button`, `Button.Group`/`Button.Action`/`Button.Circular`, `Menu.Item`, `Breadcrumbs.Item`, `OverviewBlock`, `Page.Article`, `Page.SidebarItem`, `Page.TopBarItem`). Undeclared props that the permissive shape silently accepted as `any` are now type-checked: a prop that exists on neither the component nor the `as` target is a type error. Consumers may need to remove stray props or correct the props passed to the `as` target. There is no runtime change.
+
+Known limitation: when `as` is a string intrinsic (e.g. `as="a"`), TypeScript widens the inferred type and does not strictly check that branch's attributes. Component `as` targets (e.g. `as={RouterLink}`) are fully type-checked.

--- a/packages/base/Breadcrumbs/src/BreadcrumbsItem/BreadcrumbsItem.tsx
+++ b/packages/base/Breadcrumbs/src/BreadcrumbsItem/BreadcrumbsItem.tsx
@@ -1,11 +1,7 @@
 import type { ElementType, HTMLAttributes, ReactNode } from 'react'
-import React, { forwardRef } from 'react'
-import type {
-  BaseProps,
-  TextLabelProps,
-  OverridableComponent,
-} from '@toptal/picasso-shared'
-import { useTitleCase } from '@toptal/picasso-shared'
+import React from 'react'
+import type { BaseProps, TextLabelProps } from '@toptal/picasso-shared'
+import { overridableForwardRef, useTitleCase } from '@toptal/picasso-shared'
 import { Typography } from '@toptal/picasso-typography'
 import { toTitleCase } from '@toptal/picasso-utils'
 import { twMerge } from '@toptal/picasso-tailwind-merge'
@@ -24,31 +20,30 @@ const Active = (props: { children: ReactNode }) => {
   return <Typography weight='semibold' color='black' {...props} />
 }
 
-export const BreadcrumbsItem: OverridableComponent<Props> = forwardRef<
-  HTMLElement,
-  Props
->(function BreadcrumbsItem({ as = 'span', ...props }, ref) {
-  const {
-    active,
-    children,
-    className,
-    titleCase: propsTitleCase,
-    ...rest
-  } = props
-  const Component = active ? Active : as || 'span'
+export const BreadcrumbsItem = overridableForwardRef<HTMLElement, Props>(
+  function BreadcrumbsItem({ as = 'span', ...props }, ref) {
+    const {
+      active,
+      children,
+      className,
+      titleCase: propsTitleCase,
+      ...rest
+    } = props
+    const Component = active ? Active : as || 'span'
 
-  const titleCase = useTitleCase(propsTitleCase)
+    const titleCase = useTitleCase(propsTitleCase)
 
-  return (
-    <Component
-      ref={ref}
-      className={twMerge('text-[14px] font-semibold', className)}
-      {...rest}
-    >
-      {titleCase ? toTitleCase(children) : children}
-    </Component>
-  )
-})
+    return (
+      <Component
+        ref={ref}
+        className={twMerge('text-[14px] font-semibold', className)}
+        {...rest}
+      >
+        {titleCase ? toTitleCase(children) : children}
+      </Component>
+    )
+  }
+)
 
 BreadcrumbsItem.displayName = 'BreadcrumbsItem'
 

--- a/packages/base/OverviewBlock/src/OverviewBlock/OverviewBlock.tsx
+++ b/packages/base/OverviewBlock/src/OverviewBlock/OverviewBlock.tsx
@@ -1,12 +1,11 @@
 import type { ElementType, HTMLAttributes, MouseEvent, ReactNode } from 'react'
-import React, { forwardRef } from 'react'
+import React from 'react'
 import type {
-  OverridableComponent,
   ColorType,
   BaseProps,
   TextLabelProps,
 } from '@toptal/picasso-shared'
-import { useTitleCase } from '@toptal/picasso-shared'
+import { overridableForwardRef, useTitleCase } from '@toptal/picasso-shared'
 import { Container } from '@toptal/picasso-container'
 import { Typography } from '@toptal/picasso-typography'
 import { toTitleCase, isString } from '@toptal/picasso-utils'
@@ -60,73 +59,72 @@ const getBlockWidthClassnames = (blockWidth: BlockWidth) => {
   }
 }
 
-export const OverviewBlock: OverridableComponent<Props> = forwardRef<
-  HTMLButtonElement,
-  Props
->(function OverviewBlock({ as = 'button', ...props }, ref) {
-  const {
-    value,
-    label,
-    variant,
-    className,
-    onClick,
-    titleCase: propsTitleCase,
-    ...rest
-  } = props
+export const OverviewBlock = overridableForwardRef<HTMLButtonElement, Props>(
+  function OverviewBlock({ as = 'button', ...props }, ref) {
+    const {
+      value,
+      label,
+      variant,
+      className,
+      onClick,
+      titleCase: propsTitleCase,
+      ...rest
+    } = props
 
-  const { align, blockWidth } = useOverviewBlockGroupContext()
+    const { align, blockWidth } = useOverviewBlockGroupContext()
 
-  const color: ColorSchema = {
-    value: 'black',
-    label: 'dark-grey',
-  }
+    const color: ColorSchema = {
+      value: 'black',
+      label: 'dark-grey',
+    }
 
-  if (variant) {
-    const [partName, colorName] = variant.split('-') as [
-      keyof ColorSchema,
-      ColorType
-    ]
+    if (variant) {
+      const [partName, colorName] = variant.split('-') as [
+        keyof ColorSchema,
+        ColorType
+      ]
 
-    color[partName] = colorName
-  }
+      color[partName] = colorName
+    }
 
-  const isClickable = Boolean(onClick) || typeof as !== 'string'
+    const isClickable = Boolean(onClick) || typeof as !== 'string'
 
-  const Component = isClickable && as ? as : 'div'
+    const Component = isClickable && as ? as : 'div'
 
-  const titleCase = useTitleCase(propsTitleCase)
+    const titleCase = useTitleCase(propsTitleCase)
 
-  return (
-    <Component
-      {...rest}
-      ref={ref}
-      className={twMerge(
-        isClickable
-          ? 'cursor-pointer outline-hidden hover:bg-blue-100'
-          : 'outline-hidden',
-        getAlignmentClassnames(align),
-        getBlockWidthClassnames(blockWidth),
-        'flex flex-col bg-white m-0 min-w-[9.375rem] border-none no-underline',
-        '[&:not(:first-child)]:border-0 [&:not(:first-child)]:border-l [&:not(:first-child)]:border-solid [&:not(:first-child)]:border-gray-400',
-        className
-      )}
-      onClick={onClick}
-    >
-      <Container align='left'>
-        {isString(label) ? (
-          <Typography size='xxsmall' weight='semibold' color={color.label}>
-            {titleCase ? toTitleCase(label) : label}
-          </Typography>
-        ) : (
-          label
+    return (
+      <Component
+        {...rest}
+        ref={ref}
+        className={twMerge(
+          isClickable
+            ? 'cursor-pointer outline-hidden hover:bg-blue-100'
+            : 'outline-hidden',
+          getAlignmentClassnames(align),
+          getBlockWidthClassnames(blockWidth),
+          'flex flex-col bg-white m-0 min-w-[9.375rem] border-none no-underline',
+          '[&:not(:first-child)]:border-0 [&:not(:first-child)]:border-l [&:not(:first-child)]:border-solid [&:not(:first-child)]:border-gray-400',
+          className
         )}
-        <Typography size='large' weight='semibold' color={color.value}>
-          {value}
-        </Typography>
-      </Container>
-    </Component>
-  )
-})
+        onClick={onClick}
+      >
+        <Container align='left'>
+          {isString(label) ? (
+            <Typography size='xxsmall' weight='semibold' color={color.label}>
+              {titleCase ? toTitleCase(label) : label}
+            </Typography>
+          ) : (
+            label
+          )}
+          <Typography size='large' weight='semibold' color={color.value}>
+            {value}
+          </Typography>
+        </Container>
+      </Component>
+    )
+  }
+)
 
 OverviewBlock.displayName = 'OverviewBlock'
 

--- a/packages/base/Page/src/PageArticle/PageArticle.tsx
+++ b/packages/base/Page/src/PageArticle/PageArticle.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode, HTMLAttributes } from 'react'
-import React, { forwardRef } from 'react'
-import type { BaseProps, OverridableComponent } from '@toptal/picasso-shared'
+import React from 'react'
+import { overridableForwardRef, type BaseProps } from '@toptal/picasso-shared'
 import { Container } from '@toptal/picasso-container'
 import { twMerge } from '@toptal/picasso-tailwind-merge'
 
@@ -9,23 +9,22 @@ export interface Props extends BaseProps, HTMLAttributes<HTMLDivElement> {
   children: ReactNode
 }
 
-export const PageArticle: OverridableComponent<Props> = forwardRef<
-  HTMLDivElement,
-  Props
->(function PageArticle(props, ref) {
-  const { children, className, style, ...rest } = props
+export const PageArticle = overridableForwardRef<HTMLDivElement, Props>(
+  function PageArticle(props, ref) {
+    const { children, className, style, ...rest } = props
 
-  return (
-    <Container
-      {...rest}
-      ref={ref}
-      className={twMerge('flex-1 my-0 mx-4 md:mx-8', className)}
-      style={style}
-    >
-      {children}
-    </Container>
-  )
-})
+    return (
+      <Container
+        {...rest}
+        ref={ref}
+        className={twMerge('flex-1 my-0 mx-4 md:mx-8', className)}
+        style={style}
+      >
+        {children}
+      </Container>
+    )
+  }
+)
 
 PageArticle.displayName = 'PageArticle'
 

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -2,7 +2,11 @@ import type {
   CSSProperties,
   AnchorHTMLAttributes,
   ButtonHTMLAttributes,
+  ComponentPropsWithRef,
+  ElementType,
+  ForwardRefRenderFunction,
 } from 'react'
+import { forwardRef } from 'react'
 
 import type { Classes } from './styles'
 
@@ -51,30 +55,26 @@ export interface NamedComponent<P> {
   displayName?: string
 }
 
-// TODO: [FF-125] inherit the `as` target's props for full polymorphic
-// typing — https://toptal-core.atlassian.net/browse/FF-125
-//
-// Strict on declared props, permissive on extras. Declared `P` fields are
-// type-checked at call sites (e.g. `<Button size='wrong'>` still errors).
-// Any other prop is accepted untyped. That is what keeps the polymorphic
-// `as` usage working without a generic call signature, and what lets
-// `forwardRef<HTMLElement, Props>(...)` assign directly.
-//
-// Trade-off versus the previous shape: TypeScript no longer infers prop
-// types from the `as` target. `<Button as={Link} to={42} />` and
-// `<Button as='a' href={42} />` won't validate `to`/`href` against the
-// target's props; the extras come through as `any`.
-//
-// The proper fix is a type that inherits the `as` target's props (HTML
-// element or component) so the examples above type-check against the real
-// target, without regressing the internal `forwardRef` sites whose Props
-// have required fields (Page.Article, Breadcrumbs.Item, OverviewBlock).
-// Those sites broke the previous generic call-signature shape under the
-// TS 5.5 variance change.
-export interface OverridableComponent<P = {}> extends NamedComponent<P> {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  (props: P & { [key: string]: any }): JSX.Element | null
+export type PropsWithOverridableAs<T extends ElementType, P> = Omit<P, 'as'> & {
+  as?: T
+} & ComponentPropsWithRef<T>
+
+// `defaultProps` is omitted on purpose: `forwardRef(...)` types it as
+// `Partial<P & RefAttributes>`, which isn't assignable to `Partial<P>`, so
+// keeping it would block direct assignment of all-optional components.
+export interface OverridableComponent<P = {}> {
+  displayName?: string
+  <T extends ElementType = ElementType<Omit<P, 'as'>>>(
+    props: PropsWithOverridableAs<T, P>
+  ): JSX.Element | null
 }
+
+// For components with required props, TS 5.5 won't assign a `forwardRef` result
+// to the generic call signature directly; this asserts the bridge while keeping
+// `render`'s props/ref type-checked.
+export const overridableForwardRef = <R, P>(
+  render: ForwardRefRenderFunction<R, P>
+): OverridableComponent<P> => forwardRef(render) as OverridableComponent<P>
 
 type BaseEnvironments = 'development' | 'staging' | 'production'
 type Environments = BaseEnvironments | 'temploy' | 'test'


### PR DESCRIPTION
## What

Restores the generic, inferring typing for `OverridableComponent`'s polymorphic `as` prop. `<Link as={RouterLink} to="/x" />` again type-checks the target component's props at the call site.

## Why

PR #4963 (TS 5.5 upgrade) replaced the generic call signature with a permissive `P & { [key: string]: any }` shape, which dropped `as`-target inference and forced consumers (talent-portal `chore/upgrade-topchat-8.0.2`) to add `as unknown as ElementType<…>` casts. Restoring inference lets those casts be removed.

## How

- Restored the generic call signature (`PropsWithOverridableAs<T, P>`) — identical to the pre-#4963 shape.
- Dropped the inherited `defaultProps: Partial<P>`, which was the actual TS 5.5 blocker (`forwardRef`'s `Partial<P & RefAttributes>` is not assignable to it). The 8 all-optional polymorphic components (incl. `Link`) now assign to the generic type directly, with no cast and no source changes.
- Added `overridableForwardRef` for the 3 components with required props (`Page.Article`, `Breadcrumbs.Item`, `OverviewBlock`), which TS 5.5 won't assign directly. The render input stays fully type-checked; only the bridge return is asserted.

## Breaking change

Type-level: undeclared props the permissive shape silently accepted as `any` are now type-checked. Changeset bumps the affected packages major.

Known limitation: intrinsic-string `as` (e.g. `as="a"`) widens the inferred type and doesn't strictly check that branch — matches pre-#4963 behavior; component `as` targets are fully checked.

## Verification

- `pnpm build:package` across 90 projects ✓
- Unit tests for affected components ✓
- Verified against the real `Link`: `as={RouterLink} to="/x"` infers; missing `to` errors.

## Tickets

- Jira: [TAPS-2536](https://toptal-core.atlassian.net/browse/TAPS-2536)
- Fixes: [FF-125](https://toptal-core.atlassian.net/browse/FF-125)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[TAPS-2536]: https://toptal-core.atlassian.net/browse/TAPS-2536?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ