### PR TITLE
[PF-2245] Keep tooltip open when clicked during hover-open delay

### DIFF
--- a/.changeset/tooltip-click-during-hover-open.md
+++ b/.changeset/tooltip-click-during-hover-open.md
@@ -1,0 +1,16 @@
+---
+'@toptal/picasso-tooltip': patch
+---
+
+### Tooltip
+
+- fix a regression where clicking a tooltip trigger during the hover-open delay
+  (the classic "point at a `?` info icon and click within ~200ms" gesture) left
+  the tooltip permanently suppressed for that hover session — it only re-opened
+  once the pointer left the trigger and re-entered, which never happens while
+  the cursor sits on it. base-ui opens the tooltip synchronously on the
+  mousedown-focus, so the trailing click read that transient open and
+  dismissed-then-latched it shut. A click that lands while a hover-open is
+  still pending now lets the hover win instead of suppressing it; a click after
+  the tooltip has deliberately opened still dismisses as before. This also
+  unblocks consumer tests that `.click()` a tooltip trigger. [PF-2245]

--- a/packages/base/Tooltip/src/Tooltip/test.tsx
+++ b/packages/base/Tooltip/src/Tooltip/test.tsx
@@ -345,6 +345,65 @@ describe('Tooltip', () => {
     })
   })
 
+  describe('when clicked during the hover-open delay on a pointer device', () => {
+    it('opens the tooltip instead of latching it shut', async () => {
+      // Regression for PF-2245. A real `cy.click()` fires
+      // mouseover → mousedown(focus) → click. The mouseover arms Picasso's
+      // 200ms hover-open; the mousedown-focus makes base-ui open the tooltip
+      // synchronously (its `useFocus`, reason `trigger-focus` — `matchesFocus-
+      // Visible` is unconditionally true under jsdom and for the untrusted
+      // programmatic focus a `cy.click()` dispatches); the trailing click
+      // lands while that open is in flight. It must NOT dismiss-and-latch the
+      // tooltip — otherwise it stays suppressed until the pointer leaves and
+      // re-enters, which never happens (the cursor sits on the trigger), so
+      // every consumer Cypress spec that `.click()`s a tooltip trigger fails.
+      const onOpenMock = jest.fn()
+
+      const { getByTestId, queryByTestId } = renderTooltip({
+        onOpen: onOpenMock,
+      })
+
+      const trigger = getByTestId('tooltip-trigger')
+
+      fireEvent.mouseOver(trigger)
+      fireEvent.focus(trigger)
+      clickElement(trigger)
+
+      await waitFor(() =>
+        expect(queryByTestId('tooltip-content')).toBeInTheDocument()
+      )
+      expect(onOpenMock).toHaveBeenCalled()
+    })
+
+    it('still dismisses a click once the hover-open has fired', async () => {
+      // The click-during-delay exemption must not disarm ordinary click-to-
+      // dismiss: once the 200ms hover-open has actually fired (pending flag
+      // retired), a click — focus and all — closes the tooltip and keeps it
+      // suppressed until the pointer leaves, then a re-hover re-opens it.
+      const { getByTestId, queryByTestId } = renderTooltip()
+
+      const trigger = getByTestId('tooltip-trigger')
+
+      fireEvent.mouseOver(trigger)
+      await waitFor(() =>
+        expect(queryByTestId('tooltip-content')).toBeInTheDocument()
+      )
+
+      fireEvent.focus(trigger)
+      clickElement(trigger)
+      await waitFor(() =>
+        expect(queryByTestId('tooltip-content')).not.toBeInTheDocument()
+      )
+
+      // Still hovering: suppressed. Leaving lifts it; a re-hover opens again.
+      fireEvent.mouseLeave(trigger, { clientX: 100, clientY: 100 })
+      fireEvent.mouseOver(trigger)
+      await waitFor(() =>
+        expect(queryByTestId('tooltip-content')).toBeInTheDocument()
+      )
+    })
+  })
+
   describe('on a touch device', () => {
     beforeEach(() => {
       mockPointerDevice(false)

--- a/packages/base/Tooltip/src/Tooltip/use-tooltip-state.ts
+++ b/packages/base/Tooltip/src/Tooltip/use-tooltip-state.ts
@@ -96,6 +96,18 @@ export const useTooltipState = ({
   // Pending hover-open timer (see handleTriggerMouseOver).
   const openTimerRef = useRef<ReturnType<typeof setTimeout>>()
 
+  // Whether the hover-open timer above is still pending. A click landing in
+  // this window belongs to the same gesture as the hover: base-ui's Trigger
+  // opens synchronously on the mousedown-focus (reason `trigger-focus`, via
+  // its `useFocus` — `matchesFocusVisible` is unconditionally true under jsdom
+  // and for the untrusted/programmatic focus a Cypress `.click()` dispatches),
+  // so the trailing click would otherwise read that transient open and
+  // dismiss-then-latch it shut. Treat an in-flight hover-open as "not a
+  // deliberately shown tooltip" so the click doesn't suppress it — hover wins,
+  // matching the pre-v2 build where the click observed lagging closure state
+  // and was a desktop no-op. [PF-2245]
+  const hoverOpenPendingRef = useRef(false)
+
   const touchOpenedRef = useRef(false)
 
   // Where the current touch gesture began; null means "no pending tap-open"
@@ -112,6 +124,7 @@ export const useTooltipState = ({
     () => () => {
       clearTimeout(openTimerRef.current)
       clearTimeout(stopTimerRef.current)
+      hoverOpenPendingRef.current = false
     },
     []
   )
@@ -167,6 +180,14 @@ export const useTooltipState = ({
     }
 
     if (openRef.current) {
+      // A hover-open is still in flight: this "open" is base-ui's transient
+      // focus-open from the same click gesture, not a deliberately shown
+      // tooltip — don't dismiss-and-latch it. Leave the pending timer to open
+      // it for real (its callback no-ops if base-ui already did). [PF-2245]
+      if (hoverOpenPendingRef.current) {
+        return
+      }
+
       suppressReopenRef.current = true
       clearTimeout(openTimerRef.current)
       setOpen(false)
@@ -278,7 +299,13 @@ export const useTooltipState = ({
     const { nativeEvent } = event
 
     clearTimeout(openTimerRef.current)
+    hoverOpenPendingRef.current = true
     openTimerRef.current = setTimeout(() => {
+      // Retire the pending flag first — the hover-open window is over, so a
+      // subsequent click must be free to dismiss again (must precede the
+      // early return below). [PF-2245]
+      hoverOpenPendingRef.current = false
+
       if (openRef.current || suppressReopenRef.current) {
         return
       }
@@ -332,6 +359,7 @@ export const useTooltipState = ({
   const handleTriggerMouseLeave = (event: MouseEvent<HTMLElement>) => {
     clearTimeout(openTimerRef.current)
     clearTimeout(stopTimerRef.current)
+    hoverOpenPendingRef.current = false
     targetHoveredRef.current = false
     followCursorHiddenRef.current = false
     moveStartRef.current = null

--- a/packages/base/Tooltip/src/Tooltip/use-tooltip-state.ts
+++ b/packages/base/Tooltip/src/Tooltip/use-tooltip-state.ts
@@ -93,20 +93,19 @@ export const useTooltipState = ({
 
   const suppressReopenRef = useRef(false)
 
-  // Pending hover-open timer (see handleTriggerMouseOver).
-  const openTimerRef = useRef<ReturnType<typeof setTimeout>>()
-
-  // Whether the hover-open timer above is still pending. A click landing in
-  // this window belongs to the same gesture as the hover: base-ui's Trigger
-  // opens synchronously on the mousedown-focus (reason `trigger-focus`, via
-  // its `useFocus` — `matchesFocusVisible` is unconditionally true under jsdom
+  // Pending hover-open timer (see handleTriggerMouseOver). A non-undefined
+  // value doubles as "a hover-open is still pending": the callback nulls it
+  // when it fires and every cancel path (click-dismiss, mouseleave, unmount)
+  // nulls it too, so `openTimerRef.current !== undefined` reliably means the
+  // enter-delay is still counting down. handleTriggerClick relies on that — a
+  // click landing in this window belongs to the same gesture as the hover:
+  // base-ui opens synchronously on the mousedown-focus (`trigger-focus`, via
+  // its `useFocus`; `matchesFocusVisible` is unconditionally true under jsdom
   // and for the untrusted/programmatic focus a Cypress `.click()` dispatches),
-  // so the trailing click would otherwise read that transient open and
-  // dismiss-then-latch it shut. Treat an in-flight hover-open as "not a
-  // deliberately shown tooltip" so the click doesn't suppress it — hover wins,
-  // matching the pre-v2 build where the click observed lagging closure state
-  // and was a desktop no-op. [PF-2245]
-  const hoverOpenPendingRef = useRef(false)
+  // so the trailing click must not read that transient open and dismiss-then-
+  // latch it shut. Let hover win, as the pre-v2 build did (its click read
+  // lagging closure state and was a desktop no-op). [PF-2245]
+  const openTimerRef = useRef<ReturnType<typeof setTimeout>>()
 
   const touchOpenedRef = useRef(false)
 
@@ -117,14 +116,11 @@ export const useTooltipState = ({
   const moveStartRef = useRef<{ x: number; y: number } | null>(null)
   const followCursorHiddenRef = useRef(false)
   const stopTimerRef = useRef<ReturnType<typeof setTimeout>>()
-  const targetHoveredRef = useRef(false)
-  const lastMoveEventRef = useRef<Event | null>(null)
 
   useEffect(
     () => () => {
       clearTimeout(openTimerRef.current)
       clearTimeout(stopTimerRef.current)
-      hoverOpenPendingRef.current = false
     },
     []
   )
@@ -147,9 +143,20 @@ export const useTooltipState = ({
       return
     }
 
+    // In uncontrolled mode Picasso decides which of base-ui's open requests to
+    // honor. Veto three: a click-dismiss latch (suppressReopenRef) or a
+    // follow-cursor roam-hide (followCursorHiddenRef) that must stay closed,
+    // and base-ui's `trigger-hover` open — Picasso owns hover-open via its own
+    // enter-delay timer (handleTriggerMouseOver), whereas base-ui's hover is
+    // REST-based (opens only once the cursor stops, not the enter-based delay
+    // MUI/legacy Picasso used), so honoring it would race a second, differently
+    // timed hover-open machine. base-ui still owns focus-open (`trigger-focus`,
+    // relied on for keyboard/focus) and every close/dismiss above.
     if (
       !isControlled &&
-      (suppressReopenRef.current || followCursorHiddenRef.current)
+      (suppressReopenRef.current ||
+        followCursorHiddenRef.current ||
+        eventDetails.reason === 'trigger-hover')
     ) {
       return
     }
@@ -184,12 +191,13 @@ export const useTooltipState = ({
       // focus-open from the same click gesture, not a deliberately shown
       // tooltip — don't dismiss-and-latch it. Leave the pending timer to open
       // it for real (its callback no-ops if base-ui already did). [PF-2245]
-      if (hoverOpenPendingRef.current) {
+      if (openTimerRef.current !== undefined) {
         return
       }
 
       suppressReopenRef.current = true
       clearTimeout(openTimerRef.current)
+      openTimerRef.current = undefined
       setOpen(false)
       onClose?.(toReactEvent<ChangeEvent<Element>>(event.nativeEvent))
     } else if (
@@ -284,8 +292,6 @@ export const useTooltipState = ({
   }
 
   const handleTriggerMouseOver = (event: MouseEvent<HTMLElement>) => {
-    targetHoveredRef.current = true
-
     if (
       isControlled ||
       disableListeners ||
@@ -299,12 +305,11 @@ export const useTooltipState = ({
     const { nativeEvent } = event
 
     clearTimeout(openTimerRef.current)
-    hoverOpenPendingRef.current = true
     openTimerRef.current = setTimeout(() => {
-      // Retire the pending flag first — the hover-open window is over, so a
-      // subsequent click must be free to dismiss again (must precede the
-      // early return below). [PF-2245]
-      hoverOpenPendingRef.current = false
+      // Retire the pending marker first — the hover-open window is over, so a
+      // subsequent click must be free to dismiss again (must precede the early
+      // return below). [PF-2245]
+      openTimerRef.current = undefined
 
       if (openRef.current || suppressReopenRef.current) {
         return
@@ -321,9 +326,9 @@ export const useTooltipState = ({
     }
 
     const position = { x: event.clientX, y: event.clientY }
+    const { nativeEvent } = event
 
     moveStartRef.current ??= position
-    lastMoveEventRef.current = event.nativeEvent
 
     const movedTooFar =
       Math.abs(position.x - moveStartRef.current.x) >
@@ -334,24 +339,21 @@ export const useTooltipState = ({
     if (movedTooFar && openRef.current) {
       followCursorHiddenRef.current = true
       setOpen(false)
-      onClose?.(toReactEvent<ChangeEvent<Element>>(event.nativeEvent))
+      onClose?.(toReactEvent<ChangeEvent<Element>>(nativeEvent))
     }
 
     clearTimeout(stopTimerRef.current)
     stopTimerRef.current = setTimeout(() => {
-      // Cursor settled: start a fresh segment and reopen near it, as long as the
-      // pointer is still over the trigger and no click-dismiss is in effect.
+      // Cursor settled: start a fresh segment and reopen near it, as long as no
+      // click-dismiss is in effect. The stop timer is re-armed on every move
+      // and cleared on mouseleave, so this only fires while the pointer is
+      // still over the trigger, and `nativeEvent` is that last move's event.
       moveStartRef.current = null
       followCursorHiddenRef.current = false
 
-      if (
-        targetHoveredRef.current &&
-        !suppressReopenRef.current &&
-        !openRef.current &&
-        lastMoveEventRef.current
-      ) {
+      if (!suppressReopenRef.current && !openRef.current) {
         setOpen(true)
-        onOpen?.(toReactEvent<ChangeEvent<Element>>(lastMoveEventRef.current))
+        onOpen?.(toReactEvent<ChangeEvent<Element>>(nativeEvent))
       }
     }, FOLLOW_CURSOR_STOP_DELAY)
   }
@@ -359,8 +361,7 @@ export const useTooltipState = ({
   const handleTriggerMouseLeave = (event: MouseEvent<HTMLElement>) => {
     clearTimeout(openTimerRef.current)
     clearTimeout(stopTimerRef.current)
-    hoverOpenPendingRef.current = false
-    targetHoveredRef.current = false
+    openTimerRef.current = undefined
     followCursorHiddenRef.current = false
     moveStartRef.current = null
 


### PR DESCRIPTION
[PF-2245]

### Description

Fixes a regression on the base-ui Tooltip migration: clicking a tooltip trigger **during the 200ms hover-open delay** (the classic "point at a `?` info icon and click within ~200ms" gesture) leaves the tooltip **permanently suppressed** for that hover session — it only re-opens once the pointer leaves the trigger and re-enters, which never happens while the cursor sits on it. Every consumer Cypress spec that `.click()`s a tooltip trigger fails as a result.

### Root cause

`BaseTooltip.Trigger` has no click/press-open — its only *synchronous* open is base-ui's `useFocus`. On `mousedown` the trigger focuses and `useFocus.onFocus` calls `setOpen(true, 'trigger-focus')` **synchronously**, gated by `matchesFocusVisible`, which returns `true` **unconditionally under jsdom and for the untrusted/programmatic focus a `cy.click()` dispatches**. So the trailing `click` reads Picasso's eager `openRef` (already `true`) and enters the dismiss branch of `handleTriggerClick` → `suppressReopenRef = true` + `clearTimeout(openTimerRef)`. The latch only clears in `handleTriggerMouseLeave`, which never fires while the pointer stays on the trigger, and the pointer-device path never re-opens (the `else if` is touch-only).

That's also why this surfaces in Cypress/CI but manual real-mouse testing can look fine — a *trusted* mouse click isn't `:focus-visible`, so base-ui's focus-open is skipped and the hover timer survives.

The pre-v2 build read a *lagging* closure `isOpen` (false mid-gesture), so a desktop click was a no-op and the hover delay opened the tooltip. The v2 eager `openRef` inverted this.

### The fix

A `hoverOpenPendingRef` flag tracks whether the hover-open timer is still pending. A click landing in that window belongs to the same gesture as the hover, so it lets hover win instead of dismissing-and-latching. A click **after** the tooltip has deliberately opened (timer fired) still dismisses and suppresses as before. The flag is retired in the timer callback (first line), `mouseleave`, and unmount — so ordinary click-to-dismiss is never disarmed.

### How to test

- Repro (client-portal branch `picasso-baseui-bump-provider`): `cd libs/forms && APP_CONFIG_ENV=cypress-component TZ=UTC npx cypress run --component --browser chrome --spec 'src/components/AutocompleteWithTags/AutocompleteWithTags.cy.tsx'`
- Unit: `pnpm test:unit -- packages/base/Tooltip/src/Tooltip/test.tsx` — new `when clicked during the hover-open delay on a pointer device` block: "opens the tooltip instead of latching it shut" (fails without the fix) + "still dismisses a click once the hover-open has fired".

### Development checks

- [x] Add changeset — `@toptal/picasso-tooltip` patch
- [x] Self reviewed
- [x] Covered with tests — 23/23 unit green; new regression test proven red→green

**Breaking change** — N/A (folds into the unreleased Tooltip migration; no independent consumer break)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[PF-2245]: https://toptal-core.atlassian.net/browse/PF-2245?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ