### PR TITLE
[PF-2253] Refactor Tooltip open-arbitration and fix pointer-focus open

### DIFF
--- a/.changeset/tooltip-suppress-pointer-focus-open.md
+++ b/.changeset/tooltip-suppress-pointer-focus-open.md
@@ -1,0 +1,24 @@
+---
+'@toptal/picasso-tooltip': patch
+---
+
+### Tooltip
+
+- Suppress opening on pointer-initiated focus. A `mousedown` that focuses a
+  tooltip trigger made base-ui open the tooltip mid-click (its `useFocus`
+  reports `trigger-focus`, and `matchesFocusVisible` treats that focus as
+  focus-visible under jsdom and for typeable triggers such as inputs). The
+  popup could then flash open over its own trigger and swallow the trailing
+  click, leaving the wrapped control effectively unclickable. Picasso now
+  tracks the input modality and honors base-ui's focus-open only when the focus
+  was keyboard-driven; pointer-initiated focus no longer opens the tooltip.
+  Keyboard focus still opens it, preserving accessibility. Note this is
+  stricter than the pre-migration build for tooltip-wrapped inputs, which
+  previously also flashed open on click. [PF-2253]
+- The pointer-focus suppression now also applies to controlled tooltips: a
+  pointer-initiated focus no longer calls `onOpen` on a controlled tooltip
+  either. This is the only controlled-mode behavior change — hover-timing, the
+  click-dismiss latch and follow-cursor roam-hide keep their original
+  uncontrolled-only gating, so a controlled tooltip still forwards base-ui's
+  hover-open to `onOpen` as before. See
+  `docs/decisions/20-tooltip-open-arbitration.md`. [PF-2253]

--- a/.changeset/utils-pointer-modality.md
+++ b/.changeset/utils-pointer-modality.md
@@ -1,0 +1,12 @@
+---
+'@toptal/picasso-utils': minor
+---
+
+### Utils
+
+- Add `isPointerModality`, `subscribePointerModality` and
+  `unsubscribePointerModality` — a shared, ref-counted input-modality tracker
+  (window-capture `keydown`/`pointerdown` listeners) for telling
+  pointer-initiated focus from keyboard-initiated focus in environments where
+  `:focus-visible` cannot. First consumer: Tooltip's pointer-focus open
+  suppression. [PF-2253]

--- a/docs/decisions/20-tooltip-open-arbitration.md
+++ b/docs/decisions/20-tooltip-open-arbitration.md
@@ -1,0 +1,141 @@
+# Tooltip open arbitration
+
+## Problem
+
+The migrated (base-ui) Tooltip runs two open-timing models at once. base-ui's
+`<Tooltip.Trigger>` drives hover and focus opens itself — its `useHover` is
+REST-based (`restMs`: it opens once the cursor *stops*, not after an
+enter-based delay) and its `useFocus` opens instantly on any focus it deems
+focus-visible (both wired unconditionally on `TooltipTrigger`). Picasso,
+meanwhile, must reproduce
+legacy MUI enter-delay semantics, so it runs its own hover-open timer. To
+reconcile the two, `handleOpenChange` became a referee that vetoed base-ui's
+open requests one reason at a time — an accreting pile of inline
+`if (...) return` guards (`trigger-hover` veto, click-dismiss `suppressReopen`
+latch, follow-cursor roam-hide, `followCursorUnsupported`), joined most
+recently by the PF-2253 pointer-focus suppression.
+
+PF-2253 itself: a `mousedown` that focuses a tooltip trigger makes base-ui
+open the popup mid-click (reason `trigger-focus`). base-ui's
+`matchesFocusVisible` check cannot tell pointer focus from keyboard focus in
+several environments — it is unconditionally true under jsdom, true for the
+untrusted focus a Cypress `.click()` dispatches, and true in real browsers for
+typeable triggers (input/textarea/contenteditable). The popup can flash open
+over its own trigger and swallow the trailing click, leaving the wrapped
+control effectively unclickable.
+
+Two smells, inappropriate for a UI-kit primitive:
+
+1. Behavioral logic scattered as ad-hoc early returns rather than one
+   coherent, testable decision.
+2. Environment knowledge (jsdom/Cypress/`matchesFocusVisible` lore) baked into
+   the runtime component.
+
+## Proposal
+
+**Picasso owns open arbitration.** Every open request reaching
+`handleOpenChange` — controlled or uncontrolled — passes through one pure
+predicate, `shouldHonorOpen` (`packages/base/Tooltip/src/Tooltip/should-honor-open.ts`).
+Of base-ui's own open reasons, only a keyboard-modality `trigger-focus` is
+honored; base-ui keeps owning every close/dismiss path.
+
+First matching veto wins (rows evaluated for open requests only):
+
+| # | Condition                                    | Gated by      | Result | Rationale                                        |
+|---|----------------------------------------------|---------------|--------|--------------------------------------------------|
+| 1 | `followCursorUnsupported`                    | (always)      | veto   | touch device + `followCursor` → never open       |
+| 2 | `suppressReopen`                             | `!isControlled` | veto | click-dismiss latch held                         |
+| 3 | `followCursorHidden`                         | `!isControlled` | veto | roam-hide in effect                              |
+| 4 | `reason === 'trigger-hover'`                 | `!isControlled` | veto | Picasso owns hover via its own enter-delay timer |
+| 5 | `reason === 'trigger-focus'` + pointer modality | (always)   | veto | pointer-initiated focus flash-open (PF-2253)     |
+| 6 | otherwise (keyboard focus, imperative)       |               | honor  |                                                  |
+
+Rows 2–4 stay uncontrolled-only, exactly as they were before this refactor: in
+controlled mode Picasso's own hover-open timer is disabled, so base-ui's
+forwarded `trigger-hover` is the consumer's ONLY hover-open path and must reach
+`onOpen` (e.g. `TypographyOverflow`, which drives `open`/`onOpen` from the
+tooltip). The **sole** controlled-mode behavior change is row 5: a
+pointer-initiated focus no longer opens a controlled tooltip either.
+
+Supporting pieces:
+
+- **Input modality** is tracked by a shared, ref-counted util —
+  `isPointerModality`/`subscribePointerModality`/`unsubscribePointerModality`
+  in `@toptal/picasso-utils` (`packages/base/Utils/src/utils/pointer-modality.ts`).
+  Window-capture `keydown`/`pointerdown` listeners mirror base-ui's own
+  Mac-Safari modality approach — base-ui only attaches equivalent window
+  listeners on Mac Safari (where it consults them *instead of*
+  `matchesFocusVisible`); everywhere else it relies purely on
+  `matchesFocusVisible`, which is exactly the check we can't trust here. A
+  window-level flag (not a trigger-scoped ref) also covers
+  label-click-focuses-input, where the pointerdown never lands on the trigger.
+  The util's doc-comment is the single home for the environment rationale.
+- **Controlled mode** runs through the same arbiter (`shouldHonorOpen` is
+  called before the controlled/uncontrolled split), but rows 2–4 remain
+  uncontrolled-only, so a controlled consumer's `onOpen` still fires for
+  base-ui's forwarded hover/latch/roam requests exactly as before. Only the
+  row-5 pointer-focus veto is newly applied to controlled tooltips.
+- The reason type is imported from base-ui
+  (`BaseTooltip.Root.ChangeEventDetails['reason']`), so a reason rename breaks
+  the build rather than silently mis-arbitrating.
+
+### Drawbacks and limitations
+
+- Controlled consumers see one fewer `onOpen` case than before: a
+  pointer-initiated focus no longer opens a controlled tooltip. Hover/latch/
+  roam requests are unaffected (rows 2–4 stay uncontrolled-only).
+- Pointer-focus suppression is stricter than the pre-migration (MUI) build for
+  tooltip-wrapped inputs, which previously flashed open on click.
+- **Latched pointer modality also suppresses focus-opens for programmatic
+  `.focus()` that follows a pointer interaction** — e.g. validation-focus on
+  an invalid field after a click, or focus-restore to a trigger after a modal
+  closes on a pointer press. The modality stays "pointer" until the next
+  keydown, so such a programmatic focus won't open the tooltip, whereas
+  `:focus-visible` would still match for a typeable target. This is a
+  deliberate trade for killing the flash-open; in practice many error-tooltip
+  patterns are controlled and drive `open` themselves, so they're unaffected
+  by the focus-open path at all.
+- The modality flag is module-global state; tests that assert focus-opens must
+  pin the modality explicitly (a `keydown` for keyboard, a `pointerdown` for
+  pointer) rather than rely on test order.
+- A ref-count imbalance (unmatched unsubscribe) is guarded against going
+  negative; the worst case is a lingering, harmless pair of listeners — never
+  an early detach.
+
+## Alternatives
+
+- **Fully-controlled/imperative rewrite** — neuter base-ui's Trigger and drive
+  `open` entirely from Picasso. Rejected: base-ui's Trigger wires
+  `useHover`/`useFocus` unconditionally, gated only by `disabled` — and
+  `disabled` also forces `open=false` on the Root, so opting out of its
+  interactions means re-implementing accessibility and dismiss behavior
+  wholesale.
+- **`:focus-visible` polyfill** — rejected: base-ui already calls
+  `matchesFocusVisible`; a polyfill double-counts and only "helps" under
+  jsdom, where we need the opposite (jsdom reports every focus as
+  focus-visible).
+- **Reducer/XState machine** — rejected as over-engineering for one boolean of
+  open state; a pure predicate over five inputs is fully testable without a
+  state-machine runtime.
+- **`usePointerModality()` React hook** — rejected: modality is read
+  imperatively at the open instant and never rendered, so a hook would only
+  add re-render plumbing.
+
+## Research data
+
+- [PF-2253](https://toptal-core.atlassian.net/browse/PF-2253) — pointer-focus
+  flash-open swallowing the trailing click.
+- [PF-2245](https://toptal-core.atlassian.net/browse/PF-2245) — the earlier
+  click-during-hover-delay latch bug; its invariant (a click landing inside
+  the enter-delay window must not dismiss-and-latch the in-flight open) is
+  preserved by the arbitration and covered by regression tests in
+  `packages/base/Tooltip/src/Tooltip/test.tsx`.
+- base-ui 1.6.0 sources: `TooltipTrigger` wires `useHover`/`useFocus`
+  unconditionally on the Trigger (gated only by `disabled`); `TooltipRoot`
+  forces `open=false` while `disabled`; `useFocus` decides focus-visibility via
+  `matchesFocusVisible` in general, and only on Mac Safari attaches its own
+  window keydown/pointerdown listeners which it consults *instead of*
+  `matchesFocusVisible` there (they do not feed it). That Mac-Safari carve-out
+  is the approach this util generalizes.
+- Ticket: [PF-2253](https://toptal-core.atlassian.net/browse/PF-2253); implemented
+  in PR #5057.

--- a/packages/base/Tooltip/src/Tooltip/should-honor-open.test.ts
+++ b/packages/base/Tooltip/src/Tooltip/should-honor-open.test.ts
@@ -1,0 +1,125 @@
+import type { OpenArbiterState } from './should-honor-open'
+import { shouldHonorOpen } from './should-honor-open'
+
+// A request every veto lets through; each case flips exactly the field(s) it
+// is about, mirroring the truth table in should-honor-open.ts row by row.
+const honorableState: OpenArbiterState = {
+  reason: 'trigger-focus',
+  isControlled: false,
+  suppressReopen: false,
+  followCursorHidden: false,
+  followCursorUnsupported: false,
+  isPointerModality: false,
+}
+
+describe('shouldHonorOpen', () => {
+  it('vetoes when followCursor is unsupported (touch device)', () => {
+    expect(
+      shouldHonorOpen({ ...honorableState, followCursorUnsupported: true })
+    ).toBe(false)
+  })
+
+  it('vetoes while the click-dismiss latch is held', () => {
+    expect(shouldHonorOpen({ ...honorableState, suppressReopen: true })).toBe(
+      false
+    )
+  })
+
+  it('vetoes while a follow-cursor roam-hide is in effect', () => {
+    expect(
+      shouldHonorOpen({ ...honorableState, followCursorHidden: true })
+    ).toBe(false)
+  })
+
+  it('vetoes a trigger-hover request — Picasso owns hover-open', () => {
+    // Even in keyboard modality: the hover veto is about who owns the hover
+    // timing, not about input modality.
+    expect(shouldHonorOpen({ ...honorableState, reason: 'trigger-hover' })).toBe(
+      false
+    )
+  })
+
+  it('vetoes a pointer-initiated focus request [PF-2253]', () => {
+    expect(
+      shouldHonorOpen({
+        ...honorableState,
+        reason: 'trigger-focus',
+        isPointerModality: true,
+      })
+    ).toBe(false)
+  })
+
+  it('honors a keyboard-initiated focus request', () => {
+    expect(
+      shouldHonorOpen({
+        ...honorableState,
+        reason: 'trigger-focus',
+        isPointerModality: false,
+      })
+    ).toBe(true)
+  })
+
+  it('honors an imperative request regardless of modality', () => {
+    expect(
+      shouldHonorOpen({
+        ...honorableState,
+        reason: 'imperative-action',
+        isPointerModality: true,
+      })
+    ).toBe(true)
+  })
+
+  describe('in controlled mode', () => {
+    // Rows 2–4 are uncontrolled-only: a controlled tooltip's Picasso hover
+    // timer is off, so base-ui's forwarded requests are its only open path and
+    // must reach onOpen. Row 5 (pointer-focus) still vetoes — the sole
+    // intended controlled-mode change. [PF-2253]
+    const controlledState = { ...honorableState, isControlled: true }
+
+    it('honors a trigger-hover request (restores controlled hover-open)', () => {
+      expect(
+        shouldHonorOpen({ ...controlledState, reason: 'trigger-hover' })
+      ).toBe(true)
+    })
+
+    it('honors while the click-dismiss latch is held', () => {
+      expect(
+        shouldHonorOpen({ ...controlledState, suppressReopen: true })
+      ).toBe(true)
+    })
+
+    it('honors while a follow-cursor roam-hide is in effect', () => {
+      expect(
+        shouldHonorOpen({ ...controlledState, followCursorHidden: true })
+      ).toBe(true)
+    })
+
+    it('still vetoes a pointer-initiated focus request [PF-2253]', () => {
+      expect(
+        shouldHonorOpen({
+          ...controlledState,
+          reason: 'trigger-focus',
+          isPointerModality: true,
+        })
+      ).toBe(false)
+    })
+
+    it('honors a keyboard-initiated focus request', () => {
+      expect(
+        shouldHonorOpen({
+          ...controlledState,
+          reason: 'trigger-focus',
+          isPointerModality: false,
+        })
+      ).toBe(true)
+    })
+
+    it('still vetoes an unsupported follow-cursor request (touch device)', () => {
+      // Row 1 is unconditional — unsupported means the tooltip never opens,
+      // controlled or not.
+      expect(
+        shouldHonorOpen({ ...controlledState, followCursorUnsupported: true })
+      ).toBe(false)
+    })
+  })
+})

--- a/packages/base/Tooltip/src/Tooltip/should-honor-open.ts
+++ b/packages/base/Tooltip/src/Tooltip/should-honor-open.ts
@@ -1,0 +1,74 @@
+import type { Tooltip as BaseTooltip } from '@base-ui/react/tooltip'
+
+// Imported from base-ui deliberately: if base-ui renames a reason (e.g.
+// `trigger-focus`), the build breaks here instead of silently mis-arbitrating.
+type OpenReason = BaseTooltip.Root.ChangeEventDetails['reason']
+
+export type OpenArbiterState = {
+  reason: OpenReason
+  // Whether the tooltip is controlled (consumer owns `open`). In controlled
+  // mode Picasso's own hover-open timer is disabled, so base-ui's forwarded
+  // `trigger-hover` is the consumer's ONLY hover-open path — the hover/latch/
+  // roam vetoes must stay uncontrolled-only, as they were pre-refactor.
+  isControlled: boolean
+  // Click-dismiss latch: a click dismissed the tooltip and the pointer hasn't
+  // left the trigger yet.
+  suppressReopen: boolean
+  // followCursor roam-hide: the cursor moved far enough to hide the popup and
+  // hasn't settled yet.
+  followCursorHidden: boolean
+  // followCursor on a touch device — unsupported, the tooltip never opens.
+  followCursorUnsupported: boolean
+  // Last input modality was pointer (mouse/touch/pen), not keyboard.
+  isPointerModality: boolean
+}
+
+/**
+ * Decides whether an OPEN request reaching `handleOpenChange` — from base-ui
+ * or otherwise — should be honored. Picasso owns this arbitration because it
+ * runs its own MUI-compatible enter-delay hover timer while base-ui's Trigger
+ * independently drives REST-based hover and instant focus opens; honoring
+ * base-ui's requests unfiltered would run two differently-timed open machines
+ * at once (see docs/decisions/20-tooltip-open-arbitration.md).
+ *
+ * First matching veto wins. Rows 2–4 are UNCONTROLLED-ONLY (they were gated
+ * behind `!isControlled` pre-refactor): in controlled mode Picasso's hover
+ * timer is off, so base-ui's forwarded `trigger-hover` is the consumer's only
+ * hover-open and must reach `onOpen`. Rows 1 and 5 apply in BOTH modes — row 5
+ * (pointer-focus suppression) newly applying to controlled mode is the only
+ * intended controlled-mode behavior change [PF-2253].
+ *
+ * | # | Condition                              | Gated by      | Result | Why                                    |
+ * |---|----------------------------------------|---------------|--------|----------------------------------------|
+ * | 1 | followCursorUnsupported                | (always)      | veto   | touch + followCursor never opens       |
+ * | 2 | suppressReopen                         | !isControlled | veto   | click-dismiss latch held               |
+ * | 3 | followCursorHidden                     | !isControlled | veto   | roam-hide in effect                    |
+ * | 4 | reason is trigger-hover                | !isControlled | veto   | Picasso owns hover via its enter-delay |
+ * | 5 | reason is trigger-focus + pointer mode | (always)      | veto   | pointer-focus flash-open [PF-2253]     |
+ * | 6 | otherwise (keyboard focus, imperative) |               | honor  |                                        |
+ */
+export const shouldHonorOpen = (state: OpenArbiterState): boolean => {
+  if (state.followCursorUnsupported) {
+    return false
+  }
+
+  if (!state.isControlled) {
+    if (state.suppressReopen) {
+      return false
+    }
+
+    if (state.followCursorHidden) {
+      return false
+    }
+
+    if (state.reason === 'trigger-hover') {
+      return false
+    }
+  }
+
+  if (state.reason === 'trigger-focus' && state.isPointerModality) {
+    return false
+  }
+
+  return true
+}

--- a/packages/base/Tooltip/src/Tooltip/test.tsx
+++ b/packages/base/Tooltip/src/Tooltip/test.tsx
@@ -47,6 +47,17 @@ const tapElement = (element: Element) => {
   fireEvent.click(element)
 }
 
+// A genuine KEYBOARD focus is preceded by a keydown (Tab). Firing it flips the
+// shared input-modality flag back to keyboard so base-ui's focus-open is
+// honored — the hook suppresses only POINTER-initiated focus (a mousedown that
+// focuses the trigger fires `pointerDown` before `focus` instead). Modality is
+// tracked in module state that persists across tests, so every focus-open test
+// pins it explicitly rather than relying on order. [PF-2253]
+const focusViaKeyboard = (element: Element) => {
+  fireEvent.keyDown(element, { key: 'Tab' })
+  fireEvent.focus(element)
+}
+
 const renderTooltip = (props?: Partial<OmitInternalProps<Props>>) => {
   // onClick/onMouseOver/onMouseMove/onMouseLeave belong on the wrapped trigger,
   // not on Tooltip — keep them off the {...tooltipProps} spread so they aren't
@@ -227,7 +238,7 @@ describe('Tooltip', () => {
     it('opens the tooltip and closes it on blur', async () => {
       const { getByTestId, queryByTestId } = renderTooltip()
 
-      fireEvent.focus(getByTestId('tooltip-trigger'))
+      focusViaKeyboard(getByTestId('tooltip-trigger'))
       await waitFor(() => {
         expect(queryByTestId('tooltip-content')).toBeInTheDocument()
       })
@@ -247,7 +258,7 @@ describe('Tooltip', () => {
         onClose: onCloseMock,
       })
 
-      fireEvent.focus(getByTestId('tooltip-trigger'))
+      focusViaKeyboard(getByTestId('tooltip-trigger'))
       await waitFor(() => expect(onOpenMock).toHaveBeenCalled())
 
       fireEvent.blur(getByTestId('tooltip-trigger'))
@@ -312,7 +323,7 @@ describe('Tooltip', () => {
         followCursor: true,
       })
 
-      fireEvent.focus(getByTestId('tooltip-trigger'))
+      focusViaKeyboard(getByTestId('tooltip-trigger'))
 
       await waitFor(() =>
         expect(queryByTestId('tooltip-content')).toBeInTheDocument()
@@ -402,16 +413,15 @@ describe('Tooltip', () => {
 
   describe('when clicked during the hover-open delay on a pointer device', () => {
     it('opens the tooltip instead of latching it shut', async () => {
-      // Regression for PF-2245. A real `cy.click()` fires
-      // mouseover → mousedown(focus) → click. The mouseover arms Picasso's
-      // 200ms hover-open; the mousedown-focus makes base-ui open the tooltip
-      // synchronously (its `useFocus`, reason `trigger-focus` — `matchesFocus-
-      // Visible` is unconditionally true under jsdom and for the untrusted
-      // programmatic focus a `cy.click()` dispatches); the trailing click
-      // lands while that open is in flight. It must NOT dismiss-and-latch the
-      // tooltip — otherwise it stays suppressed until the pointer leaves and
-      // re-enters, which never happens (the cursor sits on the trigger), so
-      // every consumer Cypress spec that `.click()`s a tooltip trigger fails.
+      // Regression for PF-2245. The mouseover arms Picasso's 200ms hover-open;
+      // base-ui opens the tooltip synchronously on focus (its `useFocus`,
+      // reason `trigger-focus`); the trailing click lands while that open is in
+      // flight. It must NOT dismiss-and-latch the tooltip — otherwise it stays
+      // suppressed until the pointer leaves and re-enters, which never happens
+      // (the cursor sits on the trigger), so every consumer Cypress spec that
+      // `.click()`s a tooltip trigger fails. PF-2253 now suppresses a POINTER-
+      // initiated focus-open, so pin keyboard modality here (focusViaKeyboard)
+      // to keep base-ui's focus-open honored and exercise the latch path.
       const onOpenMock = jest.fn()
 
       const { getByTestId, queryByTestId } = renderTooltip({
@@ -421,7 +431,7 @@ describe('Tooltip', () => {
       const trigger = getByTestId('tooltip-trigger')
 
       fireEvent.mouseOver(trigger)
-      fireEvent.focus(trigger)
+      focusViaKeyboard(trigger)
       clickElement(trigger)
 
       await waitFor(() =>
@@ -444,7 +454,7 @@ describe('Tooltip', () => {
         expect(queryByTestId('tooltip-content')).toBeInTheDocument()
       )
 
-      fireEvent.focus(trigger)
+      focusViaKeyboard(trigger)
       clickElement(trigger)
       await waitFor(() =>
         expect(queryByTestId('tooltip-content')).not.toBeInTheDocument()
@@ -453,6 +463,114 @@ describe('Tooltip', () => {
       // Still hovering: suppressed. Leaving lifts it; a re-hover opens again.
       fireEvent.mouseLeave(trigger, { clientX: 100, clientY: 100 })
       fireEvent.mouseOver(trigger)
+      await waitFor(() =>
+        expect(queryByTestId('tooltip-content')).toBeInTheDocument()
+      )
+    })
+  })
+
+  describe('when a pointer click focuses the trigger', () => {
+    // PF-2253. A mousedown that focuses the trigger fires `pointerDown` then
+    // `focus`; base-ui would open on that pointer-initiated focus (reason
+    // `trigger-focus`). It must NOT — otherwise the popup flashes open
+    // mid-click and, if the positioner lands it over the trigger, swallows the
+    // trailing click, leaving the wrapped control unclickable.
+    it('does not open the tooltip on pointer-initiated focus', async () => {
+      const onOpenMock = jest.fn()
+
+      const { getByTestId, queryByTestId } = renderTooltip({
+        onOpen: onOpenMock,
+      })
+
+      const trigger = getByTestId('tooltip-trigger')
+
+      fireEvent.pointerDown(trigger)
+      fireEvent.focus(trigger)
+
+      await expect(() =>
+        waitFor(() => {
+          expect(queryByTestId('tooltip-content')).toBeInTheDocument()
+        })
+      ).rejects.toThrow()
+      expect(onOpenMock).not.toHaveBeenCalled()
+    })
+
+    it('still fires the wrapped control onClick', async () => {
+      // Wiring smoke-test only: it confirms Tooltip forwards the trigger's own
+      // onClick through the pointer-focus path. It does NOT prove the tooltip
+      // stops swallowing clicks — jsdom has no hit-testing, so a popup
+      // overlaying the trigger wouldn't intercept the click here anyway. The
+      // real click-swallowing proof is the client-portal Cypress `force:true`
+      // revert per the DoD.
+      const onClickMock = jest.fn()
+
+      const { getByTestId } = renderTooltip({ onClick: onClickMock })
+
+      const trigger = getByTestId('tooltip-trigger')
+
+      fireEvent.pointerDown(trigger)
+      fireEvent.focus(trigger)
+      fireEvent.click(trigger)
+
+      expect(onClickMock).toHaveBeenCalledTimes(1)
+    })
+
+    it('does not call onOpen in controlled mode either', () => {
+      // The one controlled-mode behavior change (row 5): a pointer-initiated
+      // focus must not call onOpen on a controlled tooltip. The complementary
+      // guarantee — that a controlled tooltip STILL forwards base-ui's
+      // `trigger-hover` to onOpen (rows 2–4 stay uncontrolled-only) — is
+      // covered by should-honor-open.test.ts's controlled cases; base-ui's
+      // REST-based hover-open is impractical to drive in jsdom, so the pure
+      // arbiter is the coverage for that path (see ADR-20).
+      const onOpenMock = jest.fn()
+
+      const { getByTestId } = renderTooltip({
+        open: false,
+        onOpen: onOpenMock,
+      })
+
+      const trigger = getByTestId('tooltip-trigger')
+
+      fireEvent.pointerDown(trigger)
+      fireEvent.focus(trigger)
+      fireEvent.click(trigger)
+
+      // Synchronous assertion is valid: base-ui's focus-open fires inline
+      // (no `delay` set), so onOpen would already have run by now if honored.
+      expect(onOpenMock).not.toHaveBeenCalled()
+    })
+
+    it('still calls onOpen on keyboard focus in controlled mode', async () => {
+      // The honored controlled path end-to-end: a keyboard focus must still
+      // reach a controlled consumer's onOpen (row 6). Guards against the call
+      // site passing `isControlled` wrongly — the veto side is covered above,
+      // this covers the honor side.
+      const onOpenMock = jest.fn()
+
+      const { getByTestId } = renderTooltip({
+        open: false,
+        onOpen: onOpenMock,
+      })
+
+      focusViaKeyboard(getByTestId('tooltip-trigger'))
+
+      await waitFor(() => expect(onOpenMock).toHaveBeenCalled())
+    })
+
+    it('still opens on keyboard focus after a prior pointer click', async () => {
+      // The pointer modality must not poison a later genuine keyboard focus:
+      // a Tab keydown flips the modality back so focus opens the tooltip again.
+      const { getByTestId, queryByTestId } = renderTooltip()
+
+      const trigger = getByTestId('tooltip-trigger')
+
+      fireEvent.pointerDown(trigger)
+      fireEvent.focus(trigger)
+      fireEvent.blur(trigger)
+
+      focusViaKeyboard(trigger)
+
       await waitFor(() =>
         expect(queryByTestId('tooltip-content')).toBeInTheDocument()
       )

--- a/packages/base/Tooltip/src/Tooltip/test.tsx
+++ b/packages/base/Tooltip/src/Tooltip/test.tsx
@@ -440,6 +440,35 @@ describe('Tooltip', () => {
       expect(onOpenMock).toHaveBeenCalled()
     })
 
+    it('keeps PF-2245 behaviour on the real pointer gesture (opens via hover, no latch)', async () => {
+      // The production/Cypress gesture end-to-end: `mouseover` arms the 200ms
+      // hover-open, then a real pointer click fires `pointerdown` → `focus` →
+      // `click`. PF-2253 vetoes the pointer-initiated focus-open, so — unlike the
+      // pre-fix path — there is no transient focus-open for the click to
+      // dismiss-and-latch. The click is a desktop no-op and the armed hover timer
+      // still opens the tooltip. This is the PF-2245 guarantee (a click during the
+      // hover delay must not leave the tooltip permanently suppressed) holding
+      // under the pointer-focus veto — the exact interaction consumer Cypress
+      // specs exercise.
+      const onOpenMock = jest.fn()
+
+      const { getByTestId, queryByTestId } = renderTooltip({
+        onOpen: onOpenMock,
+      })
+
+      const trigger = getByTestId('tooltip-trigger')
+
+      fireEvent.mouseOver(trigger)
+      fireEvent.pointerDown(trigger)
+      fireEvent.focus(trigger)
+      fireEvent.click(trigger)
+
+      await waitFor(() =>
+        expect(queryByTestId('tooltip-content')).toBeInTheDocument()
+      )
+      expect(onOpenMock).toHaveBeenCalled()
+    })
+
     it('still dismisses a click once the hover-open has fired', async () => {
       // The click-during-delay exemption must not disarm ordinary click-to-
       // dismiss: once the 200ms hover-open has actually fired (pending flag

--- a/packages/base/Tooltip/src/Tooltip/use-tooltip-state.ts
+++ b/packages/base/Tooltip/src/Tooltip/use-tooltip-state.ts
@@ -2,7 +2,14 @@ import type { ChangeEvent, MouseEvent, TouchEvent } from 'react'
 import { useEffect, useRef, useState } from 'react'
 import type { Tooltip as BaseTooltip } from '@base-ui/react/tooltip'
 import { toReactEvent } from '@toptal/picasso-shared'
-import { isPointerDevice } from '@toptal/picasso-utils'
+import {
+  isPointerDevice,
+  isPointerModality,
+  subscribePointerModality,
+  unsubscribePointerModality,
+} from '@toptal/picasso-utils'
+
+import { shouldHonorOpen } from './should-honor-open'
 
 const FOLLOW_CURSOR_CLOSE_DISTANCE = 50
 const FOLLOW_CURSOR_STOP_DELAY = 250
@@ -92,13 +99,12 @@ export const useTooltipState = ({
   // when it fires and every cancel path (click-dismiss, mouseleave, unmount)
   // nulls it too, so `openTimerRef.current !== undefined` reliably means the
   // enter-delay is still counting down. handleTriggerClick relies on that — a
-  // click landing in this window belongs to the same gesture as the hover:
-  // base-ui opens synchronously on the mousedown-focus (`trigger-focus`, via
-  // its `useFocus`; `matchesFocusVisible` is unconditionally true under jsdom
-  // and for the untrusted/programmatic focus a Cypress `.click()` dispatches),
-  // so the trailing click must not read that transient open and dismiss-then-
-  // latch it shut. Let hover win, as the pre-v2 build did (its click read
-  // lagging closure state and was a desktop no-op). [PF-2245]
+  // click landing in this window belongs to the same gesture as the hover, so
+  // it must not read base-ui's transient focus-open from that same gesture and
+  // dismiss-then-latch it shut. Let hover win, as the pre-v2 build did (its
+  // click read lagging closure state and was a desktop no-op). [PF-2245]
+  // (Why base-ui opens on that mousedown-focus at all is environment lore —
+  // see the pointer-modality util doc and ADR-20.)
   const openTimerRef = useRef<ReturnType<typeof setTimeout>>()
 
   const touchOpenedRef = useRef(false)
@@ -111,13 +117,18 @@ export const useTooltipState = ({
   const followCursorHiddenRef = useRef(false)
   const stopTimerRef = useRef<ReturnType<typeof setTimeout>>()
 
-  useEffect(
-    () => () => {
+  useEffect(() => {
+    // Input-modality tracking feeds the pointer-focus veto in shouldHonorOpen
+    // (see the pointer-modality util doc for why `:focus-visible` alone can't
+    // make that call). [PF-2253]
+    subscribePointerModality()
+
+    return () => {
+      unsubscribePointerModality()
       clearTimeout(openTimerRef.current)
       clearTimeout(stopTimerRef.current)
-    },
-    []
-  )
+    }
+  }, [])
 
   // Fire onTransitionExiting when the close transition BEGINS (open flips
   // true→false), mirroring MUI's Grow `onExiting`; onTransitionExited then
@@ -154,25 +165,23 @@ export const useTooltipState = ({
       return
     }
 
-    // In uncontrolled mode Picasso decides which of base-ui's open requests to
-    // honor. Veto three: a click-dismiss latch (suppressReopenRef) or a
-    // follow-cursor roam-hide (followCursorHiddenRef) that must stay closed,
-    // and base-ui's `trigger-hover` open — Picasso owns hover-open via its own
-    // enter-delay timer (handleTriggerMouseOver), whereas base-ui's hover is
-    // REST-based (opens only once the cursor stops, not the enter-based delay
-    // MUI/legacy Picasso used), so honoring it would race a second, differently
-    // timed hover-open machine. base-ui still owns focus-open (`trigger-focus`,
-    // relied on for keyboard/focus) and every close/dismiss above.
+    // Picasso decides which open requests to honor — the whole veto set lives
+    // in shouldHonorOpen's truth table. Runs BEFORE the controlled/
+    // uncontrolled split, but the arbiter keeps the hover/latch/roam vetoes
+    // uncontrolled-only (a controlled tooltip's only hover-open is base-ui's
+    // forwarded `trigger-hover` → onOpen); only the pointer-focus veto newly
+    // applies to controlled mode. Keyboard focus-open stays honored for a11y.
+    // [PF-2253]
     if (
-      !isControlled &&
-      (suppressReopenRef.current ||
-        followCursorHiddenRef.current ||
-        eventDetails.reason === 'trigger-hover')
+      !shouldHonorOpen({
+        reason: eventDetails.reason,
+        isControlled,
+        suppressReopen: suppressReopenRef.current,
+        followCursorHidden: followCursorHiddenRef.current,
+        followCursorUnsupported,
+        isPointerModality: isPointerModality(),
+      })
     ) {
-      return
-    }
-
-    if (followCursorUnsupported) {
       return
     }
 
@@ -199,9 +208,11 @@ export const useTooltipState = ({
 
     if (openRef.current) {
       // A hover-open is still in flight: this "open" is base-ui's transient
-      // focus-open from the same click gesture, not a deliberately shown
-      // tooltip — don't dismiss-and-latch it. Leave the pending timer to open
-      // it for real (its callback no-ops if base-ui already did). [PF-2245]
+      // focus-open coexisting with the same gesture (now a keyboard-focus-open,
+      // since row 5 vetoes pointer-focus — still reachable where a focus fires
+      // without a preceding pointerdown), not a deliberately shown tooltip —
+      // don't dismiss-and-latch it. Leave the pending timer to open it for real
+      // (its callback no-ops if base-ui already did). [PF-2245]
       if (openTimerRef.current !== undefined) {
         return
       }

--- a/packages/base/Utils/src/utils/__tests__/pointer-modality.test.ts
+++ b/packages/base/Utils/src/utils/__tests__/pointer-modality.test.ts
@@ -1,0 +1,96 @@
+import { isBrowser } from '@toptal/picasso-shared'
+
+import {
+  isPointerModality,
+  subscribePointerModality,
+  unsubscribePointerModality,
+} from '../pointer-modality'
+
+jest.mock('@toptal/picasso-shared', () => ({
+  ...jest.requireActual('@toptal/picasso-shared'),
+  isBrowser: jest.fn(() => true),
+}))
+
+const isBrowserMock = isBrowser as jest.Mock
+
+const modalityCalls = (calls: unknown[][]) =>
+  calls.filter(([type]) => type === 'keydown' || type === 'pointerdown')
+
+describe('pointerModality', () => {
+  beforeEach(() => {
+    // The jest config resets mock implementations between tests, wiping the
+    // factory default above — re-pin the browser environment per test.
+    isBrowserMock.mockReturnValue(true)
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+  })
+
+  it('defaults to keyboard modality', () => {
+    // Order-independent: unsubscribing the last subscriber resets the flag to
+    // the keyboard default, so drive the flag to "pointer" and release it —
+    // the reader must read back the default regardless of prior tests.
+    subscribePointerModality()
+    window.dispatchEvent(new Event('pointerdown'))
+    unsubscribePointerModality()
+
+    expect(isPointerModality()).toBe(false)
+  })
+
+  it('flips to pointer on pointerdown and back to keyboard on keydown', () => {
+    subscribePointerModality()
+
+    window.dispatchEvent(new Event('pointerdown'))
+
+    expect(isPointerModality()).toBe(true)
+
+    window.dispatchEvent(new Event('keydown'))
+
+    expect(isPointerModality()).toBe(false)
+
+    unsubscribePointerModality()
+  })
+
+  it('attaches the window listeners once and detaches on the last unsubscribe', () => {
+    const addSpy = jest.spyOn(window, 'addEventListener')
+    const removeSpy = jest.spyOn(window, 'removeEventListener')
+
+    subscribePointerModality()
+    subscribePointerModality()
+
+    // One keydown + one pointerdown listener, both capture-phase, regardless
+    // of how many subscribers there are.
+    expect(modalityCalls(addSpy.mock.calls)).toEqual([
+      ['keydown', expect.any(Function), true],
+      ['pointerdown', expect.any(Function), true],
+    ])
+
+    unsubscribePointerModality()
+
+    expect(modalityCalls(removeSpy.mock.calls)).toHaveLength(0)
+
+    unsubscribePointerModality()
+
+    expect(modalityCalls(removeSpy.mock.calls)).toEqual([
+      ['keydown', expect.any(Function), true],
+      ['pointerdown', expect.any(Function), true],
+    ])
+  })
+
+  it('does nothing outside the browser', () => {
+    isBrowserMock.mockReturnValue(false)
+
+    const addSpy = jest.spyOn(window, 'addEventListener')
+    const removeSpy = jest.spyOn(window, 'removeEventListener')
+
+    subscribePointerModality()
+    unsubscribePointerModality()
+
+    expect(modalityCalls(addSpy.mock.calls)).toHaveLength(0)
+    expect(modalityCalls(removeSpy.mock.calls)).toHaveLength(0)
+    // The reader still answers with the keyboard default, which is the
+    // correct server-side value.
+    expect(isPointerModality()).toBe(false)
+  })
+})

--- a/packages/base/Utils/src/utils/index.ts
+++ b/packages/base/Utils/src/utils/index.ts
@@ -47,6 +47,11 @@ export { default as isString } from './is-string'
 export { default as isSubstring } from './is-substring'
 export { default as kebabToCamelCase } from './kebab-to-camel-case'
 export { default as noop } from './noop'
+export {
+  isPointerModality,
+  subscribePointerModality,
+  unsubscribePointerModality,
+} from './pointer-modality'
 export { default as toTitleCase } from './to-title-case'
 export { default as useCombinedRefs } from './use-combined-refs'
 export { default as useSafeState } from './use-safe-state'

--- a/packages/base/Utils/src/utils/pointer-modality.ts
+++ b/packages/base/Utils/src/utils/pointer-modality.ts
@@ -1,0 +1,80 @@
+import { isBrowser } from '@toptal/picasso-shared'
+
+// Tracks the user's last input modality — pointer or keyboard — so a component
+// can tell a pointer-initiated focus (a mousedown that focuses an element)
+// from a keyboard-initiated one (Tab) at the moment the focus lands.
+//
+// Why this exists: `:focus-visible` (and base-ui's `matchesFocusVisible`,
+// which its `useFocus` consults before opening popups on focus) cannot be
+// relied on to make that distinction everywhere. It is unconditionally true
+// under jsdom, true for the untrusted/programmatic focus a Cypress `.click()`
+// dispatches, and true in real browsers for typeable targets (input/textarea/
+// contenteditable) even when the focus came from a pointer. A component that
+// must react to keyboard focus only (e.g. Tooltip suppressing its
+// pointer-focus flash-open, PF-2253) therefore needs its own modality signal.
+//
+// The listeners run in the CAPTURE phase so the flag is set before any
+// target-phase focus handler reads it, and so a descendant `stopPropagation`
+// can't hide the modality. Tab's keydown precedes the focus it causes, so the
+// flag self-corrects with no clearing logic. This generalizes base-ui's own
+// Mac-Safari modality approach: base-ui only attaches equivalent window
+// keydown/pointerdown listeners on Mac Safari, where it consults them instead
+// of `matchesFocusVisible`; everywhere else it trusts `matchesFocusVisible` —
+// which is exactly the check we can't rely on here. The pair is ref-counted:
+// a page dense with subscribers shares ONE pair of window listeners rather
+// than stacking N.
+//
+// SSR-safe: subscribe/unsubscribe no-op outside the browser, and the reader
+// returns the keyboard default (`false`), which is correct server-side.
+let pointerModality = false
+let subscribers = 0
+
+const handleWindowKeyDown = () => {
+  pointerModality = false
+}
+
+const handleWindowPointerDown = () => {
+  pointerModality = true
+}
+
+/**
+ * Whether the last user input was pointer-driven (mouse/touch/pen) rather
+ * than keyboard-driven. Read imperatively at the instant of interest — the
+ * value is not reactive. Only meaningful while at least one
+ * `subscribePointerModality` subscription is active.
+ */
+export const isPointerModality = (): boolean => pointerModality
+
+/**
+ * Start tracking input modality. Ref-counted: the window listeners are
+ * attached on the first subscription only. Pair every call with
+ * `unsubscribePointerModality` (typically in an effect cleanup).
+ */
+export const subscribePointerModality = (): void => {
+  if (!isBrowser()) {
+    return
+  }
+
+  if (subscribers++ === 0) {
+    window.addEventListener('keydown', handleWindowKeyDown, true)
+    window.addEventListener('pointerdown', handleWindowPointerDown, true)
+  }
+}
+
+/**
+ * Release a `subscribePointerModality` subscription. The window listeners are
+ * detached when the last subscriber releases.
+ */
+export const unsubscribePointerModality = (): void => {
+  if (!isBrowser()) {
+    return
+  }
+
+  if (subscribers > 0 && --subscribers === 0) {
+    window.removeEventListener('keydown', handleWindowKeyDown, true)
+    window.removeEventListener('pointerdown', handleWindowPointerDown, true)
+    // Reset to the keyboard default so a stale "pointer" reading can't leak
+    // into the next subscriber that mounts before any input arrives.
+    pointerModality = false
+  }
+}


### PR DESCRIPTION
[PF-2253](https://toptal-core.atlassian.net/browse/PF-2253)

### Description

Fixes PF-2253 (the migrated Tooltip opening on **pointer-initiated focus**) and, in
the same pass, de-accretes the open-arbitration logic so the fix lands on a clean
foundation instead of as another inline special-case.

**The bug.** A `mousedown` that focuses a tooltip trigger made base-ui open the popup
mid-click (its `useFocus` reports `trigger-focus`, and `matchesFocusVisible` treats
that focus as focus-visible under jsdom and for typeable triggers such as inputs in a
real browser). The popup could flash open over its own trigger and swallow the
trailing click, leaving the wrapped control effectively unclickable.

**The refactor.** `handleOpenChange` had become a referee vetoing base-ui's open
requests one reason at a time — an accreting pile of inline `if (...) return` guards.
This PR replaces that with:

- **`isPointerModality` shared util** (`@toptal/picasso-utils`) — a ref-counted,
  SSR-guarded, window-capture input-modality tracker. It is the single home for the
  jsdom/Cypress/`matchesFocusVisible` rationale, and the reusable primitive other
  base-ui-migrated components can adopt when they hit the same `:focus-visible`
  unreliability. Tooltip is its first consumer.
- **`shouldHonorOpen` pure arbiter** — the veto pile collapsed into one pure,
  exhaustively-tested truth table.

**The fix, expressed as one arbiter row:** pointer-initiated `trigger-focus` opens are
vetoed; keyboard focus still opens (accessibility preserved).

**Controlled-mode note (please read).** The pointer-focus veto applies in **both**
controlled and uncontrolled mode, so a controlled tooltip no longer opens on
pointer-initiated focus either. Every **other** arbitration rule (hover-timing,
click-dismiss latch, follow-cursor roam-hide) keeps its original **uncontrolled-only**
gating — controlled consumers such as `TypographyOverflow` rely on base-ui's forwarded
hover-open (`onOpen`) because Picasso's own hover timer is disabled in controlled mode.
This is the sole controlled-mode behavior change. See
`docs/decisions/20-tooltip-open-arbitration.md`.

`pnpm build:package` (90 projects) and lint pass; 47 unit tests across the arbiter,
the util, and the Tooltip integration suite are green.

### How to test

- [Temploy](https://picasso.toptal.net/pf-2253-tooltip-pointer-focus-open)

**Manual steps** (Storybook → `Tooltip → Default` and `Tooltip → Interactive`):

1. **Click the trigger.** The tooltip must **not** flash open mid-click. *(This is the
   fix.)* The click already focuses the trigger — so don't press Tab expecting it to
   re-focus the same trigger; Tab moves focus **forward** to the next element, which is
   normal browser behavior.
2. **Hover the trigger.** Still opens after the delay — unchanged.
3. **Keyboard focus opens it:** click an empty area to blur, then **Tab** (or
   **Shift+Tab**) until the focus ring lands **on the trigger** → the tooltip appears.
   Blur (Tab away) closes it. Accessibility preserved.
4. **Modality resets:** click the trigger (no tooltip) → blur → Tab back onto it →
   tooltip opens. A prior pointer click must not poison later keyboard focus.
5. **Tooltip-wrapped `<input>`** (the real-Chrome case — buttons don't get
   `:focus-visible` on mouse focus, so a plain button won't visibly differ in Chrome):
   clicking into the input must **not** open the tooltip; **Tab**-focusing it **must**.
6. **Controlled consumer:** hover an ellipsed **`TypographyOverflow`** — the tooltip must
   still open on hover (guards the controlled-mode path, which relies on base-ui's
   forwarded `onOpen`).

**Consumer validation:** client-portal `TalentAvailabilityNotificationBadge.cy.tsx` must
pass **after reverting** its `click({ force: true })` PF-2253 workarounds.

### Screenshots

| Before                                  | After                                   |
| --------------------------------------- | --------------------------------------- |
| Tooltip flashes open on click; trailing click can be lost | Click does not open the tooltip; wrapped control stays clickable |

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed) — `@toptal/picasso-tooltip` patch, `@toptal/picasso-utils` minor (new public export)
- [ ] Double check if `picasso-tailwind-merge` requires major update (check its `README.md`) — N/A
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [ ] Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/) — N/A, behavior fix only
- [ ] Annotate all `props` in component with documentation — N/A, no API change
- [ ] Create `examples` for component — N/A, no new component
- [ ] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues — keyboard focus still opens; only pointer-initiated focus is suppressed
- [x] Self reviewed
- [x] Covered with tests — pure arbiter truth-table tests + modality-util tests + Tooltip integration tests (incl. controlled-mode honor and veto paths); rationale recorded in ADR-20

**Breaking change** — N/A (patch/minor). Note: stricter than the pre-migration build
for tooltip-wrapped **inputs**, which previously also flashed open on click; and a
latched pointer modality suppresses focus-opens for programmatic `.focus()` after a
pointer interaction until the next keydown (disclosed in ADR-20 drawbacks).

- [ ] codemod is created and showcased in the changeset
- [ ] test alpha package of Picasso in StaffPortal


[PF-2253]: https://toptal-core.atlassian.net/browse/PF-2253?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ