### PR TITLE
[PF-2255] Scope FormControlLabel click-forwarding to the label subtree

### DIFF
--- a/packages/base/Checkbox/src/Checkbox/test.tsx
+++ b/packages/base/Checkbox/src/Checkbox/test.tsx
@@ -209,5 +209,20 @@ describe('Checkbox', () => {
 
       expect(onChange).not.toHaveBeenCalled()
     })
+
+    describe('when nested inside a role="menuitem"', () => {
+      it('toggles on label-text click', () => {
+        const onChange = jest.fn()
+        const { getByText } = render(
+          <div role='menuitem'>
+            <Checkbox onChange={onChange} label='Select item' />
+          </div>
+        )
+
+        fireEvent.click(getByText('Select item'))
+
+        expect(onChange).toHaveBeenCalledTimes(1)
+      })
+    })
   })
 })

--- a/packages/base/FormLabel/src/FormControlLabel/FormControlLabel.tsx
+++ b/packages/base/FormLabel/src/FormControlLabel/FormControlLabel.tsx
@@ -106,20 +106,19 @@ const FormControlLabel = forwardRef<HTMLLabelElement | HTMLDivElement, Props>(
         }
 
         const target = event.target as HTMLElement
+        const wrapper = event.currentTarget
 
-        // Only forward clicks that land on the label text. Clicks on the
-        // control itself, its hidden input, or any interactive content inside
-        // the label are handled by those elements — this mirrors a native
-        // `<label>`, whose activation behavior excludes interactive descendants.
-        if (
-          target.closest(
-            'a[href],button,input,select,textarea,[role="checkbox"],[role="switch"],[role="radio"],[role="button"],[role="link"],[role="menuitem"],[role="tab"],[role="option"]'
-          )
-        ) {
+        // Mirror a native `<label>`: don't forward when the click lands on
+        // interactive content, but only *inside* the label subtree. `closest()`
+        // also matches interactive ancestors (e.g. a wrapping `role="menuitem"`
+        // in a dropdown filter), which must not suppress forwarding.
+        const interactive = target.closest(
+          'a[href],button,input,select,textarea,[role="checkbox"],[role="switch"],[role="radio"],[role="button"],[role="link"],[role="menuitem"],[role="tab"],[role="option"]'
+        )
+
+        if (interactive && wrapper.contains(interactive)) {
           return
         }
-
-        const wrapper = event.currentTarget
 
         wrapper
           .querySelector<HTMLInputElement>('input[aria-hidden="true"]')

--- a/packages/base/Switch/src/Switch/test.tsx
+++ b/packages/base/Switch/src/Switch/test.tsx
@@ -111,5 +111,20 @@ describe('Switch', () => {
 
       expect(onChange).not.toHaveBeenCalled()
     })
+
+    describe('when nested inside a role="menuitem"', () => {
+      it('toggles on label-text click', () => {
+        const onChange = jest.fn()
+        const { getByText } = render(
+          <div role='menuitem'>
+            <Switch onChange={onChange} label='A Switch' />
+          </div>
+        )
+
+        fireEvent.click(getByText('A Switch'))
+
+        expect(onChange).toHaveBeenCalledTimes(1)
+      })
+    })
   })
 })


### PR DESCRIPTION
[PF-2255](https://toptal-core.atlassian.net/browse/PF-2255)

### Description

Regression from the PF-2244 fix ("single label-associated node", #5051): a labeled `Checkbox` / `Switch` rendered **inside** a `role="menuitem"` / `option` / `tab` ancestor (the standard dropdown-filter pattern) loses **label-text click** activation — the control never toggles.

**Root cause.** The PF-2244 fix renders the wrapper as a `<div>` and re-creates label click-to-toggle by forwarding label clicks to the control's hidden input, suppressing forwarding for clicks on interactive content via `target.closest(INTERACTIVE_SELECTOR)`. `Element.closest()` walks the **whole ancestor chain**, so when the control sits inside a `role="menuitem"`, a click on the label text matches the *ancestor* menuitem and forwarding bails. Native `<label>` semantics only exclude interactive elements **inside** the label subtree. Clicking the control box itself still worked, which is why the component suite stayed green; it surfaced only in consumer integration tests (client-portal `Talent.cy.tsx` "Associated Job Contact filter").

**Fix.** Bound the guard to the label's own subtree, mirroring native `<label>`:

```js
const interactive = target.closest(INTERACTIVE_SELECTOR)
if (interactive && wrapper.contains(interactive)) return // wrapper = event.currentTarget
```

- `wrapper` is `event.currentTarget` (the label root) — no new ref needed.
- The hidden-input `!==` guard from the ticket suggestion was intentionally **dropped**: the hidden input is in-subtree, so it still bails, which keeps the `hiddenInput.click()` re-entry from double-toggling.
- Radio is **not** affected (it doesn't pass `labelId`, so it stays on the native `<label>` path). The `querySelector` focus-restore step is already wrapper-scoped and unchanged.

### How to test

- Temploy
- Render a labeled `Checkbox` (or `Switch`) inside a `role="menuitem"` ancestor — e.g. a `Dropdown`/menu filter — and click the **label text** (not the box): the control now toggles. Before this fix it did nothing.
- Clicking a genuinely interactive element **inside** the label (e.g. an `<a href>` in the label) still must **not** toggle the control.
- Consumer validation: alpha published from this PR → client-portal `containers/pages/Team/Talent/Talent.cy.tsx` "when Associated Job Contact filter is selected › triggers the query refetch" goes green.

### Screenshots

No visual change — this is a click-activation (behavioral) fix.

| Before                                     | After                                      |
| ------------------------------------------ | ------------------------------------------ |
| Label-text click inside a menu filter is a no-op — checkbox never toggles | Label-text click toggles the checkbox, filter fires |

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [ ] Double check if `picasso-tailwind-merge` requires major update (check its `README.md`)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [ ] Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core — _N/A, no design change_
- [ ] Annotate all `props` in component with documentation — _N/A, no API change_
- [ ] Create `examples` for component — _N/A, no API change_
- [ ] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md). — _restores native label-text activation (pointer accessibility)_
- [x] Self reviewed
- [x] Covered with tests ([visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md) included) — _regression tests added to Checkbox + Switch for the `role="menuitem"` nesting case_

**Breaking change**

- [ ] codemod is created and showcased in the changeset — _N/A, not a breaking change_
- [ ] test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>Alpha packages</summary>
<br />

Manually trigger the [publish.yml](https://github.com/toptal/picasso/actions/workflows/publish.yml) workflow to publish alpha packages. Specify pull request number as a parameter (only digits, e.g. `123`).

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[PF-2255]: https://toptal-core.atlassian.net/browse/PF-2255?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ