### PR TITLE
[PF-2236] Unlock react-truncate react version support

### DIFF
--- a/.changeset/show-more-react-truncate-fork.md
+++ b/.changeset/show-more-react-truncate-fork.md
@@ -1,0 +1,14 @@
+---
+'@toptal/picasso-show-more': patch
+'@toptal/picasso': patch
+---
+
+### ShowMore
+
+- replace the unmaintained `react-truncate` dependency (last published 2018, React peer locked to `<= 16`) with the maintained fork `@re-dev/react-truncate`, pinned to `0.6.0`; browser rendering, SSR markup and the public API are unchanged
+- lift React peer-dependency cap (drop `< 19.0.0`)
+- in DOM-less test environments (jsdom) the new library renders collapsed content only after it can measure real layout, so collapsed ShowMore text is not queryable in jsdom (the toggle button still renders and works) — assert on the expanded state or test in a real browser
+
+### Picasso
+
+- remove the unused `react-truncate` dependency

--- a/package.json
+++ b/package.json
@@ -205,7 +205,6 @@
     "@types/esprima": "^4.0.3",
     "@types/happo-cypress": "^4.1.3",
     "@types/pngjs": "^6.0.5",
-    "@types/react-truncate": "^2.3.4",
     "@vercel/ncc": "^0.38.3",
     "babel-loader": "^9.1.2",
     "brace": "^0.11.1",

--- a/packages/base/ShowMore/package.json
+++ b/packages/base/ShowMore/package.json
@@ -25,7 +25,7 @@
     "@toptal/picasso-button": "workspace:*",
     "@toptal/picasso-icons": "workspace:*",
     "@toptal/picasso-typography": "workspace:*",
-    "react-truncate": "^2.4.0"
+    "@re-dev/react-truncate": "0.6.0"
   },
   "sideEffects": [
     "**/styles.ts",

--- a/packages/base/ShowMore/src/ShowMore/ShowMore.tsx
+++ b/packages/base/ShowMore/src/ShowMore/ShowMore.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode } from 'react'
 import React, { forwardRef, useMemo, useCallback, useState } from 'react'
 import { twJoin } from '@toptal/picasso-tailwind-merge'
-import Truncate from 'react-truncate'
+import { Truncate } from '@re-dev/react-truncate'
 import type { BaseProps } from '@toptal/picasso-shared'
 import { ChevronRight16 } from '@toptal/picasso-icons'
 import { Typography } from '@toptal/picasso-typography'

--- a/packages/base/ShowMore/src/ShowMore/__snapshots__/test.tsx.snap
+++ b/packages/base/ShowMore/src/ShowMore/__snapshots__/test.tsx.snap
@@ -8,13 +8,8 @@ exports[`ShowMore renders 1`] = `
     <p
       class="m-0 text-md text-graphite font-regular"
     >
-      <span
-        width="0"
-      >
+      <span>
         <span />
-        <span>
-          Lorem ipsum dolor sit amet consectetur adipisicing elit. Veritatis tenetur est asperiores. Inventore quam vel neque voluptatum, tenetur consectetur sapiente veniam, sint expedita voluptate reiciendis illum numquam officia obcaecati dicta? Lorem ipsum dolor sit amet consectetur adipisicing elit. Veritatis tenetur est asperiores. Inventore quam vel neque voluptatum, tenetur consectetur sapiente veniam, sint expedita voluptate reiciendis illum numquam officia obcaecati dicta?
-        </span>
         <span
           style="position: fixed; visibility: hidden; top: 0px; left: 0px;"
         >
@@ -61,13 +56,8 @@ exports[`ShowMore when custom lessText text is specified should render with cust
     <p
       class="m-0 text-md text-graphite font-regular"
     >
-      <span
-        width="0"
-      >
+      <span>
         <span />
-        <span>
-          Lorem ipsum dolor sit amet consectetur adipisicing elit. Veritatis tenetur est asperiores. Inventore quam vel neque voluptatum, tenetur consectetur sapiente veniam, sint expedita voluptate reiciendis illum numquam officia obcaecati dicta? Lorem ipsum dolor sit amet consectetur adipisicing elit. Veritatis tenetur est asperiores. Inventore quam vel neque voluptatum, tenetur consectetur sapiente veniam, sint expedita voluptate reiciendis illum numquam officia obcaecati dicta?
-        </span>
         <span
           style="position: fixed; visibility: hidden; top: 0px; left: 0px;"
         >
@@ -114,13 +104,8 @@ exports[`ShowMore when custom showMore text is specified should render with cust
     <p
       class="m-0 text-md text-graphite font-regular"
     >
-      <span
-        width="0"
-      >
+      <span>
         <span />
-        <span>
-          Lorem ipsum dolor sit amet consectetur adipisicing elit. Veritatis tenetur est asperiores. Inventore quam vel neque voluptatum, tenetur consectetur sapiente veniam, sint expedita voluptate reiciendis illum numquam officia obcaecati dicta? Lorem ipsum dolor sit amet consectetur adipisicing elit. Veritatis tenetur est asperiores. Inventore quam vel neque voluptatum, tenetur consectetur sapiente veniam, sint expedita voluptate reiciendis illum numquam officia obcaecati dicta?
-        </span>
         <span
           style="position: fixed; visibility: hidden; top: 0px; left: 0px;"
         >
@@ -167,13 +152,8 @@ exports[`ShowMore when disableToggle prop is true should render version without 
     <p
       class="m-0 text-md text-graphite font-regular"
     >
-      <span
-        width="0"
-      >
+      <span>
         <span />
-        <span>
-          Lorem ipsum dolor sit amet consectetur adipisicing elit. Veritatis tenetur est asperiores. Inventore quam vel neque voluptatum, tenetur consectetur sapiente veniam, sint expedita voluptate reiciendis illum numquam officia obcaecati dicta? Lorem ipsum dolor sit amet consectetur adipisicing elit. Veritatis tenetur est asperiores. Inventore quam vel neque voluptatum, tenetur consectetur sapiente veniam, sint expedita voluptate reiciendis illum numquam officia obcaecati dicta?
-        </span>
         <span
           style="position: fixed; visibility: hidden; top: 0px; left: 0px;"
         >
@@ -234,13 +214,8 @@ exports[`ShowMore when initialExpanded prop is true when show less link is click
     <p
       class="m-0 text-md text-graphite font-regular"
     >
-      <span
-        width="0"
-      >
+      <span>
         <span />
-        <span>
-          Lorem ipsum dolor sit amet consectetur adipisicing elit. Veritatis tenetur est asperiores. Inventore quam vel neque voluptatum, tenetur consectetur sapiente veniam, sint expedita voluptate reiciendis illum numquam officia obcaecati dicta? Lorem ipsum dolor sit amet consectetur adipisicing elit. Veritatis tenetur est asperiores. Inventore quam vel neque voluptatum, tenetur consectetur sapiente veniam, sint expedita voluptate reiciendis illum numquam officia obcaecati dicta?
-        </span>
         <span
           style="position: fixed; visibility: hidden; top: 0px; left: 0px;"
         >

--- a/packages/picasso/package.json
+++ b/packages/picasso/package.json
@@ -120,8 +120,7 @@
     "react-content-loader": "^6.2.1",
     "react-day-picker": "^8.10.0",
     "react-dropzone": "^14.2.3",
-    "react-input-mask": "^3.0.0-alpha.2",
-    "react-truncate": "^2.4.0"
+    "react-input-mask": "^3.0.0-alpha.2"
   },
   "devDependencies": {
     "@babel/types": "^7.26.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -420,9 +420,6 @@ importers:
       '@types/pngjs':
         specifier: ^6.0.5
         version: 6.0.5
-      '@types/react-truncate':
-        specifier: ^2.3.4
-        version: 2.3.4
       '@vercel/ncc':
         specifier: ^0.38.3
         version: 0.38.3
@@ -2506,6 +2503,9 @@ importers:
 
   packages/base/ShowMore:
     dependencies:
+      '@re-dev/react-truncate':
+        specifier: 0.6.0
+        version: 0.6.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@toptal/picasso-button':
         specifier: workspace:*
         version: link:../Button
@@ -2521,9 +2521,6 @@ importers:
       react:
         specifier: ^18.2.0
         version: 18.2.0
-      react-truncate:
-        specifier: ^2.4.0
-        version: 2.4.0(prop-types@15.8.1)(react@18.2.0)
     devDependencies:
       '@toptal/picasso-tailwind-merge':
         specifier: workspace:*
@@ -3350,9 +3347,6 @@ importers:
       react-input-mask:
         specifier: ^3.0.0-alpha.2
         version: 3.0.0-alpha.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-      react-truncate:
-        specifier: ^2.4.0
-        version: 2.4.0(prop-types@15.8.1)(react@18.2.0)
       typescript:
         specifier: ^5.5.0
         version: 5.5.4
@@ -6316,6 +6310,12 @@ packages:
   '@polka/url@1.0.0-next.23':
     resolution: {integrity: sha512-C16M+IYz0rgRhWZdCmK+h58JMv8vijAA61gmz2rspCSwKwzBebpdcsiUmwrtJRdphuY30i6BSLEOP8ppbNLyLg==}
 
+  '@re-dev/react-truncate@0.6.0':
+    resolution: {integrity: sha512-wO+MMHvbNtFKQgWIie4upsih49xKDBYVTFAGyNnCwUpTCS5Bn6EB9wxA+Z9vRNoSqL0XWdIDtgOH1y9NHoKZRw==}
+    peerDependencies:
+      react: ^18.2.0
+      react-dom: ^18.2.0
+
   '@reach/router@1.3.4':
     resolution: {integrity: sha512-+mtn9wjlB9NN2CNnnC/BRYtwdKBfSyyasPYraNAyvaV1occr/5NnB4CVzjEZipNHwYebQwcndGUmpFzxAUoqSA==}
     peerDependencies:
@@ -7624,9 +7624,6 @@ packages:
     resolution: {integrity: sha512-8TV6R3h2j7a91c+1DXdJi3Syo69zzIZbz7Lg5tORM5LEJG7X/E6a1V3drRyBRZq7/utz7A+c4OgYLiLcYGHG6w==}
     peerDependencies:
       '@types/react': '17'
-
-  '@types/react-truncate@2.3.4':
-    resolution: {integrity: sha512-+ugDlho66dRn7Sw/lPkE/wlOi0KUIRwY2KOiUiehWjFf7EmiMDjMpHqrBhiLJfH2Z9EC+qRBHC9o7iZoEmmWQw==}
 
   '@types/react@17.0.39':
     resolution: {integrity: sha512-UVavlfAxDd/AgAacMa60Azl7ygyQNRwC/DsHZmKgNvPmRR5p70AJ5Q9EAmL2NWOJmeV+vVUI4IAP7GZrN8h8Ug==}
@@ -15332,12 +15329,6 @@ packages:
       react: ^18.2.0
       react-dom: ^18.2.0
 
-  react-truncate@2.4.0:
-    resolution: {integrity: sha512-3QW11/COYwi6iPUaunUhl06DW5NJBJD1WkmxW5YxqqUu6kvP+msB3jfoLg8WRbu57JqgebjVW8Lknw6T5/QZdA==}
-    peerDependencies:
-      prop-types: <= 15.x.x
-      react: ^18.2.0
-
   react@18.2.0:
     resolution: {integrity: sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==}
     engines: {node: '>=0.10.0'}
@@ -21279,6 +21270,11 @@ snapshots:
 
   '@polka/url@1.0.0-next.23': {}
 
+  '@re-dev/react-truncate@0.6.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+
   '@reach/router@1.3.4(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
       create-react-context: 0.3.0(prop-types@15.8.1)(react@18.2.0)
@@ -23652,10 +23648,6 @@ snapshots:
       '@types/react': 17.0.39
 
   '@types/react-transition-group@4.4.12(@types/react@17.0.39)':
-    dependencies:
-      '@types/react': 17.0.39
-
-  '@types/react-truncate@2.3.4':
     dependencies:
       '@types/react': 17.0.39
 
@@ -33292,11 +33284,6 @@ snapshots:
       prop-types: 15.8.1
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-
-  react-truncate@2.4.0(prop-types@15.8.1)(react@18.2.0):
-    dependencies:
-      prop-types: 15.8.1
-      react: 18.2.0
 
   react@18.2.0:
     dependencies:


### PR DESCRIPTION
[PF-2236]

### Description

`ShowMore` was the last component blocking React 19 support on its package: it depended on `react-truncate`, which is unmaintained (last published 2018) and peer-locked to `react <= 16`, so any React 19 consumer hits an unresolvable peer conflict.

Changes:

- Replace `react-truncate` with **`@re-dev/react-truncate`**, a maintained fork of exactly `react-truncate@2.4.0` (hooks + TypeScript rewrite, React 16–19 peers, zero runtime deps, ships its own types). The `Truncate` API (`lines`, `onTruncate`) is identical — the component change is the import line only.
- **Pin the version exactly to `0.6.0`** (no caret). The package has no npm provenance and a single maintainer, so the pin + lockfile integrity hash freeze the audited artifact. Security review done: OSV + npm advisories clean, no install scripts, no runtime deps, hand-audited dist (DOM/canvas measurement only — no network, storage, eval, or process access).
- **Lift the React peer cap** on `@toptal/picasso-show-more` (`>=17.0.0 < 19.0.0` → `>=17.0.0`), same as Backdrop/Accordion did when their blockers were removed.
- Remove the unused `react-truncate` dependency from `@toptal/picasso` and the now-unneeded `@types/react-truncate` from the root.
- Update ShowMore jest snapshots.

**Behavioral notes (verified):**

- Real browser (Playwright + Chrome against the built package): collapsed renders the exact row count with ellipsis, toggle appears only when content actually truncates, multiline (`\n` → `<br/>`) content clamps correctly, expand/collapse round-trips to the exact full text.
- SSR (`renderToString`): full text in markup, same structure as before — no change.
- **jsdom caveat:** the fork renders collapsed content only after it can measure real layout, so in jsdom the collapsed text is empty (the old library showed the raw text there). The toggle still renders and works in jsdom. Called out in the changeset so consumers asserting on collapsed text know to assert on the expanded state or test in a real browser.

### How to test

<!-- The temploy link will be automatically updated when the temploy is deployed -->
- [Temploy](https://picasso.toptal.net/pf-2236-react-truncate)
- Open the ShowMore story: collapsed content shows 4 rows ending with an ellipsis and a "Show more" link; clicking toggles the full text / "Show less"; content shorter than `rows` renders no toggle
- `pnpm test:unit -- packages/base/ShowMore` — 8 tests green
- Happo: no diffs expected on ShowMore (measurement moved from canvas to hidden-DOM, so sub-pixel ellipsis-placement diffs are possible — flag anything larger)

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| No visual change — dependency swap only | No visual change — dependency swap only |

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Double check if `picasso-tailwind-merge` requires major update (check its `README.md`)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests ([visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md) included)

**Breaking change**

- [ ] codemod is created and showcased in the changeset
- [ ] test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>Alpha packages</summary>
<br />

Manually trigger the [publish.yml](https://github.com/toptal/picasso/actions/workflows/publish.yml) workflow to publish alpha packages. Specify pull request number as a parameter (only digits, e.g. `123`).

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[PF-2236]: https://toptal-core.atlassian.net/browse/PF-2236?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ