### PR TITLE
[PF-2234] Tweak Accordion

### DIFF
--- a/packages/base/Accordion/src/Accordion/Accordion.tsx
+++ b/packages/base/Accordion/src/Accordion/Accordion.tsx
@@ -24,6 +24,7 @@ import {
   createExpandIconClassNames,
   expandIconAlignTopClasses,
   panelClasses,
+  panelOverflowVisibleClass,
 } from './styles'
 
 export type { Borders } from './styles'
@@ -117,11 +118,14 @@ export const Accordion = forwardRef<HTMLElement, Props>(function Accordion(
 
   const [summaryExpanded, setSummaryExpanded] = useState(defaultExpanded)
   const [prevExpanded, setPrevExpanded] = useState(defaultExpanded)
+  // Releases the panel's overflow clip only after the open transition settles.
+  const [isAnimating, setIsAnimating] = useState(false)
 
   // getDerivedStateFromProps implementation to allow expanded to be controlled
   if (expanded !== undefined && expanded !== prevExpanded) {
     setSummaryExpanded(expanded)
     setPrevExpanded(expanded)
+    setIsAnimating(true)
   }
 
   const handleValueChange = (
@@ -131,6 +135,7 @@ export const Accordion = forwardRef<HTMLElement, Props>(function Accordion(
     const newExpanded = value.length > 0
 
     setSummaryExpanded(newExpanded)
+    setIsAnimating(true)
     onChange(
       toReactEvent<ChangeEvent<Element>>(eventDetails.event),
       newExpanded
@@ -139,10 +144,15 @@ export const Accordion = forwardRef<HTMLElement, Props>(function Accordion(
 
   const handlePanelTransitionEnd = (event: TransitionEvent<HTMLDivElement>) => {
     if (
-      !summaryExpanded &&
-      event.target === event.currentTarget &&
-      event.propertyName === 'height'
+      event.target !== event.currentTarget ||
+      event.propertyName !== 'height'
     ) {
+      return
+    }
+
+    setIsAnimating(false)
+
+    if (!summaryExpanded) {
       transitionProps?.onExited?.(event.currentTarget)
     }
   }
@@ -189,15 +199,21 @@ export const Accordion = forwardRef<HTMLElement, Props>(function Accordion(
               {children}
               {expandIcon ? (
                 <ButtonAction
+                  data-component-type='accordion-summary-icon'
                   icon={decorateWithExpandIconClasses(
                     expandIcon,
                     expandIconClass
                   )}
+                  tabIndex={-1}
                 />
               ) : (
-                <div className={cx(...expandIconAlignTopClasses)}>
+                <div
+                  data-component-type='accordion-summary-icon'
+                  className={cx(...expandIconAlignTopClasses)}
+                >
                   <ButtonAction
                     icon={<ArrowDownMinor16 className={expandIconClass} />}
+                    tabIndex={-1}
                   />
                 </div>
               )}
@@ -208,7 +224,11 @@ export const Accordion = forwardRef<HTMLElement, Props>(function Accordion(
         )}
         <BaseUIAccordion.Panel
           keepMounted
-          className={cx(...panelClasses)}
+          className={twMerge(
+            cx(...panelClasses, {
+              [panelOverflowVisibleClass]: summaryExpanded && !isAnimating,
+            })
+          )}
           style={
             {
               '--accordion-duration': `${resolveTransitionDuration(

--- a/packages/base/Accordion/src/Accordion/Accordion.tsx
+++ b/packages/base/Accordion/src/Accordion/Accordion.tsx
@@ -7,12 +7,12 @@ import type {
   Ref,
   TransitionEvent,
 } from 'react'
-import React, { forwardRef, useState } from 'react'
+import React, { forwardRef, useRef, useState } from 'react'
 import cx from 'classnames'
 import { Accordion as BaseUIAccordion } from '@base-ui/react/accordion'
 import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { StandardProps, TransitionProps } from '@toptal/picasso-shared'
-import { toReactEvent } from '@toptal/picasso-shared'
+import { toReactEvent, useIsomorphicLayoutEffect } from '@toptal/picasso-shared'
 import { ArrowDownMinor16 } from '@toptal/picasso-icons'
 import { ButtonAction } from '@toptal/picasso-button'
 
@@ -33,6 +33,9 @@ const ITEM_VALUE = 'item'
 const EXPANDED_VALUE = [ITEM_VALUE]
 const COLLAPSED_VALUE: string[] = []
 const DEFAULT_TRANSITION_DURATION = 300
+// Base UI caches whether the panel animates from a one-time read of its
+// duration, so a literal `0s` would disable it permanently. 1ms is imperceptible.
+const MIN_CSS_TRANSITION_DURATION = 1
 
 const resolveTransitionDuration = (
   timeout: TransitionProps['timeout'],
@@ -118,15 +121,29 @@ export const Accordion = forwardRef<HTMLElement, Props>(function Accordion(
 
   const [summaryExpanded, setSummaryExpanded] = useState(defaultExpanded)
   const [prevExpanded, setPrevExpanded] = useState(defaultExpanded)
-  // Releases the panel's overflow clip only after the open transition settles.
-  const [isAnimating, setIsAnimating] = useState(false)
+  // Releases the panel's overflow clip once the open transition settles.
+  const [panelSettled, setPanelSettled] = useState(false)
 
   // getDerivedStateFromProps implementation to allow expanded to be controlled
   if (expanded !== undefined && expanded !== prevExpanded) {
     setSummaryExpanded(expanded)
     setPrevExpanded(expanded)
-    setIsAnimating(true)
   }
+
+  const isInitialMountRef = useRef(true)
+
+  // Reset from an effect, never during render — a render-phase write is lost.
+  useIsomorphicLayoutEffect(() => {
+    if (isInitialMountRef.current) {
+      isInitialMountRef.current = false
+      // A panel that mounts open runs no transition — settle it at once.
+      setPanelSettled(summaryExpanded)
+
+      return
+    }
+
+    setPanelSettled(false)
+  }, [summaryExpanded])
 
   const handleValueChange = (
     value: unknown[],
@@ -135,7 +152,6 @@ export const Accordion = forwardRef<HTMLElement, Props>(function Accordion(
     const newExpanded = value.length > 0
 
     setSummaryExpanded(newExpanded)
-    setIsAnimating(true)
     onChange(
       toReactEvent<ChangeEvent<Element>>(eventDetails.event),
       newExpanded
@@ -150,9 +166,9 @@ export const Accordion = forwardRef<HTMLElement, Props>(function Accordion(
       return
     }
 
-    setIsAnimating(false)
-
-    if (!summaryExpanded) {
+    if (summaryExpanded) {
+      setPanelSettled(true)
+    } else {
       transitionProps?.onExited?.(event.currentTarget)
     }
   }
@@ -198,14 +214,15 @@ export const Accordion = forwardRef<HTMLElement, Props>(function Accordion(
             >
               {children}
               {expandIcon ? (
-                <ButtonAction
-                  data-component-type='accordion-summary-icon'
-                  icon={decorateWithExpandIconClasses(
-                    expandIcon,
-                    expandIconClass
-                  )}
-                  tabIndex={-1}
-                />
+                <div data-component-type='accordion-summary-icon'>
+                  <ButtonAction
+                    icon={decorateWithExpandIconClasses(
+                      expandIcon,
+                      expandIconClass
+                    )}
+                    tabIndex={-1}
+                  />
+                </div>
               ) : (
                 <div
                   data-component-type='accordion-summary-icon'
@@ -226,14 +243,17 @@ export const Accordion = forwardRef<HTMLElement, Props>(function Accordion(
           keepMounted
           className={twMerge(
             cx(...panelClasses, {
-              [panelOverflowVisibleClass]: summaryExpanded && !isAnimating,
+              [panelOverflowVisibleClass]: summaryExpanded && panelSettled,
             })
           )}
           style={
             {
-              '--accordion-duration': `${resolveTransitionDuration(
-                transitionProps?.timeout,
-                Boolean(summaryExpanded)
+              '--accordion-duration': `${Math.max(
+                resolveTransitionDuration(
+                  transitionProps?.timeout,
+                  Boolean(summaryExpanded)
+                ),
+                MIN_CSS_TRANSITION_DURATION
               )}ms`,
             } as CSSProperties
           }

--- a/packages/base/Accordion/src/Accordion/__snapshots__/test.tsx.snap
+++ b/packages/base/Accordion/src/Accordion/__snapshots__/test.tsx.snap
@@ -142,23 +142,27 @@ exports[`Accordion renders custom icon when passed 1`] = `
               >
                 What is a dog?
               </div>
-              <button
-                aria-disabled="false"
-                class="base-Button text-lg inline-flex items-center justify-center select-none appearance-none m-0 relative normal-case align-middle transition-colors duration-350 ease-out shrink-0 outline-hidden [[data-component-type="button"]+&]:ml cursor-pointer border-none px-0 bg-transparent h-[1.5em] hover:text-blue hover:underline active:text-blue active:underline focus-visible:shadow-[0_0_0_3px_rgba(32,78,207,0.48)] focus-visible:rounded-sm"
-                data-component-type="button"
-                role="button"
-                tabindex="-1"
-                type="button"
+              <div
+                data-component-type="accordion-summary-icon"
               >
-                <span
-                  class="items-center inline-flex font-semibold text-blue text-md"
+                <button
+                  aria-disabled="false"
+                  class="base-Button text-lg inline-flex items-center justify-center select-none appearance-none m-0 relative normal-case align-middle transition-colors duration-350 ease-out shrink-0 outline-hidden [[data-component-type="button"]+&]:ml cursor-pointer border-none px-0 bg-transparent h-[1.5em] hover:text-blue hover:underline active:text-blue active:underline focus-visible:shadow-[0_0_0_3px_rgba(32,78,207,0.48)] focus-visible:rounded-sm"
+                  data-component-type="button"
+                  role="button"
+                  tabindex="-1"
+                  type="button"
                 >
                   <span
-                    class="flex-1 w-4 h-4 text-[0.7em] text-graphite transition-transform duration-150 ease-in"
-                    data-testid="custom-expand-icon"
-                  />
-                </span>
-              </button>
+                    class="items-center inline-flex font-semibold text-blue text-md"
+                  >
+                    <span
+                      class="flex-1 w-4 h-4 text-[0.7em] text-graphite transition-transform duration-150 ease-in"
+                      data-testid="custom-expand-icon"
+                    />
+                  </span>
+                </button>
+              </div>
             </div>
           </div>
         </div>

--- a/packages/base/Accordion/src/Accordion/__snapshots__/test.tsx.snap
+++ b/packages/base/Accordion/src/Accordion/__snapshots__/test.tsx.snap
@@ -24,7 +24,7 @@ exports[`Accordion renders collapsed by default 1`] = `
         >
           <div
             aria-expanded="false"
-            class="relative flex items-center select-none cursor-pointer outline-none py-[0.5625em] px-0 font-semibold text-black data-disabled:pointer-events"
+            class="relative flex items-center select-none cursor-pointer focus-visible:bg-black/12 outline-none py-[0.5625em] px-0 font-semibold text-black data-disabled:pointer-events"
             data-component-type="accordion-summary"
             data-orientation="vertical"
             data-value=""
@@ -44,13 +44,14 @@ exports[`Accordion renders collapsed by default 1`] = `
               </div>
               <div
                 class="flex items-center h-[1.5em] self-start"
+                data-component-type="accordion-summary-icon"
               >
                 <button
                   aria-disabled="false"
                   class="base-Button text-lg inline-flex items-center justify-center select-none appearance-none m-0 relative normal-case align-middle transition-colors duration-350 ease-out shrink-0 outline-hidden [[data-component-type="button"]+&]:ml cursor-pointer border-none px-0 bg-transparent h-[1.5em] hover:text-blue hover:underline active:text-blue active:underline focus-visible:shadow-[0_0_0_3px_rgba(32,78,207,0.48)] focus-visible:rounded-sm"
                   data-component-type="button"
                   role="button"
-                  tabindex="0"
+                  tabindex="-1"
                   type="button"
                 >
                   <span
@@ -123,7 +124,7 @@ exports[`Accordion renders custom icon when passed 1`] = `
         >
           <div
             aria-expanded="false"
-            class="relative flex items-center select-none cursor-pointer outline-none py-[0.5625em] px-0 font-semibold text-black data-disabled:pointer-events"
+            class="relative flex items-center select-none cursor-pointer focus-visible:bg-black/12 outline-none py-[0.5625em] px-0 font-semibold text-black data-disabled:pointer-events"
             data-component-type="accordion-summary"
             data-orientation="vertical"
             data-value=""
@@ -146,7 +147,7 @@ exports[`Accordion renders custom icon when passed 1`] = `
                 class="base-Button text-lg inline-flex items-center justify-center select-none appearance-none m-0 relative normal-case align-middle transition-colors duration-350 ease-out shrink-0 outline-hidden [[data-component-type="button"]+&]:ml cursor-pointer border-none px-0 bg-transparent h-[1.5em] hover:text-blue hover:underline active:text-blue active:underline focus-visible:shadow-[0_0_0_3px_rgba(32,78,207,0.48)] focus-visible:rounded-sm"
                 data-component-type="button"
                 role="button"
-                tabindex="0"
+                tabindex="-1"
                 type="button"
               >
                 <span
@@ -217,7 +218,7 @@ exports[`Accordion renders disabled 1`] = `
           <div
             aria-disabled="true"
             aria-expanded="false"
-            class="relative flex items-center select-none cursor-pointer outline-none py-[0.5625em] px-0 font-semibold text-black data-disabled:pointer-events"
+            class="relative flex items-center select-none cursor-pointer focus-visible:bg-black/12 outline-none py-[0.5625em] px-0 font-semibold text-black data-disabled:pointer-events"
             data-component-type="accordion-summary"
             data-disabled=""
             data-orientation="vertical"
@@ -238,13 +239,14 @@ exports[`Accordion renders disabled 1`] = `
               </div>
               <div
                 class="flex items-center h-[1.5em] self-start"
+                data-component-type="accordion-summary-icon"
               >
                 <button
                   aria-disabled="false"
                   class="base-Button text-lg inline-flex items-center justify-center select-none appearance-none m-0 relative normal-case align-middle transition-colors duration-350 ease-out shrink-0 outline-hidden [[data-component-type="button"]+&]:ml cursor-pointer border-none px-0 bg-transparent h-[1.5em] hover:text-blue hover:underline active:text-blue active:underline focus-visible:shadow-[0_0_0_3px_rgba(32,78,207,0.48)] focus-visible:rounded-sm"
                   data-component-type="button"
                   role="button"
-                  tabindex="0"
+                  tabindex="-1"
                   type="button"
                 >
                   <span

--- a/packages/base/Accordion/src/Accordion/styles.ts
+++ b/packages/base/Accordion/src/Accordion/styles.ts
@@ -88,6 +88,9 @@ export const panelClasses = [
   '[&[hidden]]:invisible',
 ]
 
+// Overrides `overflow-hidden` so a fully-open panel doesn't clip its content.
+export const panelOverflowVisibleClass = 'overflow-visible'
+
 export const summaryWrapperClasses = ['text-black']
 
 export const detailsWrapperClasses = [

--- a/packages/base/Accordion/src/AccordionSummary/__snapshots__/test.tsx.snap
+++ b/packages/base/Accordion/src/AccordionSummary/__snapshots__/test.tsx.snap
@@ -6,7 +6,7 @@ exports[`AccordionSummary renders 1`] = `
     class="Picasso-root"
   >
     <div
-      class="relative flex items-center select-none cursor-pointer outline-none py-[0.5625em] px-0 font-semibold text-black data-disabled:pointer-events"
+      class="relative flex items-center select-none cursor-pointer focus-visible:bg-black/12 outline-none py-[0.5625em] px-0 font-semibold text-black data-disabled:pointer-events"
       data-component-type="accordion-summary"
     >
       <div

--- a/packages/base/Accordion/src/AccordionSummary/styles.ts
+++ b/packages/base/Accordion/src/AccordionSummary/styles.ts
@@ -4,6 +4,7 @@ export const summaryRootClasses = [
   'items-center',
   'select-none',
   'cursor-pointer',
+  'focus-visible:bg-black/12',
   'outline-none',
   'py-[0.5625em]',
   'px-0',

--- a/packages/base/Page/src/SidebarItem/__snapshots__/test.tsx.snap
+++ b/packages/base/Page/src/SidebarItem/__snapshots__/test.tsx.snap
@@ -87,28 +87,32 @@ exports[`SidebarItem collapsible menu is expanded when one of the children is se
                           </div>
                         </div>
                       </li>
-                      <button
-                        aria-disabled="false"
-                        class="base-Button text-lg inline-flex items-center justify-center select-none appearance-none m-0 relative normal-case align-middle transition-colors duration-350 ease-out shrink-0 outline-hidden [[data-component-type="button"]+&]:ml cursor-pointer border-none px-0 bg-transparent h-[1.5em] hover:text-blue hover:underline active:text-blue active:underline focus-visible:shadow-[0_0_0_3px_rgba(32,78,207,0.48)] focus-visible:rounded-sm"
-                        data-component-type="button"
-                        role="button"
-                        tabindex="-1"
-                        type="button"
+                      <div
+                        data-component-type="accordion-summary-icon"
                       >
-                        <span
-                          class="items-center inline-flex font-semibold text-blue text-md"
+                        <button
+                          aria-disabled="false"
+                          class="base-Button text-lg inline-flex items-center justify-center select-none appearance-none m-0 relative normal-case align-middle transition-colors duration-350 ease-out shrink-0 outline-hidden [[data-component-type="button"]+&]:ml cursor-pointer border-none px-0 bg-transparent h-[1.5em] hover:text-blue hover:underline active:text-blue active:underline focus-visible:shadow-[0_0_0_3px_rgba(32,78,207,0.48)] focus-visible:rounded-sm"
+                          data-component-type="button"
+                          role="button"
+                          tabindex="-1"
+                          type="button"
                         >
-                          <svg
-                            class="fill-current inline-block align-[-.125em] flex-1 w-4 h-4 transition-transform duration-150 ease-in rotate-180 text-base text-graphite"
-                            style="min-width: 16px; min-height: 16px;"
-                            viewBox="0 0 16 16"
+                          <span
+                            class="items-center inline-flex font-semibold text-blue text-md"
                           >
-                            <path
-                              d="m11.997 5.29.707.707-4 4-.707.707-.707-.707-4-4 .707-.707 4 4 4-4Z"
-                            />
-                          </svg>
-                        </span>
-                      </button>
+                            <svg
+                              class="fill-current inline-block align-[-.125em] flex-1 w-4 h-4 transition-transform duration-150 ease-in rotate-180 text-base text-graphite"
+                              style="min-width: 16px; min-height: 16px;"
+                              viewBox="0 0 16 16"
+                            >
+                              <path
+                                d="m11.997 5.29.707.707-4 4-.707.707-.707-.707-4-4 .707-.707 4 4 4-4Z"
+                              />
+                            </svg>
+                          </span>
+                        </button>
+                      </div>
                     </div>
                   </div>
                 </div>
@@ -263,28 +267,32 @@ exports[`SidebarItem collapsible menu is expanded when one of the children is se
                           </div>
                         </div>
                       </li>
-                      <button
-                        aria-disabled="false"
-                        class="base-Button text-lg inline-flex items-center justify-center select-none appearance-none m-0 relative normal-case align-middle transition-colors duration-350 ease-out shrink-0 outline-hidden [[data-component-type="button"]+&]:ml cursor-pointer border-none px-0 bg-transparent h-[1.5em] hover:text-blue hover:underline active:text-blue active:underline focus-visible:shadow-[0_0_0_3px_rgba(32,78,207,0.48)] focus-visible:rounded-sm"
-                        data-component-type="button"
-                        role="button"
-                        tabindex="-1"
-                        type="button"
+                      <div
+                        data-component-type="accordion-summary-icon"
                       >
-                        <span
-                          class="items-center inline-flex font-semibold text-blue text-md"
+                        <button
+                          aria-disabled="false"
+                          class="base-Button text-lg inline-flex items-center justify-center select-none appearance-none m-0 relative normal-case align-middle transition-colors duration-350 ease-out shrink-0 outline-hidden [[data-component-type="button"]+&]:ml cursor-pointer border-none px-0 bg-transparent h-[1.5em] hover:text-blue hover:underline active:text-blue active:underline focus-visible:shadow-[0_0_0_3px_rgba(32,78,207,0.48)] focus-visible:rounded-sm"
+                          data-component-type="button"
+                          role="button"
+                          tabindex="-1"
+                          type="button"
                         >
-                          <svg
-                            class="fill-current inline-block align-[-.125em] flex-1 w-4 h-4 transition-transform duration-150 ease-in rotate-180 text-base text-graphite"
-                            style="min-width: 16px; min-height: 16px;"
-                            viewBox="0 0 16 16"
+                          <span
+                            class="items-center inline-flex font-semibold text-blue text-md"
                           >
-                            <path
-                              d="m11.997 5.29.707.707-4 4-.707.707-.707-.707-4-4 .707-.707 4 4 4-4Z"
-                            />
-                          </svg>
-                        </span>
-                      </button>
+                            <svg
+                              class="fill-current inline-block align-[-.125em] flex-1 w-4 h-4 transition-transform duration-150 ease-in rotate-180 text-base text-graphite"
+                              style="min-width: 16px; min-height: 16px;"
+                              viewBox="0 0 16 16"
+                            >
+                              <path
+                                d="m11.997 5.29.707.707-4 4-.707.707-.707-.707-4-4 .707-.707 4 4 4-4Z"
+                              />
+                            </svg>
+                          </span>
+                        </button>
+                      </div>
                     </div>
                   </div>
                 </div>
@@ -610,28 +618,32 @@ exports[`SidebarItem use accordion for collapsible with menu 1`] = `
                   </div>
                 </div>
               </li>
-              <button
-                aria-disabled="false"
-                class="base-Button text-lg inline-flex items-center justify-center select-none appearance-none m-0 relative normal-case align-middle transition-colors duration-350 ease-out shrink-0 outline-hidden [[data-component-type="button"]+&]:ml cursor-pointer border-none px-0 bg-transparent h-[1.5em] hover:text-blue hover:underline active:text-blue active:underline focus-visible:shadow-[0_0_0_3px_rgba(32,78,207,0.48)] focus-visible:rounded-sm"
-                data-component-type="button"
-                role="button"
-                tabindex="-1"
-                type="button"
+              <div
+                data-component-type="accordion-summary-icon"
               >
-                <span
-                  class="items-center inline-flex font-semibold text-blue text-md"
+                <button
+                  aria-disabled="false"
+                  class="base-Button text-lg inline-flex items-center justify-center select-none appearance-none m-0 relative normal-case align-middle transition-colors duration-350 ease-out shrink-0 outline-hidden [[data-component-type="button"]+&]:ml cursor-pointer border-none px-0 bg-transparent h-[1.5em] hover:text-blue hover:underline active:text-blue active:underline focus-visible:shadow-[0_0_0_3px_rgba(32,78,207,0.48)] focus-visible:rounded-sm"
+                  data-component-type="button"
+                  role="button"
+                  tabindex="-1"
+                  type="button"
                 >
-                  <svg
-                    class="fill-current inline-block align-[-.125em] flex-1 w-4 h-4 transition-transform duration-150 ease-in text-base text-graphite"
-                    style="min-width: 16px; min-height: 16px;"
-                    viewBox="0 0 16 16"
+                  <span
+                    class="items-center inline-flex font-semibold text-blue text-md"
                   >
-                    <path
-                      d="m11.997 5.29.707.707-4 4-.707.707-.707-.707-4-4 .707-.707 4 4 4-4Z"
-                    />
-                  </svg>
-                </span>
-              </button>
+                    <svg
+                      class="fill-current inline-block align-[-.125em] flex-1 w-4 h-4 transition-transform duration-150 ease-in text-base text-graphite"
+                      style="min-width: 16px; min-height: 16px;"
+                      viewBox="0 0 16 16"
+                    >
+                      <path
+                        d="m11.997 5.29.707.707-4 4-.707.707-.707-.707-4-4 .707-.707 4 4 4-4Z"
+                      />
+                    </svg>
+                  </span>
+                </button>
+              </div>
             </div>
           </div>
         </div>

--- a/packages/base/Page/src/SidebarItem/__snapshots__/test.tsx.snap
+++ b/packages/base/Page/src/SidebarItem/__snapshots__/test.tsx.snap
@@ -42,7 +42,7 @@ exports[`SidebarItem collapsible menu is expanded when one of the children is se
                   <div
                     aria-controls="base-ui-:r4:"
                     aria-expanded="true"
-                    class="relative flex items-center select-none cursor-pointer outline-none py-[0.5625em] px-0 font-semibold text-black data-disabled:pointer-events"
+                    class="relative flex items-center select-none cursor-pointer focus-visible:bg-black/12 outline-none py-[0.5625em] px-0 font-semibold text-black data-disabled:pointer-events"
                     data-component-type="accordion-summary"
                     data-orientation="vertical"
                     data-panel-open=""
@@ -92,7 +92,7 @@ exports[`SidebarItem collapsible menu is expanded when one of the children is se
                         class="base-Button text-lg inline-flex items-center justify-center select-none appearance-none m-0 relative normal-case align-middle transition-colors duration-350 ease-out shrink-0 outline-hidden [[data-component-type="button"]+&]:ml cursor-pointer border-none px-0 bg-transparent h-[1.5em] hover:text-blue hover:underline active:text-blue active:underline focus-visible:shadow-[0_0_0_3px_rgba(32,78,207,0.48)] focus-visible:rounded-sm"
                         data-component-type="button"
                         role="button"
-                        tabindex="0"
+                        tabindex="-1"
                         type="button"
                       >
                         <span
@@ -218,7 +218,7 @@ exports[`SidebarItem collapsible menu is expanded when one of the children is se
                   <div
                     aria-controls="base-ui-:r7:"
                     aria-expanded="true"
-                    class="relative flex items-center select-none cursor-pointer outline-none py-[0.5625em] px-0 font-semibold text-black data-disabled:pointer-events"
+                    class="relative flex items-center select-none cursor-pointer focus-visible:bg-black/12 outline-none py-[0.5625em] px-0 font-semibold text-black data-disabled:pointer-events"
                     data-component-type="accordion-summary"
                     data-orientation="vertical"
                     data-panel-open=""
@@ -268,7 +268,7 @@ exports[`SidebarItem collapsible menu is expanded when one of the children is se
                         class="base-Button text-lg inline-flex items-center justify-center select-none appearance-none m-0 relative normal-case align-middle transition-colors duration-350 ease-out shrink-0 outline-hidden [[data-component-type="button"]+&]:ml cursor-pointer border-none px-0 bg-transparent h-[1.5em] hover:text-blue hover:underline active:text-blue active:underline focus-visible:shadow-[0_0_0_3px_rgba(32,78,207,0.48)] focus-visible:rounded-sm"
                         data-component-type="button"
                         role="button"
-                        tabindex="0"
+                        tabindex="-1"
                         type="button"
                       >
                         <span
@@ -557,7 +557,7 @@ exports[`SidebarItem use accordion for collapsible with menu 1`] = `
         >
           <div
             aria-expanded="false"
-            class="relative flex items-center select-none cursor-pointer outline-none py-[0.5625em] px-0 font-semibold text-black data-disabled:pointer-events"
+            class="relative flex items-center select-none cursor-pointer focus-visible:bg-black/12 outline-none py-[0.5625em] px-0 font-semibold text-black data-disabled:pointer-events"
             data-component-type="accordion-summary"
             data-orientation="vertical"
             data-value=""
@@ -615,7 +615,7 @@ exports[`SidebarItem use accordion for collapsible with menu 1`] = `
                 class="base-Button text-lg inline-flex items-center justify-center select-none appearance-none m-0 relative normal-case align-middle transition-colors duration-350 ease-out shrink-0 outline-hidden [[data-component-type="button"]+&]:ml cursor-pointer border-none px-0 bg-transparent h-[1.5em] hover:text-blue hover:underline active:text-blue active:underline focus-visible:shadow-[0_0_0_3px_rgba(32,78,207,0.48)] focus-visible:rounded-sm"
                 data-component-type="button"
                 role="button"
-                tabindex="0"
+                tabindex="-1"
                 type="button"
               >
                 <span


### PR DESCRIPTION
[PF-2240]

### Description

Post-migration fixes for the `@base-ui/react` Accordion (#5002). Three
consumer-visible behaviors regressed or were missing versus the pre-migration
MUI version; this PR restores them. Public Props API is unchanged → **patch**.

1. **Keyboard-focus background restored.** MUI's `AccordionSummary` (a
   `ButtonBase`) painted `palette.action.focus` (`rgba(0,0,0,0.12)`) on keyboard
   focus. The migrated summary is a plain `<div>` with `outline-none` and nothing
   replacing it, so focusing a summary showed **no indicator at all** (WCAG 2.4.7
   regression). Re-added as `focus-visible:bg-black/12` — matches the old value,
   and `focus-visible` keeps it keyboard-only like MUI's `focusVisible`.

2. **Panel overflow clip released once fully open.** MUI `Collapse` switched to
   `overflow: visible` after the open transition finished (its `entered` state).
   The migrated Panel kept `overflow-hidden` permanently, so content that
   legitimately overflows the open panel — dropdowns, tooltips, poppers, focus
   rings on the last row — was **clipped**. Restored by releasing the clip only
   after the open height-transition settles. An `isAnimating` flag (derived with
   `summaryExpanded`) keeps the clip active for the whole open/close animation, so
   content no longer "pops" out before the box finishes growing.

3. **Expand icon removed from the tab order** (`tabIndex={-1}`). The icon
   `ButtonAction` was a redundant, unlabeled tab stop; the summary is the sole
   interactive control. Also added `data-component-type='accordion-summary-icon'`
   to the icon wrappers, matching the component's existing addressing scheme
   (`accordion`, `accordion-summary`, `accordion-summary-content`).

Files: `Accordion.tsx` (`isAnimating` state + `transitionend` rewiring,
`tabIndex`, `data-component-type`), `Accordion/styles.ts` (new
`panelOverflowVisibleClass`), `AccordionSummary/styles.ts` (focus background).

### How to test

- [Temploy](https://picasso.toptal.net/tweak/pf-2234-accordion)
- Keyboard-focus an accordion summary (Tab) → visible focus background appears;
  Tab again → focus skips the arrow and moves past the accordion.
- Open an accordion whose content overflows near the bottom edge (e.g. a
  `Dropdown` or `Tooltip`) → the popup is **not clipped** when open, and there is
  **no content "pop"** during the open animation.
- Collapse the accordion → content clips correctly while animating; if
  `transitionProps.onExited` is provided, it still fires after collapse.
- Stacked accordions and `borders` variants render unchanged.

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| No focus ring on keyboard focus; open-panel dropdown/tooltip clipped | Focus background on keyboard focus; open-panel content not clipped |

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Double check if `picasso-tailwind-merge` requires major update (check its `README.md`) — no new API used, no bump needed
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core — restores pre-migration behavior; confirm focus-token choice with design
- [x] Annotate all `props` in component with documentation — no prop changes
- [ ] Create `examples` for component — N/A, no new API
- [ ] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md). — this PR fixes two a11y issues (focus visibility, tab order)
- [x] Self reviewed
- [ ] Covered with tests ([visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md) included) — snapshots regenerated; Happo reviewed on CI

**Breaking change**

- [ ] codemod is created and showcased in the changeset
- [ ] test alpha package of Picasso in StaffPortal


[PF-2240]: https://toptal-core.atlassian.net/browse/PF-2240?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ