### PR TITLE
[PF-2222] Fix Radio label height migration difference

### DIFF
--- a/packages/base/Radio/src/Radio/Radio.tsx
+++ b/packages/base/Radio/src/Radio/Radio.tsx
@@ -105,11 +105,6 @@ export const Radio = forwardRef<HTMLButtonElement | HTMLLabelElement, Props>(
         ref={ref as React.ForwardedRef<HTMLLabelElement>}
         control={radioControl}
         classes={{
-          // These values sit on the outer `<FormLabel as='span'>`, which has no
-          // font-size of its own and inherits the label root's `text-[1rem]` (16px,
-          // set via `root` just below). So the original `em` values map 1:1 to `rem`
-          // (0.25em→4px→0.25rem, 1.5em→24px→1.5rem). The inner text span's
-          // `text-[0.8125rem]` only styles the glyphs, not this margin/max-width box.
           label: 'mt-[0.25rem] max-w-[calc(100%_-_1.5rem_+_1px)]',
           root: 'text-[1rem] items-start',
         }}

--- a/packages/base/Radio/src/Radio/Radio.tsx
+++ b/packages/base/Radio/src/Radio/Radio.tsx
@@ -105,10 +105,12 @@ export const Radio = forwardRef<HTMLButtonElement | HTMLLabelElement, Props>(
         ref={ref as React.ForwardedRef<HTMLLabelElement>}
         control={radioControl}
         classes={{
-          // rem values are the em equivalents against FormLabel's 14px font
-          // (`size='medium'`, the only size Radio renders): 0.25em→3.5px→0.21875rem,
-          // 1.5em→21px→1.3125rem. Do not "round" to 0.25rem/1.5rem — that shifts the label.
-          label: 'mt-[0.21875rem] max-w-[calc(100%_-_1.3125rem_+_1px)]',
+          // These values sit on the outer `<FormLabel as='span'>`, which has no
+          // font-size of its own and inherits the label root's `text-[1rem]` (16px,
+          // set via `root` just below). So the original `em` values map 1:1 to `rem`
+          // (0.25em→4px→0.25rem, 1.5em→24px→1.5rem). The inner text span's
+          // `text-[0.8125rem]` only styles the glyphs, not this margin/max-width box.
+          label: 'mt-[0.25rem] max-w-[calc(100%_-_1.5rem_+_1px)]',
           root: 'text-[1rem] items-start',
         }}
         style={style}

--- a/packages/base/Radio/src/Radio/__snapshots__/test.tsx.snap
+++ b/packages/base/Radio/src/Radio/__snapshots__/test.tsx.snap
@@ -35,7 +35,7 @@ exports[`Radio Radio.Group renders radio in a grid group 1`] = `
               />
             </span>
             <span
-              class="inline-block leading-[1em] mb-0 text-graphite mt-[0.21875rem] max-w-[calc(100%_"
+              class="inline-block leading-[1em] mb-0 text-graphite mt-[0.25rem] max-w-[calc(100%_"
             >
               <span
                 class="align-top text-[0.8125rem]"
@@ -68,7 +68,7 @@ exports[`Radio Radio.Group renders radio in a grid group 1`] = `
               />
             </span>
             <span
-              class="inline-block leading-[1em] mb-0 text-graphite mt-[0.21875rem] max-w-[calc(100%_"
+              class="inline-block leading-[1em] mb-0 text-graphite mt-[0.25rem] max-w-[calc(100%_"
             >
               <span
                 class="align-top text-[0.8125rem]"
@@ -101,7 +101,7 @@ exports[`Radio Radio.Group renders radio in a grid group 1`] = `
               />
             </span>
             <span
-              class="inline-block leading-[1em] mb-0 text-graphite mt-[0.21875rem] max-w-[calc(100%_"
+              class="inline-block leading-[1em] mb-0 text-graphite mt-[0.25rem] max-w-[calc(100%_"
             >
               <span
                 class="align-top text-[0.8125rem]"
@@ -134,7 +134,7 @@ exports[`Radio Radio.Group renders radio in a grid group 1`] = `
               />
             </span>
             <span
-              class="inline-block leading-[1em] mb-0 text-graphite mt-[0.21875rem] max-w-[calc(100%_"
+              class="inline-block leading-[1em] mb-0 text-graphite mt-[0.25rem] max-w-[calc(100%_"
             >
               <span
                 class="align-top text-[0.8125rem]"
@@ -167,7 +167,7 @@ exports[`Radio Radio.Group renders radio in a grid group 1`] = `
               />
             </span>
             <span
-              class="inline-block leading-[1em] mb-0 text-graphite mt-[0.21875rem] max-w-[calc(100%_"
+              class="inline-block leading-[1em] mb-0 text-graphite mt-[0.25rem] max-w-[calc(100%_"
             >
               <span
                 class="align-top text-[0.8125rem]"
@@ -200,7 +200,7 @@ exports[`Radio Radio.Group renders radio in a grid group 1`] = `
               />
             </span>
             <span
-              class="inline-block leading-[1em] mb-0 text-graphite mt-[0.21875rem] max-w-[calc(100%_"
+              class="inline-block leading-[1em] mb-0 text-graphite mt-[0.25rem] max-w-[calc(100%_"
             >
               <span
                 class="align-top text-[0.8125rem]"
@@ -251,7 +251,7 @@ exports[`Radio Radio.Group renders radio in group 1`] = `
               />
             </span>
             <span
-              class="inline-block leading-[1em] mb-0 text-graphite mt-[0.21875rem] max-w-[calc(100%_"
+              class="inline-block leading-[1em] mb-0 text-graphite mt-[0.25rem] max-w-[calc(100%_"
             >
               <span
                 class="align-top text-[0.8125rem]"
@@ -284,7 +284,7 @@ exports[`Radio Radio.Group renders radio in group 1`] = `
               />
             </span>
             <span
-              class="inline-block leading-[1em] mb-0 text-graphite mt-[0.21875rem] max-w-[calc(100%_"
+              class="inline-block leading-[1em] mb-0 text-graphite mt-[0.25rem] max-w-[calc(100%_"
             >
               <span
                 class="align-top text-[0.8125rem]"

--- a/packages/picasso-forms/src/Radio/__snapshots__/test.tsx.snap
+++ b/packages/picasso-forms/src/Radio/__snapshots__/test.tsx.snap
@@ -58,7 +58,7 @@ exports[`FormRadio renders 1`] = `
                     />
                   </span>
                   <span
-                    class="inline-block leading-[1em] mb-0 text-graphite mt-[0.21875rem] max-w-[calc(100%_"
+                    class="inline-block leading-[1em] mb-0 text-graphite mt-[0.25rem] max-w-[calc(100%_"
                   >
                     <span
                       class="align-top text-[0.8125rem]"
@@ -92,7 +92,7 @@ exports[`FormRadio renders 1`] = `
                     />
                   </span>
                   <span
-                    class="inline-block leading-[1em] mb-0 text-graphite mt-[0.21875rem] max-w-[calc(100%_"
+                    class="inline-block leading-[1em] mb-0 text-graphite mt-[0.25rem] max-w-[calc(100%_"
                   >
                     <span
                       class="align-top text-[0.8125rem]"
@@ -173,7 +173,7 @@ exports[`FormRadio required with asterisk 1`] = `
                     />
                   </span>
                   <span
-                    class="inline-block leading-[1em] mb-0 text-graphite mt-[0.21875rem] max-w-[calc(100%_"
+                    class="inline-block leading-[1em] mb-0 text-graphite mt-[0.25rem] max-w-[calc(100%_"
                   >
                     <span
                       class="align-top text-[0.8125rem]"
@@ -207,7 +207,7 @@ exports[`FormRadio required with asterisk 1`] = `
                     />
                   </span>
                   <span
-                    class="inline-block leading-[1em] mb-0 text-graphite mt-[0.21875rem] max-w-[calc(100%_"
+                    class="inline-block leading-[1em] mb-0 text-graphite mt-[0.25rem] max-w-[calc(100%_"
                   >
                     <span
                       class="align-top text-[0.8125rem]"


### PR DESCRIPTION
[PF-2222]

### Description

Follow-up fix for the Radio migration (#4999). After migrating `Radio` off
`@material-ui/core` (JSS) to Tailwind, the label sat ~1px too low and its
`max-width` was ~3px narrower than on `master`, causing a small visual
regression against the pre-migration baseline.

The migration converted the label slot's `em` spacing to `rem` using the wrong
font-size basis. The values live on the outer `<FormLabel as='span'>`, which has
**no font-size of its own** and **inherits `text-[1rem]` (16px)** from the
`FormControlLabel` label root (set via the component's `classes.root`). They had
been converted as if the basis were 13px (the inner text span's
`text-[0.8125rem]`, which only styles the glyphs — not this margin/max-width
box). At the correct 16px basis the `em`→`rem` mapping is a plain 1:1:

| Slot value | Before (13px basis, wrong) | After (16px basis, correct) | master `em` |
| --- | --- | --- | --- |
| `margin-top` | `mt-[0.21875rem]` (3.5px) | `mt-[0.25rem]` (4px) | `0.25em` = 4px |
| `max-width` term | `1.3125rem` (21px) | `1.5rem` (24px) | `1.5em` = 24px |

The corrected `rem` values now render identically to `master`'s original `em`.
A code comment documents the 16px inheritance so the values are not
re-"simplified" to a wrong basis later.

No public API, props, or behavior change — visual parity restoration only.

### How to test

- [Temploy](https://picasso.toptal.net/fix/pf-2222-radio-component-label-height)
- Open the `Radio` stories (e.g. **Radio → Checked**, **Default**, **Custom Label**).
- Confirm the label baseline aligns with the radio control and matches `master`
  (no ~1px vertical offset).
- Compare the Happo report for the Radio stories against the baseline — the label
  height/offset diff should be gone.

### Screenshots

| Before | After |
| --- | --- |
| Label ~1px low, max-width ~3px narrow | Label aligned, matches master |

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Double check if `picasso-tailwind-merge` requires major update (check its `README.md`)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests ([visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md) included)


[PF-2222]: https://toptal-core.atlassian.net/browse/PF-2222?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ