### PR TITLE
Add secret scanning workflow and 7-day Dependabot cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,8 @@ updates:
   schedule:
     interval: weekly
     time: "07:00"
+  cooldown:
+    default-days: 7
   pull-request-branch-name:
     separator: "-"
   open-pull-requests-limit: 3
@@ -19,6 +21,8 @@ updates:
   schedule:
     interval: weekly
     time: "07:00"
+  cooldown:
+    default-days: 7
   open-pull-requests-limit: 2
   ignore:
   - dependency-name: '*'

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -1,0 +1,7 @@
+name: Secret Scan
+on:
+  pull_request:
+    types: [opened, synchronize]
+jobs:
+  call_secret_scanning:
+    uses: toptal/actions/.github/workflows/security-scan.yml@main


### PR DESCRIPTION


### Description

Part of the repo security-hardening initiative (supply-chain / secret hygiene). Two changes:

- **Secret scanning** — adds `.github/workflows/security-scan.yml`, the SecOps reusable secret-scanning + SAST (Bearer) workflow, per [Add Secret Scanning to Your Repo](https://toptal-core.atlassian.net/wiki/spaces/I/pages/6146392088). Runs on PR open/synchronize; no tokens to configure.
- **Dependabot cooldown** — adds a 7-day `cooldown` to both the `npm` and `github-actions` ecosystems in `.github/dependabot.yml`, so newly published versions are quarantined for a week before Dependabot proposes them (defends against compromised releases). picasso was the last audited repo still missing this.

### How to test

- Secret Scan runs automatically on this PR — check the **Checks** tab for the `Secret Scan` run; a clean PR shows no bot findings.
- Dependabot config change is validated by GitHub on merge to the default branch.

### Development checks

N/A — CI/security config only, no product code, components, or design changes.