### PR TITLE
Remove secret-scan workflow (unusable on public repo)

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -1,7 +1,0 @@
-name: Secret Scan
-on:
-  pull_request:
-    types: [opened, synchronize]
-jobs:
-  call_secret_scanning:
-    uses: toptal/actions/.github/workflows/security-scan.yml@main


### PR DESCRIPTION


### Description

Reverts the `security-scan.yml` added in #5031. That workflow calls the **private** `toptal/actions` reusable workflow, and **a public repository cannot invoke a private reusable workflow** — so the `Secret Scan` job fails at workflow resolution on every PR (picasso is public). It can never succeed here as-is.

Secret scanning for picasso is instead covered by **GitHub-native secret scanning + push protection** (free and on-by-default for public repos), and native **CodeQL** already runs for SAST.

This also clears the failing `Dependabot Updates` run on master, whose sole cause was this file's reference to the unreachable private `toptal/actions`.

**Kept:** the 7-day Dependabot `cooldown` from #5031 (npm + github-actions) — that change works and is unaffected.

### How to test

- No `Secret Scan` failure will appear on this PR (the workflow is gone).
- `Dependabot Updates` on master no longer errors on `toptal/actions`.

### Development checks

N/A — CI/security config only; no product code, components, or design changes.