### PR TITLE
[PF-2244] Expose single label node for base-ui Checkbox and Switch

### DIFF
--- a/.changeset/checkbox-switch-single-label-node.md
+++ b/.changeset/checkbox-switch-single-label-node.md
@@ -1,0 +1,13 @@
+---
+'@toptal/picasso-form-label': minor
+'@toptal/picasso-checkbox': minor
+'@toptal/picasso-switch': minor
+---
+
+### Checkbox, Switch
+
+- expose a single label-associated node when a `label` is provided, so `getByLabelText`, `getByText` and `getByRole` match once. The base-ui control renders an accessible `role` element plus a hidden native `<input>`; both used to be label-associated (the `role` element via `aria-labelledby`, the input via the wrapping `<label>`), which made those queries throw "Found multiple elements" in consumer tests. The control now names itself via `aria-labelledby`. Note the DOM contract change: a labeled control's root element changes from `<label>` to `<div>`, and the derived `"<id>-label"` node id is gone — update selectors/styles that relied on the `label` tag or that id. Label clicks are still forwarded to preserve click-to-toggle and focus, and interactive content inside the label (links, buttons) no longer toggles the control
+
+### FormControlLabel
+
+- add an optional `labelId` prop. When provided, the wrapper renders as a non-`<label>` element (so a control's hidden native input is not a second label-associated node) and forwards label-text clicks to the control (skipping interactive descendants). The default `<label>` path is unchanged, so `Radio` and other consumers are unaffected

--- a/packages/base/Button/src/ButtonCheckbox/__snapshots__/test.tsx.snap
+++ b/packages/base/Button/src/ButtonCheckbox/__snapshots__/test.tsx.snap
@@ -9,7 +9,7 @@ exports[`ButtonCheckbox renders 1`] = `
       aria-disabled="false"
       class="base-Button text-lg inline-flex items-center justify-center select-none appearance-none m-0 relative normal-case align-middle transition-colors duration-350 ease-out shrink-0 outline-hidden [[data-component-type="button"]+&]:ml cursor-pointer no-underline hover:no-underline rounded-sm shadow-none focus-visible:shadow-[0_0_0_3px_rgba(32,78,207,0.48)] focus-within:shadow-[0_0_0_3px_rgba(32,78,207,0.48)] border border-solid text-black hover:border-black visited:text-black active:bg-gray active:border-black bg-white border-gray min-w h-8 px-4 text-center py-2 pr-6 pl-4"
       data-component-type="button"
-      id="base-ui-:r2:"
+      id="base-ui-:r3:"
       role="button"
       tabindex="0"
       type="button"
@@ -22,10 +22,10 @@ exports[`ButtonCheckbox renders 1`] = `
         >
           <span
             aria-checked="false"
-            aria-labelledby="base-ui-:r2:"
+            aria-labelledby="base-ui-:r3:"
             class="relative box-border inline-block h-4 w-4 rounded-sm border border-solid text-[1rem] leading-4 cursor-pointer transition-all duration-350 ease-in data-unchecked:bg-white data-unchecked:border-gray data-checked:bg-blue data-checked:border-blue data-checked:text-white data-indeterminate:bg-blue data-indeterminate:border-blue data-indeterminate:text-white [&[data-unchecked]:not([data-disabled]):hover]:border-gray [&[data-checked]:not([data-disabled]):hover]:bg-[color-mix(in_srgb,theme(colors.blue.500)_84%,white)] [&[data-checked]:not([data-disabled]):hover]:border-[color-mix(in_srgb,theme(colors.blue.500)_84%,white)] [&[data-indeterminate]:not([data-disabled]):hover]:bg-[color-mix(in_srgb,theme(colors.blue.500)_84%,white)] [&[data-indeterminate]:not([data-disabled]):hover]:border-[color-mix(in_srgb,theme(colors.blue.500)_84%,white)] focus-visible:outline-none focus-visible:shadow-[0_0_0_3px_color-mix(in_srgb,theme(colors.blue.500)_48%,transparent)] data-focused:shadow-[0_0_0_3px_color-mix(in_srgb,theme(colors.blue.500)_48%,transparent)] data-disabled:opacity-[0.48] data-disabled:cursor-default data-checked:before:absolute data-checked:before:content-[''] data-checked:before:top-[calc(0.5rem_-_1px)] data-checked:before:left-[calc(0.1875rem_-_1px)] data-checked:before:h-[0.125rem] data-checked:before:w-[0.1875rem] data-checked:before:bg-white data-checked:before:[transform:rotate(45deg)] data-checked:after:absolute data-checked:after:content-[''] data-checked:after:top-[calc(0.4375rem_-_1px)] data-checked:after:left-[calc(0.25rem_-_1px)] data-checked:after:h-[0.125rem] data-checked:after:w-[0.5625rem] data-checked:after:bg-white data-checked:after:[transform:rotate(-45deg)] data-indeterminate:before:absolute data-indeterminate:before:content-[''] data-indeterminate:before:top-1/2 data-indeterminate:before:left-1/2 data-indeterminate:before:h-[0.125rem] data-indeterminate:before:w-[0.625rem] data-indeterminate:before:bg-white data-indeterminate:before:[transform:translate(-50%,-50%)]"
             data-unchecked=""
-            id="base-ui-:r0:"
+            id="base-ui-:r1:"
             role="checkbox"
             tabindex="0"
           />

--- a/packages/base/Checkbox/src/Checkbox/Checkbox.tsx
+++ b/packages/base/Checkbox/src/Checkbox/Checkbox.tsx
@@ -1,4 +1,5 @@
 import { Checkbox as BaseCheckbox } from '@base-ui/react/checkbox'
+import { useBaseUiId } from '@base-ui/react/internals/useBaseUiId'
 import type {
   ButtonOrAnchorProps,
   BaseProps,
@@ -52,91 +53,101 @@ export interface Props
   value?: string
 }
 
-export const Checkbox = forwardRef<HTMLButtonElement | HTMLLabelElement, Props>(
-  function Checkbox(
-    { disabled = false, indeterminate = false, onChange = () => {}, ...props },
-    ref
-  ) {
-    const {
-      label,
-      id,
-      className,
-      style,
-      labelStyle,
-      requiredDecoration,
-      value,
-      checked,
-      titleCase,
-      ...rest
-    } = props
+export const Checkbox = forwardRef<
+  HTMLButtonElement | HTMLLabelElement | HTMLDivElement,
+  Props
+>(function Checkbox(
+  { disabled = false, indeterminate = false, onChange = () => {}, ...props },
+  ref
+) {
+  const {
+    label,
+    id,
+    className,
+    style,
+    labelStyle,
+    requiredDecoration,
+    value,
+    checked,
+    titleCase,
+    ...rest
+  } = props
 
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const { color, 'data-private': dataPrivate, ...checkboxAttributes } = rest
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { color, 'data-private': dataPrivate, ...checkboxAttributes } = rest
 
-    // Element-variance boundary: `Props` extends button/anchor HTML attributes,
-    // but BaseCheckbox.Root renders a <span>. The event-handler element types
-    // are runtime-compatible, so we resolve the variance once here instead of
-    // narrowing the public API.
-    const rootRest = checkboxAttributes as CheckboxRootProps
+  // Element-variance boundary: `Props` extends button/anchor HTML attributes,
+  // but BaseCheckbox.Root renders a <span>. The event-handler element types
+  // are runtime-compatible, so we resolve the variance once here instead of
+  // narrowing the public API.
+  const rootRest = checkboxAttributes as CheckboxRootProps
 
-    const checkboxElement = (
-      // Tame Base UI's visually-hidden <input>, which ships
-      // `position:absolute; top:0; left:0; margin:-1px` (inline). `relative` +
-      // the `translate-px` pair anchor it inside the 16px box so its bounds
-      // don't grow the rendered box past the legacy size (fixes the Happo
-      // dimension_mismatch). `appearance-none` keeps the native control from
-      // ever painting now that the input sits over the box.
-      <span className='relative inline-flex self-start align-middle [&_input]:appearance-none [&_input]:translate-x-px [&_input]:translate-y-px'>
-        <BaseCheckbox.Root
-          {...rootRest}
-          ref={label ? undefined : (ref as React.Ref<HTMLElement>)}
-          checked={checked}
-          disabled={disabled}
-          id={id}
-          value={value}
-          indeterminate={indeterminate}
-          onCheckedChange={(nextChecked, { event }) =>
-            onChange(toReactChangeEvent(event), nextChecked)
-          }
-          className={twMerge(checkboxClassNames, className)}
-          style={style}
-        />
-      </span>
-    )
+  // Name the control via `aria-labelledby` so it is the single
+  // label-associated node (see FormControlLabel `labelId`). Only relevant
+  // when there is a label to point at. `useBaseUiId` wraps `React.useId`
+  // with a React < 18 fallback, matching base-ui's own peer support.
+  const generatedLabelId = useBaseUiId()
+  const labelId = label ? generatedLabelId : undefined
 
-    if (!label) {
-      return checkboxElement
-    }
-
-    const externalEventListeners = {
-      onMouseLeave: rest.onMouseLeave,
-      onMouseOver: rest.onMouseOver,
-    } as ComponentProps<typeof FormControlLabel>
-
-    return (
-      <FormControlLabel
-        {...externalEventListeners}
-        style={labelStyle}
-        ref={ref as React.ForwardedRef<HTMLLabelElement>}
-        classes={{
-          root: 'text-[1rem]',
-          label: twJoin(
-            'max-w-[calc(100%_-_1.5em_+_1px)]',
-            'ml-[0.5em]',
-            disabled && 'text-gray-500'
-          ),
-        }}
-        control={checkboxElement}
-        requiredDecoration={requiredDecoration}
+  const checkboxElement = (
+    // Tame Base UI's visually-hidden <input>, which ships
+    // `position:absolute; top:0; left:0; margin:-1px` (inline). `relative` +
+    // the `translate-px` pair anchor it inside the 16px box so its bounds
+    // don't grow the rendered box past the legacy size (fixes the Happo
+    // dimension_mismatch). `appearance-none` keeps the native control from
+    // ever painting now that the input sits over the box.
+    <span className='relative inline-flex self-start align-middle [&_input]:appearance-none [&_input]:translate-x-px [&_input]:translate-y-px'>
+      <BaseCheckbox.Root
+        {...rootRest}
+        ref={label ? undefined : (ref as React.Ref<HTMLElement>)}
+        aria-labelledby={rootRest['aria-labelledby'] ?? labelId}
+        checked={checked}
         disabled={disabled}
-        label={label}
-        titleCase={titleCase}
-        className='picasso-checkbox'
-        data-private={dataPrivate}
+        id={id}
+        value={value}
+        indeterminate={indeterminate}
+        onCheckedChange={(nextChecked, { event }) =>
+          onChange(toReactChangeEvent(event), nextChecked)
+        }
+        className={twMerge(checkboxClassNames, className)}
+        style={style}
       />
-    )
+    </span>
+  )
+
+  if (!label) {
+    return checkboxElement
   }
-)
+
+  const externalEventListeners = {
+    onMouseLeave: rest.onMouseLeave,
+    onMouseOver: rest.onMouseOver,
+  } as ComponentProps<typeof FormControlLabel>
+
+  return (
+    <FormControlLabel
+      {...externalEventListeners}
+      style={labelStyle}
+      ref={ref as React.ForwardedRef<HTMLLabelElement | HTMLDivElement>}
+      classes={{
+        root: 'text-[1rem]',
+        label: twJoin(
+          'max-w-[calc(100%_-_1.5em_+_1px)]',
+          'ml-[0.5em]',
+          disabled && 'text-gray-500'
+        ),
+      }}
+      control={checkboxElement}
+      labelId={labelId}
+      requiredDecoration={requiredDecoration}
+      disabled={disabled}
+      label={label}
+      titleCase={titleCase}
+      className='picasso-checkbox'
+      data-private={dataPrivate}
+    />
+  )
+})
 
 Checkbox.displayName = 'Checkbox'
 

--- a/packages/base/Checkbox/src/Checkbox/__snapshots__/test.tsx.snap
+++ b/packages/base/Checkbox/src/Checkbox/__snapshots__/test.tsx.snap
@@ -14,19 +14,18 @@ exports[`Checkbox Checkbox.Group renders checkbox in a grid group 1`] = `
         <div
           class="box-border m-0 p-[8px] sm:basis-4/12 sm:max-w leading-none pt-0 pb-0 [&_.picasso-checkbox]:mb-[0.5em]"
         >
-          <label
+          <div
             class="inline-flex items-center max-w align-middle -webkit-tap-highlight-color mx-0 cursor-pointer text-[1rem] picasso-checkbox"
-            id="base-ui-:r10:"
           >
             <span
               class="relative inline-flex self-start align-middle [&_input]:appearance-none [&_input]:translate-x [&_input]:translate-y"
             >
               <span
                 aria-checked="false"
-                aria-labelledby="base-ui-:r10:"
+                aria-labelledby="base-ui-:r18:"
                 class="relative box-border inline-block h-4 w-4 rounded-sm border border-solid text-[1rem] leading-4 cursor-pointer transition-all duration-350 ease-in data-unchecked:bg-white data-unchecked:border-gray data-checked:bg-blue data-checked:border-blue data-checked:text-white data-indeterminate:bg-blue data-indeterminate:border-blue data-indeterminate:text-white [&[data-unchecked]:not([data-disabled]):hover]:border-gray [&[data-checked]:not([data-disabled]):hover]:bg-[color-mix(in_srgb,theme(colors.blue.500)_84%,white)] [&[data-checked]:not([data-disabled]):hover]:border-[color-mix(in_srgb,theme(colors.blue.500)_84%,white)] [&[data-indeterminate]:not([data-disabled]):hover]:bg-[color-mix(in_srgb,theme(colors.blue.500)_84%,white)] [&[data-indeterminate]:not([data-disabled]):hover]:border-[color-mix(in_srgb,theme(colors.blue.500)_84%,white)] focus-visible:outline-none focus-visible:shadow-[0_0_0_3px_color-mix(in_srgb,theme(colors.blue.500)_48%,transparent)] data-focused:shadow-[0_0_0_3px_color-mix(in_srgb,theme(colors.blue.500)_48%,transparent)] data-disabled:opacity-[0.48] data-disabled:cursor-default data-checked:before:absolute data-checked:before:content-[''] data-checked:before:top-[calc(0.5rem_-_1px)] data-checked:before:left-[calc(0.1875rem_-_1px)] data-checked:before:h-[0.125rem] data-checked:before:w-[0.1875rem] data-checked:before:bg-white data-checked:before:[transform:rotate(45deg)] data-checked:after:absolute data-checked:after:content-[''] data-checked:after:top-[calc(0.4375rem_-_1px)] data-checked:after:left-[calc(0.25rem_-_1px)] data-checked:after:h-[0.125rem] data-checked:after:w-[0.5625rem] data-checked:after:bg-white data-checked:after:[transform:rotate(-45deg)] data-indeterminate:before:absolute data-indeterminate:before:content-[''] data-indeterminate:before:top-1/2 data-indeterminate:before:left-1/2 data-indeterminate:before:h-[0.125rem] data-indeterminate:before:w-[0.625rem] data-indeterminate:before:bg-white data-indeterminate:before:[transform:translate(-50%,-50%)]"
                 data-unchecked=""
-                id="base-ui-:ru:"
+                id="base-ui-:r19:"
                 role="checkbox"
                 tabindex="0"
               />
@@ -40,6 +39,7 @@ exports[`Checkbox Checkbox.Group renders checkbox in a grid group 1`] = `
             </span>
             <span
               class="inline-block leading-[1em] mb-0 text-graphite max-w-[calc(100%_ ml-[0.5em]"
+              id="base-ui-:r18:"
             >
               <span
                 class="align-top text-[0.8125rem]"
@@ -47,24 +47,23 @@ exports[`Checkbox Checkbox.Group renders checkbox in a grid group 1`] = `
                 Checkbox 1
               </span>
             </span>
-          </label>
+          </div>
         </div>
         <div
           class="box-border m-0 p-[8px] sm:basis-4/12 sm:max-w leading-none pt-0 pb-0 [&_.picasso-checkbox]:mb-[0.5em]"
         >
-          <label
+          <div
             class="inline-flex items-center max-w align-middle -webkit-tap-highlight-color mx-0 cursor-pointer text-[1rem] picasso-checkbox"
-            id="base-ui-:r13:"
           >
             <span
               class="relative inline-flex self-start align-middle [&_input]:appearance-none [&_input]:translate-x [&_input]:translate-y"
             >
               <span
                 aria-checked="false"
-                aria-labelledby="base-ui-:r13:"
+                aria-labelledby="base-ui-:r1c:"
                 class="relative box-border inline-block h-4 w-4 rounded-sm border border-solid text-[1rem] leading-4 cursor-pointer transition-all duration-350 ease-in data-unchecked:bg-white data-unchecked:border-gray data-checked:bg-blue data-checked:border-blue data-checked:text-white data-indeterminate:bg-blue data-indeterminate:border-blue data-indeterminate:text-white [&[data-unchecked]:not([data-disabled]):hover]:border-gray [&[data-checked]:not([data-disabled]):hover]:bg-[color-mix(in_srgb,theme(colors.blue.500)_84%,white)] [&[data-checked]:not([data-disabled]):hover]:border-[color-mix(in_srgb,theme(colors.blue.500)_84%,white)] [&[data-indeterminate]:not([data-disabled]):hover]:bg-[color-mix(in_srgb,theme(colors.blue.500)_84%,white)] [&[data-indeterminate]:not([data-disabled]):hover]:border-[color-mix(in_srgb,theme(colors.blue.500)_84%,white)] focus-visible:outline-none focus-visible:shadow-[0_0_0_3px_color-mix(in_srgb,theme(colors.blue.500)_48%,transparent)] data-focused:shadow-[0_0_0_3px_color-mix(in_srgb,theme(colors.blue.500)_48%,transparent)] data-disabled:opacity-[0.48] data-disabled:cursor-default data-checked:before:absolute data-checked:before:content-[''] data-checked:before:top-[calc(0.5rem_-_1px)] data-checked:before:left-[calc(0.1875rem_-_1px)] data-checked:before:h-[0.125rem] data-checked:before:w-[0.1875rem] data-checked:before:bg-white data-checked:before:[transform:rotate(45deg)] data-checked:after:absolute data-checked:after:content-[''] data-checked:after:top-[calc(0.4375rem_-_1px)] data-checked:after:left-[calc(0.25rem_-_1px)] data-checked:after:h-[0.125rem] data-checked:after:w-[0.5625rem] data-checked:after:bg-white data-checked:after:[transform:rotate(-45deg)] data-indeterminate:before:absolute data-indeterminate:before:content-[''] data-indeterminate:before:top-1/2 data-indeterminate:before:left-1/2 data-indeterminate:before:h-[0.125rem] data-indeterminate:before:w-[0.625rem] data-indeterminate:before:bg-white data-indeterminate:before:[transform:translate(-50%,-50%)]"
                 data-unchecked=""
-                id="base-ui-:r11:"
+                id="base-ui-:r1d:"
                 role="checkbox"
                 tabindex="0"
               />
@@ -78,6 +77,7 @@ exports[`Checkbox Checkbox.Group renders checkbox in a grid group 1`] = `
             </span>
             <span
               class="inline-block leading-[1em] mb-0 text-graphite max-w-[calc(100%_ ml-[0.5em]"
+              id="base-ui-:r1c:"
             >
               <span
                 class="align-top text-[0.8125rem]"
@@ -85,24 +85,23 @@ exports[`Checkbox Checkbox.Group renders checkbox in a grid group 1`] = `
                 Checkbox 2
               </span>
             </span>
-          </label>
+          </div>
         </div>
         <div
           class="box-border m-0 p-[8px] sm:basis-4/12 sm:max-w leading-none pt-0 pb-0 [&_.picasso-checkbox]:mb-[0.5em]"
         >
-          <label
+          <div
             class="inline-flex items-center max-w align-middle -webkit-tap-highlight-color mx-0 cursor-pointer text-[1rem] picasso-checkbox"
-            id="base-ui-:r16:"
           >
             <span
               class="relative inline-flex self-start align-middle [&_input]:appearance-none [&_input]:translate-x [&_input]:translate-y"
             >
               <span
                 aria-checked="false"
-                aria-labelledby="base-ui-:r16:"
+                aria-labelledby="base-ui-:r1g:"
                 class="relative box-border inline-block h-4 w-4 rounded-sm border border-solid text-[1rem] leading-4 cursor-pointer transition-all duration-350 ease-in data-unchecked:bg-white data-unchecked:border-gray data-checked:bg-blue data-checked:border-blue data-checked:text-white data-indeterminate:bg-blue data-indeterminate:border-blue data-indeterminate:text-white [&[data-unchecked]:not([data-disabled]):hover]:border-gray [&[data-checked]:not([data-disabled]):hover]:bg-[color-mix(in_srgb,theme(colors.blue.500)_84%,white)] [&[data-checked]:not([data-disabled]):hover]:border-[color-mix(in_srgb,theme(colors.blue.500)_84%,white)] [&[data-indeterminate]:not([data-disabled]):hover]:bg-[color-mix(in_srgb,theme(colors.blue.500)_84%,white)] [&[data-indeterminate]:not([data-disabled]):hover]:border-[color-mix(in_srgb,theme(colors.blue.500)_84%,white)] focus-visible:outline-none focus-visible:shadow-[0_0_0_3px_color-mix(in_srgb,theme(colors.blue.500)_48%,transparent)] data-focused:shadow-[0_0_0_3px_color-mix(in_srgb,theme(colors.blue.500)_48%,transparent)] data-disabled:opacity-[0.48] data-disabled:cursor-default data-checked:before:absolute data-checked:before:content-[''] data-checked:before:top-[calc(0.5rem_-_1px)] data-checked:before:left-[calc(0.1875rem_-_1px)] data-checked:before:h-[0.125rem] data-checked:before:w-[0.1875rem] data-checked:before:bg-white data-checked:before:[transform:rotate(45deg)] data-checked:after:absolute data-checked:after:content-[''] data-checked:after:top-[calc(0.4375rem_-_1px)] data-checked:after:left-[calc(0.25rem_-_1px)] data-checked:after:h-[0.125rem] data-checked:after:w-[0.5625rem] data-checked:after:bg-white data-checked:after:[transform:rotate(-45deg)] data-indeterminate:before:absolute data-indeterminate:before:content-[''] data-indeterminate:before:top-1/2 data-indeterminate:before:left-1/2 data-indeterminate:before:h-[0.125rem] data-indeterminate:before:w-[0.625rem] data-indeterminate:before:bg-white data-indeterminate:before:[transform:translate(-50%,-50%)]"
                 data-unchecked=""
-                id="base-ui-:r14:"
+                id="base-ui-:r1h:"
                 role="checkbox"
                 tabindex="0"
               />
@@ -116,6 +115,7 @@ exports[`Checkbox Checkbox.Group renders checkbox in a grid group 1`] = `
             </span>
             <span
               class="inline-block leading-[1em] mb-0 text-graphite max-w-[calc(100%_ ml-[0.5em]"
+              id="base-ui-:r1g:"
             >
               <span
                 class="align-top text-[0.8125rem]"
@@ -123,24 +123,23 @@ exports[`Checkbox Checkbox.Group renders checkbox in a grid group 1`] = `
                 Checkbox 3
               </span>
             </span>
-          </label>
+          </div>
         </div>
         <div
           class="box-border m-0 p-[8px] sm:basis-4/12 sm:max-w leading-none pt-0 pb-0 [&_.picasso-checkbox]:mb-[0.5em]"
         >
-          <label
+          <div
             class="inline-flex items-center max-w align-middle -webkit-tap-highlight-color mx-0 cursor-pointer text-[1rem] picasso-checkbox"
-            id="base-ui-:r19:"
           >
             <span
               class="relative inline-flex self-start align-middle [&_input]:appearance-none [&_input]:translate-x [&_input]:translate-y"
             >
               <span
                 aria-checked="false"
-                aria-labelledby="base-ui-:r19:"
+                aria-labelledby="base-ui-:r1k:"
                 class="relative box-border inline-block h-4 w-4 rounded-sm border border-solid text-[1rem] leading-4 cursor-pointer transition-all duration-350 ease-in data-unchecked:bg-white data-unchecked:border-gray data-checked:bg-blue data-checked:border-blue data-checked:text-white data-indeterminate:bg-blue data-indeterminate:border-blue data-indeterminate:text-white [&[data-unchecked]:not([data-disabled]):hover]:border-gray [&[data-checked]:not([data-disabled]):hover]:bg-[color-mix(in_srgb,theme(colors.blue.500)_84%,white)] [&[data-checked]:not([data-disabled]):hover]:border-[color-mix(in_srgb,theme(colors.blue.500)_84%,white)] [&[data-indeterminate]:not([data-disabled]):hover]:bg-[color-mix(in_srgb,theme(colors.blue.500)_84%,white)] [&[data-indeterminate]:not([data-disabled]):hover]:border-[color-mix(in_srgb,theme(colors.blue.500)_84%,white)] focus-visible:outline-none focus-visible:shadow-[0_0_0_3px_color-mix(in_srgb,theme(colors.blue.500)_48%,transparent)] data-focused:shadow-[0_0_0_3px_color-mix(in_srgb,theme(colors.blue.500)_48%,transparent)] data-disabled:opacity-[0.48] data-disabled:cursor-default data-checked:before:absolute data-checked:before:content-[''] data-checked:before:top-[calc(0.5rem_-_1px)] data-checked:before:left-[calc(0.1875rem_-_1px)] data-checked:before:h-[0.125rem] data-checked:before:w-[0.1875rem] data-checked:before:bg-white data-checked:before:[transform:rotate(45deg)] data-checked:after:absolute data-checked:after:content-[''] data-checked:after:top-[calc(0.4375rem_-_1px)] data-checked:after:left-[calc(0.25rem_-_1px)] data-checked:after:h-[0.125rem] data-checked:after:w-[0.5625rem] data-checked:after:bg-white data-checked:after:[transform:rotate(-45deg)] data-indeterminate:before:absolute data-indeterminate:before:content-[''] data-indeterminate:before:top-1/2 data-indeterminate:before:left-1/2 data-indeterminate:before:h-[0.125rem] data-indeterminate:before:w-[0.625rem] data-indeterminate:before:bg-white data-indeterminate:before:[transform:translate(-50%,-50%)]"
                 data-unchecked=""
-                id="base-ui-:r17:"
+                id="base-ui-:r1l:"
                 role="checkbox"
                 tabindex="0"
               />
@@ -154,6 +153,7 @@ exports[`Checkbox Checkbox.Group renders checkbox in a grid group 1`] = `
             </span>
             <span
               class="inline-block leading-[1em] mb-0 text-graphite max-w-[calc(100%_ ml-[0.5em]"
+              id="base-ui-:r1k:"
             >
               <span
                 class="align-top text-[0.8125rem]"
@@ -161,24 +161,23 @@ exports[`Checkbox Checkbox.Group renders checkbox in a grid group 1`] = `
                 Checkbox 4
               </span>
             </span>
-          </label>
+          </div>
         </div>
         <div
           class="box-border m-0 p-[8px] sm:basis-4/12 sm:max-w leading-none pt-0 pb-0 [&_.picasso-checkbox]:mb-[0.5em]"
         >
-          <label
+          <div
             class="inline-flex items-center max-w align-middle -webkit-tap-highlight-color mx-0 cursor-pointer text-[1rem] picasso-checkbox"
-            id="base-ui-:r1c:"
           >
             <span
               class="relative inline-flex self-start align-middle [&_input]:appearance-none [&_input]:translate-x [&_input]:translate-y"
             >
               <span
                 aria-checked="false"
-                aria-labelledby="base-ui-:r1c:"
+                aria-labelledby="base-ui-:r1o:"
                 class="relative box-border inline-block h-4 w-4 rounded-sm border border-solid text-[1rem] leading-4 cursor-pointer transition-all duration-350 ease-in data-unchecked:bg-white data-unchecked:border-gray data-checked:bg-blue data-checked:border-blue data-checked:text-white data-indeterminate:bg-blue data-indeterminate:border-blue data-indeterminate:text-white [&[data-unchecked]:not([data-disabled]):hover]:border-gray [&[data-checked]:not([data-disabled]):hover]:bg-[color-mix(in_srgb,theme(colors.blue.500)_84%,white)] [&[data-checked]:not([data-disabled]):hover]:border-[color-mix(in_srgb,theme(colors.blue.500)_84%,white)] [&[data-indeterminate]:not([data-disabled]):hover]:bg-[color-mix(in_srgb,theme(colors.blue.500)_84%,white)] [&[data-indeterminate]:not([data-disabled]):hover]:border-[color-mix(in_srgb,theme(colors.blue.500)_84%,white)] focus-visible:outline-none focus-visible:shadow-[0_0_0_3px_color-mix(in_srgb,theme(colors.blue.500)_48%,transparent)] data-focused:shadow-[0_0_0_3px_color-mix(in_srgb,theme(colors.blue.500)_48%,transparent)] data-disabled:opacity-[0.48] data-disabled:cursor-default data-checked:before:absolute data-checked:before:content-[''] data-checked:before:top-[calc(0.5rem_-_1px)] data-checked:before:left-[calc(0.1875rem_-_1px)] data-checked:before:h-[0.125rem] data-checked:before:w-[0.1875rem] data-checked:before:bg-white data-checked:before:[transform:rotate(45deg)] data-checked:after:absolute data-checked:after:content-[''] data-checked:after:top-[calc(0.4375rem_-_1px)] data-checked:after:left-[calc(0.25rem_-_1px)] data-checked:after:h-[0.125rem] data-checked:after:w-[0.5625rem] data-checked:after:bg-white data-checked:after:[transform:rotate(-45deg)] data-indeterminate:before:absolute data-indeterminate:before:content-[''] data-indeterminate:before:top-1/2 data-indeterminate:before:left-1/2 data-indeterminate:before:h-[0.125rem] data-indeterminate:before:w-[0.625rem] data-indeterminate:before:bg-white data-indeterminate:before:[transform:translate(-50%,-50%)]"
                 data-unchecked=""
-                id="base-ui-:r1a:"
+                id="base-ui-:r1p:"
                 role="checkbox"
                 tabindex="0"
               />
@@ -192,6 +191,7 @@ exports[`Checkbox Checkbox.Group renders checkbox in a grid group 1`] = `
             </span>
             <span
               class="inline-block leading-[1em] mb-0 text-graphite max-w-[calc(100%_ ml-[0.5em]"
+              id="base-ui-:r1o:"
             >
               <span
                 class="align-top text-[0.8125rem]"
@@ -199,24 +199,23 @@ exports[`Checkbox Checkbox.Group renders checkbox in a grid group 1`] = `
                 Checkbox 5
               </span>
             </span>
-          </label>
+          </div>
         </div>
         <div
           class="box-border m-0 p-[8px] sm:basis-4/12 sm:max-w leading-none pt-0 pb-0 [&_.picasso-checkbox]:mb-[0.5em]"
         >
-          <label
+          <div
             class="inline-flex items-center max-w align-middle -webkit-tap-highlight-color mx-0 cursor-pointer text-[1rem] picasso-checkbox"
-            id="base-ui-:r1f:"
           >
             <span
               class="relative inline-flex self-start align-middle [&_input]:appearance-none [&_input]:translate-x [&_input]:translate-y"
             >
               <span
                 aria-checked="false"
-                aria-labelledby="base-ui-:r1f:"
+                aria-labelledby="base-ui-:r1s:"
                 class="relative box-border inline-block h-4 w-4 rounded-sm border border-solid text-[1rem] leading-4 cursor-pointer transition-all duration-350 ease-in data-unchecked:bg-white data-unchecked:border-gray data-checked:bg-blue data-checked:border-blue data-checked:text-white data-indeterminate:bg-blue data-indeterminate:border-blue data-indeterminate:text-white [&[data-unchecked]:not([data-disabled]):hover]:border-gray [&[data-checked]:not([data-disabled]):hover]:bg-[color-mix(in_srgb,theme(colors.blue.500)_84%,white)] [&[data-checked]:not([data-disabled]):hover]:border-[color-mix(in_srgb,theme(colors.blue.500)_84%,white)] [&[data-indeterminate]:not([data-disabled]):hover]:bg-[color-mix(in_srgb,theme(colors.blue.500)_84%,white)] [&[data-indeterminate]:not([data-disabled]):hover]:border-[color-mix(in_srgb,theme(colors.blue.500)_84%,white)] focus-visible:outline-none focus-visible:shadow-[0_0_0_3px_color-mix(in_srgb,theme(colors.blue.500)_48%,transparent)] data-focused:shadow-[0_0_0_3px_color-mix(in_srgb,theme(colors.blue.500)_48%,transparent)] data-disabled:opacity-[0.48] data-disabled:cursor-default data-checked:before:absolute data-checked:before:content-[''] data-checked:before:top-[calc(0.5rem_-_1px)] data-checked:before:left-[calc(0.1875rem_-_1px)] data-checked:before:h-[0.125rem] data-checked:before:w-[0.1875rem] data-checked:before:bg-white data-checked:before:[transform:rotate(45deg)] data-checked:after:absolute data-checked:after:content-[''] data-checked:after:top-[calc(0.4375rem_-_1px)] data-checked:after:left-[calc(0.25rem_-_1px)] data-checked:after:h-[0.125rem] data-checked:after:w-[0.5625rem] data-checked:after:bg-white data-checked:after:[transform:rotate(-45deg)] data-indeterminate:before:absolute data-indeterminate:before:content-[''] data-indeterminate:before:top-1/2 data-indeterminate:before:left-1/2 data-indeterminate:before:h-[0.125rem] data-indeterminate:before:w-[0.625rem] data-indeterminate:before:bg-white data-indeterminate:before:[transform:translate(-50%,-50%)]"
                 data-unchecked=""
-                id="base-ui-:r1d:"
+                id="base-ui-:r1t:"
                 role="checkbox"
                 tabindex="0"
               />
@@ -230,6 +229,7 @@ exports[`Checkbox Checkbox.Group renders checkbox in a grid group 1`] = `
             </span>
             <span
               class="inline-block leading-[1em] mb-0 text-graphite max-w-[calc(100%_ ml-[0.5em]"
+              id="base-ui-:r1s:"
             >
               <span
                 class="align-top text-[0.8125rem]"
@@ -237,7 +237,7 @@ exports[`Checkbox Checkbox.Group renders checkbox in a grid group 1`] = `
                 Checkbox 6
               </span>
             </span>
-          </label>
+          </div>
         </div>
       </div>
     </div>
@@ -250,19 +250,18 @@ exports[`Checkbox checkbox interaction should render checked checkbox 1`] = `
   <div
     class="flex-1 box-border [:where(&)_*]:font-sans [&_*]:[box-sizing:inherit] [&_*::before]:[box-sizing:inherit] [&_*::after]:[box-sizing:inherit]"
   >
-    <label
+    <div
       class="inline-flex items-center max-w align-middle -webkit-tap-highlight-color mx-0 cursor-pointer text-[1rem] picasso-checkbox"
-      id="base-ui-:rq:"
     >
       <span
         class="relative inline-flex self-start align-middle [&_input]:appearance-none [&_input]:translate-x [&_input]:translate-y"
       >
         <span
           aria-checked="true"
-          aria-labelledby="base-ui-:rq:"
+          aria-labelledby="base-ui-:r10:"
           class="relative box-border inline-block h-4 w-4 rounded-sm border border-solid text-[1rem] leading-4 cursor-pointer transition-all duration-350 ease-in data-unchecked:bg-white data-unchecked:border-gray data-checked:bg-blue data-checked:border-blue data-checked:text-white data-indeterminate:bg-blue data-indeterminate:border-blue data-indeterminate:text-white [&[data-unchecked]:not([data-disabled]):hover]:border-gray [&[data-checked]:not([data-disabled]):hover]:bg-[color-mix(in_srgb,theme(colors.blue.500)_84%,white)] [&[data-checked]:not([data-disabled]):hover]:border-[color-mix(in_srgb,theme(colors.blue.500)_84%,white)] [&[data-indeterminate]:not([data-disabled]):hover]:bg-[color-mix(in_srgb,theme(colors.blue.500)_84%,white)] [&[data-indeterminate]:not([data-disabled]):hover]:border-[color-mix(in_srgb,theme(colors.blue.500)_84%,white)] focus-visible:outline-none focus-visible:shadow-[0_0_0_3px_color-mix(in_srgb,theme(colors.blue.500)_48%,transparent)] data-focused:shadow-[0_0_0_3px_color-mix(in_srgb,theme(colors.blue.500)_48%,transparent)] data-disabled:opacity-[0.48] data-disabled:cursor-default data-checked:before:absolute data-checked:before:content-[''] data-checked:before:top-[calc(0.5rem_-_1px)] data-checked:before:left-[calc(0.1875rem_-_1px)] data-checked:before:h-[0.125rem] data-checked:before:w-[0.1875rem] data-checked:before:bg-white data-checked:before:[transform:rotate(45deg)] data-checked:after:absolute data-checked:after:content-[''] data-checked:after:top-[calc(0.4375rem_-_1px)] data-checked:after:left-[calc(0.25rem_-_1px)] data-checked:after:h-[0.125rem] data-checked:after:w-[0.5625rem] data-checked:after:bg-white data-checked:after:[transform:rotate(-45deg)] data-indeterminate:before:absolute data-indeterminate:before:content-[''] data-indeterminate:before:top-1/2 data-indeterminate:before:left-1/2 data-indeterminate:before:h-[0.125rem] data-indeterminate:before:w-[0.625rem] data-indeterminate:before:bg-white data-indeterminate:before:[transform:translate(-50%,-50%)]"
           data-checked=""
-          id="base-ui-:ro:"
+          id="base-ui-:r11:"
           role="checkbox"
           tabindex="0"
         />
@@ -275,6 +274,7 @@ exports[`Checkbox checkbox interaction should render checked checkbox 1`] = `
       </span>
       <span
         class="inline-block leading-[1em] mb-0 text-graphite max-w-[calc(100%_ ml-[0.5em]"
+        id="base-ui-:r10:"
       >
         <span
           class="align-top text-[0.8125rem]"
@@ -282,7 +282,7 @@ exports[`Checkbox checkbox interaction should render checked checkbox 1`] = `
           Select item
         </span>
       </span>
-    </label>
+    </div>
   </div>
 </div>
 `;
@@ -299,7 +299,7 @@ exports[`Checkbox renders default checkbox without label 1`] = `
         aria-checked="false"
         class="relative box-border inline-block h-4 w-4 rounded-sm border border-solid text-[1rem] leading-4 cursor-pointer transition-all duration-350 ease-in data-unchecked:bg-white data-unchecked:border-gray data-checked:bg-blue data-checked:border-blue data-checked:text-white data-indeterminate:bg-blue data-indeterminate:border-blue data-indeterminate:text-white [&[data-unchecked]:not([data-disabled]):hover]:border-gray [&[data-checked]:not([data-disabled]):hover]:bg-[color-mix(in_srgb,theme(colors.blue.500)_84%,white)] [&[data-checked]:not([data-disabled]):hover]:border-[color-mix(in_srgb,theme(colors.blue.500)_84%,white)] [&[data-indeterminate]:not([data-disabled]):hover]:bg-[color-mix(in_srgb,theme(colors.blue.500)_84%,white)] [&[data-indeterminate]:not([data-disabled]):hover]:border-[color-mix(in_srgb,theme(colors.blue.500)_84%,white)] focus-visible:outline-none focus-visible:shadow-[0_0_0_3px_color-mix(in_srgb,theme(colors.blue.500)_48%,transparent)] data-focused:shadow-[0_0_0_3px_color-mix(in_srgb,theme(colors.blue.500)_48%,transparent)] data-disabled:opacity-[0.48] data-disabled:cursor-default data-checked:before:absolute data-checked:before:content-[''] data-checked:before:top-[calc(0.5rem_-_1px)] data-checked:before:left-[calc(0.1875rem_-_1px)] data-checked:before:h-[0.125rem] data-checked:before:w-[0.1875rem] data-checked:before:bg-white data-checked:before:[transform:rotate(45deg)] data-checked:after:absolute data-checked:after:content-[''] data-checked:after:top-[calc(0.4375rem_-_1px)] data-checked:after:left-[calc(0.25rem_-_1px)] data-checked:after:h-[0.125rem] data-checked:after:w-[0.5625rem] data-checked:after:bg-white data-checked:after:[transform:rotate(-45deg)] data-indeterminate:before:absolute data-indeterminate:before:content-[''] data-indeterminate:before:top-1/2 data-indeterminate:before:left-1/2 data-indeterminate:before:h-[0.125rem] data-indeterminate:before:w-[0.625rem] data-indeterminate:before:bg-white data-indeterminate:before:[transform:translate(-50%,-50%)]"
         data-unchecked=""
-        id="base-ui-:r0:"
+        id="base-ui-:r1:"
         role="checkbox"
         tabindex="0"
       />
@@ -328,7 +328,7 @@ exports[`Checkbox renders disabled state 1`] = `
         class="relative box-border inline-block h-4 w-4 rounded-sm border border-solid text-[1rem] leading-4 cursor-pointer transition-all duration-350 ease-in data-unchecked:bg-white data-unchecked:border-gray data-checked:bg-blue data-checked:border-blue data-checked:text-white data-indeterminate:bg-blue data-indeterminate:border-blue data-indeterminate:text-white [&[data-unchecked]:not([data-disabled]):hover]:border-gray [&[data-checked]:not([data-disabled]):hover]:bg-[color-mix(in_srgb,theme(colors.blue.500)_84%,white)] [&[data-checked]:not([data-disabled]):hover]:border-[color-mix(in_srgb,theme(colors.blue.500)_84%,white)] [&[data-indeterminate]:not([data-disabled]):hover]:bg-[color-mix(in_srgb,theme(colors.blue.500)_84%,white)] [&[data-indeterminate]:not([data-disabled]):hover]:border-[color-mix(in_srgb,theme(colors.blue.500)_84%,white)] focus-visible:outline-none focus-visible:shadow-[0_0_0_3px_color-mix(in_srgb,theme(colors.blue.500)_48%,transparent)] data-focused:shadow-[0_0_0_3px_color-mix(in_srgb,theme(colors.blue.500)_48%,transparent)] data-disabled:opacity-[0.48] data-disabled:cursor-default data-checked:before:absolute data-checked:before:content-[''] data-checked:before:top-[calc(0.5rem_-_1px)] data-checked:before:left-[calc(0.1875rem_-_1px)] data-checked:before:h-[0.125rem] data-checked:before:w-[0.1875rem] data-checked:before:bg-white data-checked:before:[transform:rotate(45deg)] data-checked:after:absolute data-checked:after:content-[''] data-checked:after:top-[calc(0.4375rem_-_1px)] data-checked:after:left-[calc(0.25rem_-_1px)] data-checked:after:h-[0.125rem] data-checked:after:w-[0.5625rem] data-checked:after:bg-white data-checked:after:[transform:rotate(-45deg)] data-indeterminate:before:absolute data-indeterminate:before:content-[''] data-indeterminate:before:top-1/2 data-indeterminate:before:left-1/2 data-indeterminate:before:h-[0.125rem] data-indeterminate:before:w-[0.625rem] data-indeterminate:before:bg-white data-indeterminate:before:[transform:translate(-50%,-50%)]"
         data-disabled=""
         data-unchecked=""
-        id="base-ui-:r6:"
+        id="base-ui-:r9:"
         role="checkbox"
         tabindex="-1"
       />
@@ -356,7 +356,7 @@ exports[`Checkbox renders indeterminate state 1`] = `
         aria-checked="mixed"
         class="relative box-border inline-block h-4 w-4 rounded-sm border border-solid text-[1rem] leading-4 cursor-pointer transition-all duration-350 ease-in data-unchecked:bg-white data-unchecked:border-gray data-checked:bg-blue data-checked:border-blue data-checked:text-white data-indeterminate:bg-blue data-indeterminate:border-blue data-indeterminate:text-white [&[data-unchecked]:not([data-disabled]):hover]:border-gray [&[data-checked]:not([data-disabled]):hover]:bg-[color-mix(in_srgb,theme(colors.blue.500)_84%,white)] [&[data-checked]:not([data-disabled]):hover]:border-[color-mix(in_srgb,theme(colors.blue.500)_84%,white)] [&[data-indeterminate]:not([data-disabled]):hover]:bg-[color-mix(in_srgb,theme(colors.blue.500)_84%,white)] [&[data-indeterminate]:not([data-disabled]):hover]:border-[color-mix(in_srgb,theme(colors.blue.500)_84%,white)] focus-visible:outline-none focus-visible:shadow-[0_0_0_3px_color-mix(in_srgb,theme(colors.blue.500)_48%,transparent)] data-focused:shadow-[0_0_0_3px_color-mix(in_srgb,theme(colors.blue.500)_48%,transparent)] data-disabled:opacity-[0.48] data-disabled:cursor-default data-checked:before:absolute data-checked:before:content-[''] data-checked:before:top-[calc(0.5rem_-_1px)] data-checked:before:left-[calc(0.1875rem_-_1px)] data-checked:before:h-[0.125rem] data-checked:before:w-[0.1875rem] data-checked:before:bg-white data-checked:before:[transform:rotate(45deg)] data-checked:after:absolute data-checked:after:content-[''] data-checked:after:top-[calc(0.4375rem_-_1px)] data-checked:after:left-[calc(0.25rem_-_1px)] data-checked:after:h-[0.125rem] data-checked:after:w-[0.5625rem] data-checked:after:bg-white data-checked:after:[transform:rotate(-45deg)] data-indeterminate:before:absolute data-indeterminate:before:content-[''] data-indeterminate:before:top-1/2 data-indeterminate:before:left-1/2 data-indeterminate:before:h-[0.125rem] data-indeterminate:before:w-[0.625rem] data-indeterminate:before:bg-white data-indeterminate:before:[transform:translate(-50%,-50%)]"
         data-indeterminate=""
-        id="base-ui-:r9:"
+        id="base-ui-:rd:"
         role="checkbox"
         tabindex="0"
       />
@@ -383,7 +383,7 @@ exports[`Checkbox renders with (optional) 1`] = `
         aria-checked="false"
         class="relative box-border inline-block h-4 w-4 rounded-sm border border-solid text-[1rem] leading-4 cursor-pointer transition-all duration-350 ease-in data-unchecked:bg-white data-unchecked:border-gray data-checked:bg-blue data-checked:border-blue data-checked:text-white data-indeterminate:bg-blue data-indeterminate:border-blue data-indeterminate:text-white [&[data-unchecked]:not([data-disabled]):hover]:border-gray [&[data-checked]:not([data-disabled]):hover]:bg-[color-mix(in_srgb,theme(colors.blue.500)_84%,white)] [&[data-checked]:not([data-disabled]):hover]:border-[color-mix(in_srgb,theme(colors.blue.500)_84%,white)] [&[data-indeterminate]:not([data-disabled]):hover]:bg-[color-mix(in_srgb,theme(colors.blue.500)_84%,white)] [&[data-indeterminate]:not([data-disabled]):hover]:border-[color-mix(in_srgb,theme(colors.blue.500)_84%,white)] focus-visible:outline-none focus-visible:shadow-[0_0_0_3px_color-mix(in_srgb,theme(colors.blue.500)_48%,transparent)] data-focused:shadow-[0_0_0_3px_color-mix(in_srgb,theme(colors.blue.500)_48%,transparent)] data-disabled:opacity-[0.48] data-disabled:cursor-default data-checked:before:absolute data-checked:before:content-[''] data-checked:before:top-[calc(0.5rem_-_1px)] data-checked:before:left-[calc(0.1875rem_-_1px)] data-checked:before:h-[0.125rem] data-checked:before:w-[0.1875rem] data-checked:before:bg-white data-checked:before:[transform:rotate(45deg)] data-checked:after:absolute data-checked:after:content-[''] data-checked:after:top-[calc(0.4375rem_-_1px)] data-checked:after:left-[calc(0.25rem_-_1px)] data-checked:after:h-[0.125rem] data-checked:after:w-[0.5625rem] data-checked:after:bg-white data-checked:after:[transform:rotate(-45deg)] data-indeterminate:before:absolute data-indeterminate:before:content-[''] data-indeterminate:before:top-1/2 data-indeterminate:before:left-1/2 data-indeterminate:before:h-[0.125rem] data-indeterminate:before:w-[0.625rem] data-indeterminate:before:bg-white data-indeterminate:before:[transform:translate(-50%,-50%)]"
         data-unchecked=""
-        id="base-ui-:rf:"
+        id="base-ui-:rl:"
         role="checkbox"
         tabindex="0"
       />
@@ -410,7 +410,7 @@ exports[`Checkbox renders with asterisk 1`] = `
         aria-checked="false"
         class="relative box-border inline-block h-4 w-4 rounded-sm border border-solid text-[1rem] leading-4 cursor-pointer transition-all duration-350 ease-in data-unchecked:bg-white data-unchecked:border-gray data-checked:bg-blue data-checked:border-blue data-checked:text-white data-indeterminate:bg-blue data-indeterminate:border-blue data-indeterminate:text-white [&[data-unchecked]:not([data-disabled]):hover]:border-gray [&[data-checked]:not([data-disabled]):hover]:bg-[color-mix(in_srgb,theme(colors.blue.500)_84%,white)] [&[data-checked]:not([data-disabled]):hover]:border-[color-mix(in_srgb,theme(colors.blue.500)_84%,white)] [&[data-indeterminate]:not([data-disabled]):hover]:bg-[color-mix(in_srgb,theme(colors.blue.500)_84%,white)] [&[data-indeterminate]:not([data-disabled]):hover]:border-[color-mix(in_srgb,theme(colors.blue.500)_84%,white)] focus-visible:outline-none focus-visible:shadow-[0_0_0_3px_color-mix(in_srgb,theme(colors.blue.500)_48%,transparent)] data-focused:shadow-[0_0_0_3px_color-mix(in_srgb,theme(colors.blue.500)_48%,transparent)] data-disabled:opacity-[0.48] data-disabled:cursor-default data-checked:before:absolute data-checked:before:content-[''] data-checked:before:top-[calc(0.5rem_-_1px)] data-checked:before:left-[calc(0.1875rem_-_1px)] data-checked:before:h-[0.125rem] data-checked:before:w-[0.1875rem] data-checked:before:bg-white data-checked:before:[transform:rotate(45deg)] data-checked:after:absolute data-checked:after:content-[''] data-checked:after:top-[calc(0.4375rem_-_1px)] data-checked:after:left-[calc(0.25rem_-_1px)] data-checked:after:h-[0.125rem] data-checked:after:w-[0.5625rem] data-checked:after:bg-white data-checked:after:[transform:rotate(-45deg)] data-indeterminate:before:absolute data-indeterminate:before:content-[''] data-indeterminate:before:top-1/2 data-indeterminate:before:left-1/2 data-indeterminate:before:h-[0.125rem] data-indeterminate:before:w-[0.625rem] data-indeterminate:before:bg-white data-indeterminate:before:[transform:translate(-50%,-50%)]"
         data-unchecked=""
-        id="base-ui-:rc:"
+        id="base-ui-:rh:"
         role="checkbox"
         tabindex="0"
       />
@@ -430,19 +430,18 @@ exports[`Checkbox should render default checkbox with label 1`] = `
   <div
     class="flex-1 box-border [:where(&)_*]:font-sans [&_*]:[box-sizing:inherit] [&_*::before]:[box-sizing:inherit] [&_*::after]:[box-sizing:inherit]"
   >
-    <label
+    <div
       class="inline-flex items-center max-w align-middle -webkit-tap-highlight-color mx-0 cursor-pointer text-[1rem] picasso-checkbox"
-      id="base-ui-:r5:"
     >
       <span
         class="relative inline-flex self-start align-middle [&_input]:appearance-none [&_input]:translate-x [&_input]:translate-y"
       >
         <span
           aria-checked="false"
-          aria-labelledby="base-ui-:r5:"
+          aria-labelledby="base-ui-:r4:"
           class="relative box-border inline-block h-4 w-4 rounded-sm border border-solid text-[1rem] leading-4 cursor-pointer transition-all duration-350 ease-in data-unchecked:bg-white data-unchecked:border-gray data-checked:bg-blue data-checked:border-blue data-checked:text-white data-indeterminate:bg-blue data-indeterminate:border-blue data-indeterminate:text-white [&[data-unchecked]:not([data-disabled]):hover]:border-gray [&[data-checked]:not([data-disabled]):hover]:bg-[color-mix(in_srgb,theme(colors.blue.500)_84%,white)] [&[data-checked]:not([data-disabled]):hover]:border-[color-mix(in_srgb,theme(colors.blue.500)_84%,white)] [&[data-indeterminate]:not([data-disabled]):hover]:bg-[color-mix(in_srgb,theme(colors.blue.500)_84%,white)] [&[data-indeterminate]:not([data-disabled]):hover]:border-[color-mix(in_srgb,theme(colors.blue.500)_84%,white)] focus-visible:outline-none focus-visible:shadow-[0_0_0_3px_color-mix(in_srgb,theme(colors.blue.500)_48%,transparent)] data-focused:shadow-[0_0_0_3px_color-mix(in_srgb,theme(colors.blue.500)_48%,transparent)] data-disabled:opacity-[0.48] data-disabled:cursor-default data-checked:before:absolute data-checked:before:content-[''] data-checked:before:top-[calc(0.5rem_-_1px)] data-checked:before:left-[calc(0.1875rem_-_1px)] data-checked:before:h-[0.125rem] data-checked:before:w-[0.1875rem] data-checked:before:bg-white data-checked:before:[transform:rotate(45deg)] data-checked:after:absolute data-checked:after:content-[''] data-checked:after:top-[calc(0.4375rem_-_1px)] data-checked:after:left-[calc(0.25rem_-_1px)] data-checked:after:h-[0.125rem] data-checked:after:w-[0.5625rem] data-checked:after:bg-white data-checked:after:[transform:rotate(-45deg)] data-indeterminate:before:absolute data-indeterminate:before:content-[''] data-indeterminate:before:top-1/2 data-indeterminate:before:left-1/2 data-indeterminate:before:h-[0.125rem] data-indeterminate:before:w-[0.625rem] data-indeterminate:before:bg-white data-indeterminate:before:[transform:translate(-50%,-50%)]"
           data-unchecked=""
-          id="base-ui-:r3:"
+          id="base-ui-:r5:"
           role="checkbox"
           tabindex="0"
         />
@@ -455,6 +454,7 @@ exports[`Checkbox should render default checkbox with label 1`] = `
       </span>
       <span
         class="inline-block leading-[1em] mb-0 text-graphite max-w-[calc(100%_ ml-[0.5em]"
+        id="base-ui-:r4:"
       >
         <span
           class="align-top text-[0.8125rem]"
@@ -462,7 +462,7 @@ exports[`Checkbox should render default checkbox with label 1`] = `
           Select item
         </span>
       </span>
-    </label>
+    </div>
   </div>
 </div>
 `;

--- a/packages/base/Checkbox/src/Checkbox/test.tsx
+++ b/packages/base/Checkbox/src/Checkbox/test.tsx
@@ -140,4 +140,74 @@ describe('Checkbox', () => {
       expect(container).toMatchSnapshot()
     })
   })
+
+  describe('single label-associated node (PF-2244)', () => {
+    it('matches getByLabelText once and resolves to the accessible control', () => {
+      const { getByLabelText, getByRole } = renderCheckbox({
+        label: 'No Rate Limit',
+      })
+
+      // Regression: the base-ui control renders a role="checkbox" span plus a
+      // hidden native <input>. Both used to be label-associated (the span via
+      // aria-labelledby, the input via the wrapping <label>), so getByLabelText
+      // threw "Found multiple elements". It must now match exactly the
+      // accessible control.
+      expect(getByLabelText('No Rate Limit')).toBe(
+        getByRole('checkbox', { name: 'No Rate Limit' })
+      )
+    })
+
+    it('toggles once when the label text is clicked', () => {
+      const onChange = jest.fn()
+      const { getByText } = renderCheckbox({
+        label: 'No Rate Limit',
+        onChange,
+      })
+
+      fireEvent.click(getByText('No Rate Limit'))
+
+      expect(onChange).toHaveBeenCalledTimes(1)
+    })
+
+    it('does not toggle when disabled and the label is clicked', () => {
+      const onChange = jest.fn()
+      const { getByText } = renderCheckbox({
+        label: 'No Rate Limit',
+        disabled: true,
+        onChange,
+      })
+
+      fireEvent.click(getByText('No Rate Limit'))
+
+      expect(onChange).not.toHaveBeenCalled()
+    })
+
+    it('moves focus to the control when the label text is clicked', () => {
+      const { getByText, getByRole } = renderCheckbox({
+        label: 'No Rate Limit',
+      })
+
+      fireEvent.click(getByText('No Rate Limit'))
+
+      expect(getByRole('checkbox')).toHaveFocus()
+    })
+
+    it('does not toggle when an interactive element inside the label is clicked', () => {
+      const onChange = jest.fn()
+      const { getByRole } = render(
+        <Checkbox
+          onChange={onChange}
+          label={
+            <>
+              I agree to the <a href='/terms'>Terms</a>
+            </>
+          }
+        />
+      )
+
+      fireEvent.click(getByRole('link', { name: 'Terms' }))
+
+      expect(onChange).not.toHaveBeenCalled()
+    })
+  })
 })

--- a/packages/base/FormLabel/src/FormControlLabel/FormControlLabel.tsx
+++ b/packages/base/FormLabel/src/FormControlLabel/FormControlLabel.tsx
@@ -29,13 +29,22 @@ export interface Props
   disabled?: boolean
   /** Whether to show asterisk or (optional) postfix as a 'required' decoration */
   requiredDecoration?: RequiredDecoration
+  /**
+   * Id of the label text node, for controls that name themselves via
+   * `aria-labelledby` (base-ui Checkbox/Switch). When provided, the wrapper is
+   * rendered as a non-`<label>` element so the control's hidden native input
+   * is not a second label-associated node — this keeps `getByLabelText` /
+   * `getByRole` matching a single accessible control. Label clicks are
+   * forwarded to the control to preserve click-to-toggle.
+   */
+  labelId?: string
   classes?: {
     root?: string
     label?: string
   }
 }
 
-const FormControlLabel = forwardRef<HTMLLabelElement, Props>(
+const FormControlLabel = forwardRef<HTMLLabelElement | HTMLDivElement, Props>(
   function FormControlLabel(props, ref) {
     const {
       control,
@@ -46,39 +55,110 @@ const FormControlLabel = forwardRef<HTMLLabelElement, Props>(
       requiredDecoration,
       titleCase,
       classes,
+      labelId,
+      onClick,
       ...rest
     } = props
 
     const { layout } = useFieldsLayoutContext()
     const isHorizontalLayout = layout === 'horizontal'
 
-    return (
-      <label
-        {...rest}
-        ref={ref}
-        className={twMerge(
-          'inline-flex items-center',
-          'max-w-full',
-          'align-middle',
-          '-webkit-tap-highlight-color-transparent',
-          'mx-0',
-          disabled ? 'cursor-default' : 'cursor-pointer',
-          isHorizontalLayout && 'col-start-1 col-span-2',
-          classes?.root,
-          className
-        )}
-        style={style}
-      >
+    const rootClassName = twMerge(
+      'inline-flex items-center',
+      'max-w-full',
+      'align-middle',
+      '-webkit-tap-highlight-color-transparent',
+      'mx-0',
+      disabled ? 'cursor-default' : 'cursor-pointer',
+      isHorizontalLayout && 'col-start-1 col-span-2',
+      classes?.root,
+      className
+    )
+
+    const content = (
+      <>
         {React.cloneElement(control, { disabled })}
         <FormLabel
           className={twMerge(disabled && 'pointer-events-auto', classes?.label)}
           as='span'
+          id={labelId}
           requiredDecoration={requiredDecoration}
           disabled={disabled}
           titleCase={titleCase}
         >
           {label}
         </FormLabel>
+      </>
+    )
+
+    // Opt-in path: control names itself via `aria-labelledby`, so we avoid a
+    // native `<label>` (which would make the control's hidden native input a
+    // second label-associated node) and re-create label click-to-toggle by
+    // forwarding clicks to that hidden input.
+    if (labelId !== undefined) {
+      const handleClick: React.MouseEventHandler<HTMLDivElement> = event => {
+        onClick?.(
+          event as unknown as React.MouseEvent<HTMLLabelElement, MouseEvent>
+        )
+
+        if (disabled || event.defaultPrevented) {
+          return
+        }
+
+        const target = event.target as HTMLElement
+
+        // Only forward clicks that land on the label text. Clicks on the
+        // control itself, its hidden input, or any interactive content inside
+        // the label are handled by those elements — this mirrors a native
+        // `<label>`, whose activation behavior excludes interactive descendants.
+        if (
+          target.closest(
+            'a[href],button,input,select,textarea,[role="checkbox"],[role="switch"],[role="radio"],[role="button"],[role="link"],[role="menuitem"],[role="tab"],[role="option"]'
+          )
+        ) {
+          return
+        }
+
+        const wrapper = event.currentTarget
+
+        wrapper
+          .querySelector<HTMLInputElement>('input[aria-hidden="true"]')
+          ?.click()
+
+        // A native `<label>` moves focus to its control on activation; restore
+        // that so keyboard interaction keeps working after a label-text click.
+        wrapper
+          .querySelector<HTMLElement>(
+            '[role="checkbox"],[role="switch"],[role="radio"]'
+          )
+          ?.focus()
+      }
+
+      return (
+        // Element-variance boundary: `rest` carries label-typed HTML
+        // attributes, but this wrapper renders a <div>. The attributes are
+        // runtime-compatible, so we resolve the variance once here.
+        <div
+          {...(rest as unknown as React.HTMLAttributes<HTMLDivElement>)}
+          ref={ref as React.ForwardedRef<HTMLDivElement>}
+          className={rootClassName}
+          style={style}
+          onClick={handleClick}
+        >
+          {content}
+        </div>
+      )
+    }
+
+    return (
+      <label
+        {...rest}
+        onClick={onClick}
+        ref={ref as React.ForwardedRef<HTMLLabelElement>}
+        className={rootClassName}
+        style={style}
+      >
+        {content}
       </label>
     )
   }

--- a/packages/base/Switch/src/Switch/Switch.tsx
+++ b/packages/base/Switch/src/Switch/Switch.tsx
@@ -1,4 +1,5 @@
 import { Switch as BaseUISwitch } from '@base-ui/react/switch'
+import { useBaseUiId } from '@base-ui/react/internals/useBaseUiId'
 import type { BaseProps, TextLabelProps } from '@toptal/picasso-shared'
 import { toReactChangeEvent } from '@toptal/picasso-shared'
 import type { ButtonHTMLAttributes, ReactNode } from 'react'
@@ -49,14 +50,28 @@ export const Switch = forwardRef<HTMLButtonElement, Props>(function Switch(
 
   const rootRest = rest as Omit<
     BaseUISwitch.Root.Props,
-    'checked' | 'disabled' | 'id' | 'value' | 'className' | 'style' | 'onCheckedChange'
+    | 'checked'
+    | 'disabled'
+    | 'id'
+    | 'value'
+    | 'className'
+    | 'style'
+    | 'onCheckedChange'
   >
+
+  // Name the control via `aria-labelledby` so it is the single
+  // label-associated node (see FormControlLabel `labelId`). Only relevant when
+  // there is a label to point at. `useBaseUiId` wraps `React.useId` with a
+  // React < 18 fallback, matching base-ui's own peer support.
+  const generatedLabelId = useBaseUiId()
+  const labelId = label ? generatedLabelId : undefined
 
   const switchElement = (
     <span className='relative inline-flex shrink-0 align-middle overflow-clip [overflow-clip-margin:6px]'>
       <BaseUISwitch.Root
         {...rootRest}
         ref={ref}
+        aria-labelledby={rootRest['aria-labelledby'] ?? labelId}
         checked={checked}
         className={twMerge(
           'w-[40px] h-[24px] p-0 relative inline-flex z-0 overflow-visible shrink-0 align-middle group',
@@ -103,6 +118,7 @@ export const Switch = forwardRef<HTMLButtonElement, Props>(function Switch(
         label: 'ml-[0.5em] mt-[0.25em] max-w-[calc(100%-1em-0.5em+1px)]',
       }}
       control={switchElement}
+      labelId={labelId}
       disabled={disabled}
       label={label}
       titleCase={titleCase}

--- a/packages/base/Switch/src/Switch/__snapshots__/test.tsx.snap
+++ b/packages/base/Switch/src/Switch/__snapshots__/test.tsx.snap
@@ -1,20 +1,19 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Switch behaves correctly when interacting 1`] = `
-<label
+<div
   class="inline-flex max-w align-middle -webkit-tap-highlight-color mx-0 cursor-pointer items-start text-lg"
   data-testid="switch"
-  id="base-ui-:rg:-label"
 >
   <span
     class="relative inline-flex shrink-0 align-middle overflow-clip [overflow-clip"
   >
     <span
       aria-checked="true"
-      aria-labelledby="base-ui-:rg:-label"
+      aria-labelledby="base-ui-:rk:"
       class="w-[40px] h-[24px] p-0 relative inline-flex z-0 overflow-visible shrink-0 align-middle group cursor-pointer outline-none data-[disabled]:cursor-default"
       data-checked=""
-      id="base-ui-:rf:"
+      id="base-ui-:rl:"
       role="switch"
       tabindex="0"
     >
@@ -28,7 +27,7 @@ exports[`Switch behaves correctly when interacting 1`] = `
     </span>
     <input
       aria-hidden="true"
-      id="base-ui-:rg:"
+      id="base-ui-:rm:"
       style="clip-path: inset(50%); overflow: hidden; white-space: nowrap; border: 0px; padding: 0px; width: 1px; height: 1px; margin: -1px; position: fixed; top: 0px; left: 0px;"
       tabindex="-1"
       type="checkbox"
@@ -36,6 +35,7 @@ exports[`Switch behaves correctly when interacting 1`] = `
   </span>
   <span
     class="inline-block leading-[1em] mb-0 text-graphite ml-[0.5em] mt-[0.25em] max-w-[calc(100%-1em"
+    id="base-ui-:rk:"
   >
     <span
       class="align-top text-[0.8125rem]"
@@ -43,7 +43,7 @@ exports[`Switch behaves correctly when interacting 1`] = `
       Switch
     </span>
   </span>
-</label>
+</div>
 `;
 
 exports[`Switch renders default Switch without label 1`] = `
@@ -59,7 +59,7 @@ exports[`Switch renders default Switch without label 1`] = `
         class="w-[40px] h-[24px] p-0 relative inline-flex z-0 overflow-visible shrink-0 align-middle group cursor-pointer outline-none data-[disabled]:cursor-default"
         data-testid="switch"
         data-unchecked=""
-        id="base-ui-:r0:"
+        id="base-ui-:r1:"
         role="switch"
         tabindex="0"
       >
@@ -73,7 +73,7 @@ exports[`Switch renders default Switch without label 1`] = `
       </span>
       <input
         aria-hidden="true"
-        id="base-ui-:r1:"
+        id="base-ui-:r2:"
         style="clip-path: inset(50%); overflow: hidden; white-space: nowrap; border: 0px; padding: 0px; width: 1px; height: 1px; margin: -1px; position: fixed; top: 0px; left: 0px;"
         tabindex="-1"
         type="checkbox"
@@ -84,10 +84,9 @@ exports[`Switch renders default Switch without label 1`] = `
 `;
 
 exports[`Switch renders disabled state 1`] = `
-<label
+<div
   class="inline-flex max-w align-middle -webkit-tap-highlight-color mx-0 cursor-default items-start text-lg"
   data-testid="switch"
-  id="base-ui-:r7:-label"
 >
   <span
     class="relative inline-flex shrink-0 align-middle overflow-clip [overflow-clip"
@@ -96,11 +95,11 @@ exports[`Switch renders disabled state 1`] = `
     <span
       aria-checked="false"
       aria-disabled="true"
-      aria-labelledby="base-ui-:r7:-label"
+      aria-labelledby="base-ui-:r8:"
       class="w-[40px] h-[24px] p-0 relative inline-flex z-0 overflow-visible shrink-0 align-middle group cursor-pointer outline-none data-[disabled]:cursor-default"
       data-disabled=""
       data-unchecked=""
-      id="base-ui-:r6:"
+      id="base-ui-:r9:"
       role="switch"
       tabindex="-1"
     >
@@ -116,7 +115,7 @@ exports[`Switch renders disabled state 1`] = `
     <input
       aria-hidden="true"
       disabled=""
-      id="base-ui-:r7:"
+      id="base-ui-:ra:"
       style="clip-path: inset(50%); overflow: hidden; white-space: nowrap; border: 0px; padding: 0px; width: 1px; height: 1px; margin: -1px; position: fixed; top: 0px; left: 0px;"
       tabindex="-1"
       type="checkbox"
@@ -124,6 +123,7 @@ exports[`Switch renders disabled state 1`] = `
   </span>
   <span
     class="inline-block leading-[1em] mb-0 text-graphite pointer-events ml-[0.5em] mt-[0.25em] max-w-[calc(100%-1em"
+    id="base-ui-:r8:"
   >
     <span
       class="align-top text-[0.8125rem]"
@@ -131,5 +131,5 @@ exports[`Switch renders disabled state 1`] = `
       Disabled
     </span>
   </span>
-</label>
+</div>
 `;

--- a/packages/base/Switch/src/Switch/test.tsx
+++ b/packages/base/Switch/src/Switch/test.tsx
@@ -76,4 +76,40 @@ describe('Switch', () => {
     expect(onChange).toHaveBeenCalled()
     expect(getByTestId('switch')).toMatchSnapshot()
   })
+
+  describe('single label-associated node (PF-2244)', () => {
+    it('matches getByLabelText once and resolves to the accessible control', () => {
+      const { getByLabelText, getByRole } = renderSwitch({ label: 'A Switch' })
+
+      // Regression: the base-ui control renders a role="switch" span plus a
+      // hidden native <input>. Both used to be label-associated, so
+      // getByLabelText threw "Found multiple elements". It must now match
+      // exactly the accessible control.
+      expect(getByLabelText('A Switch')).toBe(
+        getByRole('switch', { name: 'A Switch' })
+      )
+    })
+
+    it('toggles when the label text is clicked', () => {
+      const onChange = jest.fn()
+      const { getByText } = renderSwitch({ label: 'A Switch', onChange })
+
+      fireEvent.click(getByText('A Switch'))
+
+      expect(onChange).toHaveBeenCalledTimes(1)
+    })
+
+    it('does not toggle when disabled and the label text is clicked', () => {
+      const onChange = jest.fn()
+      const { getByText } = renderSwitch({
+        label: 'A Switch',
+        disabled: true,
+        onChange,
+      })
+
+      fireEvent.click(getByText('A Switch'))
+
+      expect(onChange).not.toHaveBeenCalled()
+    })
+  })
 })

--- a/packages/picasso-forms/src/Checkbox/__snapshots__/test.tsx.snap
+++ b/packages/picasso-forms/src/Checkbox/__snapshots__/test.tsx.snap
@@ -36,9 +36,8 @@ exports[`Form.Checkbox default render for checkboxes in a group 1`] = `
               <div
                 class="box-border m-0 leading-none pt-0 pb-0 [&_.picasso-checkbox]:mb-[0.5em]"
               >
-                <label
+                <div
                   class="inline-flex items-center max-w align-middle -webkit-tap-highlight-color mx-0 cursor-pointer text-[1rem] picasso-checkbox"
-                  id="base-ui-:r8:"
                 >
                   <span
                     class="relative inline-flex self-start align-middle [&_input]:appearance-none [&_input]:translate-x [&_input]:translate-y"
@@ -46,44 +45,6 @@ exports[`Form.Checkbox default render for checkboxes in a group 1`] = `
                     <span
                       aria-checked="false"
                       aria-labelledby="base-ui-:r8:"
-                      class="relative box-border inline-block h-4 w-4 rounded-sm border border-solid text-[1rem] leading-4 cursor-pointer transition-all duration-350 ease-in data-unchecked:bg-white data-unchecked:border-gray data-checked:bg-blue data-checked:border-blue data-checked:text-white data-indeterminate:bg-blue data-indeterminate:border-blue data-indeterminate:text-white [&[data-unchecked]:not([data-disabled]):hover]:border-gray [&[data-checked]:not([data-disabled]):hover]:bg-[color-mix(in_srgb,theme(colors.blue.500)_84%,white)] [&[data-checked]:not([data-disabled]):hover]:border-[color-mix(in_srgb,theme(colors.blue.500)_84%,white)] [&[data-indeterminate]:not([data-disabled]):hover]:bg-[color-mix(in_srgb,theme(colors.blue.500)_84%,white)] [&[data-indeterminate]:not([data-disabled]):hover]:border-[color-mix(in_srgb,theme(colors.blue.500)_84%,white)] focus-visible:outline-none focus-visible:shadow-[0_0_0_3px_color-mix(in_srgb,theme(colors.blue.500)_48%,transparent)] data-focused:shadow-[0_0_0_3px_color-mix(in_srgb,theme(colors.blue.500)_48%,transparent)] data-disabled:opacity-[0.48] data-disabled:cursor-default data-checked:before:absolute data-checked:before:content-[''] data-checked:before:top-[calc(0.5rem_-_1px)] data-checked:before:left-[calc(0.1875rem_-_1px)] data-checked:before:h-[0.125rem] data-checked:before:w-[0.1875rem] data-checked:before:bg-white data-checked:before:[transform:rotate(45deg)] data-checked:after:absolute data-checked:after:content-[''] data-checked:after:top-[calc(0.4375rem_-_1px)] data-checked:after:left-[calc(0.25rem_-_1px)] data-checked:after:h-[0.125rem] data-checked:after:w-[0.5625rem] data-checked:after:bg-white data-checked:after:[transform:rotate(-45deg)] data-indeterminate:before:absolute data-indeterminate:before:content-[''] data-indeterminate:before:top-1/2 data-indeterminate:before:left-1/2 data-indeterminate:before:h-[0.125rem] data-indeterminate:before:w-[0.625rem] data-indeterminate:before:bg-white data-indeterminate:before:[transform:translate(-50%,-50%)]"
-                      data-unchecked=""
-                      id="base-ui-:r6:"
-                      role="checkbox"
-                      tabindex="0"
-                    />
-                    <input
-                      aria-hidden="true"
-                      name="checkbox-group"
-                      style="clip-path: inset(50%); overflow: hidden; white-space: nowrap; border: 0px; padding: 0px; width: 1px; height: 1px; margin: -1px; position: absolute;"
-                      tabindex="-1"
-                      type="checkbox"
-                    />
-                  </span>
-                  <span
-                    class="inline-block leading-[1em] mb-0 text-graphite max-w-[calc(100%_ ml-[0.5em]"
-                  >
-                    <span
-                      class="align-top text-[0.8125rem]"
-                    >
-                      checkbox-label-0
-                    </span>
-                  </span>
-                </label>
-              </div>
-              <div
-                class="box-border m-0 leading-none pt-0 pb-0 [&_.picasso-checkbox]:mb-[0.5em]"
-              >
-                <label
-                  class="inline-flex items-center max-w align-middle -webkit-tap-highlight-color mx-0 cursor-pointer text-[1rem] picasso-checkbox"
-                  id="base-ui-:rb:"
-                >
-                  <span
-                    class="relative inline-flex self-start align-middle [&_input]:appearance-none [&_input]:translate-x [&_input]:translate-y"
-                  >
-                    <span
-                      aria-checked="false"
-                      aria-labelledby="base-ui-:rb:"
                       class="relative box-border inline-block h-4 w-4 rounded-sm border border-solid text-[1rem] leading-4 cursor-pointer transition-all duration-350 ease-in data-unchecked:bg-white data-unchecked:border-gray data-checked:bg-blue data-checked:border-blue data-checked:text-white data-indeterminate:bg-blue data-indeterminate:border-blue data-indeterminate:text-white [&[data-unchecked]:not([data-disabled]):hover]:border-gray [&[data-checked]:not([data-disabled]):hover]:bg-[color-mix(in_srgb,theme(colors.blue.500)_84%,white)] [&[data-checked]:not([data-disabled]):hover]:border-[color-mix(in_srgb,theme(colors.blue.500)_84%,white)] [&[data-indeterminate]:not([data-disabled]):hover]:bg-[color-mix(in_srgb,theme(colors.blue.500)_84%,white)] [&[data-indeterminate]:not([data-disabled]):hover]:border-[color-mix(in_srgb,theme(colors.blue.500)_84%,white)] focus-visible:outline-none focus-visible:shadow-[0_0_0_3px_color-mix(in_srgb,theme(colors.blue.500)_48%,transparent)] data-focused:shadow-[0_0_0_3px_color-mix(in_srgb,theme(colors.blue.500)_48%,transparent)] data-disabled:opacity-[0.48] data-disabled:cursor-default data-checked:before:absolute data-checked:before:content-[''] data-checked:before:top-[calc(0.5rem_-_1px)] data-checked:before:left-[calc(0.1875rem_-_1px)] data-checked:before:h-[0.125rem] data-checked:before:w-[0.1875rem] data-checked:before:bg-white data-checked:before:[transform:rotate(45deg)] data-checked:after:absolute data-checked:after:content-[''] data-checked:after:top-[calc(0.4375rem_-_1px)] data-checked:after:left-[calc(0.25rem_-_1px)] data-checked:after:h-[0.125rem] data-checked:after:w-[0.5625rem] data-checked:after:bg-white data-checked:after:[transform:rotate(-45deg)] data-indeterminate:before:absolute data-indeterminate:before:content-[''] data-indeterminate:before:top-1/2 data-indeterminate:before:left-1/2 data-indeterminate:before:h-[0.125rem] data-indeterminate:before:w-[0.625rem] data-indeterminate:before:bg-white data-indeterminate:before:[transform:translate(-50%,-50%)]"
                       data-unchecked=""
                       id="base-ui-:r9:"
@@ -100,6 +61,45 @@ exports[`Form.Checkbox default render for checkboxes in a group 1`] = `
                   </span>
                   <span
                     class="inline-block leading-[1em] mb-0 text-graphite max-w-[calc(100%_ ml-[0.5em]"
+                    id="base-ui-:r8:"
+                  >
+                    <span
+                      class="align-top text-[0.8125rem]"
+                    >
+                      checkbox-label-0
+                    </span>
+                  </span>
+                </div>
+              </div>
+              <div
+                class="box-border m-0 leading-none pt-0 pb-0 [&_.picasso-checkbox]:mb-[0.5em]"
+              >
+                <div
+                  class="inline-flex items-center max-w align-middle -webkit-tap-highlight-color mx-0 cursor-pointer text-[1rem] picasso-checkbox"
+                >
+                  <span
+                    class="relative inline-flex self-start align-middle [&_input]:appearance-none [&_input]:translate-x [&_input]:translate-y"
+                  >
+                    <span
+                      aria-checked="false"
+                      aria-labelledby="base-ui-:rc:"
+                      class="relative box-border inline-block h-4 w-4 rounded-sm border border-solid text-[1rem] leading-4 cursor-pointer transition-all duration-350 ease-in data-unchecked:bg-white data-unchecked:border-gray data-checked:bg-blue data-checked:border-blue data-checked:text-white data-indeterminate:bg-blue data-indeterminate:border-blue data-indeterminate:text-white [&[data-unchecked]:not([data-disabled]):hover]:border-gray [&[data-checked]:not([data-disabled]):hover]:bg-[color-mix(in_srgb,theme(colors.blue.500)_84%,white)] [&[data-checked]:not([data-disabled]):hover]:border-[color-mix(in_srgb,theme(colors.blue.500)_84%,white)] [&[data-indeterminate]:not([data-disabled]):hover]:bg-[color-mix(in_srgb,theme(colors.blue.500)_84%,white)] [&[data-indeterminate]:not([data-disabled]):hover]:border-[color-mix(in_srgb,theme(colors.blue.500)_84%,white)] focus-visible:outline-none focus-visible:shadow-[0_0_0_3px_color-mix(in_srgb,theme(colors.blue.500)_48%,transparent)] data-focused:shadow-[0_0_0_3px_color-mix(in_srgb,theme(colors.blue.500)_48%,transparent)] data-disabled:opacity-[0.48] data-disabled:cursor-default data-checked:before:absolute data-checked:before:content-[''] data-checked:before:top-[calc(0.5rem_-_1px)] data-checked:before:left-[calc(0.1875rem_-_1px)] data-checked:before:h-[0.125rem] data-checked:before:w-[0.1875rem] data-checked:before:bg-white data-checked:before:[transform:rotate(45deg)] data-checked:after:absolute data-checked:after:content-[''] data-checked:after:top-[calc(0.4375rem_-_1px)] data-checked:after:left-[calc(0.25rem_-_1px)] data-checked:after:h-[0.125rem] data-checked:after:w-[0.5625rem] data-checked:after:bg-white data-checked:after:[transform:rotate(-45deg)] data-indeterminate:before:absolute data-indeterminate:before:content-[''] data-indeterminate:before:top-1/2 data-indeterminate:before:left-1/2 data-indeterminate:before:h-[0.125rem] data-indeterminate:before:w-[0.625rem] data-indeterminate:before:bg-white data-indeterminate:before:[transform:translate(-50%,-50%)]"
+                      data-unchecked=""
+                      id="base-ui-:rd:"
+                      role="checkbox"
+                      tabindex="0"
+                    />
+                    <input
+                      aria-hidden="true"
+                      name="checkbox-group"
+                      style="clip-path: inset(50%); overflow: hidden; white-space: nowrap; border: 0px; padding: 0px; width: 1px; height: 1px; margin: -1px; position: absolute;"
+                      tabindex="-1"
+                      type="checkbox"
+                    />
+                  </span>
+                  <span
+                    class="inline-block leading-[1em] mb-0 text-graphite max-w-[calc(100%_ ml-[0.5em]"
+                    id="base-ui-:rc:"
                   >
                     <span
                       class="align-top text-[0.8125rem]"
@@ -107,7 +107,7 @@ exports[`Form.Checkbox default render for checkboxes in a group 1`] = `
                       checkbox-label-1
                     </span>
                   </span>
-                </label>
+                </div>
               </div>
             </div>
           </div>
@@ -134,19 +134,18 @@ exports[`Form.Checkbox default render for single checkbox 1`] = `
           data-field-has-error="false"
           data-testid="single-checkbox"
         >
-          <label
+          <div
             class="inline-flex items-center max-w align-middle -webkit-tap-highlight-color mx-0 cursor-pointer text-[1rem] picasso-checkbox"
-            id="single-checkbox-label"
           >
             <span
               class="relative inline-flex self-start align-middle [&_input]:appearance-none [&_input]:translate-x [&_input]:translate-y"
             >
               <span
                 aria-checked="false"
-                aria-labelledby="single-checkbox-label"
+                aria-labelledby="base-ui-:r0:"
                 class="relative box-border inline-block h-4 w-4 rounded-sm border border-solid text-[1rem] leading-4 cursor-pointer transition-all duration-350 ease-in data-unchecked:bg-white data-unchecked:border-gray data-checked:bg-blue data-checked:border-blue data-checked:text-white data-indeterminate:bg-blue data-indeterminate:border-blue data-indeterminate:text-white [&[data-unchecked]:not([data-disabled]):hover]:border-gray [&[data-checked]:not([data-disabled]):hover]:bg-[color-mix(in_srgb,theme(colors.blue.500)_84%,white)] [&[data-checked]:not([data-disabled]):hover]:border-[color-mix(in_srgb,theme(colors.blue.500)_84%,white)] [&[data-indeterminate]:not([data-disabled]):hover]:bg-[color-mix(in_srgb,theme(colors.blue.500)_84%,white)] [&[data-indeterminate]:not([data-disabled]):hover]:border-[color-mix(in_srgb,theme(colors.blue.500)_84%,white)] focus-visible:outline-none focus-visible:shadow-[0_0_0_3px_color-mix(in_srgb,theme(colors.blue.500)_48%,transparent)] data-focused:shadow-[0_0_0_3px_color-mix(in_srgb,theme(colors.blue.500)_48%,transparent)] data-disabled:opacity-[0.48] data-disabled:cursor-default data-checked:before:absolute data-checked:before:content-[''] data-checked:before:top-[calc(0.5rem_-_1px)] data-checked:before:left-[calc(0.1875rem_-_1px)] data-checked:before:h-[0.125rem] data-checked:before:w-[0.1875rem] data-checked:before:bg-white data-checked:before:[transform:rotate(45deg)] data-checked:after:absolute data-checked:after:content-[''] data-checked:after:top-[calc(0.4375rem_-_1px)] data-checked:after:left-[calc(0.25rem_-_1px)] data-checked:after:h-[0.125rem] data-checked:after:w-[0.5625rem] data-checked:after:bg-white data-checked:after:[transform:rotate(-45deg)] data-indeterminate:before:absolute data-indeterminate:before:content-[''] data-indeterminate:before:top-1/2 data-indeterminate:before:left-1/2 data-indeterminate:before:h-[0.125rem] data-indeterminate:before:w-[0.625rem] data-indeterminate:before:bg-white data-indeterminate:before:[transform:translate(-50%,-50%)]"
                 data-unchecked=""
-                id="base-ui-:r0:"
+                id="base-ui-:r1:"
                 role="checkbox"
                 tabindex="0"
                 type="checkbox"
@@ -162,6 +161,7 @@ exports[`Form.Checkbox default render for single checkbox 1`] = `
             </span>
             <span
               class="inline-block leading-[1em] mb-0 text-graphite max-w-[calc(100%_ ml-[0.5em]"
+              id="base-ui-:r0:"
             >
               <span
                 class="align-top text-[0.8125rem]"
@@ -169,7 +169,7 @@ exports[`Form.Checkbox default render for single checkbox 1`] = `
                 The checkbox label
               </span>
             </span>
-          </label>
+          </div>
         </div>
       </form>
     </div>
@@ -193,19 +193,18 @@ exports[`Form.Checkbox required with asterisk single checkbox 1`] = `
           data-field-has-error="false"
           data-testid="single-checkbox"
         >
-          <label
+          <div
             class="inline-flex items-center max-w align-middle -webkit-tap-highlight-color mx-0 cursor-pointer text-[1rem] picasso-checkbox"
-            id="single-checkbox-label"
           >
             <span
               class="relative inline-flex self-start align-middle [&_input]:appearance-none [&_input]:translate-x [&_input]:translate-y"
             >
               <span
                 aria-checked="false"
-                aria-labelledby="single-checkbox-label"
+                aria-labelledby="base-ui-:rg:"
                 class="relative box-border inline-block h-4 w-4 rounded-sm border border-solid text-[1rem] leading-4 cursor-pointer transition-all duration-350 ease-in data-unchecked:bg-white data-unchecked:border-gray data-checked:bg-blue data-checked:border-blue data-checked:text-white data-indeterminate:bg-blue data-indeterminate:border-blue data-indeterminate:text-white [&[data-unchecked]:not([data-disabled]):hover]:border-gray [&[data-checked]:not([data-disabled]):hover]:bg-[color-mix(in_srgb,theme(colors.blue.500)_84%,white)] [&[data-checked]:not([data-disabled]):hover]:border-[color-mix(in_srgb,theme(colors.blue.500)_84%,white)] [&[data-indeterminate]:not([data-disabled]):hover]:bg-[color-mix(in_srgb,theme(colors.blue.500)_84%,white)] [&[data-indeterminate]:not([data-disabled]):hover]:border-[color-mix(in_srgb,theme(colors.blue.500)_84%,white)] focus-visible:outline-none focus-visible:shadow-[0_0_0_3px_color-mix(in_srgb,theme(colors.blue.500)_48%,transparent)] data-focused:shadow-[0_0_0_3px_color-mix(in_srgb,theme(colors.blue.500)_48%,transparent)] data-disabled:opacity-[0.48] data-disabled:cursor-default data-checked:before:absolute data-checked:before:content-[''] data-checked:before:top-[calc(0.5rem_-_1px)] data-checked:before:left-[calc(0.1875rem_-_1px)] data-checked:before:h-[0.125rem] data-checked:before:w-[0.1875rem] data-checked:before:bg-white data-checked:before:[transform:rotate(45deg)] data-checked:after:absolute data-checked:after:content-[''] data-checked:after:top-[calc(0.4375rem_-_1px)] data-checked:after:left-[calc(0.25rem_-_1px)] data-checked:after:h-[0.125rem] data-checked:after:w-[0.5625rem] data-checked:after:bg-white data-checked:after:[transform:rotate(-45deg)] data-indeterminate:before:absolute data-indeterminate:before:content-[''] data-indeterminate:before:top-1/2 data-indeterminate:before:left-1/2 data-indeterminate:before:h-[0.125rem] data-indeterminate:before:w-[0.625rem] data-indeterminate:before:bg-white data-indeterminate:before:[transform:translate(-50%,-50%)]"
                 data-unchecked=""
-                id="base-ui-:rc:"
+                id="base-ui-:rh:"
                 role="checkbox"
                 tabindex="0"
                 type="checkbox"
@@ -221,6 +220,7 @@ exports[`Form.Checkbox required with asterisk single checkbox 1`] = `
             </span>
             <span
               class="inline-block leading-[1em] mb-0 text-graphite max-w-[calc(100%_ ml-[0.5em]"
+              id="base-ui-:rg:"
             >
               <span
                 class="align-top text-[0.8125rem]"
@@ -233,7 +233,7 @@ exports[`Form.Checkbox required with asterisk single checkbox 1`] = `
                 The checkbox label
               </span>
             </span>
-          </label>
+          </div>
         </div>
       </form>
     </div>


### PR DESCRIPTION
## What & why

[PF-2244](https://toptal-core.atlassian.net/browse/PF-2244): base-ui form controls (`Checkbox`, `Switch`) render **two** label-associated nodes for one control — an accessible `role` element (named via `aria-labelledby`) plus a hidden native `<input>` (label-associated because it's wrapped in `FormControlLabel`'s `<label>`). So `getByLabelText` / `getByText` / `getByRole` match **twice** and throw *"Found multiple elements"*, breaking ~17 consumer form tests across repos (Staff Portal, Client Portal, …).

Root cause was confirmed by rendering the real base-ui control: the native input is already `aria-hidden` (so `getByRole` already matches once), but `getByLabelText` reads `.labels`, which ignores `aria-hidden`. You can't fix it with attribute tweaks while keeping a native `<label>` — dropping `aria-labelledby` kills the accessible name, and detaching the input's native association also drops the name and click-to-toggle.

## The fix

Opt-in at the shared `FormControlLabel`, so it fixes `Checkbox` + `Switch` at once and `Radio` when it migrates:

- **`FormControlLabel`** gains an optional `labelId` prop. When provided it renders a non-`<label>` wrapper (so the hidden input is no longer a second label-associated node), puts `labelId` on the label text, and forwards label-text clicks to the control's hidden input to preserve click-to-toggle. **The default `<label>` path is unchanged.**
- **`Checkbox` / `Switch`** generate a `labelId`, name their base-ui root via `aria-labelledby={labelId}`, and pass `labelId` to `FormControlLabel`.

Result: `getByLabelText(label)` resolves to exactly the accessible control; `getByRole('checkbox'|'switch', { name })` still works; label clicks still toggle.

## Verification

- New regression tests (Checkbox + Switch): single `getByLabelText` match resolving to the accessible control, toggle-once on label click, no toggle when disabled.
- **Radio + `FormControlLabel` own tests: zero snapshot churn** — the default path is byte-identical, so `Radio` and other consumers are unaffected.
- Full unit suite green; typecheck + lint clean. Snapshot updates are limited to the label→`<div>` / `aria-labelledby` change (+ opaque base-ui id shifts) in Checkbox/Switch/ButtonCheckbox/`Form.Checkbox`.
- End-to-end consumer validation via an alpha against the failing specs is in progress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[PF-2244]: https://toptal-core.atlassian.net/browse/PF-2244?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ