### PR TITLE
[PF-1994] Mark Tooltip migration merged in manifest

### DIFF
--- a/docs/migration/manifest.json
+++ b/docs/migration/manifest.json
@@ -866,7 +866,7 @@
     "Tooltip": {
       "tier": 2,
       "package": "packages/base/Tooltip",
-      "status": "awaiting_review",
+      "status": "done",
       "depends_on": [],
       "target_path": "@base-ui/react/tooltip",
       "versionBump": "major",
@@ -874,7 +874,7 @@
       "branch": null,
       "worktree": null,
       "iterations": 0,
-      "merged_at": null,
+      "merged_at": "2026-07-09T14:09:17Z",
       "notes": "Heavy path. Direct match: Tooltip.Provider + Tooltip.Root + Tooltip.Trigger + Tooltip.Portal + Tooltip.Positioner + Tooltip.Popup. FileInput + RTE depend on this — sequence first within Tier 2.",
       "variants": {
         "vedrani": {
@@ -905,12 +905,12 @@
           "awaiting_ci_since": null
         },
         "v2": {
-          "status": "needs_human",
+          "status": "done",
           "pr": "https://github.com/toptal/picasso/pull/5005",
           "branch": "migrate-Tooltip-v2",
           "worktree": "migration-runs/2026-06-11/Tooltip-v2/worktree",
           "iterations": 2,
-          "merged_at": null,
+          "merged_at": "2026-07-09T14:09:17Z",
           "escalation_reason": "review-sweep 2026-07-06: shipped confirmed id→popup change (commit 16e8a163c); posted 2 MEDIUM proposals awaiting 👍 (restore aria-describedby parity; graduate spacing/placement helpers to shared). Open human items: vedrani PF-2203 Popper cleanup, disabled-button anchor spacing.",
           "last_ci_green_at": "2026-06-11T18:59:10.304Z",
           "last_review_seen_at": "2026-07-06T09:52:58.000Z",


### PR DESCRIPTION
## What

Marks the Tooltip migration as merged in `docs/migration/manifest.json`, now that **PR #5005** (`migrate-Tooltip-v2` → `feature/picasso-modernization-temp`) has merged (commit `2a94f999f`, 2026-07-09T14:09:17Z).

## Changes

- `Tooltip` component: `status` `awaiting_review` → `done`, `merged_at` → `2026-07-09T14:09:17Z`
- `Tooltip.variants.v2` (the winning variant): `status` `needs_human` → `done`, `merged_at` → `2026-07-09T14:09:17Z`

Nothing else in the manifest is touched (verified byte-identical JSON round-trip before/after the field edit).

## Note on the losing variants

Tooltip is the only multi-variant component in the manifest (`vedrani`, `v1`, `v2`). There's no `superseded`/`abandoned` status in the current enum, so I left `vedrani` (`needs_human`) and `v1` (`in_progress`) as-is rather than invent a status. The component-level `status: done` is what the orchestrator reads to skip Tooltip, so this is correct as-is — but if you'd prefer the losing variants pruned or explicitly marked, say the word.

🤖 Generated with [Claude Code](https://claude.com/claude-code)