### PR TITLE
[PF-2208] Fix Grid.Item gridsize type

### DIFF
--- a/packages/base/Checkbox/src/CheckboxGroup/CheckboxGroup.tsx
+++ b/packages/base/Checkbox/src/CheckboxGroup/CheckboxGroup.tsx
@@ -1,20 +1,24 @@
 /* eslint-disable react/no-array-index-key */
 import type { HTMLAttributes } from 'react'
 import React from 'react'
-import type { GridSizeProps, GridProps } from '@toptal/picasso-grid'
+import type { GridItemSizeProps, GridProps } from '@toptal/picasso-grid'
 import { GridCompound as Grid } from '@toptal/picasso-grid'
 import { twMerge } from '@toptal/picasso-tailwind-merge'
+import { fromPx } from '@toptal/picasso-shared'
+import { SPACING_4, spacingToPx } from '@toptal/picasso-utils'
 
 type GridSpacing = GridProps['spacing']
 
-export interface Props extends HTMLAttributes<HTMLDivElement>, GridSizeProps {
+export interface Props
+  extends HTMLAttributes<HTMLDivElement>,
+    GridItemSizeProps {
   /** Align checkboxes horizontally  */
   horizontal?: boolean
   /** Defines amount of space between checkbox components (in px) */
   spacing?: GridSpacing
 }
 
-const HORIZONTAL_SPACING = 16
+const HORIZONTAL_SPACING = fromPx(spacingToPx(SPACING_4)) as GridSpacing
 
 const CheckboxGroup = ({ horizontal = false, ...props }: Props) => {
   const { spacing, xs, sm, md, lg, xl, className, ...rest } = props
@@ -33,11 +37,7 @@ const CheckboxGroup = ({ horizontal = false, ...props }: Props) => {
         className
       )}
     >
-      <Grid
-        direction={direction}
-        spacing={gridSpacing as GridSpacing}
-        className='mt-0 mb-0'
-      >
+      <Grid direction={direction} spacing={gridSpacing} className='mt-0 mb-0'>
         {children.map((child, index) => (
           <Grid.Item
             key={index}

--- a/packages/base/Grid/src/GridItem/GridItem.tsx
+++ b/packages/base/Grid/src/GridItem/GridItem.tsx
@@ -7,7 +7,7 @@ import { GridContext } from '../GridContext'
 import type { GridSize, GridSpacing } from '../types'
 import { getSizesClassNames } from './utils/get-sizes-class-names'
 
-export interface GridSizes {
+export interface GridItemSizeProps {
   /** Defines the number of grids the component is going to use. It's applied for all the screen sizes with the lowest priority */
   xs?: boolean | GridSize
   /** Defines the number of grids the component is going to use. It's applied for the sm breakpoint and wider screens */
@@ -22,7 +22,7 @@ export interface GridSizes {
 
 export interface Props
   extends BaseProps,
-    GridSizes,
+    GridItemSizeProps,
     HTMLAttributes<HTMLElement> {
   /** Content of Grid.Item */
   children?: ReactNode

--- a/packages/base/Grid/src/GridItem/index.ts
+++ b/packages/base/Grid/src/GridItem/index.ts
@@ -1,7 +1,9 @@
 import type { OmitInternalProps } from '@toptal/picasso-shared'
 
-import type { Props, GridSizes } from './GridItem'
+import type { Props, GridItemSizeProps } from './GridItem'
 
 export { default as GridItem } from './GridItem'
 export type GridItemProps = OmitInternalProps<Props>
-export type GridSizeProps = GridSizes
+export type { GridItemSizeProps } from './GridItem'
+/** @deprecated Use `GridItemSizeProps` instead. [PF-2208] */
+export type GridSizeProps = GridItemSizeProps

--- a/packages/base/Grid/src/GridItem/utils/get-sizes-class-names.ts
+++ b/packages/base/Grid/src/GridItem/utils/get-sizes-class-names.ts
@@ -1,7 +1,13 @@
-import type { GridSizes } from '../GridItem'
+import type { GridItemSizeProps } from '../GridItem'
 import { getClassNamesForBreakpoint } from './get-class-names-for-breakpoint'
 
-export const getSizesClassNames = ({ xs, sm, md, lg, xl }: GridSizes) => [
+export const getSizesClassNames = ({
+  xs,
+  sm,
+  md,
+  lg,
+  xl,
+}: GridItemSizeProps) => [
   getClassNamesForBreakpoint('xs', xs),
   getClassNamesForBreakpoint('sm', sm),
   getClassNamesForBreakpoint('md', md),

--- a/packages/base/Grid/src/types.ts
+++ b/packages/base/Grid/src/types.ts
@@ -1,20 +1,6 @@
 export type GridSpacing = 0 | 8 | 16 | 24 | 32 | 64 | 72 | 80
 
-export type GridSize =
-  | true
-  | 'auto'
-  | 1
-  | 2
-  | 3
-  | 4
-  | 5
-  | 6
-  | 7
-  | 8
-  | 9
-  | 10
-  | 11
-  | 12
+export type GridSize = 'auto' | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 | 11 | 12
 
 export type GridJustification =
   | 'flex-start'

--- a/packages/base/Radio/src/RadioGroup/RadioGroup.tsx
+++ b/packages/base/Radio/src/RadioGroup/RadioGroup.tsx
@@ -2,11 +2,10 @@
 import type { ChangeEvent, HTMLAttributes } from 'react'
 import React, { useState } from 'react'
 import { fromPx, type BaseProps } from '@toptal/picasso-shared'
-import type { GridSizeProps, GridProps } from '@toptal/picasso-grid'
+import type { GridItemSizeProps, GridProps } from '@toptal/picasso-grid'
 import { GridCompound as Grid } from '@toptal/picasso-grid'
 import { twMerge } from '@toptal/picasso-tailwind-merge'
-import { SPACING_4 } from '@toptal/picasso-utils'
-import { spacingToPx } from '@toptal/picasso-provider'
+import { SPACING_4, spacingToPx } from '@toptal/picasso-utils'
 
 import { RadioGroupContext } from '../RadioGroupContext'
 
@@ -16,7 +15,7 @@ const HORIZONTAL_SPACING = fromPx(spacingToPx(SPACING_4)) as GridSpacing
 
 export interface Props
   extends BaseProps,
-    GridSizeProps,
+    GridItemSizeProps,
     Omit<HTMLAttributes<HTMLDivElement>, 'onChange' | 'defaultValue'> {
   /** Align radios horizontally  */
   horizontal?: boolean

--- a/packages/picasso/src/index.ts
+++ b/packages/picasso/src/index.ts
@@ -150,6 +150,7 @@ export type {
   GridSize,
   GridItemProps,
   GridSizeProps,
+  GridItemSizeProps,
 } from '@toptal/picasso-grid'
 export { HelpboxCompound as Helpbox } from '@toptal/picasso-helpbox'
 export type { HelpboxProps } from '@toptal/picasso-helpbox'


### PR DESCRIPTION
[PF-2208]

### Description

Renames `Grid.Item`'s size-props interface to `GridItemSizeProps` so it reads as belonging to `Grid.Item`, and collapses the previous two-name situation (`GridSizes` internally / `GridSizeProps` publicly) into a single canonical name. `GridSizeProps` is kept as a `@deprecated` alias so no consumer is forced to migrate.

- Rename the interface `GridSizes` → `GridItemSizeProps`; update internal consumers (`Grid.Item` `Props`, `getSizesClassNames`).
- Export `GridItemSizeProps` from `@toptal/picasso-grid` and re-export it from the `@toptal/picasso` barrel.
- Keep `GridSizeProps` as a `@deprecated` alias of `GridItemSizeProps` — existing imports keep working and now surface a deprecation hint.
- Point `RadioGroup` / `CheckboxGroup` at `GridItemSizeProps`. In `CheckboxGroup`, replace the hard-coded `HORIZONTAL_SPACING = 16` with `fromPx(spacingToPx(SPACING_4))` to match `RadioGroup` and drop the `as GridSpacing` cast at the `Grid` callsite; consolidate imports in both.
- Narrow the `GridSize` union by dropping the `true` member (`true | 'auto' | 1..12` → `'auto' | 1..12`). The breakpoint props stay `boolean | GridSize`, so `<Grid.Item xs />` / `xs={true}` still typecheck and runtime handling of `true` is unchanged; only code annotating a value directly as `GridSize` and assigning `true` is affected.

### How to test

- [Temploy](https://picasso.toptal.net/fix/pf-2208-griditem-gridsize-type)
- Existing `Grid`, `RadioGroup`, and `CheckboxGroup` stories render and behave identically — the change is type-surface only, no runtime behavior change.
- `import type { GridItemSizeProps } from '@toptal/picasso'` resolves; `import type { GridSizeProps }` still resolves and shows a deprecation hint in the editor.


### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [ ] Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core — n/a, no design change
- [x] Annotate all `props` in component with documentation
- [x] Self reviewed
- [ ] Covered with tests ([visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md) included) — n/a, type-only change; existing tests unchanged


[PF-2208]: https://toptal-core.atlassian.net/browse/PF-2208?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ