### PR TITLE
[FF-125] Widen Link and Typography `as` prop to ElementType

### DIFF
--- a/.changeset/widen-link-typography-as.md
+++ b/.changeset/widen-link-typography-as.md
@@ -1,0 +1,12 @@
+---
+'@toptal/picasso-link': minor
+'@toptal/picasso-typography': minor
+---
+
+### Link
+
+- widen the `as` prop type from `ElementType<HTMLAttributes<HTMLElement>>` to `ElementType`, so components that require extra props (e.g. react-router's `Link`, which needs `to`) can be passed to `as` without an `as unknown as ElementType<…>` cast. Matches the other polymorphic components.
+
+### Typography
+
+- widen the `as` prop type to `ElementType` to match `Link` and the other polymorphic components.

--- a/packages/base/Link/src/Link/Link.tsx
+++ b/packages/base/Link/src/Link/Link.tsx
@@ -62,7 +62,7 @@ export type Props = BaseProps &
      * The component used for the root node.
      * Either a string to use a DOM element or a component.
      */
-    as?: ElementType<React.HTMLAttributes<HTMLElement>>
+    as?: ElementType
     /** Either it's a regular hyperlink or an _action_ */
     variant?: VariantType
     /** Controls color of the link */

--- a/packages/base/Typography/src/Typography/Typography.tsx
+++ b/packages/base/Typography/src/Typography/Typography.tsx
@@ -145,7 +145,7 @@ export interface Props
   /** Enable ellipsis for overflowing text */
   noWrap?: boolean
   /** Rendered HTML markup */
-  as?: React.ElementType<React.HTMLAttributes<HTMLElement>>
+  as?: React.ElementType
   /** Controls when the Typography should have an underline */
   underline?: 'solid' | 'dashed'
   /** Controls when the Typography should have line through */


### PR DESCRIPTION
## What

Widen the `as` prop on `Link` and `Typography` from `ElementType<HTMLAttributes<HTMLElement>>` to `ElementType`.

## Why

`Link` was the only polymorphic component still typing `as` narrowly (`Button`, `Menu.Item`, `Breadcrumbs.Item`, `OverviewBlock`, `Tag`… already use `ElementType`). The narrow type rejects components that require extra props — e.g. react-router's `Link` (which needs `to`) — forcing consumers (talent-portal) to write `as={RouterLink as unknown as ElementType<HTMLAttributes<HTMLElement>>}`. `Link` forwards `as` to `Typography`, so `Typography`'s matching narrow type is widened too (it already coerces to `ElementType` internally).

## Result

`<Link as={RouterLink} to="/x" />` now type-checks without a cast (verified against the real component), so the talent-portal casts can be removed. Non-breaking: widening only accepts more `as` targets.

This is the minimal fix for the consumer pain — no change to `OverridableComponent`.

## Verification

- `pnpm build:package` across 90 projects ✓
- Confirmed `<Link as={RouterLink} to="/x" />` compiles cast-free against the built `Link`.

## Tickets

- Jira: [TAPS-2536](https://toptal-core.atlassian.net/browse/TAPS-2536)
- Relates to: [FF-125](https://toptal-core.atlassian.net/browse/FF-125)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[TAPS-2536]: https://toptal-core.atlassian.net/browse/TAPS-2536?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ