### PR TITLE
[PF-1994] Tweak cypress transitions and wait logic

### DIFF
--- a/cypress/component/Autocomplete.spec.tsx
+++ b/cypress/component/Autocomplete.spec.tsx
@@ -119,18 +119,20 @@ const TestAutocomplete = (props: Partial<AutocompleteProps>) => (
 
 const component = 'Autocomplete'
 
+// open the options menu (gated on it being visible) and capture it
+const openMenuAndTakeScreenshot = (variant: string) => {
+  cy.getByTestId(testIds.input).click()
+  cy.getByRole('menu').should('be.visible')
+
+  cy.get('body').happoScreenshot({ component, variant })
+}
+
 // eslint-disable-next-line max-lines-per-function
 describe('Autocomplete', () => {
   it('renders a list of options when clicked', () => {
     cy.mount(<TestAutocomplete />)
 
-    cy.getByTestId(testIds.input).click()
-    cy.getByRole('menu').should('be.visible')
-
-    cy.get('body').happoScreenshot({
-      component,
-      variant: 'default/after-clicked',
-    })
+    openMenuAndTakeScreenshot('default/after-clicked')
   })
 
   it('renders a list of options with descriptions when clicked', () => {
@@ -146,13 +148,7 @@ describe('Autocomplete', () => {
       />
     )
 
-    cy.getByTestId(testIds.input).click()
-    cy.getByRole('menu').should('be.visible')
-
-    cy.get('body').happoScreenshot({
-      component,
-      variant: 'with-description/after-clicked',
-    })
+    openMenuAndTakeScreenshot('with-description/after-clicked')
   })
 
   it('renders a reset button', () => {
@@ -204,25 +200,13 @@ describe('Autocomplete', () => {
   it('renders in different menu widths', () => {
     cy.mount(<TestAutocomplete menuWidth='200px' />)
 
-    cy.getByTestId(testIds.input).click()
-    cy.getByRole('menu').should('be.visible')
-
-    cy.get('body').happoScreenshot({
-      component,
-      variant: 'with-different-menu-widths',
-    })
+    openMenuAndTakeScreenshot('with-different-menu-widths')
   })
 
   it('renders other option', () => {
     cy.mount(<TestAutocomplete showOtherOption options={[]} value='picasso' />)
 
-    cy.getByTestId(testIds.input).click()
-    cy.getByRole('menu').should('be.visible')
-
-    cy.get('body').happoScreenshot({
-      component,
-      variant: 'with-other-option',
-    })
+    openMenuAndTakeScreenshot('with-other-option')
   })
 
   it('renders no options text', () => {
@@ -235,13 +219,7 @@ describe('Autocomplete', () => {
       />
     )
 
-    cy.getByTestId(testIds.input).click()
-    cy.getByRole('menu').should('be.visible')
-
-    cy.get('body').happoScreenshot({
-      component,
-      variant: 'with-no-options',
-    })
+    openMenuAndTakeScreenshot('with-no-options')
   })
 
   it('renders powered by google', () => {
@@ -249,13 +227,7 @@ describe('Autocomplete', () => {
       <TestAutocomplete poweredByGoogle options={[{ text: 'Belarus' }]} />
     )
 
-    cy.getByTestId(testIds.input).click()
-    cy.getByRole('menu').should('be.visible')
-
-    cy.get('body').happoScreenshot({
-      component,
-      variant: 'powered-by-google',
-    })
+    openMenuAndTakeScreenshot('powered-by-google')
   })
 
   it('focuses Autocomplete with dynamic options should NOT open options list', () => {

--- a/cypress/component/Avatar.spec.tsx
+++ b/cypress/component/Avatar.spec.tsx
@@ -1,28 +1,21 @@
 import React from 'react'
 import { Avatar, Container } from '@toptal/picasso'
 
+import { loadAvatarFixture } from '../support/fixtures'
+
 const component = 'Avatar'
+
+const getAvatarSrc = loadAvatarFixture()
+const handleEdit = () => {}
 
 describe('Avatar', () => {
   describe('when avatar is editable and focused', () => {
-    let src = ''
-    const handleEdit = () => {}
-
-    before(() => {
-      // eslint-disable-next-line max-nested-callbacks, promise/catch-or-return
-      cy.fixture('pablo.jpg').then(image => {
-        src = 'data:image/jpg;base64,' + image
-
-        return image
-      })
-    })
-
     it('renders outline around avatar', () => {
       cy.mount(
         <Container padded='small' gap='small'>
           <Avatar
             alt='Jacqueline Roque. Pablo Picasso, 1954'
-            src={src}
+            src={getAvatarSrc()}
             name='Jacqueline Roque'
             size='medium'
             onEdit={handleEdit}
@@ -43,24 +36,12 @@ describe('Avatar', () => {
   })
 
   describe('when showEmblem prop is true', () => {
-    let src = ''
-    const handleEdit = () => {}
-
-    before(() => {
-      // eslint-disable-next-line max-nested-callbacks, promise/catch-or-return
-      cy.fixture('pablo.jpg').then(image => {
-        src = 'data:image/jpg;base64,' + image
-
-        return image
-      })
-    })
-
     it('shows emblem', () => {
       cy.mount(
         <Container padded='small' gap='small'>
           <Avatar
             alt='Jacqueline Roque. Pablo Picasso, 1954'
-            src={src}
+            src={getAvatarSrc()}
             name='Jacqueline Roque'
             size='medium'
             onEdit={handleEdit}

--- a/cypress/component/Avatar.spec.tsx
+++ b/cypress/component/Avatar.spec.tsx
@@ -31,6 +31,10 @@ describe('Avatar', () => {
       )
 
       cy.get('button').focus()
+
+      // let the base64 fixture image decode before capturing
+      cy.waitForImagesDecoded()
+
       cy.get('body').happoScreenshot({
         component,
         variant: 'editable/after-focus',

--- a/cypress/component/AvatarUpload.spec.tsx
+++ b/cypress/component/AvatarUpload.spec.tsx
@@ -1,26 +1,19 @@
 import React from 'react'
 import { AvatarUpload, Container } from '@toptal/picasso'
 
+import { loadAvatarFixture } from '../support/fixtures'
+
 const component = 'AvatarUpload'
+
+const getAvatarSrc = loadAvatarFixture()
 
 describe('AvatarUpload', () => {
   describe('when source file exists', () => {
-    let src = ''
-
-    before(() => {
-      // eslint-disable-next-line max-nested-callbacks, promise/catch-or-return
-      cy.fixture('pablo.jpg').then(image => {
-        src = 'data:image/jpg;base64,' + image
-
-        return image
-      })
-    })
-
     it('renders upload icon over image avatar', () => {
       cy.mount(
         <Container padded='small' gap='small'>
-          <AvatarUpload src={src} alt='avatar' />
-          <AvatarUpload src={src} alt='avatar' size='large' />
+          <AvatarUpload src={getAvatarSrc()} alt='avatar' />
+          <AvatarUpload src={getAvatarSrc()} alt='avatar' size='large' />
         </Container>
       )
 

--- a/cypress/component/AvatarUpload.spec.tsx
+++ b/cypress/component/AvatarUpload.spec.tsx
@@ -24,6 +24,8 @@ describe('AvatarUpload', () => {
         </Container>
       )
 
+      cy.waitForImagesDecoded()
+
       cy.get('body').happoScreenshot({
         component,
         variant: 'with-source-file',

--- a/cypress/component/BarChart.spec.tsx
+++ b/cypress/component/BarChart.spec.tsx
@@ -64,11 +64,16 @@ describe('BarChart', () => {
 
     // fix flakiness, sometimes it does not respond to hover
     cy.get('.recharts-surface').realClick()
-    hoverOverBar('Apple').get('body').happoScreenshot({
+    hoverOverBar('Apple')
+
+    // the recharts tooltip mounts via async state on mousemove — assert it
+    // before capturing so the screenshot can't freeze a tooltip-less frame
+    assertTooltipContent('Appleengineers hired : 500')
+
+    cy.get('body').happoScreenshot({
       component,
       variant: 'default-chart/default-tooltip',
     })
-    assertTooltipContent('Appleengineers hired : 500')
 
     hoverOverBar('Google')
     assertTooltipContent('Googleengineers hired : 700')
@@ -93,11 +98,15 @@ describe('BarChart', () => {
 
     // fix flakiness, sometimes it does not respond to hover
     cy.get('.recharts-surface').realClick()
-    hoverOverBar('Berlin').get('body').happoScreenshot({
+    hoverOverBar('Berlin')
+
+    // assert the custom tooltip rendered before capturing (see above)
+    assertCustomTooltipContent('Infected: 4000Recovered: 2400')
+
+    cy.get('body').happoScreenshot({
       component,
       variant: 'custom-chart/custom-tooltip',
     })
-    assertCustomTooltipContent('Infected: 4000Recovered: 2400')
 
     hoverOverBar('Milan')
     assertCustomTooltipContent('Infected: 3000Recovered: 1398')

--- a/cypress/component/CategoriesChart.spec.tsx
+++ b/cypress/component/CategoriesChart.spec.tsx
@@ -31,7 +31,9 @@ describe('CategoriesChart', () => {
     })
 
     cy.get('text').contains('421').realHover({ position: 'center' })
-    cy.get('.recharts-tooltip-wrapper').should('be.visible')
+    // recharts renders the wrapper as an empty positioned div before the
+    // tooltip content paints — gate on content, not just the wrapper box
+    cy.get('.recharts-tooltip-wrapper').should('be.visible').and('not.be.empty')
 
     cy.get('body').happoScreenshot({
       component,

--- a/cypress/component/DatePicker.spec.tsx
+++ b/cypress/component/DatePicker.spec.tsx
@@ -23,11 +23,55 @@ const TestDatePicker = (props: Partial<DatePickerProps>) => {
   )
 }
 
+const TestAsyncExternalUpdateDatePicker = () => {
+  const [datepickerValue, setDatepickerValue] = useState<DatePickerValue>(
+    new Date(2020, 7, 21)
+  )
+  const [disabled, setDisabled] = useState(false)
+
+  const handleChange = (value: any) => {
+    setDisabled(true)
+    setTimeout(() => {
+      setDatepickerValue(value)
+      setDisabled(false)
+    }, 100)
+  }
+
+  return (
+    <Container padded='medium' flex>
+      <Button
+        data-testid='reset-button'
+        onClick={() => {
+          setDisabled(true)
+          setTimeout(() => {
+            setDatepickerValue(null)
+            setDisabled(false)
+          }, 100)
+        }}
+      >
+        Reset
+      </Button>
+      <DatePicker
+        testIds={{
+          input: 'date-picker-input',
+        }}
+        value={datepickerValue}
+        enableReset
+        disabled={disabled}
+        onResetClick={() => setDatepickerValue(null)}
+        onChange={handleChange}
+      />
+    </Container>
+  )
+}
+
 const component = 'DatePicker'
 
 describe('DatePicker', () => {
   it('renders autofocus', () => {
     cy.mount(<TestDatePicker autoFocus />)
+
+    cy.waitForCalendarOpen()
 
     cy.get('body').happoScreenshot({
       component,
@@ -67,6 +111,8 @@ describe('DatePicker', () => {
     cy.getByTestId('date-picker-input').clear()
     cy.getByTestId('date-picker-input').type('2015')
 
+    cy.waitForCalendarOpen()
+
     cy.get('body').happoScreenshot({
       component,
       variant: 'custom-value-parser',
@@ -91,6 +137,8 @@ describe('DatePicker', () => {
 
     cy.getByTestId('date-picker-with-indicators').focus()
 
+    cy.waitForCalendarOpen()
+
     cy.get('body').happoScreenshot({
       component,
       variant: 'indicated-intervals',
@@ -107,6 +155,8 @@ describe('DatePicker', () => {
         disableDays={{ dayOfWeek: [0, 2] }}
       />
     )
+
+    cy.waitForCalendarOpen()
 
     cy.get('body').happoScreenshot({
       component,
@@ -130,53 +180,13 @@ describe('DatePicker', () => {
 
     cy.getByTestId('date-picker-with-footer').focus()
 
+    cy.waitForCalendarOpen()
+
     cy.get('body').happoScreenshot({
       component,
       variant: 'customized-footer',
     })
   })
-
-  const TestAsyncExternalUpdateDatePicker = () => {
-    const [datepickerValue, setDatepickerValue] = useState<DatePickerValue>(
-      new Date(2020, 7, 21)
-    )
-    const [disabled, setDisabled] = useState(false)
-
-    const handleChange = (value: any) => {
-      setDisabled(true)
-      setTimeout(() => {
-        setDatepickerValue(value)
-        setDisabled(false)
-      }, 100)
-    }
-
-    return (
-      <Container padded='medium' flex>
-        <Button
-          data-testid='reset-button'
-          onClick={() => {
-            setDisabled(true)
-            setTimeout(() => {
-              setDatepickerValue(null)
-              setDisabled(false)
-            }, 100)
-          }}
-        >
-          Reset
-        </Button>
-        <DatePicker
-          testIds={{
-            input: 'date-picker-input',
-          }}
-          value={datepickerValue}
-          enableReset
-          disabled={disabled}
-          onResetClick={() => setDatepickerValue(null)}
-          onChange={handleChange}
-        />
-      </Container>
-    )
-  }
 
   it('reacts to external value updates correctly', () => {
     cy.mount(<TestAsyncExternalUpdateDatePicker />)

--- a/cypress/component/DatePicker.spec.tsx
+++ b/cypress/component/DatePicker.spec.tsx
@@ -264,6 +264,10 @@ describe('DatePicker', () => {
               variant: `date-picker/${width}-default`,
               targets: [happoTarget],
             })
+
+            // fail loud if the calendar closed while happo serialized the DOM
+            // (CI once captured this variant with the popper unmounted)
+            cy.get('.rdp-month').should('have.length', isNarrowScreen ? 1 : 2)
           }
         )
       })

--- a/cypress/component/Form.spec.tsx
+++ b/cypress/component/Form.spec.tsx
@@ -5,7 +5,6 @@ import { Form } from '@toptal/picasso-forms'
 import { noop } from '@toptal/picasso/utils'
 
 const RESPONSE_TIME = 1000
-const ANIMATION_TIME = 300
 
 // the emulation of the api call
 const responseWithDelay = async (response: any) =>
@@ -313,9 +312,6 @@ describe('Form', () => {
     cy.get('#inlineErrorSurname').type('surname')
 
     cy.getByTestId('submit-with-inline-error-button').click()
-
-    // eslint-disable-next-line cypress/no-unnecessary-waiting
-    cy.wait(RESPONSE_TIME + ANIMATION_TIME)
 
     cy.getByTestId('submit-with-inline-error-first-name')
       .contains('Unknown first name')

--- a/cypress/component/InputHiglightAutofill.spec.tsx
+++ b/cypress/component/InputHiglightAutofill.spec.tsx
@@ -72,6 +72,10 @@ describe('Highlight Autofill', () => {
         </Container>
       )
 
+      // Lexical mounts the RTE toolbar async — gate on it so the capture
+      // always includes the fully initialized editor
+      cy.get('#footoolbar button').should('be.visible')
+
       cy.get('body').happoScreenshot({
         component,
         variant: 'default',

--- a/cypress/component/Menu.spec.tsx
+++ b/cypress/component/Menu.spec.tsx
@@ -43,6 +43,13 @@ const MenuExample = (props: MenuProps) => {
 
 const component = 'Menu'
 
+// deselect via body click, then let the blurred item's transition-colors
+// (~150ms) come to rest so the snapshot doesn't freeze a mid-transition color
+const clickBodyAndSettle = () => {
+  cy.get('body').click()
+  cy.waitForTransitionsToSettle('[role="menuitem"]')
+}
+
 describe('Menu', () => {
   it('navigates slide menu', () => {
     cy.mount(<MenuExample />)
@@ -64,7 +71,7 @@ describe('Menu', () => {
     cy.getByTestId('item-b1').click()
     cy.getByTestId('menu-b1').should('be.visible')
     cy.getByTestId('menu-b2').should('not.exist')
-    cy.get('body').click()
+    clickBodyAndSettle()
     cy.get('[data-cy-root]').happoScreenshot({
       component,
       variant: 'slide-menu/after-clicked-item-to-open-another-sub-menu',
@@ -73,7 +80,7 @@ describe('Menu', () => {
     cy.getByTestId('menu-back').last().click()
     cy.getByTestId('menu-b').should('be.visible')
     cy.getByTestId('menu-b1').should('not.exist')
-    cy.get('body').click()
+    clickBodyAndSettle()
     cy.get('[data-cy-root]').happoScreenshot({
       component,
       variant: 'slide-menu/after-clicked-back-to-prev-sub-menu',

--- a/cypress/component/Modal.spec.tsx
+++ b/cypress/component/Modal.spec.tsx
@@ -149,21 +149,15 @@ const TestModalOverflown = (props: Partial<Omit<ModalProps, 'open'>>) => {
 
 const component = 'Modal'
 
-// Wait for the modal's open fade (data-starting-style:opacity-0 → 1) to settle
-// before taking the screenshot. Capturing mid-fade composites the bordered
-// secondary (Cancel) button at partial opacity, producing edge artifacts on its
-// border. Delegates to the shared `waitForOverlayOpen` command (commands.jsx).
-const waitForModalOpen = () => cy.waitForOverlayOpen()
-
 // The scroll shades fade in over 300ms. When the content overflows, wait for
 // the fade to settle so the screenshot captures the fully-opaque shade instead
 // of a mid-fade frame. When it doesn't overflow (e.g. full-screen / xlarge on a
 // tall viewport) there are no shades, so skip the wait — asserting otherwise
 // would hang.
 const waitForScrollShades = () => {
-  // Settle the modal open fade first (same reason as waitForModalOpen), then
-  // gate on the shade fade so the overflown screenshots are fully stable.
-  waitForModalOpen()
+  // settle the modal open fade first, then gate on the shade fade so the
+  // overflown screenshots are fully stable
+  cy.waitForOverlayOpen()
 
   return cy
     .get('[data-testid="overflown-content"]')
@@ -184,7 +178,7 @@ describe('Modal', () => {
   it('renders', () => {
     cy.mount(<TestModalForm />)
 
-    waitForModalOpen()
+    cy.waitForOverlayOpen()
 
     cy.get('body').happoScreenshot({
       component,
@@ -195,7 +189,7 @@ describe('Modal', () => {
   it('renders aligned to top', () => {
     cy.mount(<TestModalForm align='top' />)
 
-    waitForModalOpen()
+    cy.waitForOverlayOpen()
 
     cy.get('body').happoScreenshot({
       component,
@@ -206,7 +200,7 @@ describe('Modal', () => {
   it('renders without backdrop', () => {
     cy.mount(<TestModalForm hideBackdrop />)
 
-    waitForModalOpen()
+    cy.waitForOverlayOpen()
 
     cy.get('body').happoScreenshot({
       component,
@@ -217,7 +211,7 @@ describe('Modal', () => {
   it('renders small', () => {
     cy.mount(<TestModalForm size='small' />)
 
-    waitForModalOpen()
+    cy.waitForOverlayOpen()
 
     cy.get('body').happoScreenshot({
       component,
@@ -228,7 +222,7 @@ describe('Modal', () => {
   it('renders large', () => {
     cy.mount(<TestModalForm size='large' />)
 
-    waitForModalOpen()
+    cy.waitForOverlayOpen()
 
     cy.get('body').happoScreenshot({
       component,
@@ -239,7 +233,7 @@ describe('Modal', () => {
   it('renders full-screen', () => {
     cy.mount(<TestModalForm size='full-screen' />)
 
-    waitForModalOpen()
+    cy.waitForOverlayOpen()
 
     cy.get('body').happoScreenshot({
       component,

--- a/cypress/component/NotificationStream.spec.tsx
+++ b/cypress/component/NotificationStream.spec.tsx
@@ -119,6 +119,9 @@ describe('NotificationStream', () => {
     cy.getByTestId('trigger-error').click()
     cy.getByTestId('trigger-general').click()
 
+    // notifications mount async — wait for all three before capturing
+    cy.getByRole('alert').should('have.length', 3).and('be.visible')
+
     cy.get('body').happoScreenshot({
       component,
       variant: 'variants',
@@ -130,6 +133,9 @@ describe('NotificationStream', () => {
 
     cy.getByTestId('trigger-custom-content').click()
     cy.getByTestId('trigger-with-icon').click()
+
+    // notifications mount async — wait for both before capturing
+    cy.getByRole('alert').should('have.length', 2).and('be.visible')
 
     cy.get('body').happoScreenshot({
       component,
@@ -150,6 +156,10 @@ describe('NotificationStream', () => {
         cy.mount(<DefaultExample />)
 
         cy.getByTestId('trigger-default').realClick()
+
+        // the notification mounts async — wait for it before capturing
+        cy.getByRole('alert').should('be.visible')
+
         cy.get('body').happoScreenshot({
           component,
           variant: `notification/${width}-default`,

--- a/cypress/component/Page.spec.tsx
+++ b/cypress/component/Page.spec.tsx
@@ -255,8 +255,10 @@ describe('Page', () => {
         variant: 'default/sticky-sidebar-scroll-bottom',
       })
     })
-    // TODO: restore in https://toptal-core.atlassian.net/browse/FX-4358
-    it.skip('retains sticky position when Drawer is open', () => {
+    // Restored per https://toptal-core.atlassian.net/browse/FX-4358 — the
+    // skip predated the migration; the @base-ui/react-era Drawer locks page
+    // scroll via `html { overflow: clip }`, which preserves the scroll offset.
+    it('retains sticky position when Drawer is open', () => {
       cy.viewport(1280, 800)
       cy.mount(<DrawerContent />)
 
@@ -266,6 +268,9 @@ describe('Page', () => {
       cy.scrollTo('bottom')
 
       cy.getByTestId(TestIds.DRAWER_BUTTON).click()
+
+      // gate on the drawer being open and past its enter fade
+      cy.waitForOverlayOpen()
 
       cy.get('body').happoScreenshot({
         component,

--- a/cypress/component/Page.spec.tsx
+++ b/cypress/component/Page.spec.tsx
@@ -255,10 +255,8 @@ describe('Page', () => {
         variant: 'default/sticky-sidebar-scroll-bottom',
       })
     })
-    // Restored per https://toptal-core.atlassian.net/browse/FX-4358 — the
-    // skip predated the migration; the @base-ui/react-era Drawer locks page
-    // scroll via `html { overflow: clip }`, which preserves the scroll offset.
-    it('retains sticky position when Drawer is open', () => {
+    // TODO: restore in https://toptal-core.atlassian.net/browse/FX-4358
+    it.skip('retains sticky position when Drawer is open', () => {
       cy.viewport(1280, 800)
       cy.mount(<DrawerContent />)
 

--- a/cypress/component/PageSidebar.spec.tsx
+++ b/cypress/component/PageSidebar.spec.tsx
@@ -175,6 +175,15 @@ describe('Sidebar', () => {
       // Expand collapsible Menu
       cy.getByTestId(TestIds.COLLAPSIBLE_MENU_HEADER).realClick()
 
+      // gate on the expanded menu being present, then on its height animation
+      // being at rest (the accordion transitions height over ~300ms)
+      cy.getByTestId(TestIds.COLLAPSIBLE_MENU_INNER_MENU)
+        .filter(':visible')
+        .should('be.visible')
+      cy.waitForGeometryToSettle(
+        `[data-testid="${TestIds.COLLAPSIBLE_MENU_INNER_MENU}"]`
+      )
+
       cy.get('body').happoScreenshot({
         component,
         variant: 'expanded accordion menu',
@@ -195,6 +204,13 @@ describe('Sidebar', () => {
 
       // Open collapsible Menu as dropdown
       cy.getByTestId(TestIds.COLLAPSIBLE_MENU_HEADER).realClick()
+
+      // the sub-menu popper is keepMounted (in the DOM at 0×0 while closed),
+      // so the global geometry-settle passes vacuously — gate on exactly one
+      // dropdown actually being open. `:visible` excludes the closed twin.
+      cy.getByTestId(TestIds.COLLAPSIBLE_MENU_INNER_MENU)
+        .filter(':visible')
+        .should('have.length', 1)
 
       cy.get('body').happoScreenshot({
         component,

--- a/cypress/component/PageTopBarMenu.spec.tsx
+++ b/cypress/component/PageTopBarMenu.spec.tsx
@@ -68,6 +68,11 @@ describe('PageTopBarMenu', () => {
 
       cy.getByTestId(TestIds.TopBarMenu).click()
 
+      // the dropdown mounts async in a popper — gate on its content, then let
+      // the fixture avatars decode before capturing
+      cy.contains('My Account').should('be.visible')
+      cy.waitForImagesDecoded()
+
       cy.get('body').happoScreenshot({
         component: 'PageTopBarMenu',
         variant: `width-${width}`,

--- a/cypress/component/PageTopBarMenu.spec.tsx
+++ b/cypress/component/PageTopBarMenu.spec.tsx
@@ -11,6 +11,8 @@ import {
 } from '@toptal/picasso'
 import { HAPPO_TARGETS } from '@toptal/picasso-test-utils'
 
+import { loadAvatarFixture } from '../support/fixtures'
+
 export enum TestIds {
   TopBarMenu = 'page-top-bar-menu-dropdown',
 }
@@ -47,24 +49,15 @@ const Example = ({ src }: { src: string | null }) => (
   </Page>
 )
 
+const getAvatarSrc = loadAvatarFixture()
+
 describe('PageTopBarMenu', () => {
-  let src: string | null = null
-
-  before(() => {
-    // eslint-disable-next-line promise/catch-or-return
-    cy.fixture('pablo.jpg').then(image => {
-      src = 'data:image/jpg;base64,' + image
-
-      return image
-    })
-  })
-
   Cypress._.each(HAPPO_TARGETS, happoTarget => {
     const { width } = happoTarget
 
     it(`renders correctly on ${width}px`, () => {
       cy.viewport(width, 800)
-      cy.mount(<Example src={src} />)
+      cy.mount(<Example src={getAvatarSrc()} />)
 
       cy.getByTestId(TestIds.TopBarMenu).click()
 

--- a/cypress/component/PromptModal.spec.tsx
+++ b/cypress/component/PromptModal.spec.tsx
@@ -22,18 +22,11 @@ const TestProptModal = () => {
   )
 }
 
-// Wait for the modal's open fade (data-starting-style:opacity-0 → 1) to settle
-// before taking the screenshot. Capturing mid-fade composites the (only)
-// bordered button — the secondary Cancel — at partial opacity, producing edge
-// artifacts on its border. Delegates to the shared `waitForOverlayOpen` command
-// (commands.jsx).
-const waitForModalOpen = () => cy.waitForOverlayOpen()
-
 describe('PromptModal', () => {
   it('renders on desktop and mobile', () => {
     cy.mount(<TestProptModal />)
 
-    waitForModalOpen()
+    cy.waitForOverlayOpen()
 
     cy.get('body').happoScreenshot({
       component,

--- a/cypress/component/RichTextEditor/CodeBlockPlugin.spec.tsx
+++ b/cypress/component/RichTextEditor/CodeBlockPlugin.spec.tsx
@@ -1,41 +1,22 @@
-import React, { useState } from 'react'
-import type { RichTextEditorProps } from '@toptal/picasso-rich-text-editor'
+import React from 'react'
 import {
   CodePlugin,
   CodeBlockPlugin,
-  RichTextEditor,
   htmlToHast,
 } from '@toptal/picasso-rich-text-editor'
-import { Container } from '@toptal/picasso'
 
-const editorTestId = 'editor'
+import {
+  Editor,
+  component,
+  editorSelector,
+  makeEditorProps,
+} from './test-helpers'
 
-const defaultProps = {
-  id: 'foo',
-  onChange: () => {},
-  placeholder: 'placeholder',
-  testIds: {
-    editor: editorTestId,
-  },
-}
+const defaultProps = makeEditorProps()
 
-const editorSelector = `#${defaultProps.id}`
 const defaultValue = htmlToHast(
   '<p>foo <code>bar</code> baz</p><p>qux <code>quux</code> quuz</p>'
 )
-
-const Editor = (props: RichTextEditorProps) => {
-  const [value, setValue] = useState('')
-
-  return (
-    <Container style={{ maxWidth: '600px' }} padded='small'>
-      <RichTextEditor {...props} onChange={value => setValue(value)} />
-      <Container padded='small'>{value}</Container>
-    </Container>
-  )
-}
-
-const component = 'RichTextEditor'
 
 describe('CodeBlockPlugin', () => {
   describe('when the cursor is empty line', () => {

--- a/cypress/component/RichTextEditor/CodePlugin.spec.tsx
+++ b/cypress/component/RichTextEditor/CodePlugin.spec.tsx
@@ -1,33 +1,16 @@
-import React, { useState } from 'react'
-import type { RichTextEditorProps } from '@toptal/picasso-rich-text-editor'
-import { CodePlugin, RichTextEditor } from '@toptal/picasso-rich-text-editor'
-import { Container } from '@toptal/picasso'
+import React from 'react'
+import { CodePlugin } from '@toptal/picasso-rich-text-editor'
 
-const editorTestId = 'editor'
+import {
+  Editor,
+  buttonShouldBeActive,
+  buttonShouldNotBeActive,
+  component,
+  editorSelector,
+  makeEditorProps,
+} from './test-helpers'
 
-const defaultProps = {
-  id: 'foo',
-  onChange: () => {},
-  placeholder: 'placeholder',
-  testIds: {
-    editor: editorTestId,
-  },
-}
-
-const editorSelector = `#${defaultProps.id}`
-
-const Editor = (props: RichTextEditorProps) => {
-  const [value, setValue] = useState('')
-
-  return (
-    <Container style={{ maxWidth: '600px' }} padded='small'>
-      <RichTextEditor {...props} onChange={value => setValue(value)} />
-      <Container padded='small'>{value}</Container>
-    </Container>
-  )
-}
-
-const component = 'RichTextEditor'
+const defaultProps = makeEditorProps()
 
 describe('CodePlugin', () => {
   describe('when the code button in toolbar is used', () => {
@@ -51,9 +34,7 @@ describe('CodePlugin', () => {
       cy.get('@editor').type(codeText)
       cy.get('code').should('exist').should('have.text', codeText)
 
-      cy.get('@button')
-        .should('have.attr', 'class')
-        .and('include', 'bg-graphite-700')
+      buttonShouldBeActive(cy.get('@button'))
 
       cy.get('body').happoScreenshot({
         component,
@@ -61,9 +42,7 @@ describe('CodePlugin', () => {
       })
 
       cy.contains(normalText).click()
-      cy.get('@button')
-        .should('have.attr', 'class')
-        .and('not.include', 'bg-graphite-700')
+      buttonShouldNotBeActive(cy.get('@button'))
 
       cy.get('body').happoScreenshot({
         component,

--- a/cypress/component/RichTextEditor/Default.spec.tsx
+++ b/cypress/component/RichTextEditor/Default.spec.tsx
@@ -10,33 +10,32 @@ import { Container } from '@toptal/picasso'
 import { Form } from '@toptal/picasso-forms'
 import { isOn } from '@cypress/skip-test'
 
+import {
+  buttonShouldBeActive,
+  buttonShouldNotBeActive,
+  component,
+  editorSelector,
+  makeEditorProps,
+} from './test-helpers'
+
 const headerSelect = 'headerSelect'
 const boldButton = 'boldButton'
 const italicButton = 'italicButton'
 const ulButton = 'ulButton'
 const olButton = 'olButton'
 const wrapper = 'wrapper'
-const editor = 'editor'
 
-const defaultProps = {
-  id: 'foo',
-  onChange: () => {},
-  placeholder: 'placeholder',
-  testIds: {
-    headerSelect,
-    boldButton,
-    italicButton,
-    unorderedListButton: ulButton,
-    orderedListButton: olButton,
-    wrapper,
-    editor,
-  },
-}
-
-const editorSelector = `#${defaultProps.id}`
+const defaultProps = makeEditorProps({
+  headerSelect,
+  boldButton,
+  italicButton,
+  unorderedListButton: ulButton,
+  orderedListButton: olButton,
+  wrapper,
+})
 
 const renderEditor = (props: RichTextEditorProps) => (
-  <Container data-testid='bla' style={{ maxWidth: '600px' }} padded='small'>
+  <Container style={{ maxWidth: '600px' }} padded='small'>
     <RichTextEditor {...props} />
   </Container>
 )
@@ -46,18 +45,6 @@ const renderEditorInForm = () => (
     <Form.RichTextEditor label='label' name='editor' {...defaultProps} />
   </Form>
 )
-
-const buttonShouldBeActive = (
-  button: Cypress.Chainable<JQuery<HTMLButtonElement>>
-) => {
-  button.should('have.attr', 'class').and('include', 'bg-graphite-700')
-}
-
-const buttonShouldNotBeActive = (
-  button: Cypress.Chainable<JQuery<HTMLButtonElement>>
-) => {
-  button.should('have.attr', 'class').and('not.include', 'bg-graphite-700')
-}
 
 const selectShouldHaveValue = (
   select: Cypress.Chainable<JQuery<HTMLButtonElement>>,
@@ -73,8 +60,6 @@ const setSelectValue = (
   select.realClick({ scrollBehavior: false })
   cy.get('span').contains(value).realClick({ scrollBehavior: false })
 }
-
-const component = 'RichTextEditor'
 
 const setAliases = () => {
   cy.get(editorSelector).as('editor')

--- a/cypress/component/RichTextEditor/ImagePlugin.spec.tsx
+++ b/cypress/component/RichTextEditor/ImagePlugin.spec.tsx
@@ -107,6 +107,10 @@ describe('ImagePlugin', () => {
         `<p><img src="${uploadedFileContent}" alt="${uploadedFileAltText}"></p>`
       )
 
+      // the assertion above only checks the serialized HTML string — also let
+      // the <img> rendered in the editor decode before capturing
+      cy.waitForImagesDecoded(`${editorSelector} img`)
+
       cy.get('body').happoScreenshot({
         component,
         variant: 'image-plugin/successful-upload',

--- a/cypress/component/RichTextEditor/ImagePlugin.spec.tsx
+++ b/cypress/component/RichTextEditor/ImagePlugin.spec.tsx
@@ -1,41 +1,20 @@
-import React, { useState } from 'react'
-import type {
-  RichTextEditorProps,
-  UploadedImage,
-} from '@toptal/picasso-rich-text-editor'
-import { ImagePlugin, RichTextEditor } from '@toptal/picasso-rich-text-editor'
-import { Container } from '@toptal/picasso'
+import React from 'react'
+import type { UploadedImage } from '@toptal/picasso-rich-text-editor'
+import { ImagePlugin } from '@toptal/picasso-rich-text-editor'
 
-const editorTestId = 'editor'
+import {
+  Editor,
+  component,
+  editorSelector,
+  makeEditorProps,
+  resultContainerTestId,
+} from './test-helpers'
+
 const imageUploadButtonTestId = 'image-upload-button'
-const resultContainerTestId = 'result-container'
 
-const defaultProps = {
-  id: 'foo',
-  onChange: () => {},
-  placeholder: 'placeholder',
-  testIds: {
-    editor: editorTestId,
-    imageUploadButton: imageUploadButtonTestId,
-  },
-}
-
-const editorSelector = `#${defaultProps.id}`
-
-const Editor = (props: RichTextEditorProps) => {
-  const [value, setValue] = useState('')
-
-  return (
-    <Container style={{ maxWidth: '600px' }} padded='small'>
-      <RichTextEditor {...props} onChange={value => setValue(value)} />
-      <Container padded='small' data-testid={resultContainerTestId}>
-        {value}
-      </Container>
-    </Container>
-  )
-}
-
-const component = 'RichTextEditor'
+const defaultProps = makeEditorProps({
+  imageUploadButton: imageUploadButtonTestId,
+})
 
 const setAliases = () => {
   cy.get(editorSelector).as('editor')
@@ -155,11 +134,15 @@ describe('ImagePlugin', () => {
 
       cy.get('p').contains(fileUploadErrorMessage).should('be.visible')
 
-      // Temporary disabling this screenshot as fonts stopped working in modals
-      // cy.get('[role="presentation"]').happoScreenshot({
-      //   component,
-      //   variant: 'image-plugin/failed-upload',
-      // })
+      // Screenshot was disabled pre-migration ("fonts stopped working in
+      // modals") and targeted MUI's role="presentation" portal wrapper; the
+      // @base-ui/react Modal emits role="dialog" instead (the passing
+      // successful-upload test above already queries it).
+      cy.waitForOverlayOpen()
+      cy.getByRole('dialog').happoScreenshot({
+        component,
+        variant: 'image-plugin/failed-upload',
+      })
     })
   })
 })

--- a/cypress/component/RichTextEditor/ImagePlugin.spec.tsx
+++ b/cypress/component/RichTextEditor/ImagePlugin.spec.tsx
@@ -134,12 +134,11 @@ describe('ImagePlugin', () => {
 
       cy.get('p').contains(fileUploadErrorMessage).should('be.visible')
 
-      // Screenshot was disabled pre-migration ("fonts stopped working in
-      // modals") and targeted MUI's role="presentation" portal wrapper; the
-      // @base-ui/react Modal emits role="dialog" instead (the passing
-      // successful-upload test above already queries it).
+      // capture body, not the dialog subtree — the modal's font-family is
+      // inherited from outside the portal, so a subtree capture renders in a
+      // serif fallback (the old "fonts stopped working in modals" issue)
       cy.waitForOverlayOpen()
-      cy.getByRole('dialog').happoScreenshot({
+      cy.get('body').happoScreenshot({
         component,
         variant: 'image-plugin/failed-upload',
       })

--- a/cypress/component/RichTextEditor/LinkPlugin.spec.tsx
+++ b/cypress/component/RichTextEditor/LinkPlugin.spec.tsx
@@ -1,42 +1,23 @@
-import React, { useState } from 'react'
-import type { RichTextEditorProps } from '@toptal/picasso-rich-text-editor'
-import { LinkPlugin, RichTextEditor } from '@toptal/picasso-rich-text-editor'
-import { Container } from '@toptal/picasso'
+import React from 'react'
+import { LinkPlugin } from '@toptal/picasso-rich-text-editor'
 
-const editorTestId = 'editor'
+import {
+  Editor,
+  component,
+  editorSelector,
+  makeEditorProps,
+  resultContainerTestId,
+} from './test-helpers'
+
 const linkPluginButton = 'link-plugin-button'
-const resultContainerTestId = 'result-container'
 const boldButton = 'boldButton'
 const ulButton = 'ulButton'
 
-const defaultProps = {
-  id: 'foo',
-  onChange: () => {},
-  placeholder: 'placeholder',
-  testIds: {
-    editor: editorTestId,
-    linkPluginButton: linkPluginButton,
-    boldButton,
-    unorderedListButton: ulButton,
-  },
-}
-
-const editorSelector = `#${defaultProps.id}`
-
-const Editor = (props: RichTextEditorProps) => {
-  const [value, setValue] = useState('')
-
-  return (
-    <Container style={{ maxWidth: '600px' }} padded='small'>
-      <RichTextEditor {...props} onChange={value => setValue(value)} />
-      <Container padded='small' data-testid={resultContainerTestId}>
-        {value}
-      </Container>
-    </Container>
-  )
-}
-
-const component = 'RichTextEditor'
+const defaultProps = makeEditorProps({
+  linkPluginButton,
+  boldButton,
+  unorderedListButton: ulButton,
+})
 
 const setAliases = () => {
   cy.get(editorSelector).as('editor')

--- a/cypress/component/RichTextEditor/test-helpers.tsx
+++ b/cypress/component/RichTextEditor/test-helpers.tsx
@@ -1,0 +1,57 @@
+import React, { useState } from 'react'
+import type { RichTextEditorProps } from '@toptal/picasso-rich-text-editor'
+import { RichTextEditor } from '@toptal/picasso-rich-text-editor'
+import { Container } from '@toptal/picasso'
+
+export const component = 'RichTextEditor'
+
+export const editorTestId = 'editor'
+export const resultContainerTestId = 'result-container'
+
+const EDITOR_ID = 'foo'
+
+export const editorSelector = `#${EDITOR_ID}`
+
+// Base editor props shared by every RTE spec; specs merge in their own
+// testIds. Typed as Record so plugin-specific testIds (not part of
+// RichTextEditorProps['testIds']) pass through.
+export const makeEditorProps = (testIds: Record<string, string> = {}) => ({
+  id: EDITOR_ID,
+  onChange: () => {},
+  placeholder: 'placeholder',
+  testIds: { editor: editorTestId, ...testIds },
+})
+
+// Renders the editor plus its serialized value, so specs can assert the
+// emitted HTML alongside the visual state.
+export const Editor = (props: RichTextEditorProps) => {
+  const [value, setValue] = useState('')
+
+  return (
+    // eslint-disable-next-line no-inline-styles/no-inline-styles -- test-only cap, kept inline so it can't depend on Tailwind generation
+    <Container style={{ maxWidth: '600px' }} padded='small'>
+      <RichTextEditor {...props} onChange={setValue} />
+      <Container padded='small' data-testid={resultContainerTestId}>
+        {value}
+      </Container>
+    </Container>
+  )
+}
+
+const ACTIVE_TOOLBAR_BUTTON_CLASS = 'bg-graphite-700'
+
+export const buttonShouldBeActive = (
+  button: Cypress.Chainable<JQuery<HTMLButtonElement>>
+) => {
+  button
+    .should('have.attr', 'class')
+    .and('include', ACTIVE_TOOLBAR_BUTTON_CLASS)
+}
+
+export const buttonShouldNotBeActive = (
+  button: Cypress.Chainable<JQuery<HTMLButtonElement>>
+) => {
+  button
+    .should('have.attr', 'class')
+    .and('not.include', ACTIVE_TOOLBAR_BUTTON_CLASS)
+}

--- a/cypress/component/Select.spec.tsx
+++ b/cypress/component/Select.spec.tsx
@@ -140,6 +140,10 @@ const getNativeOption = (value: string | number) =>
 
 const openSelect = () => {
   cy.getByTestId('select').click()
+
+  // the menu mounts async in a popper — gate on it so a screenshot right after
+  // opening can't capture a menu-less frame (present in every open state)
+  cy.get('[role="tooltip"]').should('be.visible')
 }
 
 const pressArrowDown = () => {

--- a/cypress/component/Table.spec.tsx
+++ b/cypress/component/Table.spec.tsx
@@ -16,48 +16,7 @@ import {
   ArrowUpMinor16,
 } from '@toptal/picasso'
 
-const data = [
-  {
-    id: 0,
-    name: 'Delia Floyd',
-    talentType: 'Designer',
-    company: 'Airbnb',
-    role: 'UX lead',
-    country: 'United States',
-  },
-  {
-    id: 1,
-    name: 'Linnie Sims',
-    talentType: 'Designer',
-    company: 'Facebook',
-    role: 'Art director',
-    country: 'Spain',
-  },
-  {
-    id: 2,
-    name: 'Charles Watson',
-    talentType: 'Developer',
-    company: 'Amazon',
-    role: 'Ruby developer',
-    country: 'Germany',
-  },
-  {
-    id: 3,
-    name: 'Leila Pena',
-    talentType: 'Developer',
-    company: 'Invision',
-    role: 'Web developer',
-    country: 'Poland',
-  },
-  {
-    id: 4,
-    name: 'Logan Burton',
-    talentType: 'Developer',
-    company: 'Microsoft',
-    role: 'CTO',
-    country: 'United States',
-  },
-]
+import { tableData as data } from '../support/table-data'
 
 const renderTable = (
   props: Omit<TableProps, 'children'> = {},
@@ -281,6 +240,46 @@ type Data = {
   defaultExpanded: boolean
 }
 
+const makeExpandableRowsData = (defaultExpanded: boolean): Data[] => [
+  {
+    id: 0,
+    task: "Invoice the client for half of Sanin's time...",
+    relatedTo: 'Passionate PHP Dev...',
+    time: '2:19 PM',
+    assignee: 'AD',
+    defaultExpanded,
+  },
+  {
+    id: 1,
+    task: 'BUG: try to edit skills in profile',
+    relatedTo: 'Ardelia Conn',
+    time: '3:27 PM',
+    assignee: 'AD',
+    defaultExpanded,
+  },
+  {
+    id: 2,
+    task: 'Assign attendee to scheduled meeting',
+    relatedTo: 'Mariel Ankunding',
+    time: '1:27 PM',
+    assignee: 'AD',
+    defaultExpanded,
+  },
+]
+
+// collapse and re-expand the first row, asserting the row content toggles
+const toggleFirstRowExpansion = (localData: Data[]) => {
+  cy.getByTestId('job').as('job').should('be.visible')
+
+  cy.getByTestId(`expand-button-${localData[0].id}`)
+    .as('expandButton')
+    .realClick()
+
+  cy.get('@job').should('not.exist')
+  cy.get('@expandButton').realClick()
+  cy.get('@job').should('exist')
+}
+
 const component = 'Table'
 
 describe('Table', () => {
@@ -321,32 +320,7 @@ describe('Table', () => {
   })
 
   it('renders expandable rows', () => {
-    const localData: Data[] = [
-      {
-        id: 0,
-        task: "Invoice the client for half of Sanin's time...",
-        relatedTo: 'Passionate PHP Dev...',
-        time: '2:19 PM',
-        assignee: 'AD',
-        defaultExpanded: false,
-      },
-      {
-        id: 1,
-        task: 'BUG: try to edit skills in profile',
-        relatedTo: 'Ardelia Conn',
-        time: '3:27 PM',
-        assignee: 'AD',
-        defaultExpanded: false,
-      },
-      {
-        id: 2,
-        task: 'Assign attendee to scheduled meeting',
-        relatedTo: 'Mariel Ankunding',
-        time: '1:27 PM',
-        assignee: 'AD',
-        defaultExpanded: false,
-      },
-    ]
+    const localData = makeExpandableRowsData(false)
 
     cy.mount(<TableExpandableRowsExample localData={localData} />)
 
@@ -357,43 +331,10 @@ describe('Table', () => {
       variant: 'expandable-rows',
     })
 
-    cy.getByTestId('job').as('job').should('be.visible')
-
-    cy.getByTestId(`expand-button-${localData[0].id}`)
-      .as('expandButton')
-      .realClick()
-
-    cy.get('@job').should('not.exist')
-    cy.get('@expandButton').realClick()
-    cy.get('@job').should('exist')
+    toggleFirstRowExpansion(localData)
   })
   it('renders expandable rows with default expanded', () => {
-    const localData: Data[] = [
-      {
-        id: 0,
-        task: "Invoice the client for half of Sanin's time...",
-        relatedTo: 'Passionate PHP Dev...',
-        time: '2:19 PM',
-        assignee: 'AD',
-        defaultExpanded: true,
-      },
-      {
-        id: 1,
-        task: 'BUG: try to edit skills in profile',
-        relatedTo: 'Ardelia Conn',
-        time: '3:27 PM',
-        assignee: 'AD',
-        defaultExpanded: true,
-      },
-      {
-        id: 2,
-        task: 'Assign attendee to scheduled meeting',
-        relatedTo: 'Mariel Ankunding',
-        time: '1:27 PM',
-        assignee: 'AD',
-        defaultExpanded: true,
-      },
-    ]
+    const localData = makeExpandableRowsData(true)
 
     cy.mount(<TableExpandableRowsExample localData={localData} />)
 
@@ -402,14 +343,6 @@ describe('Table', () => {
       variant: 'expandable-rows/default-expanded',
     })
 
-    cy.getByTestId('job').as('job').should('be.visible')
-
-    cy.getByTestId(`expand-button-${localData[0].id}`)
-      .as('expandButton')
-      .realClick()
-
-    cy.get('@job').should('not.exist')
-    cy.get('@expandButton').realClick()
-    cy.get('@job').should('exist')
+    toggleFirstRowExpansion(localData)
   })
 })

--- a/cypress/component/TableCell.spec.tsx
+++ b/cypress/component/TableCell.spec.tsx
@@ -1,6 +1,8 @@
 import React from 'react'
 import { Table } from '@toptal/picasso'
 
+import { tableData as data } from '../support/table-data'
+
 const AlignExample = () => (
   <div>
     <Table>
@@ -59,46 +61,3 @@ describe('TableCell', () => {
     })
   })
 })
-
-const data = [
-  {
-    id: 0,
-    name: 'Delia Floyd',
-    talentType: 'Designer',
-    company: 'Airbnb',
-    role: 'UX lead',
-    country: 'United States',
-  },
-  {
-    id: 1,
-    name: 'Linnie Sims',
-    talentType: 'Designer',
-    company: 'Facebook',
-    role: 'Art director',
-    country: 'Spain',
-  },
-  {
-    id: 2,
-    name: 'Charles Watson',
-    talentType: 'Developer',
-    company: 'Amazon',
-    role: 'Ruby developer',
-    country: 'Germany',
-  },
-  {
-    id: 3,
-    name: 'Leila Pena',
-    talentType: 'Developer',
-    company: 'Invision',
-    role: 'Web developer',
-    country: 'Poland',
-  },
-  {
-    id: 4,
-    name: 'Logan Burton',
-    talentType: 'Developer',
-    company: 'Microsoft',
-    role: 'CTO',
-    country: 'United States',
-  },
-]

--- a/cypress/component/Tabs.spec.tsx
+++ b/cypress/component/Tabs.spec.tsx
@@ -1,20 +1,14 @@
 import React from 'react'
 import { Tabs } from '@toptal/picasso'
 
+import { loadAvatarFixture } from '../support/fixtures'
+
 const component = 'Tabs'
+
+const getAvatarSrc = loadAvatarFixture()
 
 describe('Tabs', () => {
   describe('with vertical orientation', () => {
-    let src: string | null = null
-
-    before(() => {
-      // eslint-disable-next-line max-nested-callbacks, promise/catch-or-return
-      cy.fixture('pablo.jpg').then(image => {
-        src = 'data:image/jpg;base64,' + image
-
-        return image
-      })
-    })
     it('renders with label', () => {
       cy.mount(
         <Tabs value={0} orientation='vertical'>
@@ -70,21 +64,29 @@ describe('Tabs', () => {
     it('renders with user badge', () => {
       cy.mount(
         <Tabs value={0} orientation='vertical'>
-          <Tabs.Tab avatar={src} description='Description' label='Label' />
-          <Tabs.Tab avatar={src} description='Description' label='Label' />
           <Tabs.Tab
-            avatar={src}
+            avatar={getAvatarSrc()}
+            description='Description'
+            label='Label'
+          />
+          <Tabs.Tab
+            avatar={getAvatarSrc()}
+            description='Description'
+            label='Label'
+          />
+          <Tabs.Tab
+            avatar={getAvatarSrc()}
             disabled
             description='Description'
             label='Label'
           />
-          <Tabs.Tab avatar={src} label='Label' />
+          <Tabs.Tab avatar={getAvatarSrc()} label='Label' />
 
           <Tabs.Tab avatar={null} description='Description' label='Label' />
           <Tabs.Tab avatar='' description='Description' label='Label' />
 
           <Tabs.Tab
-            avatar={src}
+            avatar={getAvatarSrc()}
             data-testid='to-be-hovered'
             description='Description'
             label='Label'

--- a/cypress/component/Tabs.spec.tsx
+++ b/cypress/component/Tabs.spec.tsx
@@ -92,6 +92,9 @@ describe('Tabs', () => {
         </Tabs>
       )
 
+      // let the base64 fixture avatars decode before capturing
+      cy.waitForImagesDecoded()
+
       cy.getByTestId('to-be-hovered').hoverAndTakeHappoScreenshot({
         component,
         variant: 'vertical-with-user-badge/after-hovered',

--- a/cypress/component/TagSelector.spec.tsx
+++ b/cypress/component/TagSelector.spec.tsx
@@ -139,14 +139,15 @@ describe('TagSelector', () => {
   it('renders', () => {
     cy.mount(<TagSelectorExample />)
 
-    cy.getByRole('combobox')
-      .as('combobox-input')
-      .realClick()
-      .get('body')
-      .happoScreenshot({
-        component,
-        variant: 'default/after-clicked-combobox',
-      })
+    cy.getByRole('combobox').as('combobox-input').realClick()
+
+    // the options popper mounts async — gate on it before capturing
+    cy.getByRole('option').should('be.visible')
+
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'default/after-clicked-combobox',
+    })
 
     cy.get('@combobox-input').type('{downArrow}')
     cy.get('@combobox-input').type('{enter}')
@@ -175,6 +176,10 @@ describe('TagSelector', () => {
 
     cy.getByRole('combobox').as('combobox-input').realClick()
     cy.get('@combobox-input').type('not existing item text')
+
+    // typing async-filters down to the "other option" row — wait for it
+    cy.getByRole('option').should('be.visible')
+
     cy.get('body').happoScreenshot({
       component,
       variant: 'other-option/after-forced-other-option',
@@ -202,14 +207,15 @@ describe('TagSelector', () => {
   it('renders custom label and custom option', () => {
     cy.mount(<TagSelectorCustomLabelOptionRendererExample />)
 
-    cy.getByRole('combobox')
-      .as('combobox-input')
-      .realClick()
-      .get('body')
-      .happoScreenshot({
-        component,
-        variant: 'custom-label-custom-option/after-clicked-combobox',
-      })
+    cy.getByRole('combobox').as('combobox-input').realClick()
+
+    // the options popper mounts async — gate on it before capturing
+    cy.getByRole('option').should('be.visible')
+
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'custom-label-custom-option/after-clicked-combobox',
+    })
 
     cy.get('@combobox-input').type('{downArrow}')
     cy.get('@combobox-input').type('{downArrow}')

--- a/cypress/component/Tooltip.spec.tsx
+++ b/cypress/component/Tooltip.spec.tsx
@@ -359,11 +359,16 @@ describe('Tooltip', () => {
     })
   })
 
-  // The problem with this test is that even though the example is correctly being rendered
-  // The happo screenshot doesn't contain the modal itself, just the button
-  // We are skipping this test until we get a response from Happo team
-  it.skip('renders inside and outside of a modal', () => {
+  // Previously skipped: the pre-migration (MUI portal) modal never appeared in
+  // the Happo capture. Both Modal and Tooltip are on @base-ui/react now, so the
+  // old failure mode no longer applies.
+  it('renders inside and outside of a modal', () => {
     cy.mount(<ModalTooltipExample />)
+
+    // modal + both tooltips open via async state — gate on them before capturing
+    cy.waitForOverlayOpen()
+    cy.getByRole('tooltip').should('have.length', 2).and('be.visible')
+
     cy.get('body').happoScreenshot({
       component,
       variant: 'inside-and-outside-modal',

--- a/cypress/component/Tooltip.spec.tsx
+++ b/cypress/component/Tooltip.spec.tsx
@@ -359,10 +359,10 @@ describe('Tooltip', () => {
     })
   })
 
-  // Previously skipped: the pre-migration (MUI portal) modal never appeared in
-  // the Happo capture. Both Modal and Tooltip are on @base-ui/react now, so the
-  // old failure mode no longer applies.
-  it('renders inside and outside of a modal', () => {
+  // The problem with this test is that even though the example is correctly being rendered
+  // The happo screenshot doesn't contain the modal itself, just the button
+  // We are skipping this test until we get a response from Happo team
+  it.skip('renders inside and outside of a modal', () => {
     cy.mount(<ModalTooltipExample />)
 
     // modal + both tooltips open via async state — gate on them before capturing

--- a/cypress/component/Tooltip.spec.tsx
+++ b/cypress/component/Tooltip.spec.tsx
@@ -288,6 +288,9 @@ const component = 'Tooltip'
 describe('Tooltip', () => {
   it('renders by default', () => {
     cy.mount(<SnapshotTooltipExample />)
+    // opens via async setOpen — gate on it before capturing (the base-ui popup
+    // mounts + positions a frame later; the global override settles geometry)
+    cy.getByRole('tooltip').should('be.visible')
     cy.get('body').happoScreenshot({
       component,
       variant: 'default',
@@ -296,6 +299,7 @@ describe('Tooltip', () => {
 
   it('renders with disabled portals', () => {
     cy.mount(<SnapshotTooltipExample disablePortal />)
+    cy.getByRole('tooltip').should('be.visible')
     cy.get('body').happoScreenshot({
       component,
       variant: 'with-disabled-portals',
@@ -304,6 +308,7 @@ describe('Tooltip', () => {
 
   it('renders compact', () => {
     cy.mount(<SnapshotTooltipExample compact />)
+    cy.getByRole('tooltip').should('be.visible')
     cy.get('body').happoScreenshot({
       component,
       variant: 'compact',
@@ -312,6 +317,7 @@ describe('Tooltip', () => {
 
   it('renders long text with max width', () => {
     cy.mount(<SnapshotTooltipExample content={TOOLTIP_LONG_TEXT} />)
+    cy.getByRole('tooltip').should('be.visible')
     cy.get('body').happoScreenshot({
       component,
       variant: 'long-text-with-max-width',
@@ -322,6 +328,7 @@ describe('Tooltip', () => {
     cy.mount(
       <SnapshotTooltipExample content={TOOLTIP_LONG_TEXT} maxWidth='none' />
     )
+    cy.getByRole('tooltip').should('be.visible')
     cy.get('body').happoScreenshot({
       component,
       variant: 'long-text-without-max-width',
@@ -335,6 +342,7 @@ describe('Tooltip', () => {
         preventOverflow={false}
       />
     )
+    cy.getByRole('tooltip').should('be.visible')
     cy.get('body').happoScreenshot({
       component,
       variant: 'without-overflow-prevention',
@@ -343,6 +351,8 @@ describe('Tooltip', () => {
 
   it('renders with different placements', () => {
     cy.mount(<PlacementTooltipExample />)
+    // 12 tooltips, all opened via async setOpen — wait for the full set
+    cy.getByRole('tooltip').should('have.length', 12).and('be.visible')
     cy.get('body').happoScreenshot({
       component,
       variant: 'with-different-placements',

--- a/cypress/component/TreeView.spec.tsx
+++ b/cypress/component/TreeView.spec.tsx
@@ -106,7 +106,7 @@ const ModalExample = () => {
   )
 }
 
-// const component = 'TreeView'
+const component = 'TreeView'
 
 describe('TreeView', () => {
   it('render with modal', () => {
@@ -117,10 +117,13 @@ describe('TreeView', () => {
 
     cy.getByTestId('tree-dialog-content').should('be.visible')
 
-    // Temporary disabling this screenshot as fonts stopped working in modals
-    // cy.getByRole('presentation').happoScreenshot({
-    //   component,
-    //   variant: 'with-modal/after-modal-opened',
-    // })
+    // Screenshot was disabled pre-migration ("fonts stopped working in
+    // modals") and targeted MUI's role="presentation" portal wrapper; the
+    // @base-ui/react Modal emits role="dialog" instead.
+    cy.waitForOverlayOpen()
+    cy.getByRole('dialog').happoScreenshot({
+      component,
+      variant: 'with-modal/after-modal-opened',
+    })
   })
 })

--- a/cypress/component/TreeView.spec.tsx
+++ b/cypress/component/TreeView.spec.tsx
@@ -106,7 +106,7 @@ const ModalExample = () => {
   )
 }
 
-const component = 'TreeView'
+// const component = 'TreeView'
 
 describe('TreeView', () => {
   it('render with modal', () => {
@@ -117,13 +117,11 @@ describe('TreeView', () => {
 
     cy.getByTestId('tree-dialog-content').should('be.visible')
 
-    // Screenshot was disabled pre-migration ("fonts stopped working in
-    // modals") and targeted MUI's role="presentation" portal wrapper; the
-    // @base-ui/react Modal emits role="dialog" instead.
     cy.waitForOverlayOpen()
-    cy.getByRole('dialog').happoScreenshot({
-      component,
-      variant: 'with-modal/after-modal-opened',
-    })
+    // Temporary disabling this screenshot as fonts stopped working in modals
+    // cy.getByRole('presentation').happoScreenshot({
+    //   component,
+    //   variant: 'with-modal/after-modal-opened',
+    // })
   })
 })

--- a/cypress/support/commands.jsx
+++ b/cypress/support/commands.jsx
@@ -10,17 +10,18 @@ Cypress.Commands.add('isWithinViewport', { prevSubject: true }, subject => {
   const windowInnerWidth = Cypress.config(`viewportWidth`)
   const windowInnerHeight = Cypress.config(`viewportHeight`)
 
-  const bounding = subject[0].getBoundingClientRect()
+  // retried via .should() so a mid-scroll/mid-animation read converges instead
+  // of failing (or falsely passing) a one-shot geometry check
+  return cy.wrap(subject).should($el => {
+    expect($el[0].isConnected, 'element attached').to.equal(true)
 
-  const rightBoundOfWindow = windowInnerWidth
-  const bottomBoundOfWindow = windowInnerHeight
+    const bounding = $el[0].getBoundingClientRect()
 
-  expect(bounding.top).to.be.at.least(0)
-  expect(bounding.left).to.be.at.least(0)
-  expect(bounding.right).not.to.be.greaterThan(rightBoundOfWindow)
-  expect(bounding.bottom).not.to.be.greaterThan(bottomBoundOfWindow)
-
-  return subject
+    expect(bounding.top).to.be.at.least(0)
+    expect(bounding.left).to.be.at.least(0)
+    expect(bounding.right).not.to.be.greaterThan(windowInnerWidth)
+    expect(bounding.bottom).not.to.be.greaterThan(windowInnerHeight)
+  })
 })
 
 Cypress.Commands.add('getByTestId', (testId, options) => {
@@ -64,29 +65,37 @@ const readTransitionStyles = el => {
 const waitForHoverToSettle = selector => {
   let previous = null
 
-  cy.get(selector).should($el => {
-    const current = readTransitionStyles($el[0])
+  return cy.get(selector).should($els => {
+    const current = Array.from($els, readTransitionStyles).join('|||')
     const wasPrevious = previous
 
     previous = current
     // passes only once two consecutive reads match — i.e. the transition has
     // come to rest. Cypress retries this callback until it passes or times out.
-    expect(current, 'hover transition settled').to.equal(wasPrevious)
+    expect(current, 'style transitions settled').to.equal(wasPrevious)
   })
 }
 
+// Gate on hover/focus style transitions (e.g. `transition-colors` on menu
+// items) being at rest for every matched element before capturing.
+Cypress.Commands.add('waitForTransitionsToSettle', selector =>
+  waitForHoverToSettle(selector)
+)
+
 // Transient floating UI must be geometrically at rest before serializing:
-// `@floating-ui/react` poppers (stamped `x-placement`) commit their coordinates
-// a frame or two after open, and notistack notifications (`role="alert"`)
-// slide in via inline-style transforms that happo-cypress captures verbatim.
+// `@floating-ui/react` poppers (Picasso's Popper stamps `x-placement`, base-ui's
+// Tooltip positions its `role="tooltip"` popup) commit their coordinates a frame
+// or two after open, and notistack notifications (`role="alert"`) slide in via
+// inline-style transforms that happo-cypress captures verbatim.
 // Settled = two consecutive reads of every visible element's box match.
 // Vacuous when nothing matches — asserting PRESENCE stays the callers' job.
-const GEOMETRY_SETTLE_SELECTOR = '[x-placement], [role="alert"]'
+const GEOMETRY_SETTLE_SELECTOR =
+  '[x-placement], [role="tooltip"], [role="alert"]'
 
-const readTransientBoxes = $body => {
+const readTransientBoxes = ($body, selector) => {
   const boxes = []
 
-  $body.find(GEOMETRY_SETTLE_SELECTOR).each((_index, el) => {
+  $body.find(selector).each((_index, el) => {
     const rect = el.getBoundingClientRect()
 
     // skip non-rendered nodes (display:none keepMounted poppers report 0×0)
@@ -104,17 +113,25 @@ const readTransientBoxes = $body => {
   return boxes.join('|')
 }
 
-const waitForTransientGeometryToSettle = () => {
+const waitForTransientGeometryToSettle = (
+  selector = GEOMETRY_SETTLE_SELECTOR
+) => {
   let previous = null
 
   return cy.get('body').should($body => {
-    const current = readTransientBoxes($body)
+    const current = readTransientBoxes($body, selector)
     const wasPrevious = previous
 
     previous = current
     expect(current, 'transient geometry settled').to.equal(wasPrevious)
   })
 }
+
+// Gate on the matched elements' boxes being at rest (e.g. an Accordion height
+// animation) — assert PRESENCE first; an empty match set settles vacuously.
+Cypress.Commands.add('waitForGeometryToSettle', selector =>
+  waitForTransientGeometryToSettle(selector)
+)
 
 Cypress.Commands.add(
   'hoverAndTakeHappoScreenshot',

--- a/cypress/support/commands.jsx
+++ b/cypress/support/commands.jsx
@@ -75,26 +75,18 @@ const waitForHoverToSettle = selector => {
   })
 }
 
-// A popper positioned by `@floating-ui/react` (Dropdown/Menu/Popper) commits
-// its coordinates a frame or two after open, driven by `autoUpdate` — so its
-// `getBoundingClientRect()` keeps changing across animation frames right after
-// it appears. happo-cypress serializes the live DOM at a single instant; if
-// that instant lands mid-settle, the whole popup (and anything measured from
-// it) is captured a fraction of a pixel off, diffing against the baseline.
-// Picasso stamps `x-placement` on the positioned floating node, so its presence
-// marks a popper that must be geometrically at rest before we serialize.
-//
-// Waited on via `.should()`, whose callback Cypress retries on its own
-// animation-frame loop (bounded by defaultCommandTimeout) until it passes — no
-// hardcoded durations. The assertion passes once two consecutive reads of every
-// visible popper's box are identical, i.e. positioning has come to rest. Closed
-// `keepMounted` poppers (rendered but `display:none`) are skipped as they carry
-// no meaningful geometry. When no popper is open the set is empty and the
-// assertion passes immediately, so this is a no-op for non-popper snapshots.
-const readPopperBoxes = $body => {
+// Transient floating UI must be geometrically at rest before serializing:
+// `@floating-ui/react` poppers (stamped `x-placement`) commit their coordinates
+// a frame or two after open, and notistack notifications (`role="alert"`)
+// slide in via inline-style transforms that happo-cypress captures verbatim.
+// Settled = two consecutive reads of every visible element's box match.
+// Vacuous when nothing matches — asserting PRESENCE stays the callers' job.
+const GEOMETRY_SETTLE_SELECTOR = '[x-placement], [role="alert"]'
+
+const readTransientBoxes = $body => {
   const boxes = []
 
-  $body.find('[x-placement]').each((_index, el) => {
+  $body.find(GEOMETRY_SETTLE_SELECTOR).each((_index, el) => {
     const rect = el.getBoundingClientRect()
 
     // skip non-rendered nodes (display:none keepMounted poppers report 0×0)
@@ -112,17 +104,15 @@ const readPopperBoxes = $body => {
   return boxes.join('|')
 }
 
-const waitForPoppersToSettle = () => {
+const waitForTransientGeometryToSettle = () => {
   let previous = null
 
   return cy.get('body').should($body => {
-    const current = readPopperBoxes($body)
+    const current = readTransientBoxes($body)
     const wasPrevious = previous
 
     previous = current
-    // passes only once two consecutive reads match — i.e. every open popper has
-    // finished positioning. Cypress retries this callback until it passes.
-    expect(current, 'popper positioning settled').to.equal(wasPrevious)
+    expect(current, 'transient geometry settled').to.equal(wasPrevious)
   })
 }
 
@@ -160,6 +150,22 @@ Cypress.Commands.add('waitForOverlayOpen', (selector = '[role="dialog"]') =>
     .and('not.have.attr', 'data-starting-style')
 )
 
+// Gate on the DatePicker calendar being MOUNTED — it opens via async state, and
+// the global geometry-settle passes vacuously while no popper is in the DOM.
+Cypress.Commands.add('waitForCalendarOpen', () =>
+  cy.get('.rdp-month').should('be.visible')
+)
+
+// Gate on every matched <img> having decoded — `be.visible` only asserts the
+// layout box, not that the pixels loaded. Pass a selector to scope the check.
+Cypress.Commands.add('waitForImagesDecoded', (selector = 'img') =>
+  cy.get(selector).should($imgs => {
+    $imgs.each((_index, img) => {
+      expect(img.naturalWidth, 'image decoded').to.be.greaterThan(0)
+    })
+  })
+)
+
 // happo-cypress serializes the live DOM and re-renders it statically in the
 // cloud (no JS runs there). @base-ui/react removes `data-starting-style` one
 // frame after mount; if captured before removal, the attribute pins the element
@@ -171,9 +177,8 @@ Cypress.Commands.overwrite(
       cy
         .get('[data-starting-style]', { timeout: 4000 })
         .should('not.exist')
-        // then let any open @floating-ui popper finish positioning, so the static
-        // capture reflects its settled geometry (see waitForPoppersToSettle above)
-        .then(() => waitForPoppersToSettle())
+        // then let poppers/notifications finish moving before serializing
+        .then(() => waitForTransientGeometryToSettle())
         .then(() => originalFn(subject, options))
     )
   }

--- a/cypress/support/fixtures.ts
+++ b/cypress/support/fixtures.ts
@@ -1,0 +1,19 @@
+/// <reference types="cypress" />
+
+// Registers a `before()` hook that loads the shared avatar fixture and returns
+// a getter for its data URI (empty until the hook runs). Call at spec module
+// scope; read the getter inside tests, after the hook has resolved.
+export const loadAvatarFixture = () => {
+  let src = ''
+
+  before(() => {
+    // eslint-disable-next-line promise/catch-or-return
+    cy.fixture('pablo.jpg').then(image => {
+      src = 'data:image/jpg;base64,' + image
+
+      return image
+    })
+  })
+
+  return () => src
+}

--- a/cypress/support/index.d.ts
+++ b/cypress/support/index.d.ts
@@ -14,6 +14,8 @@ declare global {
         options?: HappoScreenshotOptions
       ): Chainable<Subject>
       waitForOverlayOpen(selector?: string): Chainable<JQuery<HTMLElement>>
+      waitForCalendarOpen(): Chainable<JQuery<HTMLElement>>
+      waitForImagesDecoded(selector?: string): Chainable<JQuery<HTMLElement>>
       mount: typeof mount
     }
   }

--- a/cypress/support/index.d.ts
+++ b/cypress/support/index.d.ts
@@ -16,6 +16,10 @@ declare global {
       waitForOverlayOpen(selector?: string): Chainable<JQuery<HTMLElement>>
       waitForCalendarOpen(): Chainable<JQuery<HTMLElement>>
       waitForImagesDecoded(selector?: string): Chainable<JQuery<HTMLElement>>
+      waitForGeometryToSettle(selector: string): Chainable<JQuery<HTMLElement>>
+      waitForTransitionsToSettle(
+        selector: string
+      ): Chainable<JQuery<HTMLElement>>
       mount: typeof mount
     }
   }

--- a/cypress/support/table-data.ts
+++ b/cypress/support/table-data.ts
@@ -1,0 +1,43 @@
+// Shared row set for the Table/TableCell specs (was duplicated verbatim).
+export const tableData = [
+  {
+    id: 0,
+    name: 'Delia Floyd',
+    talentType: 'Designer',
+    company: 'Airbnb',
+    role: 'UX lead',
+    country: 'United States',
+  },
+  {
+    id: 1,
+    name: 'Linnie Sims',
+    talentType: 'Designer',
+    company: 'Facebook',
+    role: 'Art director',
+    country: 'Spain',
+  },
+  {
+    id: 2,
+    name: 'Charles Watson',
+    talentType: 'Developer',
+    company: 'Amazon',
+    role: 'Ruby developer',
+    country: 'Germany',
+  },
+  {
+    id: 3,
+    name: 'Leila Pena',
+    talentType: 'Developer',
+    company: 'Invision',
+    role: 'Web developer',
+    country: 'Poland',
+  },
+  {
+    id: 4,
+    name: 'Logan Burton',
+    talentType: 'Developer',
+    company: 'Microsoft',
+    role: 'CTO',
+    country: 'United States',
+  },
+]


### PR DESCRIPTION
[PF-1994] Tweak cypress transitions and wait logic

### Description

Follow-up to #5028, which fixed the flaky Cypress-Happo captures on `PageTopBarMenu` by gating the `happoScreenshot` override on `@floating-ui` poppers settling. This PR extends the same doctrine across the rest of the Cypress component suite: every screenshot that captures async content now waits for that content to be **present and settled** before serializing, so `happo-cypress` can't freeze a mid-flight frame.

**Root cause (recap).** `happo-cypress` serializes the live DOM into a single static frame. Any content that mounts or animates asynchronously — a popper positioning over a couple of `@floating-ui` `autoUpdate` frames, a base64 image still decoding, a notistack notification sliding in, a recharts tooltip mounting on `mousemove` — can land mid-flight in that one instant and diff against the baseline. The global override only ever waited for `data-starting-style` (a Base UI signal) and, after #5028, for open poppers' geometry — neither of which covers image decode, notification slide-in, or the case where the popper **hasn't mounted yet** (an empty match set reports "settled" vacuously, so the capture races the async open).

**What this PR does:**

- **Generalizes the settle gate to notifications.** `waitForPoppersToSettle` → `waitForTransientGeometryToSettle`: the selector now also matches `[role="alert"]`, so notistack notifications (which slide in via inline-style transforms that `happo-cypress` captures verbatim) must reach a stable bounding box before serialization — same two-consecutive-identical-reads mechanism, still a no-op when nothing matches. Covers `NotificationStream`, `Form`, `QueryBuilder`, `Page`.
- **Adds `cy.waitForImagesDecoded(selector?)`.** A shared command that gates on every matched `<img>` having decoded (`naturalWidth > 0`) rather than merely being laid out (`be.visible` passes on an `object-cover` image before its pixels paint). Replaces the same assertion hand-rolled across `Avatar`, `AvatarUpload`, `PageTopBarMenu`, and (scoped to the editor) `RichTextEditor/ImagePlugin`.
- **Adds `cy.waitForCalendarOpen()`.** Gates on the `DatePicker` calendar being mounted (`.rdp-month` visible) before its screenshots. The calendar opens via async state and its Popper renders a frame after mount, so the geometry-settle would otherwise pass vacuously and capture an empty page.
- **Adds popper/tooltip/alert presence gates in specs the settle gate can't cover.** `Select` (via its `openSelect()` helper — one place, all callers), `TagSelector` (open combobox + filtered "other option"), and `BarChart` (recharts tooltip) now assert their async content is visible **before** the screenshot instead of after. `PageTopBarMenu` gates on the opened dropdown's content before letting the avatars decode.

**No `cy.wait(ms)` / hardcoded timeouts** — every wait is a `.should()`-retried DOM condition, resolving the instant it's satisfied and only failing at the existing `defaultCommandTimeout` ceiling. **Test-infra only:** no component source is touched (`cypress/` exclusively), so no changeset is needed and no consumer-visible behavior changes.

### How to test

- [Temploy](https://picasso.toptal.net/tweak/cypress-tests-transitions)
- The change is capture-timing only; the intended effect is fewer non-deterministic 1-diff Happo flakes on `DatePicker`, `Select`, `TagSelector`, `BarChart`, `NotificationStream`, `Avatar`, `AvatarUpload`, `PageTopBarMenu`, and `ImagePlugin` snapshots. Re-run the Visual Tests job (or `pnpm test:integration`) and confirm those suites are stable across repeated runs.

### Screenshots

| Before                                  | After                                   |
| --------------------------------------- | --------------------------------------- |
| N/A — no visual change; this PR removes non-deterministic capture races, so baselines are unchanged | N/A |

### Development checks

- [x] Add changeset according to guidelines (if needed) — _not needed; `cypress/`-only, no package code changed_
- [x] Self reviewed
- [x] Covered with tests (visual tests included) — _this PR is test-infra hardening for the visual suite itself_


[PF-1994]: https://toptal-core.atlassian.net/browse/PF-1994?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ