### PR TITLE
[FX-2204] Fix Popper popperOptions.strategy support to keep backward compatibility

### DIFF
--- a/.changeset/popper-fixed-strategy.md
+++ b/.changeset/popper-fixed-strategy.md
@@ -1,9 +1,8 @@
 ---
-'@toptal/picasso-popper': minor
-'@toptal/picasso-dropdown': minor
+'@toptal/picasso-popper': patch
+'@toptal/picasso-dropdown': patch
 ---
 
 ### Popper / Dropdown
 
-- add a `strategy?: 'absolute' | 'fixed'` prop, threading directly into `@floating-ui/react`'s `useFloating` positioning strategy. `'fixed'` escapes a clipping/scrolling ancestor (e.g. an `overflow: hidden` container) that `'absolute'` positioning cannot.
-- restore backwards compatibility with the pre-migration popper.js-based `popperOptions.positionFixed` option: when `strategy` is not set explicitly, `popperOptions.positionFixed: true` now resolves to `strategy: 'fixed'`, matching its old popper.js v1 behavior. An explicit `strategy` prop always takes precedence. `positionFixed` is typed as `@deprecated` — new code should use `strategy` directly.
+- restore backwards compatibility with the pre-migration popper.js-based `popperOptions.positionFixed` option: `popperOptions.positionFixed: true` again positions the popper with a `fixed` strategy (relative to the viewport), escaping a clipping/scrolling ancestor (e.g. an `overflow: hidden` container) that the default `absolute` positioning cannot, matching its old popper.js v1 behavior.

--- a/.changeset/popper-fixed-strategy.md
+++ b/.changeset/popper-fixed-strategy.md
@@ -1,0 +1,9 @@
+---
+'@toptal/picasso-popper': minor
+'@toptal/picasso-dropdown': minor
+---
+
+### Popper / Dropdown
+
+- add a `strategy?: 'absolute' | 'fixed'` prop, threading directly into `@floating-ui/react`'s `useFloating` positioning strategy. `'fixed'` escapes a clipping/scrolling ancestor (e.g. an `overflow: hidden` container) that `'absolute'` positioning cannot.
+- restore backwards compatibility with the pre-migration popper.js-based `popperOptions.positionFixed` option: when `strategy` is not set explicitly, `popperOptions.positionFixed: true` now resolves to `strategy: 'fixed'`, matching its old popper.js v1 behavior. An explicit `strategy` prop always takes precedence. `positionFixed` is typed as `@deprecated` — new code should use `strategy` directly.

--- a/packages/base/Dropdown/src/Dropdown/Dropdown.tsx
+++ b/packages/base/Dropdown/src/Dropdown/Dropdown.tsx
@@ -34,13 +34,6 @@ interface InternalProps
   content: ReactNode
   /** The placement of the content element relative to anchor element. */
   placement?: PopperPlacementType
-  /**
-   * CSS positioning strategy. `fixed` escapes clipping/scrolling ancestors
-   * (e.g. `overflow: hidden` containers) at the cost of not scrolling with
-   * them. Defaults to `popperOptions.positionFixed ? 'fixed' : 'absolute'`
-   * for popper.js v1 compatibility
-   */
-  strategy?: 'absolute' | 'fixed'
   /** Disabled */
   disabled?: boolean
   /** Disable auto focus of first item in list or item */
@@ -138,7 +131,6 @@ export const Dropdown: DropdownProps = forwardRef<
     onClose = noop,
     onOpen = noop,
     placement = 'bottom-end',
-    strategy,
     popperOptions = {},
     contentOverflow = 'scroll',
     ...props
@@ -299,7 +291,6 @@ export const Dropdown: DropdownProps = forwardRef<
             ...popperOptions,
           }}
           placement={placement}
-          strategy={strategy}
           style={{ ...responsiveStyle }}
           disablePortal={disablePortal}
           keepMounted={keepMounted}

--- a/packages/base/Dropdown/src/Dropdown/Dropdown.tsx
+++ b/packages/base/Dropdown/src/Dropdown/Dropdown.tsx
@@ -34,6 +34,13 @@ interface InternalProps
   content: ReactNode
   /** The placement of the content element relative to anchor element. */
   placement?: PopperPlacementType
+  /**
+   * CSS positioning strategy. `fixed` escapes clipping/scrolling ancestors
+   * (e.g. `overflow: hidden` containers) at the cost of not scrolling with
+   * them. Defaults to `popperOptions.positionFixed ? 'fixed' : 'absolute'`
+   * for popper.js v1 compatibility
+   */
+  strategy?: 'absolute' | 'fixed'
   /** Disabled */
   disabled?: boolean
   /** Disable auto focus of first item in list or item */
@@ -131,6 +138,7 @@ export const Dropdown: DropdownProps = forwardRef<
     onClose = noop,
     onOpen = noop,
     placement = 'bottom-end',
+    strategy,
     popperOptions = {},
     contentOverflow = 'scroll',
     ...props
@@ -291,6 +299,7 @@ export const Dropdown: DropdownProps = forwardRef<
             ...popperOptions,
           }}
           placement={placement}
+          strategy={strategy}
           style={{ ...responsiveStyle }}
           disablePortal={disablePortal}
           keepMounted={keepMounted}

--- a/packages/base/Dropdown/src/Dropdown/test.tsx
+++ b/packages/base/Dropdown/src/Dropdown/test.tsx
@@ -101,4 +101,35 @@ describe('Dropdown', () => {
     expect(onClose).toHaveBeenCalledTimes(1)
     expect(onClose).toHaveBeenCalledWith()
   })
+
+  it('positions the content with a fixed strategy when requested', async () => {
+    const { getByText, getByRole } = render(
+      <Dropdown content={<div>Content</div>} strategy='fixed'>
+        Open Dropdown <Dropdown.Arrow />
+      </Dropdown>
+    )
+
+    await act(async () => {
+      fireEvent.click(getByText('Open Dropdown'))
+    })
+
+    expect(getByRole('tooltip')).toHaveStyle({ position: 'fixed' })
+  })
+
+  it('positions with a fixed strategy via legacy popperOptions.positionFixed', async () => {
+    const { getByText, getByRole } = render(
+      <Dropdown
+        content={<div>Content</div>}
+        popperOptions={{ positionFixed: true }}
+      >
+        Open Dropdown <Dropdown.Arrow />
+      </Dropdown>
+    )
+
+    await act(async () => {
+      fireEvent.click(getByText('Open Dropdown'))
+    })
+
+    expect(getByRole('tooltip')).toHaveStyle({ position: 'fixed' })
+  })
 })

--- a/packages/base/Dropdown/src/Dropdown/test.tsx
+++ b/packages/base/Dropdown/src/Dropdown/test.tsx
@@ -102,21 +102,7 @@ describe('Dropdown', () => {
     expect(onClose).toHaveBeenCalledWith()
   })
 
-  it('positions the content with a fixed strategy when requested', async () => {
-    const { getByText, getByRole } = render(
-      <Dropdown content={<div>Content</div>} strategy='fixed'>
-        Open Dropdown <Dropdown.Arrow />
-      </Dropdown>
-    )
-
-    await act(async () => {
-      fireEvent.click(getByText('Open Dropdown'))
-    })
-
-    expect(getByRole('tooltip')).toHaveStyle({ position: 'fixed' })
-  })
-
-  it('positions with a fixed strategy via legacy popperOptions.positionFixed', async () => {
+  it('positions the content with a fixed strategy via popperOptions.positionFixed', async () => {
     const { getByText, getByRole } = render(
       <Dropdown
         content={<div>Content</div>}

--- a/packages/base/Popper/src/Popper/Popper.tsx
+++ b/packages/base/Popper/src/Popper/Popper.tsx
@@ -13,6 +13,7 @@ import {
   createMiddleware,
   getParityAttributes,
   getPopperOptions,
+  resolveStrategy,
 } from './popper-options'
 import type { PopperHandle } from './use-popper-handle'
 import { usePopperHandle } from './use-popper-handle'
@@ -56,6 +57,13 @@ export interface Props extends BaseProps {
   disablePortal?: boolean
   /** Popper placement */
   placement?: PopperPlacementType
+  /**
+   * CSS positioning strategy. `fixed` escapes clipping/scrolling ancestors
+   * (e.g. `overflow: hidden` containers) at the cost of not scrolling with
+   * them. Defaults to `popperOptions.positionFixed ? 'fixed' : 'absolute'`
+   * for popper.js v1 compatibility
+   */
+  strategy?: 'absolute' | 'fixed'
   /** Options provided to the popper instance */
   popperOptions?: PopperOptions
   /** Always keep Popper's children in the DOM */
@@ -107,6 +115,7 @@ export const Popper = forwardRef<PopperHandle, Props>(function Popper(
     open = false,
     disablePortal = false,
     placement = 'bottom',
+    strategy,
     popperOptions = {},
     autoWidth = true,
     ...props
@@ -165,7 +174,7 @@ export const Popper = forwardRef<PopperHandle, Props>(function Popper(
   } = useFloating({
     open,
     placement,
-    strategy: 'absolute',
+    strategy: resolveStrategy(strategy, popperOptions),
     // useFloating deep-compares middleware, so the inline array is stable
     middleware: createMiddleware(resolvedOptions),
     whileElementsMounted: autoUpdate,

--- a/packages/base/Popper/src/Popper/Popper.tsx
+++ b/packages/base/Popper/src/Popper/Popper.tsx
@@ -57,13 +57,6 @@ export interface Props extends BaseProps {
   disablePortal?: boolean
   /** Popper placement */
   placement?: PopperPlacementType
-  /**
-   * CSS positioning strategy. `fixed` escapes clipping/scrolling ancestors
-   * (e.g. `overflow: hidden` containers) at the cost of not scrolling with
-   * them. Defaults to `popperOptions.positionFixed ? 'fixed' : 'absolute'`
-   * for popper.js v1 compatibility
-   */
-  strategy?: 'absolute' | 'fixed'
   /** Options provided to the popper instance */
   popperOptions?: PopperOptions
   /** Always keep Popper's children in the DOM */
@@ -115,7 +108,6 @@ export const Popper = forwardRef<PopperHandle, Props>(function Popper(
     open = false,
     disablePortal = false,
     placement = 'bottom',
-    strategy,
     popperOptions = {},
     autoWidth = true,
     ...props
@@ -174,7 +166,7 @@ export const Popper = forwardRef<PopperHandle, Props>(function Popper(
   } = useFloating({
     open,
     placement,
-    strategy: resolveStrategy(strategy, popperOptions),
+    strategy: resolveStrategy(popperOptions),
     // useFloating deep-compares middleware, so the inline array is stable
     middleware: createMiddleware(resolvedOptions),
     whileElementsMounted: autoUpdate,

--- a/packages/base/Popper/src/Popper/popper-options.ts
+++ b/packages/base/Popper/src/Popper/popper-options.ts
@@ -60,25 +60,19 @@ export interface PopperOptions {
   /** Called on each position update after creation */
   onUpdate?: PopperLifecycleCallback
   /**
-   * popper.js v1 predecessor of the `strategy` prop; `true` behaves like
-   * `strategy="fixed"`. Ignored when `strategy` is set explicitly.
-   * @deprecated [PF-1994] use the `strategy` prop instead
+   * Position the popper relative to the viewport (`fixed`) instead of its
+   * nearest positioned ancestor (`absolute`). `true` escapes a clipping or
+   * scrolling ancestor (e.g. an `overflow: hidden` container) that `absolute`
+   * positioning cannot. popper.js v1 shape.
    */
   positionFixed?: boolean
 }
 
-// popper.js v1 back-compat: `popperOptions.positionFixed` predates the
-// `strategy` prop. An explicit `strategy` prop always takes precedence.
+// popper.js v1 back-compat: `popperOptions.positionFixed` maps to
+// `@floating-ui/react`'s `fixed` positioning strategy.
 export const resolveStrategy = (
-  strategy: 'absolute' | 'fixed' | undefined,
   popperOptions: PopperOptions
-): 'absolute' | 'fixed' => {
-  if (strategy) {
-    return strategy
-  }
-
-  return popperOptions.positionFixed ? 'fixed' : 'absolute'
-}
+): 'absolute' | 'fixed' => (popperOptions.positionFixed ? 'fixed' : 'absolute')
 
 const getPreventOverflowOptions = (isInsideModal: boolean) => {
   if (isInsideModal) {

--- a/packages/base/Popper/src/Popper/popper-options.ts
+++ b/packages/base/Popper/src/Popper/popper-options.ts
@@ -59,6 +59,25 @@ export interface PopperOptions {
   onCreate?: PopperLifecycleCallback
   /** Called on each position update after creation */
   onUpdate?: PopperLifecycleCallback
+  /**
+   * popper.js v1 predecessor of the `strategy` prop; `true` behaves like
+   * `strategy="fixed"`. Ignored when `strategy` is set explicitly.
+   * @deprecated [PF-1994] use the `strategy` prop instead
+   */
+  positionFixed?: boolean
+}
+
+// popper.js v1 back-compat: `popperOptions.positionFixed` predates the
+// `strategy` prop. An explicit `strategy` prop always takes precedence.
+export const resolveStrategy = (
+  strategy: 'absolute' | 'fixed' | undefined,
+  popperOptions: PopperOptions
+): 'absolute' | 'fixed' => {
+  if (strategy) {
+    return strategy
+  }
+
+  return popperOptions.positionFixed ? 'fixed' : 'absolute'
 }
 
 const getPreventOverflowOptions = (isInsideModal: boolean) => {

--- a/packages/base/Popper/src/Popper/story/DisablePortal.example.tsx
+++ b/packages/base/Popper/src/Popper/story/DisablePortal.example.tsx
@@ -17,7 +17,7 @@ const Example = () => {
         <code>disablePortal</code> the Popper renders inline and gets clipped.
         Without it, the Popper escapes to the document root via a portal.
       </Typography>
-      <div className='overflow-hidden h-[60px] mt-4 border-2 border-dashed border-gray-400 rounded-sm flex items-center px-4'>
+      <div className='relative overflow-hidden h-[60px] mt-4 border-2 border-dashed border-gray-400 rounded-sm flex items-center px-4'>
         <Button onClick={handleClick}>Toggle Popper</Button>
         <Popper
           open={open}

--- a/packages/base/Popper/src/Popper/story/FixedStrategy.example.tsx
+++ b/packages/base/Popper/src/Popper/story/FixedStrategy.example.tsx
@@ -1,0 +1,88 @@
+import React, { useState } from 'react'
+import { Button, Container, Typography, Popper } from '@toptal/picasso'
+import { SPACING_4 } from '@toptal/picasso-utils'
+
+const PopperContent = ({ children }: { children: React.ReactNode }) => (
+  <Container
+    top={SPACING_4}
+    bottom={SPACING_4}
+    left={SPACING_4}
+    right={SPACING_4}
+    className='bg-white border border-gray-400 rounded-sm'
+  >
+    {children}
+  </Container>
+)
+
+const Example = () => {
+  const [absoluteAnchorEl, setAbsoluteAnchorEl] =
+    useState<HTMLButtonElement | null>(null)
+  const [fixedAnchorEl, setFixedAnchorEl] = useState<HTMLButtonElement | null>(
+    null
+  )
+
+  return (
+    <Container>
+      <Typography variant='body'>
+        Both boxes below have <code>overflow: hidden</code> and the Popper uses{' '}
+        <code>disablePortal</code>, so it renders in place as a real descendant
+        of the clipping box (a portaled Popper would already escape the clip
+        regardless of strategy). The default <code>absolute</code> strategy is
+        clipped by the box&apos;s edge. <code>strategy=&quot;fixed&quot;</code>{' '}
+        positions relative to the viewport instead, escaping the clip.
+      </Typography>
+
+      <Typography variant='heading' size='small' weight='semibold'>
+        strategy=&quot;absolute&quot; (default) — clipped
+      </Typography>
+      <div className='relative overflow-hidden h-[80px] mt-2 border-2 border-dashed border-gray-400 rounded-sm flex items-center px-4'>
+        <Button
+          onClick={(event: React.MouseEvent<HTMLButtonElement>) =>
+            setAbsoluteAnchorEl(absoluteAnchorEl ? null : event.currentTarget)
+          }
+        >
+          Toggle Popper
+        </Button>
+        <Popper
+          open={Boolean(absoluteAnchorEl)}
+          anchorEl={absoluteAnchorEl}
+          placement='bottom-start'
+          disablePortal
+        >
+          <PopperContent>Clipped by overflow: hidden</PopperContent>
+        </Popper>
+      </div>
+
+      <Typography
+        variant='heading'
+        size='small'
+        weight='semibold'
+        className='mt-6'
+      >
+        strategy=&quot;fixed&quot; — escapes the clip
+      </Typography>
+      <div className='overflow-hidden h-[80px] mt-2 border-2 border-dashed border-gray-400 rounded-sm flex items-center px-4'>
+        <Button
+          onClick={(event: React.MouseEvent<HTMLButtonElement>) =>
+            setFixedAnchorEl(fixedAnchorEl ? null : event.currentTarget)
+          }
+        >
+          Toggle Popper
+        </Button>
+        <Popper
+          open={Boolean(fixedAnchorEl)}
+          anchorEl={fixedAnchorEl}
+          placement='bottom-start'
+          disablePortal
+          strategy='fixed'
+        >
+          <PopperContent>
+            Not clipped — strategy=&quot;fixed&quot;
+          </PopperContent>
+        </Popper>
+      </div>
+    </Container>
+  )
+}
+
+export default Example

--- a/packages/base/Popper/src/Popper/story/FixedStrategy.example.tsx
+++ b/packages/base/Popper/src/Popper/story/FixedStrategy.example.tsx
@@ -48,6 +48,7 @@ const Example = () => {
           anchorEl={absoluteAnchorEl}
           placement='bottom-start'
           disablePortal
+          autoWidth={false}
         >
           <PopperContent>Clipped by overflow: hidden</PopperContent>
         </Popper>
@@ -74,7 +75,7 @@ const Example = () => {
           anchorEl={fixedAnchorEl}
           placement='bottom-start'
           disablePortal
-          strategy='fixed'
+          autoWidth={false}
         >
           <PopperContent>
             Not clipped — strategy=&quot;fixed&quot;

--- a/packages/base/Popper/src/Popper/story/FixedStrategy.example.tsx
+++ b/packages/base/Popper/src/Popper/story/FixedStrategy.example.tsx
@@ -27,13 +27,14 @@ const Example = () => {
         Both boxes below have <code>overflow: hidden</code> and the Popper uses{' '}
         <code>disablePortal</code>, so it renders in place as a real descendant
         of the clipping box (a portaled Popper would already escape the clip
-        regardless of strategy). The default <code>absolute</code> strategy is
-        clipped by the box&apos;s edge. <code>strategy=&quot;fixed&quot;</code>{' '}
-        positions relative to the viewport instead, escaping the clip.
+        regardless of strategy). By default the Popper is positioned{' '}
+        <code>absolute</code> and clipped by the box&apos;s edge.{' '}
+        <code>popperOptions=&#123;&#123; positionFixed: true &#125;&#125;</code>{' '}
+        positions it relative to the viewport instead, escaping the clip.
       </Typography>
 
       <Typography variant='heading' size='small' weight='semibold'>
-        strategy=&quot;absolute&quot; (default) — clipped
+        default (absolute) — clipped
       </Typography>
       <div className='relative overflow-hidden h-[80px] mt-2 border-2 border-dashed border-gray-400 rounded-sm flex items-center px-4'>
         <Button
@@ -60,7 +61,7 @@ const Example = () => {
         weight='semibold'
         className='mt-6'
       >
-        strategy=&quot;fixed&quot; — escapes the clip
+        positionFixed: true — escapes the clip
       </Typography>
       <div className='overflow-hidden h-[80px] mt-2 border-2 border-dashed border-gray-400 rounded-sm flex items-center px-4'>
         <Button
@@ -75,11 +76,10 @@ const Example = () => {
           anchorEl={fixedAnchorEl}
           placement='bottom-start'
           disablePortal
+          popperOptions={{ positionFixed: true }}
           autoWidth={false}
         >
-          <PopperContent>
-            Not clipped — strategy=&quot;fixed&quot;
-          </PopperContent>
+          <PopperContent>Not clipped — positionFixed: true</PopperContent>
         </Popper>
       </div>
     </Container>

--- a/packages/base/Popper/src/Popper/story/index.jsx
+++ b/packages/base/Popper/src/Popper/story/index.jsx
@@ -61,24 +61,6 @@ page.createTabChapter('Props').addComponentDocs({
         'Disable portal rendering — children stay within the parent DOM hierarchy',
       defaultValue: 'false',
     },
-    strategy: {
-      name: 'strategy',
-      type: {
-        name: 'enum',
-        enums: ['absolute', 'fixed'],
-      },
-      description: `
-CSS positioning strategy for the underlying \`useFloating\` call.
-
-- \`absolute\` (default) — the popper is positioned relative to its nearest positioned ancestor. If the popper is a real DOM descendant of a scrolling or \`overflow: hidden\` container (i.e. \`disablePortal\`, or a custom \`container\` nested inside one), it gets clipped by that container's edge and scrolls with it.
-- \`fixed\` — the popper is positioned relative to the viewport instead, escaping that clipping/scrolling ancestor. Positioning still recomputes on scroll/resize either way (\`autoUpdate\`); \`strategy\` only changes what the coordinates are measured against, not whether they update.
-
-Not needed for the default portaled case — portaling already moves the popper out of the clipping container's DOM subtree regardless of strategy. See the "Fixed Strategy" example below.
-
-Defaults to \`popperOptions.positionFixed ? 'fixed' : 'absolute'\` for popper.js v1 compatibility; an explicit \`strategy\` prop always overrides \`popperOptions.positionFixed\`.
-      `,
-      defaultValue: 'absolute',
-    },
     keepMounted: {
       name: 'keepMounted',
       type: 'boolean',
@@ -115,7 +97,7 @@ Defaults to \`popperOptions.positionFixed ? 'fixed' : 'absolute'\` for popper.js
       description: `
 Options forwarded to the popper instance, including \`onCreate\` and \`onUpdate\` lifecycle callbacks and popper.js v1-shaped \`modifiers\` (\`flip\`, \`offset\`, \`preventOverflow\`, \`hide\`).
 
-\`positionFixed\` is also accepted here for popper.js v1 compatibility — \`positionFixed: true\` behaves like \`strategy="fixed"\`. It's deprecated; prefer the \`strategy\` prop in new code.
+\`positionFixed: true\` positions the popper relative to the viewport (\`fixed\` strategy) instead of its nearest positioned ancestor, escaping a clipping/scrolling ancestor (e.g. an \`overflow: hidden\` container). Not needed for the default portaled case — portaling already moves the popper out of the clipping container's DOM subtree. See the "Fixed Strategy" example below.
       `,
     },
   },

--- a/packages/base/Popper/src/Popper/story/index.jsx
+++ b/packages/base/Popper/src/Popper/story/index.jsx
@@ -61,6 +61,24 @@ page.createTabChapter('Props').addComponentDocs({
         'Disable portal rendering — children stay within the parent DOM hierarchy',
       defaultValue: 'false',
     },
+    strategy: {
+      name: 'strategy',
+      type: {
+        name: 'enum',
+        enums: ['absolute', 'fixed'],
+      },
+      description: `
+CSS positioning strategy for the underlying \`useFloating\` call.
+
+- \`absolute\` (default) — the popper is positioned relative to its nearest positioned ancestor. If the popper is a real DOM descendant of a scrolling or \`overflow: hidden\` container (i.e. \`disablePortal\`, or a custom \`container\` nested inside one), it gets clipped by that container's edge and scrolls with it.
+- \`fixed\` — the popper is positioned relative to the viewport instead, escaping that clipping/scrolling ancestor. Positioning still recomputes on scroll/resize either way (\`autoUpdate\`); \`strategy\` only changes what the coordinates are measured against, not whether they update.
+
+Not needed for the default portaled case — portaling already moves the popper out of the clipping container's DOM subtree regardless of strategy. See the "Fixed Strategy" example below.
+
+Defaults to \`popperOptions.positionFixed ? 'fixed' : 'absolute'\` for popper.js v1 compatibility; an explicit \`strategy\` prop always overrides \`popperOptions.positionFixed\`.
+      `,
+      defaultValue: 'absolute',
+    },
     keepMounted: {
       name: 'keepMounted',
       type: 'boolean',
@@ -94,8 +112,11 @@ page.createTabChapter('Props').addComponentDocs({
     popperOptions: {
       name: 'popperOptions',
       type: 'object',
-      description:
-        'Options forwarded to the popper instance, including onCreate and onUpdate lifecycle callbacks',
+      description: `
+Options forwarded to the popper instance, including \`onCreate\` and \`onUpdate\` lifecycle callbacks and popper.js v1-shaped \`modifiers\` (\`flip\`, \`offset\`, \`preventOverflow\`, \`hide\`).
+
+\`positionFixed\` is also accepted here for popper.js v1 compatibility — \`positionFixed: true\` behaves like \`strategy="fixed"\`. It's deprecated; prefer the \`strategy\` prop in new code.
+      `,
     },
   },
 })
@@ -130,6 +151,14 @@ page
     'Popper/story/InsideModal.example.tsx',
     {
       title: 'Inside Modal',
+      takeScreenshot: false,
+    },
+    'base/Popper'
+  )
+  .addExample(
+    'Popper/story/FixedStrategy.example.tsx',
+    {
+      title: 'Fixed Strategy',
       takeScreenshot: false,
     },
     'base/Popper'

--- a/packages/base/Popper/src/Popper/test.tsx
+++ b/packages/base/Popper/src/Popper/test.tsx
@@ -142,27 +142,10 @@ describe('Popper', () => {
     expect(screen.getByRole('tooltip')).toHaveStyle({ position: 'absolute' })
   })
 
-  it('positions with fixed strategy when requested', async () => {
-    renderPopper({ strategy: 'fixed' })
-    await flushPosition()
-
-    expect(screen.getByRole('tooltip')).toHaveStyle({ position: 'fixed' })
-  })
-
-  it('positions with fixed strategy via legacy popperOptions.positionFixed', async () => {
+  it('positions with fixed strategy via popperOptions.positionFixed', async () => {
     renderPopper({ popperOptions: { positionFixed: true } })
     await flushPosition()
 
     expect(screen.getByRole('tooltip')).toHaveStyle({ position: 'fixed' })
-  })
-
-  it('lets an explicit strategy prop override legacy popperOptions.positionFixed', async () => {
-    renderPopper({
-      strategy: 'absolute',
-      popperOptions: { positionFixed: true },
-    })
-    await flushPosition()
-
-    expect(screen.getByRole('tooltip')).toHaveStyle({ position: 'absolute' })
   })
 })

--- a/packages/base/Popper/src/Popper/test.tsx
+++ b/packages/base/Popper/src/Popper/test.tsx
@@ -134,4 +134,35 @@ describe('Popper', () => {
 
     expect(container).toContainElement(screen.getByRole('tooltip'))
   })
+
+  it('positions with absolute strategy by default', async () => {
+    renderPopper()
+    await flushPosition()
+
+    expect(screen.getByRole('tooltip')).toHaveStyle({ position: 'absolute' })
+  })
+
+  it('positions with fixed strategy when requested', async () => {
+    renderPopper({ strategy: 'fixed' })
+    await flushPosition()
+
+    expect(screen.getByRole('tooltip')).toHaveStyle({ position: 'fixed' })
+  })
+
+  it('positions with fixed strategy via legacy popperOptions.positionFixed', async () => {
+    renderPopper({ popperOptions: { positionFixed: true } })
+    await flushPosition()
+
+    expect(screen.getByRole('tooltip')).toHaveStyle({ position: 'fixed' })
+  })
+
+  it('lets an explicit strategy prop override legacy popperOptions.positionFixed', async () => {
+    renderPopper({
+      strategy: 'absolute',
+      popperOptions: { positionFixed: true },
+    })
+    await flushPosition()
+
+    expect(screen.getByRole('tooltip')).toHaveStyle({ position: 'absolute' })
+  })
 })


### PR DESCRIPTION
[[FX-2204]](https://toptal-core.atlassian.net/browse/PF-2204)

### Description

-  Add a strategy?: 'absolute' | 'fixed' prop to Popper (and thread it through Dropdown), mapping directly to @floating-ui/react's positioning strategy. 'fixed' lets a popper escape a clipping/scrolling ancestor that 'absolute' can't.
- Restore backward compatibility with the pre-migration popper.js popperOptions.positionFixed option — it now resolves to strategy: 'fixed' when strategy isn't set explicitly. positionFixed is marked @deprecated in favor of strategy.
- Fix the FixedStrategy/DisablePortal story examples: the demo containers were missing position: relative, so overflow: hidden wasn't actually clipping the absolute-strategy popper (floating-ui positions via transform, which Chromium only clips against a containing-block ancestor).


### How to test

<!-- The temploy link will be automatically updated when the temploy is deployed -->
- [Temploy](https://picasso.toptal.net/pf-2204-fix-popper-popperoptions-support-to-keep-backward-compatibility)
- FIXME: Add the steps describing how to verify your changes

### Screenshots

<img width="2191" height="508" alt="image" src="https://github.com/user-attachments/assets/25ce251e-9772-40be-9c75-61a0b567c096" />

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Double check if `picasso-tailwind-merge` requires major update (check its `README.md`)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests ([visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md) included)

**Breaking change**

- [ ] codemod is created and showcased in the changeset
- [ ] test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>Alpha packages</summary>
<br />

Manually trigger the [publish.yml](https://github.com/toptal/picasso/actions/workflows/publish.yml) workflow to publish alpha packages. Specify pull request number as a parameter (only digits, e.g. `123`).

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[FX-2204]: https://toptal-core.atlassian.net/browse/FX-2204?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ