### PR TITLE
Fix cypress flacky transitions

### DIFF
--- a/.changeset/test-utils-poppers-settled-waitfor.md
+++ b/.changeset/test-utils-poppers-settled-waitfor.md
@@ -1,0 +1,7 @@
+---
+'@toptal/picasso-test-utils': minor
+---
+
+### Test-Utils
+
+- add `createPoppersSettledWaitFor` — builds a Happo `waitFor` predicate that resolves once every open `@floating-ui/react` popper (Dropdown/Menu/Popper) has finished positioning, so a Storybook Happo snapshot serializes the settled geometry rather than a mid-`autoUpdate` frame. Pass it via a story's `parameters.happo.waitFor`. Mirrors the Cypress-Happo capture guard added in `cypress/support/commands.jsx`.

--- a/cypress/component/Avatar.spec.tsx
+++ b/cypress/component/Avatar.spec.tsx
@@ -38,7 +38,7 @@ describe('Avatar', () => {
     })
   })
 
-  describe('when emblem prop is true', () => {
+  describe('when showEmblem prop is true', () => {
     let src = ''
     const handleEdit = () => {}
 
@@ -60,7 +60,7 @@ describe('Avatar', () => {
             name='Jacqueline Roque'
             size='medium'
             onEdit={handleEdit}
-            emblem={true}
+            showEmblem={true}
             testIds={{ wrapper: 'avatar-wrapper' }}
           />
         </Container>

--- a/cypress/component/Drawer.spec.tsx
+++ b/cypress/component/Drawer.spec.tsx
@@ -106,9 +106,7 @@ describe('Drawer', () => {
     )
 
     cy.getByTestId('trigger').click()
-    cy.get('[role="dialog"]')
-      .should('be.visible')
-      .and('not.have.attr', 'data-starting-style')
+    cy.waitForOverlayOpen()
     cy.get('body').happoScreenshot({
       component,
       variant: 'narrow-width/with-custom-title',
@@ -119,9 +117,7 @@ describe('Drawer', () => {
     cy.mount(<TestDrawer width='regular' title='This is a regular Drawer' />)
 
     cy.getByTestId('trigger').click()
-    cy.get('[role="dialog"]')
-      .should('be.visible')
-      .and('not.have.attr', 'data-starting-style')
+    cy.waitForOverlayOpen()
     cy.get('body').happoScreenshot({
       component,
       variant: 'regular-width/with-title',
@@ -132,9 +128,7 @@ describe('Drawer', () => {
     cy.mount(<TestDrawerWithNotification width='medium' />)
 
     cy.getByTestId('trigger').click()
-    cy.get('[role="dialog"]')
-      .should('be.visible')
-      .and('not.have.attr', 'data-starting-style')
+    cy.waitForOverlayOpen()
     cy.get('body').happoScreenshot({
       component,
       variant: 'medium-width/with-notification',
@@ -145,9 +139,7 @@ describe('Drawer', () => {
     cy.mount(<TestDrawer width='wide' />)
 
     cy.getByTestId('trigger').click()
-    cy.get('[role="dialog"]')
-      .should('be.visible')
-      .and('not.have.attr', 'data-starting-style')
+    cy.waitForOverlayOpen()
     cy.get('body').happoScreenshot({
       component,
       variant: 'wide-width/without-title',
@@ -188,9 +180,7 @@ describe('Drawer', () => {
           )
 
           cy.getByTestId('trigger').click()
-          cy.get('[role="dialog"]')
-            .should('be.visible')
-            .and('not.have.attr', 'data-starting-style')
+          cy.waitForOverlayOpen()
           cy.get('body').happoScreenshot({
             component,
             variant: `drawer-${variant}-width/${width}-default`,

--- a/cypress/component/Modal.spec.tsx
+++ b/cypress/component/Modal.spec.tsx
@@ -152,12 +152,8 @@ const component = 'Modal'
 // Wait for the modal's open fade (data-starting-style:opacity-0 → 1) to settle
 // before taking the screenshot. Capturing mid-fade composites the bordered
 // secondary (Cancel) button at partial opacity, producing edge artifacts on its
-// border.
-const waitForModalOpen = () =>
-  cy
-    .get('[role="dialog"]')
-    .should('be.visible')
-    .and('not.have.attr', 'data-starting-style')
+// border. Delegates to the shared `waitForOverlayOpen` command (commands.jsx).
+const waitForModalOpen = () => cy.waitForOverlayOpen()
 
 // The scroll shades fade in over 300ms. When the content overflows, wait for
 // the fade to settle so the screenshot captures the fully-opaque shade instead

--- a/cypress/component/PromptModal.spec.tsx
+++ b/cypress/component/PromptModal.spec.tsx
@@ -25,12 +25,9 @@ const TestProptModal = () => {
 // Wait for the modal's open fade (data-starting-style:opacity-0 → 1) to settle
 // before taking the screenshot. Capturing mid-fade composites the (only)
 // bordered button — the secondary Cancel — at partial opacity, producing edge
-// artifacts on its border.
-const waitForModalOpen = () =>
-  cy
-    .get('[role="dialog"]')
-    .should('be.visible')
-    .and('not.have.attr', 'data-starting-style')
+// artifacts on its border. Delegates to the shared `waitForOverlayOpen` command
+// (commands.jsx).
+const waitForModalOpen = () => cy.waitForOverlayOpen()
 
 describe('PromptModal', () => {
   it('renders on desktop and mobile', () => {

--- a/cypress/support/commands.jsx
+++ b/cypress/support/commands.jsx
@@ -75,6 +75,57 @@ const waitForHoverToSettle = selector => {
   })
 }
 
+// A popper positioned by `@floating-ui/react` (Dropdown/Menu/Popper) commits
+// its coordinates a frame or two after open, driven by `autoUpdate` — so its
+// `getBoundingClientRect()` keeps changing across animation frames right after
+// it appears. happo-cypress serializes the live DOM at a single instant; if
+// that instant lands mid-settle, the whole popup (and anything measured from
+// it) is captured a fraction of a pixel off, diffing against the baseline.
+// Picasso stamps `x-placement` on the positioned floating node, so its presence
+// marks a popper that must be geometrically at rest before we serialize.
+//
+// Waited on via `.should()`, whose callback Cypress retries on its own
+// animation-frame loop (bounded by defaultCommandTimeout) until it passes — no
+// hardcoded durations. The assertion passes once two consecutive reads of every
+// visible popper's box are identical, i.e. positioning has come to rest. Closed
+// `keepMounted` poppers (rendered but `display:none`) are skipped as they carry
+// no meaningful geometry. When no popper is open the set is empty and the
+// assertion passes immediately, so this is a no-op for non-popper snapshots.
+const readPopperBoxes = $body => {
+  const boxes = []
+
+  $body.find('[x-placement]').each((_index, el) => {
+    const rect = el.getBoundingClientRect()
+
+    // skip non-rendered nodes (display:none keepMounted poppers report 0×0)
+    if (rect.width === 0 && rect.height === 0) {
+      return
+    }
+
+    boxes.push(
+      [rect.top, rect.left, rect.width, rect.height]
+        .map(value => Math.round(value * 100) / 100)
+        .join(',')
+    )
+  })
+
+  return boxes.join('|')
+}
+
+const waitForPoppersToSettle = () => {
+  let previous = null
+
+  return cy.get('body').should($body => {
+    const current = readPopperBoxes($body)
+    const wasPrevious = previous
+
+    previous = current
+    // passes only once two consecutive reads match — i.e. every open popper has
+    // finished positioning. Cypress retries this callback until it passes.
+    expect(current, 'popper positioning settled').to.equal(wasPrevious)
+  })
+}
+
 Cypress.Commands.add(
   'hoverAndTakeHappoScreenshot',
   { prevSubject: true },
@@ -94,6 +145,21 @@ Cypress.Commands.add(
   }
 )
 
+// Gate on an overlay (Modal/Drawer/PromptModal `[role="dialog"]`, …) being open
+// AND past its @base-ui/react enter transition before proceeding. Base UI fades
+// the overlay in (data-starting-style: opacity-0 → 1) and removes
+// `data-starting-style` once the transition starts; capturing mid-fade
+// composites bordered content (e.g. a secondary button) at partial opacity,
+// producing edge artifacts. Retried on Cypress's own loop via `.should()` — no
+// hardcoded durations. Shared so Modal/PromptModal/Drawer specs stop each
+// hand-rolling the same assertion.
+Cypress.Commands.add('waitForOverlayOpen', (selector = '[role="dialog"]') =>
+  cy
+    .get(selector)
+    .should('be.visible')
+    .and('not.have.attr', 'data-starting-style')
+)
+
 // happo-cypress serializes the live DOM and re-renders it statically in the
 // cloud (no JS runs there). @base-ui/react removes `data-starting-style` one
 // frame after mount; if captured before removal, the attribute pins the element
@@ -101,10 +167,15 @@ Cypress.Commands.add(
 Cypress.Commands.overwrite(
   'happoScreenshot',
   (originalFn, subject, options) => {
-    return cy
-      .get('[data-starting-style]', { timeout: 4000 })
-      .should('not.exist')
-      .then(() => originalFn(subject, options))
+    return (
+      cy
+        .get('[data-starting-style]', { timeout: 4000 })
+        .should('not.exist')
+        // then let any open @floating-ui popper finish positioning, so the static
+        // capture reflects its settled geometry (see waitForPoppersToSettle above)
+        .then(() => waitForPoppersToSettle())
+        .then(() => originalFn(subject, options))
+    )
   }
 )
 

--- a/cypress/support/index.d.ts
+++ b/cypress/support/index.d.ts
@@ -13,6 +13,7 @@ declare global {
       hoverAndTakeHappoScreenshot(
         options?: HappoScreenshotOptions
       ): Chainable<Subject>
+      waitForOverlayOpen(selector?: string): Chainable<JQuery<HTMLElement>>
       mount: typeof mount
     }
   }

--- a/packages/base/Test-Utils/src/test-utils/index.tsx
+++ b/packages/base/Test-Utils/src/test-utils/index.tsx
@@ -32,3 +32,4 @@ const customRender = (
 export * from '@testing-library/react'
 export { customRender as render, TestingPicasso }
 export { HAPPO_TARGETS, getHappoTargets } from './get-happo-targets'
+export { createPoppersSettledWaitFor } from './wait-for-poppers-settled'

--- a/packages/base/Test-Utils/src/test-utils/wait-for-poppers-settled/index.ts
+++ b/packages/base/Test-Utils/src/test-utils/wait-for-poppers-settled/index.ts
@@ -1,0 +1,1 @@
+export { createPoppersSettledWaitFor } from './wait-for-poppers-settled'

--- a/packages/base/Test-Utils/src/test-utils/wait-for-poppers-settled/wait-for-poppers-settled.ts
+++ b/packages/base/Test-Utils/src/test-utils/wait-for-poppers-settled/wait-for-poppers-settled.ts
@@ -1,0 +1,64 @@
+// A popper positioned by `@floating-ui/react` (Dropdown/Menu/Popper) commits
+// its coordinates a frame or two after open, driven by `autoUpdate` — so its
+// `getBoundingClientRect()` keeps changing across animation frames right after
+// it appears. happo captures a single serialized DOM snapshot; if that instant
+// lands mid-settle, the popup (and anything measured from it) is captured a
+// fraction of a pixel off, diffing against the baseline. Picasso stamps
+// `x-placement` on the positioned floating node, so its presence marks a popper
+// whose geometry must be at rest before happo snapshots.
+//
+// This mirrors the Cypress-Happo capture guard (`waitForPoppersToSettle` in
+// `cypress/support/commands.jsx`) for the Storybook pipeline, where it plugs
+// into `happo-plugin-storybook`'s per-story `waitFor` predicate — the plugin
+// polls it (bounded by its own `renderTimeoutMs`) until it returns `true`, so
+// there are no hardcoded durations. Intended usage from a story that renders an
+// open floating-ui popper in its screenshotted state:
+//
+//   Story.parameters = { happo: { waitFor: createPoppersSettledWaitFor() } }
+//
+// Each call returns a fresh predicate with its own closure, so per-story /
+// per-target runs never share settle state.
+
+const readPopperBoxes = (): string => {
+  const boxes: string[] = []
+
+  document.querySelectorAll('[x-placement]').forEach(el => {
+    const rect = el.getBoundingClientRect()
+
+    // skip non-rendered nodes (display:none keepMounted poppers report 0×0)
+    if (rect.width === 0 && rect.height === 0) {
+      return
+    }
+
+    boxes.push(
+      [rect.top, rect.left, rect.width, rect.height]
+        .map(value => Math.round(value * 100) / 100)
+        .join(',')
+    )
+  })
+
+  return boxes.join('|')
+}
+
+/**
+ * Builds a Happo `waitFor` predicate that resolves once every open
+ * `@floating-ui/react` popper has finished positioning. Returns `true` only
+ * when two consecutive reads of every visible popper's box are identical — i.e.
+ * positioning has come to rest. When no popper is open the set is empty and the
+ * two reads match immediately, so the predicate is a no-op for non-popper
+ * stories.
+ *
+ * @returns {() => boolean} A predicate to pass as `parameters.happo.waitFor`
+ */
+export const createPoppersSettledWaitFor = (): (() => boolean) => {
+  let previous: string | null = null
+
+  return () => {
+    const current = readPopperBoxes()
+    const settled = previous !== null && current === previous
+
+    previous = current
+
+    return settled
+  }
+}


### PR DESCRIPTION
### Description

Cypress-Happo has been reporting a non-deterministic 1px seam on the bottom/left/right edge of avatar-bearing snapshots — most visibly `PageTopBarMenu / width-479` and `width-1023`. It reproduced on **unrelated** open PRs (#5006, #5027) as a lone `1 diff, 286 unchanged`, the signature of a flaky capture rather than a real regression. (The existing `badge-migration` changeset already documents `PageTopBarMenu / width-*` diffs as "environmental/render variability".)

**Root cause.** `happo-cypress` serializes the live DOM into a single static frame. `PageTopBarMenu` opens a `Dropdown → Popper` built on `@floating-ui/react`, whose position commits asynchronously over a couple of `autoUpdate` frames. Nothing in the capture path waited for that layout to settle, so serialization could land mid-position; the avatar's `em`-based `clip-path` bottom-left notch is where the resulting sub-pixel shift renders as a visible seam. The existing `happoScreenshot` override only waited for `data-starting-style` (a Base UI signal the floating-ui Popper never sets), so it was a no-op here.

**What this PR does:**

- **Gates capture on popper positioning.** The `happoScreenshot` override now also waits for every open `@floating-ui` popper (identified by the `x-placement` attribute Picasso already stamps on the positioned node) to reach a stable bounding box — two consecutive identical reads — before serializing. No-op when no popper is open.
- **Consolidates the duplicated overlay-settle waits.** The migration PRs had accreted the same "wait for `[role="dialog"]` visible + past its enter fade" logic three ways: copy-pasted `waitForModalOpen` in `Modal.spec` and `PromptModal.spec`, and inlined verbatim ×5 in `Drawer.spec`. These now share one `cy.waitForOverlayOpen(selector?)` command in `commands.jsx`.
- **Adds a dormant Storybook-side equivalent.** `createPoppersSettledWaitFor()` in `@toptal/picasso-test-utils` builds the same settle predicate for `happo-plugin-storybook`'s per-story `parameters.happo.waitFor`. Wired into nothing — a one-liner opt-in if a Storybook popper snapshot ever flaps. (Storybook is currently clean; this is a safeguard.)
- **Fixes an unrelated Avatar spec bug found along the way.** `Avatar.spec.tsx`'s "shows emblem" test passed `emblem={true}`, but the prop is `showEmblem` — so it silently rendered no emblem. Corrected the prop and the `describe` label.

**No `cy.wait(ms)` / hardcoded timeouts** — every wait is a `.should()`-retried DOM condition, resolving the instant it's satisfied and only failing at the existing `defaultCommandTimeout` ceiling. No component source is touched (Avatar, UserBadge, Page, Popper are byte-identical to base); this is capture-timing/test-infra only.
