### PR TITLE
[PF-2243] Fix Modal duplicate role attribute

### DIFF
--- a/packages/base/Modal/src/Modal/Modal.tsx
+++ b/packages/base/Modal/src/Modal/Modal.tsx
@@ -213,12 +213,6 @@ export const Modal = forwardRef<HTMLDivElement, Props>(function Modal(
     (typeof container === 'function' ? container() : container) ||
     picassoRootContainer
 
-  // Base UI's Dialog.Popup already renders `role="dialog"`. Honor a consumer's
-  // `paperProps.role` override on the popup (the element Base UI treats as the
-  // dialog) rather than the inner Paper.
-  const { role: paperRole, ...restPaperProps } = paperProps ?? {}
-  const popupRoleProps = paperRole !== undefined ? { role: paperRole } : {}
-
   const handlePopupClick = (event: React.MouseEvent<HTMLDivElement>) => {
     if (event.target === event.currentTarget && !disableBackdropClick) {
       onBackdropClick?.()
@@ -253,7 +247,6 @@ export const Modal = forwardRef<HTMLDivElement, Props>(function Modal(
         )}
         <BaseUIDialog.Popup
           {...rest}
-          {...popupRoleProps}
           ref={modalRef}
           initialFocus={() =>
             modalRef.current?.contains(document.activeElement)
@@ -267,12 +260,7 @@ export const Modal = forwardRef<HTMLDivElement, Props>(function Modal(
           style={{ ...style, ...durationStyle }}
           onClick={handlePopupClick}
         >
-          <ModalPaper
-            size={size}
-            align={align}
-            tabIndex={-1}
-            {...restPaperProps}
-          >
+          <ModalPaper size={size} align={align} tabIndex={-1} {...paperProps}>
             <ModalContext.Provider value>
               {children}
               {onClose && (

--- a/packages/base/Modal/src/Modal/Modal.tsx
+++ b/packages/base/Modal/src/Modal/Modal.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode, HTMLAttributes } from 'react'
-import { Dialog } from '@base-ui/react/dialog'
+import { Dialog as BaseUIDialog } from '@base-ui/react/dialog'
 import React, { forwardRef, useEffect, useRef, useContext } from 'react'
 import type {
   BaseProps,
@@ -213,6 +213,12 @@ export const Modal = forwardRef<HTMLDivElement, Props>(function Modal(
     (typeof container === 'function' ? container() : container) ||
     picassoRootContainer
 
+  // Base UI's Dialog.Popup already renders `role="dialog"`. Honor a consumer's
+  // `paperProps.role` override on the popup (the element Base UI treats as the
+  // dialog) rather than the inner Paper.
+  const { role: paperRole, ...restPaperProps } = paperProps ?? {}
+  const popupRoleProps = paperRole !== undefined ? { role: paperRole } : {}
+
   const handlePopupClick = (event: React.MouseEvent<HTMLDivElement>) => {
     if (event.target === event.currentTarget && !disableBackdropClick) {
       onBackdropClick?.()
@@ -223,7 +229,7 @@ export const Modal = forwardRef<HTMLDivElement, Props>(function Modal(
   }
 
   return (
-    <Dialog.Root
+    <BaseUIDialog.Root
       open={open}
       modal={false}
       disablePointerDismissal
@@ -238,15 +244,16 @@ export const Modal = forwardRef<HTMLDivElement, Props>(function Modal(
         }
       }}
     >
-      <Dialog.Portal container={resolvedContainer}>
+      <BaseUIDialog.Portal container={resolvedContainer}>
         {!hideBackdrop && (
-          <Dialog.Backdrop
+          <BaseUIDialog.Backdrop
             className='fixed z-modal inset-0 bg-black/50 transition-opacity data-starting-style:opacity-0 data-ending-style:opacity-0'
             style={durationStyle}
           />
         )}
-        <Dialog.Popup
+        <BaseUIDialog.Popup
           {...rest}
+          {...popupRoleProps}
           ref={modalRef}
           initialFocus={() =>
             modalRef.current?.contains(document.activeElement)
@@ -260,7 +267,12 @@ export const Modal = forwardRef<HTMLDivElement, Props>(function Modal(
           style={{ ...style, ...durationStyle }}
           onClick={handlePopupClick}
         >
-          <ModalPaper size={size} align={align} tabIndex={-1} {...paperProps}>
+          <ModalPaper
+            size={size}
+            align={align}
+            tabIndex={-1}
+            {...restPaperProps}
+          >
             <ModalContext.Provider value>
               {children}
               {onClose && (
@@ -279,9 +291,9 @@ export const Modal = forwardRef<HTMLDivElement, Props>(function Modal(
               )}
             </ModalContext.Provider>
           </ModalPaper>
-        </Dialog.Popup>
-      </Dialog.Portal>
-    </Dialog.Root>
+        </BaseUIDialog.Popup>
+      </BaseUIDialog.Portal>
+    </BaseUIDialog.Root>
   )
 })
 

--- a/packages/base/Modal/src/Modal/__snapshots__/test.tsx.snap
+++ b/packages/base/Modal/src/Modal/__snapshots__/test.tsx.snap
@@ -57,7 +57,6 @@ exports[`Modal renders 1`] = `
     >
       <div
         class="bg-white shadow-2 transition-shadow duration-300 delay-0 outline-hidden overflow-y flex flex-col m-4 sm:h-auto sm:m-8 max-w-[calc(100%_ sm:max-w-[calc(100%_ rounded-md w-[40.625rem] relative max-h-[calc(100%_ sm:max-h-[calc(100%_"
-        role="dialog"
         tabindex="-1"
       >
         <div
@@ -209,7 +208,6 @@ exports[`Modal useModal opens and closes modal 1`] = `
         >
           <div
             class="bg-white shadow-2 transition-shadow duration-300 delay-0 outline-hidden overflow-y flex flex-col m-4 sm:h-auto sm:m-8 max-w-[calc(100%_ sm:max-w-[calc(100%_ rounded-md w-[40.625rem] relative max-h-[calc(100%_ sm:max-h-[calc(100%_"
-            role="dialog"
             tabindex="-1"
           >
             <p>
@@ -360,7 +358,6 @@ exports[`Modal useModal shows multiple modals at the same time 1`] = `
         >
           <div
             class="bg-white shadow-2 transition-shadow duration-300 delay-0 outline-hidden overflow-y flex flex-col m-4 sm:h-auto sm:m-8 max-w-[calc(100%_ sm:max-w-[calc(100%_ rounded-md w-[40.625rem] relative max-h-[calc(100%_ sm:max-h-[calc(100%_"
-            role="dialog"
             tabindex="-1"
           >
             <p>
@@ -430,7 +427,6 @@ exports[`Modal useModal shows multiple modals at the same time 1`] = `
         >
           <div
             class="bg-white shadow-2 transition-shadow duration-300 delay-0 outline-hidden overflow-y flex flex-col m-4 sm:h-auto sm:m-8 max-w-[calc(100%_ sm:max-w-[calc(100%_ rounded-md w-[40.625rem] relative max-h-[calc(100%_ sm:max-h-[calc(100%_"
-            role="dialog"
             tabindex="-1"
           >
             <p>

--- a/packages/base/Modal/src/ModalPaper/ModalPaper.tsx
+++ b/packages/base/Modal/src/ModalPaper/ModalPaper.tsx
@@ -49,7 +49,6 @@ export const ModalPaper = React.forwardRef<HTMLDivElement, Props>(
     return (
       <Paper
         ref={ref}
-        role='dialog'
         elevation={2}
         className={twMerge(
           'outline-hidden overflow-y-auto',

--- a/packages/base/PromptModal/src/PromptModal/__snapshots__/test.tsx.snap
+++ b/packages/base/PromptModal/src/PromptModal/__snapshots__/test.tsx.snap
@@ -36,7 +36,6 @@ exports[`PromptModal renders 1`] = `
         >
           <div
             class="bg-white shadow-2 transition-shadow duration-300 delay-0 outline-hidden overflow-y flex flex-col m-4 sm:h-auto sm:m-8 max-w-[calc(100%_ sm:max-w-[calc(100%_ rounded-md w-[32.5rem] relative max-h-[calc(100%_ sm:max-h-[calc(100%_"
-            role="dialog"
             tabindex="-1"
           >
             <div
@@ -216,7 +215,6 @@ exports[`PromptModal showPrompt opens and closes modal on Submit action 2`] = `
         >
           <div
             class="bg-white shadow-2 transition-shadow duration-300 delay-0 outline-hidden overflow-y flex flex-col m-4 sm:h-auto sm:m-8 max-w-[calc(100%_ sm:max-w-[calc(100%_ rounded-md w-[32.5rem] relative max-h-[calc(100%_ sm:max-h-[calc(100%_"
-            role="dialog"
             tabindex="-1"
           >
             <div

--- a/packages/base/Utils/src/utils/Modal/__snapshots__/test.tsx.snap
+++ b/packages/base/Utils/src/utils/Modal/__snapshots__/test.tsx.snap
@@ -57,7 +57,6 @@ exports[`Modal useModal opens and closes modal 1`] = `
         >
           <div
             class="bg-white shadow-2 transition-shadow duration-300 delay-0 outline-hidden overflow-y flex flex-col m-4 sm:h-auto sm:m-8 max-w-[calc(100%_ sm:max-w-[calc(100%_ rounded-md w-[40.625rem] relative max-h-[calc(100%_ sm:max-h-[calc(100%_"
-            role="dialog"
             tabindex="-1"
           >
             <p>
@@ -236,7 +235,6 @@ exports[`Modal useModal shows multiple modals at the same time 1`] = `
         >
           <div
             class="bg-white shadow-2 transition-shadow duration-300 delay-0 outline-hidden overflow-y flex flex-col m-4 sm:h-auto sm:m-8 max-w-[calc(100%_ sm:max-w-[calc(100%_ rounded-md w-[40.625rem] relative max-h-[calc(100%_ sm:max-h-[calc(100%_"
-            role="dialog"
             tabindex="-1"
           >
             <p>
@@ -285,7 +283,6 @@ exports[`Modal useModal shows multiple modals at the same time 1`] = `
         >
           <div
             class="bg-white shadow-2 transition-shadow duration-300 delay-0 outline-hidden overflow-y flex flex-col m-4 sm:h-auto sm:m-8 max-w-[calc(100%_ sm:max-w-[calc(100%_ rounded-md w-[40.625rem] relative max-h-[calc(100%_ sm:max-h-[calc(100%_"
-            role="dialog"
             tabindex="-1"
           >
             <p>


### PR DESCRIPTION
[PF-2243]

### Description

Modal rendered **two nested `role="dialog"`** elements: Base UI's `Dialog.Popup` supplies one by default, and `ModalPaper` also set its own — a regression introduced by the `@base-ui/react` migration. Previously `@mui/base`'s Modal root had no role, so the paper legitimately carried it; after the swap, Base UI's popup provides the role natively, making the paper's copy a duplicate.

Nested duplicate dialog roles are an accessibility anti-pattern (a screen reader sees two dialogs) and break test/automation that assumes a single match — `getByRole('dialog')` throws on multiple matches, and `[role="dialog"]` selectors (e.g. the shared `waitForOverlayOpen` Cypress command) become ambiguous.

**Changes (`@toptal/picasso-modal`)**
- Remove `role="dialog"` from `ModalPaper`. The role now lives only on Base UI's `Dialog.Popup` — the element that actually hosts the focus trap and aria wiring, so semantics and behavior stay on the same node.
- Route a consumer's `paperProps.role` override onto the `Dialog.Popup` instead of the inner Paper, so "changing role" still works and still targets the true dialog element. The role key is applied conditionally (`paperProps.role !== undefined`) — passing it through unconditionally would send `role={undefined}` and clobber Base UI's default, because Base UI's `mergeProps` copies `undefined` keys.
- Alias the import to `BaseUIDialog` for readability against the local `Modal`/`ModalContext` names.

**Snapshots**
- Updated `Modal`, `PromptModal`, and `Utils/Modal` jest snapshots to drop the removed duplicate `role="dialog"` from the paper node. Each now shows a single `role="dialog"` (on the popup).

Found during an ARIA-role audit of `packages/base`. No visual change — ARIA roles are invisible to Happo.

### How to test

- Open any Modal (and PromptModal) and inspect the DOM — there should be exactly **one** `role="dialog"` (on Base UI's popup), not two nested.
- Pass `paperProps={{ role: 'alertdialog' }}` — the override should land on the dialog popup, and there should still be only one dialog role in the tree.
- Confirm existing Modal/Drawer/PromptModal Cypress specs still pass (`waitForOverlayOpen` resolves a single `[role="dialog"]`).
- Run the Storybook accessibility addon on Modal — no new violations.

### Screenshots

_No visual change — ARIA roles only._

| Before | After |
| --- | --- |
| Two nested `role="dialog"` (Base UI popup **and** inner Paper) | Single `role="dialog"` on the Base UI popup; `paperProps.role` override applied there |

### Development checks

- [ ] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [ ] Double check if `picasso-tailwind-merge` requires major update (check its `README.md`)
- [ ] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [ ] Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [x] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests ([visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md) included)

**Breaking change**

- [ ] codemod is created and showcased in the changeset
- [ ] test alpha package of Picasso in StaffPortal


[PF-2243]: https://toptal-core.atlassian.net/browse/PF-2243?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ