### PR TITLE
[PF-2230] Fix Popper default role

### DIFF
--- a/.changeset/popper-role-prop.md
+++ b/.changeset/popper-role-prop.md
@@ -1,0 +1,20 @@
+---
+'@toptal/picasso-popper': minor
+'@toptal/picasso-select': patch
+'@toptal/picasso-autocomplete': patch
+'@toptal/picasso-dropdown': patch
+'@toptal/picasso-menu': patch
+'@toptal/picasso-date-picker': patch
+---
+
+### Popper
+
+- add a `role` prop for the floating element (defaults to `tooltip`)
+
+### DatePicker
+
+- expose the calendar popup as `role="dialog"` instead of Popper's default `tooltip`
+
+### Select / Autocomplete / Dropdown / Menu
+
+- mark the popup positioning wrapper as `role="presentation"` — the inner listbox/menu owns the popup semantics, so assistive tech no longer announces these popups as tooltips

--- a/.changeset/popup-focus-fixes.md
+++ b/.changeset/popup-focus-fixes.md
@@ -1,0 +1,13 @@
+---
+'@toptal/picasso-modal': patch
+'@toptal/picasso-date-picker': patch
+---
+
+### Modal
+
+- exempt Popper-based popups (Select, DatePicker, Dropdown, Menu) from the focus trap, so focus is no longer stolen from a popup opened inside a Modal (e.g. a Select's search input)
+
+### DatePicker
+
+- fix Tab dead-ending on the input when entering an open calendar a second time
+- fix Shift+Tab on the input jumping forward into the calendar instead of moving back to the previous field

--- a/cypress/component/DatePicker.spec.tsx
+++ b/cypress/component/DatePicker.spec.tsx
@@ -225,6 +225,14 @@ describe('DatePicker', () => {
     cy.mount(<DrawerExample />)
 
     cy.getByTestId(DATEPICKER_INPUT_TESTID).as('input').click()
+
+    // the visually risky state — the calendar popper layering above the drawer
+    cy.waitForCalendarOpen()
+    cy.get('body').happoScreenshot({
+      component,
+      variant: 'inside-drawer-calendar-open',
+    })
+
     cy.getByTestId('day-button-15').click()
 
     cy.get('@input')

--- a/cypress/component/Menu.spec.tsx
+++ b/cypress/component/Menu.spec.tsx
@@ -30,7 +30,8 @@ const MenuExample = (props: MenuProps) => {
 
   return (
     <Container style={{ width: '240px' }}>
-      <div data-testid='spacer' style={{ height: 1 }} />
+      {/* in-flow filler — removing it shifts every baseline by 1px */}
+      <div style={{ height: 1 }} />
       <Menu {...props} data-testid='menu'>
         <Menu.Item data-testid='item-a'>Item A</Menu.Item>
         <Menu.Item menu={menuForItemB} data-testid='item-b'>
@@ -97,8 +98,15 @@ describe('Menu', () => {
 
   it('navigates drilldown menu', () => {
     cy.mount(<MenuExample variant='drilldown' />)
-    cy.getByTestId('spacer').realHover()
+    // park the pointer off the menu — drilldown hover is state-driven and
+    // would serialize into the capture
+    cy.get('body').realHover({ position: 'bottomRight' })
     cy.getByTestId('menu-b').should('not.exist')
+    cy.getByTestId('item-a').should(
+      'have.css',
+      'background-color',
+      'rgba(0, 0, 0, 0)'
+    )
     cy.get('[data-cy-root]').happoScreenshot({
       component,
       variant: 'drilldown/before-mouseover-item',

--- a/cypress/component/Modal.spec.tsx
+++ b/cypress/component/Modal.spec.tsx
@@ -147,6 +147,38 @@ const TestModalOverflown = (props: Partial<Omit<ModalProps, 'open'>>) => {
   )
 }
 
+const TestModalWithSearchableSelect = () => {
+  const [isOpen, setOpen] = React.useState(false)
+
+  useEffect(() => {
+    setOpen(true)
+  }, [])
+
+  return (
+    <Modal open={isOpen}>
+      <Modal.Title>Edit address details</Modal.Title>
+      <Modal.Content>
+        <Form.Field>
+          <Input width='full' placeholder='City' value='Alabaster' />
+        </Form.Field>
+        <Form.Field>
+          <Select
+            data-testid='state-select'
+            placeholder='State'
+            searchThreshold={-1}
+            testIds={{ searchInput: 'state-search' }}
+            options={[
+              { text: 'Alabama', value: 'Alabama' },
+              { text: 'Utah', value: 'Utah' },
+            ]}
+            value='Alabama'
+          />
+        </Form.Field>
+      </Modal.Content>
+    </Modal>
+  )
+}
+
 const component = 'Modal'
 
 // The scroll shades fade in over 300ms. When the content overflows, wait for
@@ -250,6 +282,22 @@ describe('Modal', () => {
       component,
       variant: 'overflown',
     })
+  })
+
+  // the options popup portals outside the modal — the focus trap must exempt
+  // it or it steals focus back to the modal's first input
+  it('keeps focus inside a Popper-based popup opened from the modal', () => {
+    cy.mount(<TestModalWithSearchableSelect />)
+
+    cy.waitForOverlayOpen()
+    cy.getByTestId('state-select').click()
+
+    cy.getByTestId('state-search').find('input').click()
+    cy.getByTestId('state-search').find('input').type('Ut')
+    cy.getByTestId('state-search')
+      .find('input')
+      .should('have.focus')
+      .and('have.value', 'Ut')
   })
 
   Cypress._.each(HAPPO_TARGETS, happoTarget => {

--- a/cypress/component/RichTextEditor/ImagePlugin.spec.tsx
+++ b/cypress/component/RichTextEditor/ImagePlugin.spec.tsx
@@ -86,8 +86,10 @@ describe('ImagePlugin', () => {
         `<p><img src="${uploadedFileContent}" alt="${uploadedFileAltText}"></p>`
       )
 
-      // the assertion above only checks the serialized HTML string — also let
-      // the <img> rendered in the editor decode before capturing
+      // let the dialog fully unmount — capturing mid-exit serializes it
+      cy.getByRole('dialog').should('not.exist')
+
+      // also let the <img> rendered in the editor decode before capturing
       cy.waitForImagesDecoded(`${editorSelector} img`)
 
       cy.get('body').happoScreenshot({

--- a/cypress/component/Select.spec.tsx
+++ b/cypress/component/Select.spec.tsx
@@ -338,7 +338,11 @@ describe('Select', () => {
         <Drawer open>
           <Form>
             <Form.Field>
-              <TestSelect searchThreshold={-1} disablePortal />
+              <TestSelect
+                searchThreshold={-1}
+                disablePortal
+                testIds={{ searchInput: 'search-input' }}
+              />
             </Form.Field>
           </Form>
         </Drawer>
@@ -346,7 +350,7 @@ describe('Select', () => {
 
       openSelect()
 
-      cy.get('[role="tooltip"]').find('input').as('searchInput')
+      cy.getByTestId('search-input').find('input').as('searchInput')
 
       cy.get('@searchInput').should('be.visible')
       cy.get('@searchInput').click()

--- a/cypress/component/Select.spec.tsx
+++ b/cypress/component/Select.spec.tsx
@@ -141,9 +141,9 @@ const getNativeOption = (value: string | number) =>
 const openSelect = () => {
   cy.getByTestId('select').click()
 
-  // the menu mounts async in a popper — gate on it so a screenshot right after
-  // opening can't capture a menu-less frame (present in every open state)
-  cy.get('[role="tooltip"]').should('be.visible')
+  // the menu mounts async in a popper — gate on its stable marker (roles vary)
+  // so a screenshot right after opening can't capture a menu-less frame
+  cy.get('[data-picasso-popper]').should('be.visible')
 }
 
 const pressArrowDown = () => {

--- a/cypress/support/commands.jsx
+++ b/cypress/support/commands.jsx
@@ -187,12 +187,13 @@ Cypress.Commands.add('waitForImagesDecoded', (selector = 'img') =>
 // cloud (no JS runs there). @base-ui/react removes `data-starting-style` one
 // frame after mount; if captured before removal, the attribute pins the element
 // at its starting style (e.g. opacity-0), producing a blank capture.
+// `data-ending-style` marks an exit in flight — wait it out too.
 Cypress.Commands.overwrite(
   'happoScreenshot',
   (originalFn, subject, options) => {
     return (
       cy
-        .get('[data-starting-style]', { timeout: 4000 })
+        .get('[data-starting-style], [data-ending-style]', { timeout: 4000 })
         .should('not.exist')
         // then let poppers/notifications finish moving before serializing
         .then(() => waitForTransientGeometryToSettle())

--- a/packages/base/Autocomplete/src/Autocomplete/Autocomplete.tsx
+++ b/packages/base/Autocomplete/src/Autocomplete/Autocomplete.tsx
@@ -287,6 +287,7 @@ export const Autocomplete = forwardRef<HTMLInputElement, Props>(
         <div role='listbox'>
           {isOpen && inputWrapperRef.current && optionsMenu && (
             <Popper
+              role='presentation'
               autoWidth
               width={menuWidth}
               placement='bottom-start'

--- a/packages/base/DatePicker/src/DatePicker/DatePicker.tsx
+++ b/packages/base/DatePicker/src/DatePicker/DatePicker.tsx
@@ -422,6 +422,7 @@ export const DatePicker = ({
       </Container>
       {inputWrapperRef.current && (
         <Popper
+          role='dialog'
           placement='bottom-start'
           open={calendarIsShown}
           anchorEl={inputWrapperRef.current}

--- a/packages/base/DatePicker/src/DatePicker/DatePicker.tsx
+++ b/packages/base/DatePicker/src/DatePicker/DatePicker.tsx
@@ -341,22 +341,19 @@ export const DatePicker = ({
       return
     }
 
-    if (key === 'Tab' && calendarIsShown) {
+    // forward Tab only — Shift+Tab moves back; the input blur closes the calendar
+    if (key === 'Tab' && !event.shiftKey && calendarIsShown) {
       event.preventDefault()
       event.stopPropagation()
 
-      if (!calendarIsShown) {
-        event.currentTarget.blur()
-      } else {
-        const firstButton =
-          calendarRef.current?.querySelector<HTMLButtonElement>(
-            'button:not([tabindex="-1"])'
-          )
+      // also match buttons swept to tabindex="-1" by floating-ui's
+      // disableFocusInside — focusing one restores them; disabled days lack
+      // data-tabindex and stay excluded
+      const firstButton = calendarRef.current?.querySelector<HTMLButtonElement>(
+        'button:not([tabindex="-1"]), button[data-tabindex]:not([data-tabindex="-1"])'
+      )
 
-        if (firstButton) {
-          firstButton.focus()
-        }
-      }
+      firstButton?.focus()
     }
   }
 

--- a/packages/base/Dropdown/src/Dropdown/Dropdown.tsx
+++ b/packages/base/Dropdown/src/Dropdown/Dropdown.tsx
@@ -274,6 +274,7 @@ export const Dropdown: DropdownProps = forwardRef<
 
       {(isOpen || keepMounted) && (
         <Popper
+          role='presentation'
           className={twJoin(
             'shadow-2',
             externalClasses?.popper,

--- a/packages/base/Dropdown/src/Dropdown/__snapshots__/test.tsx.snap
+++ b/packages/base/Dropdown/src/Dropdown/__snapshots__/test.tsx.snap
@@ -63,7 +63,7 @@ exports[`Dropdown should render menu 1`] = `
       >
         <div
           class="z-modal xs:max-md:w-screen xs:max-md:max-w xs:max-md:p-0 xs:max-md:m-0 [&[x-out-of shadow-2"
-          role="tooltip"
+          role="presentation"
           style="position: absolute; left: 0px; top: 0px; transform: translate(0px, 0px);"
           x-placement="bottom-end"
         >
@@ -195,7 +195,7 @@ exports[`Dropdown should render menu with focus 1`] = `
       >
         <div
           class="z-modal xs:max-md:w-screen xs:max-md:max-w xs:max-md:p-0 xs:max-md:m-0 [&[x-out-of shadow-2"
-          role="tooltip"
+          role="presentation"
           style="position: absolute; left: 0px; top: 0px; transform: translate(5px, 5px);"
           x-out-of-boundaries=""
           x-placement="bottom-end"

--- a/packages/base/Dropdown/src/Dropdown/__snapshots__/test.tsx.snap
+++ b/packages/base/Dropdown/src/Dropdown/__snapshots__/test.tsx.snap
@@ -63,6 +63,7 @@ exports[`Dropdown should render menu 1`] = `
       >
         <div
           class="z-modal xs:max-md:w-screen xs:max-md:max-w xs:max-md:p-0 xs:max-md:m-0 [&[x-out-of shadow-2"
+          data-picasso-popper=""
           role="presentation"
           style="position: absolute; left: 0px; top: 0px; transform: translate(0px, 0px);"
           x-placement="bottom-end"
@@ -195,6 +196,7 @@ exports[`Dropdown should render menu with focus 1`] = `
       >
         <div
           class="z-modal xs:max-md:w-screen xs:max-md:max-w xs:max-md:p-0 xs:max-md:m-0 [&[x-out-of shadow-2"
+          data-picasso-popper=""
           role="presentation"
           style="position: absolute; left: 0px; top: 0px; transform: translate(5px, 5px);"
           x-out-of-boundaries=""

--- a/packages/base/Dropdown/src/Dropdown/test.tsx
+++ b/packages/base/Dropdown/src/Dropdown/test.tsx
@@ -116,6 +116,6 @@ describe('Dropdown', () => {
       fireEvent.click(getByText('Open Dropdown'))
     })
 
-    expect(getByRole('tooltip')).toHaveStyle({ position: 'fixed' })
+    expect(getByRole('presentation')).toHaveStyle({ position: 'fixed' })
   })
 })

--- a/packages/base/Menu/src/MenuItem/MenuItem.tsx
+++ b/packages/base/Menu/src/MenuItem/MenuItem.tsx
@@ -234,6 +234,7 @@ export const MenuItem: OverridableComponent<Props> = forwardRef<
       </Component>
       {menu && isOpened && (
         <Popper
+          role='presentation'
           anchorEl={anchorRef.current}
           placement='right-start'
           open

--- a/packages/base/Modal/src/Modal/Modal.tsx
+++ b/packages/base/Modal/src/Modal/Modal.tsx
@@ -64,7 +64,9 @@ const defaultManager = new ModalManager()
 // found in https://developers.google.com/web/fundamentals/accessibility/focus/using-tabindex
 const focusableElementsString =
   'a[href], area[href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), button:not([disabled]), iframe, object, embed, [tabindex="0"], [contenteditable]'
-const tooltipContainerString = '[role=tooltip]'
+// Popups portaled outside the modal that must keep focus: tooltips and any
+// Picasso Popper popup (marked `data-picasso-popper` — roles vary per consumer).
+const exemptPopupContainerString = '[role=tooltip], [data-picasso-popper]'
 
 const focusFirstFocusableElement = (node: Element) => {
   const elements = node.querySelectorAll(focusableElementsString)
@@ -86,18 +88,18 @@ const isFocusInsideModal = (modalNode: Element) => {
   return false
 }
 
-const isFocusInsideTooltip = () => {
-  const tooltipContainers = document.querySelectorAll(tooltipContainerString)
+const isFocusInsideExemptPopup = () => {
+  const popupContainers = document.querySelectorAll(exemptPopupContainerString)
 
-  if (tooltipContainers.length === 0) {
+  if (popupContainers.length === 0) {
     return false
   }
 
-  const tooltipContainsFocusedElement = Array.from(tooltipContainers).some(
+  const popupContainsFocusedElement = Array.from(popupContainers).some(
     container => container.contains(document.activeElement)
   )
 
-  if (tooltipContainsFocusedElement) {
+  if (popupContainsFocusedElement) {
     return true
   }
 
@@ -167,7 +169,7 @@ export const Modal = forwardRef<HTMLDivElement, Props>(function Modal(
         return
       }
 
-      if (isFocusInsideTooltip()) {
+      if (isFocusInsideExemptPopup()) {
         return
       }
 

--- a/packages/base/Popper/src/Popper/Popper.tsx
+++ b/packages/base/Popper/src/Popper/Popper.tsx
@@ -78,6 +78,8 @@ export interface Props extends BaseProps {
   width?: string
   /** Take full window width on small and medium screens */
   enableCompactMode?: boolean
+  /** ARIA role of the floating element. Defaults to `tooltip`; set it to match the popup's content (e.g. `dialog`, `presentation`). */
+  role?: React.AriaRole
 }
 
 const getAnchorEl = (
@@ -110,11 +112,6 @@ export const Popper = forwardRef<PopperHandle, Props>(function Popper(
     placement = 'bottom',
     popperOptions = {},
     autoWidth = true,
-    ...props
-  },
-  ref
-) {
-  const {
     children,
     anchorEl,
     className,
@@ -123,9 +120,11 @@ export const Popper = forwardRef<PopperHandle, Props>(function Popper(
     width,
     enableCompactMode,
     style,
+    role = 'tooltip',
     ...rest
-  } = props
-
+  },
+  ref
+) {
   const picassoRootContainer = usePicassoRoot()
   const isInsideModal = useContext(ModalContext)
 
@@ -216,7 +215,7 @@ export const Popper = forwardRef<PopperHandle, Props>(function Popper(
   const popperNode = (
     <div
       ref={setFloatingRef}
-      role='tooltip'
+      role={role}
       className={twMerge(
         'z-modal',
         'xs:max-md:w-screen xs:max-md:max-w-screen xs:max-md:p-0 xs:max-md:m-0',

--- a/packages/base/Popper/src/Popper/Popper.tsx
+++ b/packages/base/Popper/src/Popper/Popper.tsx
@@ -78,7 +78,7 @@ export interface Props extends BaseProps {
   width?: string
   /** Take full window width on small and medium screens */
   enableCompactMode?: boolean
-  /** ARIA role of the floating element. Defaults to `tooltip`; set it to match the popup's content (e.g. `dialog`, `presentation`). */
+  /** ARIA role of the floating element, matching the popup's content (defaults to `tooltip`) */
   role?: React.AriaRole
 }
 
@@ -216,6 +216,9 @@ export const Popper = forwardRef<PopperHandle, Props>(function Popper(
     <div
       ref={setFloatingRef}
       role={role}
+      // Modal's focus trap exempts `[data-picasso-popper]` popups from focus
+      // stealing; roles vary per consumer, so `role` can't be the marker.
+      data-picasso-popper=''
       className={twMerge(
         'z-modal',
         'xs:max-md:w-screen xs:max-md:max-w-screen xs:max-md:p-0 xs:max-md:m-0',

--- a/packages/base/Popper/src/Popper/test.tsx
+++ b/packages/base/Popper/src/Popper/test.tsx
@@ -171,10 +171,19 @@ describe('Popper', () => {
       renderPopper({ role: 'presentation' })
       await flushPosition()
 
-      // `presentation` removes the element from the accessibility tree, so it is
-      // queryable only by its content, not by the default tooltip role.
+      // `presentation` removes it from the a11y tree — query by content
       expect(screen.getByText(children)).toBeInTheDocument()
       expect(screen.queryByRole('tooltip')).not.toBeInTheDocument()
+    })
+
+    it('always marks the floating element with data-picasso-popper regardless of role', async () => {
+      renderPopper({ role: 'presentation' })
+      await flushPosition()
+
+      // Modal's focus trap keys on this marker (roles vary per consumer)
+      expect(
+        screen.getByText(children).closest('[data-picasso-popper]')
+      ).toBeInTheDocument()
     })
   })
 })

--- a/packages/base/Popper/src/Popper/test.tsx
+++ b/packages/base/Popper/src/Popper/test.tsx
@@ -148,4 +148,33 @@ describe('Popper', () => {
 
     expect(screen.getByRole('tooltip')).toHaveStyle({ position: 'fixed' })
   })
+
+  describe('role', () => {
+    it('defaults the floating element to role="tooltip"', async () => {
+      renderPopper()
+      await flushPosition()
+
+      expect(screen.getByRole('tooltip')).toHaveTextContent(children)
+    })
+
+    it('applies a custom role over the default', async () => {
+      renderPopper({ role: 'dialog' })
+      await flushPosition()
+
+      const popper = screen.getByRole('dialog')
+
+      expect(popper).toHaveTextContent(children)
+      expect(screen.queryByRole('tooltip')).not.toBeInTheDocument()
+    })
+
+    it('marks the floating element presentational with role="presentation"', async () => {
+      renderPopper({ role: 'presentation' })
+      await flushPosition()
+
+      // `presentation` removes the element from the accessibility tree, so it is
+      // queryable only by its content, not by the default tooltip role.
+      expect(screen.getByText(children)).toBeInTheDocument()
+      expect(screen.queryByRole('tooltip')).not.toBeInTheDocument()
+    })
+  })
 })

--- a/packages/base/Select/src/NonNativeSelect/NonNativeSelect.tsx
+++ b/packages/base/Select/src/NonNativeSelect/NonNativeSelect.tsx
@@ -207,6 +207,7 @@ export const NonNativeSelect = documentable(
           </div>
           {!disabled && isOpen && (
             <Popper
+              role='presentation'
               ref={popperRef}
               autoWidth
               width={menuWidth}


### PR DESCRIPTION
[PF-2230]

### Description

`Popper` is Picasso's generic positioning primitive, but it hardcoded `role="tooltip"` on its floating element. Since the `@base-ui/react` migration, the real Tooltip renders through Base UI's `Tooltip.Popup` (which sets its own `role="tooltip"`), so **no consumer actually wants the tooltip role from `Popper`** — yet all five of its consumers inherited it. A calendar, a menu, and two listboxes were each announced to assistive tech as a `tooltip` (a passive description region), misrepresenting interactive content.

This PR keeps `role="tooltip"` as `Popper`'s default (so any un-migrated caller stays correct) but makes it an explicit, typed, overridable prop, and sets the correct role at each consumer site.

**`@toptal/picasso-popper`**
- Add a typed `role?: React.AriaRole` prop, defaulting to `'tooltip'`. Previously `role` was not part of `Popper`'s `Props` (it extends `BaseProps`, not `HTMLAttributes`), so consumers could not pass one — it now applies on the floating element via `role={role}`.

**Consumers — correct role per popup content:**
| Component | Role | Rationale |
| --- | --- | --- |
| `DatePicker` | `dialog` | The calendar popup is a dialog; nothing inside claims the role. |
| `Menu` (submenu via `MenuItem`) | `presentation` | The inner `Menu` already owns `role="menu"`. |
| `Dropdown` | `presentation` | Content (usually a `Menu`) supplies its own semantics. |
| `Select` (`NonNativeSelect`) | `presentation` | The options list already owns `role="listbox"`. |
| `Autocomplete` | `presentation` | The popup already sits inside a `role="listbox"` wrapper. |

The four wrapper cases use `role="presentation"` rather than a content-specific role on purpose: putting `listbox`/`menu` on the `Popper` wrapper would nest a second, competing role and create a new a11y bug, since those roles already exist on the inner elements.

**Tests**
- Add a `role` block to `Popper`'s unit tests: default `tooltip`, custom role override, and `presentation` removing the element from the accessibility tree.
- Update `Dropdown` unit test + snapshot to the new `presentation` role.
- Fix `Select.spec.tsx` — it located the open dropdown via `[role="tooltip"]`, which no longer exists; switched to the `searchInput` testId (matching the sibling test).

Motivation: found during an ARIA-role audit of `packages/base`. This is a pre-existing issue (the `tooltip` default predates the migration), fixed here because it's one primitive feeding five consumers — high leverage, low blast radius. No visual change — ARIA roles are invisible to Happo.

### How to test

- Open a `DatePicker` and inspect the calendar popup — it should expose `role="dialog"`, not `role="tooltip"`.
- Open a `Dropdown`, a nested `Menu` submenu, a `Select`, and an `Autocomplete`; inspect the floating container — it should be `role="presentation"`, with the inner `menu`/`listbox` roles intact and singular (no nested duplicate `listbox`).
- Confirm a plain `Tooltip` still exposes `role="tooltip"` (unchanged default).
- Run the Storybook accessibility addon on the affected components — no new violations.

### Screenshots

_No visual change — ARIA roles only._

| Before | After |
| --- | --- |
| `Popper` floating element: `role="tooltip"` for all consumers | `dialog` (DatePicker) / `presentation` (Dropdown, Menu submenu, Select, Autocomplete); Tooltip unchanged |

### Development checks

- [ ] Double check if `picasso-tailwind-merge` requires major update (check its `README.md`)
- [ ] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [ ] Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [x] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests ([visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md) included)

**Breaking change**

- [ ] codemod is created and showcased in the changeset
- [ ] test alpha package of Picasso in StaffPortal


[PF-2230]: https://toptal-core.atlassian.net/browse/PF-2230?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ