### PR TITLE
[PF-2236] Unlock react-truncate react version support

### DIFF
--- a/.changeset/show-more-css-line-clamp.md
+++ b/.changeset/show-more-css-line-clamp.md
@@ -1,0 +1,15 @@
+---
+'@toptal/picasso-show-more': patch
+'@toptal/picasso': patch
+---
+
+### ShowMore
+
+- replace the unmaintained `react-truncate` dependency (last published 2018, React peer locked to `<= 16`) with a dependency-free CSS `line-clamp` implementation; the public API is unchanged and the toggle still appears only when content actually overflows
+- lift React peer-dependency cap (drop `< 19.0.0`)
+- the SSR output now contains the full text already clamped by CSS, where previously the text was truncated only client-side after measurement
+- collapsed content now keeps the full text in the DOM (clamping is visual), so it stays selectable, findable and queryable in tests
+
+### Picasso
+
+- remove the unused `react-truncate` dependency

--- a/package.json
+++ b/package.json
@@ -207,7 +207,6 @@
     "@types/esprima": "^4.0.3",
     "@types/happo-cypress": "^4.1.3",
     "@types/pngjs": "^6.0.5",
-    "@types/react-truncate": "^2.3.4",
     "@vercel/ncc": "^0.38.3",
     "babel-loader": "^9.1.2",
     "brace": "^0.11.1",

--- a/packages/base/ShowMore/package.json
+++ b/packages/base/ShowMore/package.json
@@ -24,8 +24,9 @@
   "dependencies": {
     "@toptal/picasso-button": "workspace:*",
     "@toptal/picasso-icons": "workspace:*",
+    "@toptal/picasso-shared": "workspace:*",
     "@toptal/picasso-typography": "workspace:*",
-    "react-truncate": "^2.4.0"
+    "@toptal/picasso-utils": "workspace:*"
   },
   "sideEffects": [
     "**/styles.ts",
@@ -34,7 +35,7 @@
   "peerDependencies": {
     "@toptal/picasso-tailwind": "workspace:^",
     "@toptal/picasso-tailwind-merge": "workspace:^",
-    "react": ">=17.0.0 < 19.0.0"
+    "react": ">=17.0.0"
   },
   "exports": {
     ".": "./dist-package/src/index.js"

--- a/packages/base/ShowMore/src/ShowMore/ShowMore.tsx
+++ b/packages/base/ShowMore/src/ShowMore/ShowMore.tsx
@@ -1,8 +1,9 @@
 import type { ReactNode } from 'react'
-import React, { forwardRef, useMemo, useCallback, useState } from 'react'
+import React, { forwardRef, useMemo, useRef, useState } from 'react'
 import { twJoin } from '@toptal/picasso-tailwind-merge'
-import Truncate from 'react-truncate'
 import type { BaseProps } from '@toptal/picasso-shared'
+import { useIsomorphicLayoutEffect } from '@toptal/picasso-shared'
+import { isOverflown } from '@toptal/picasso-utils'
 import { ChevronRight16 } from '@toptal/picasso-icons'
 import { Typography } from '@toptal/picasso-typography'
 import { ButtonAction } from '@toptal/picasso-button'
@@ -49,6 +50,7 @@ export const ShowMore = forwardRef<HTMLSpanElement, Props>(function ShowMore(
   } = props
   const [shownMore, setShownMore] = useState(initialExpanded)
   const [needsTruncation, setNeedsTruncation] = useState(true)
+  const contentRef = useRef<HTMLSpanElement>(null)
   const content = useMemo(
     () =>
       typeof children === 'string'
@@ -56,18 +58,48 @@ export const ShowMore = forwardRef<HTMLSpanElement, Props>(function ShowMore(
         : children,
     [children]
   )
-  const handleNeedsTruncation = useCallback(
-    (truncated: boolean) => setNeedsTruncation(truncated),
-    [setNeedsTruncation]
-  )
+
+  useIsomorphicLayoutEffect(() => {
+    const element = contentRef.current
+
+    if (!element || shownMore) {
+      return
+    }
+
+    const updateNeedsTruncation = () => {
+      // Zero size means an unmeasurable environment (jsdom, display: none
+      // container) — keep the previous assumption instead of hiding the toggle
+      if (element.scrollHeight === 0) {
+        return
+      }
+
+      setNeedsTruncation(isOverflown(element))
+    }
+
+    updateNeedsTruncation()
+
+    if (typeof ResizeObserver === 'undefined') {
+      return
+    }
+
+    const observer = new ResizeObserver(updateNeedsTruncation)
+
+    observer.observe(element)
+
+    return () => observer.disconnect()
+  }, [shownMore, content, rows])
 
   const isContentVisible = rows !== 0 || shownMore
   const formattedContent = shownMore ? (
     content
   ) : (
-    <Truncate onTruncate={handleNeedsTruncation} lines={rows}>
+    <span
+      ref={contentRef}
+      className='overflow-hidden [display:-webkit-box] [-webkit-box-orient:vertical] break-words'
+      style={{ WebkitLineClamp: rows }}
+    >
       {content}
-    </Truncate>
+    </span>
   )
 
   return (

--- a/packages/base/ShowMore/src/ShowMore/__snapshots__/test.tsx.snap
+++ b/packages/base/ShowMore/src/ShowMore/__snapshots__/test.tsx.snap
@@ -9,17 +9,9 @@ exports[`ShowMore renders 1`] = `
       class="m-0 text-md text-graphite font-regular"
     >
       <span
-        width="0"
+        class="overflow-hidden [display:-webkit [-webkit-box break-words"
       >
-        <span />
-        <span>
-          Lorem ipsum dolor sit amet consectetur adipisicing elit. Veritatis tenetur est asperiores. Inventore quam vel neque voluptatum, tenetur consectetur sapiente veniam, sint expedita voluptate reiciendis illum numquam officia obcaecati dicta? Lorem ipsum dolor sit amet consectetur adipisicing elit. Veritatis tenetur est asperiores. Inventore quam vel neque voluptatum, tenetur consectetur sapiente veniam, sint expedita voluptate reiciendis illum numquam officia obcaecati dicta?
-        </span>
-        <span
-          style="position: fixed; visibility: hidden; top: 0px; left: 0px;"
-        >
-          …
-        </span>
+        Lorem ipsum dolor sit amet consectetur adipisicing elit. Veritatis tenetur est asperiores. Inventore quam vel neque voluptatum, tenetur consectetur sapiente veniam, sint expedita voluptate reiciendis illum numquam officia obcaecati dicta? Lorem ipsum dolor sit amet consectetur adipisicing elit. Veritatis tenetur est asperiores. Inventore quam vel neque voluptatum, tenetur consectetur sapiente veniam, sint expedita voluptate reiciendis illum numquam officia obcaecati dicta?
       </span>
     </p>
     <button
@@ -62,17 +54,9 @@ exports[`ShowMore when custom lessText text is specified should render with cust
       class="m-0 text-md text-graphite font-regular"
     >
       <span
-        width="0"
+        class="overflow-hidden [display:-webkit [-webkit-box break-words"
       >
-        <span />
-        <span>
-          Lorem ipsum dolor sit amet consectetur adipisicing elit. Veritatis tenetur est asperiores. Inventore quam vel neque voluptatum, tenetur consectetur sapiente veniam, sint expedita voluptate reiciendis illum numquam officia obcaecati dicta? Lorem ipsum dolor sit amet consectetur adipisicing elit. Veritatis tenetur est asperiores. Inventore quam vel neque voluptatum, tenetur consectetur sapiente veniam, sint expedita voluptate reiciendis illum numquam officia obcaecati dicta?
-        </span>
-        <span
-          style="position: fixed; visibility: hidden; top: 0px; left: 0px;"
-        >
-          …
-        </span>
+        Lorem ipsum dolor sit amet consectetur adipisicing elit. Veritatis tenetur est asperiores. Inventore quam vel neque voluptatum, tenetur consectetur sapiente veniam, sint expedita voluptate reiciendis illum numquam officia obcaecati dicta? Lorem ipsum dolor sit amet consectetur adipisicing elit. Veritatis tenetur est asperiores. Inventore quam vel neque voluptatum, tenetur consectetur sapiente veniam, sint expedita voluptate reiciendis illum numquam officia obcaecati dicta?
       </span>
     </p>
     <button
@@ -115,17 +99,9 @@ exports[`ShowMore when custom showMore text is specified should render with cust
       class="m-0 text-md text-graphite font-regular"
     >
       <span
-        width="0"
+        class="overflow-hidden [display:-webkit [-webkit-box break-words"
       >
-        <span />
-        <span>
-          Lorem ipsum dolor sit amet consectetur adipisicing elit. Veritatis tenetur est asperiores. Inventore quam vel neque voluptatum, tenetur consectetur sapiente veniam, sint expedita voluptate reiciendis illum numquam officia obcaecati dicta? Lorem ipsum dolor sit amet consectetur adipisicing elit. Veritatis tenetur est asperiores. Inventore quam vel neque voluptatum, tenetur consectetur sapiente veniam, sint expedita voluptate reiciendis illum numquam officia obcaecati dicta?
-        </span>
-        <span
-          style="position: fixed; visibility: hidden; top: 0px; left: 0px;"
-        >
-          …
-        </span>
+        Lorem ipsum dolor sit amet consectetur adipisicing elit. Veritatis tenetur est asperiores. Inventore quam vel neque voluptatum, tenetur consectetur sapiente veniam, sint expedita voluptate reiciendis illum numquam officia obcaecati dicta? Lorem ipsum dolor sit amet consectetur adipisicing elit. Veritatis tenetur est asperiores. Inventore quam vel neque voluptatum, tenetur consectetur sapiente veniam, sint expedita voluptate reiciendis illum numquam officia obcaecati dicta?
       </span>
     </p>
     <button
@@ -168,17 +144,9 @@ exports[`ShowMore when disableToggle prop is true should render version without 
       class="m-0 text-md text-graphite font-regular"
     >
       <span
-        width="0"
+        class="overflow-hidden [display:-webkit [-webkit-box break-words"
       >
-        <span />
-        <span>
-          Lorem ipsum dolor sit amet consectetur adipisicing elit. Veritatis tenetur est asperiores. Inventore quam vel neque voluptatum, tenetur consectetur sapiente veniam, sint expedita voluptate reiciendis illum numquam officia obcaecati dicta? Lorem ipsum dolor sit amet consectetur adipisicing elit. Veritatis tenetur est asperiores. Inventore quam vel neque voluptatum, tenetur consectetur sapiente veniam, sint expedita voluptate reiciendis illum numquam officia obcaecati dicta?
-        </span>
-        <span
-          style="position: fixed; visibility: hidden; top: 0px; left: 0px;"
-        >
-          …
-        </span>
+        Lorem ipsum dolor sit amet consectetur adipisicing elit. Veritatis tenetur est asperiores. Inventore quam vel neque voluptatum, tenetur consectetur sapiente veniam, sint expedita voluptate reiciendis illum numquam officia obcaecati dicta? Lorem ipsum dolor sit amet consectetur adipisicing elit. Veritatis tenetur est asperiores. Inventore quam vel neque voluptatum, tenetur consectetur sapiente veniam, sint expedita voluptate reiciendis illum numquam officia obcaecati dicta?
       </span>
     </p>
   </div>
@@ -235,17 +203,9 @@ exports[`ShowMore when initialExpanded prop is true when show less link is click
       class="m-0 text-md text-graphite font-regular"
     >
       <span
-        width="0"
+        class="overflow-hidden [display:-webkit [-webkit-box break-words"
       >
-        <span />
-        <span>
-          Lorem ipsum dolor sit amet consectetur adipisicing elit. Veritatis tenetur est asperiores. Inventore quam vel neque voluptatum, tenetur consectetur sapiente veniam, sint expedita voluptate reiciendis illum numquam officia obcaecati dicta? Lorem ipsum dolor sit amet consectetur adipisicing elit. Veritatis tenetur est asperiores. Inventore quam vel neque voluptatum, tenetur consectetur sapiente veniam, sint expedita voluptate reiciendis illum numquam officia obcaecati dicta?
-        </span>
-        <span
-          style="position: fixed; visibility: hidden; top: 0px; left: 0px;"
-        >
-          …
-        </span>
+        Lorem ipsum dolor sit amet consectetur adipisicing elit. Veritatis tenetur est asperiores. Inventore quam vel neque voluptatum, tenetur consectetur sapiente veniam, sint expedita voluptate reiciendis illum numquam officia obcaecati dicta? Lorem ipsum dolor sit amet consectetur adipisicing elit. Veritatis tenetur est asperiores. Inventore quam vel neque voluptatum, tenetur consectetur sapiente veniam, sint expedita voluptate reiciendis illum numquam officia obcaecati dicta?
       </span>
     </p>
     <button

--- a/packages/base/ShowMore/tsconfig.json
+++ b/packages/base/ShowMore/tsconfig.json
@@ -5,8 +5,10 @@
   "references": [
     { "path": "../../picasso-tailwind" },
     { "path": "../../picasso-tailwind-merge" },
+    { "path": "../../shared" },
     { "path": "../Button" },
     { "path": "../Icons" },
-    { "path": "../Typography" }
+    { "path": "../Typography" },
+    { "path": "../Utils" }
   ]
 }

--- a/packages/picasso/package.json
+++ b/packages/picasso/package.json
@@ -119,8 +119,7 @@
     "glider-js": "^1.7.8",
     "react-content-loader": "^6.2.1",
     "react-dropzone": "^14.2.3",
-    "react-input-mask": "^3.0.0-alpha.2",
-    "react-truncate": "^2.4.0"
+    "react-input-mask": "^3.0.0-alpha.2"
   },
   "devDependencies": {
     "@babel/types": "^7.26.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -423,9 +423,6 @@ importers:
       '@types/pngjs':
         specifier: ^6.0.5
         version: 6.0.5
-      '@types/react-truncate':
-        specifier: ^2.3.4
-        version: 2.3.4
       '@vercel/ncc':
         specifier: ^0.38.3
         version: 0.38.3
@@ -2524,18 +2521,21 @@ importers:
       '@toptal/picasso-icons':
         specifier: workspace:*
         version: link:../Icons
+      '@toptal/picasso-shared':
+        specifier: workspace:*
+        version: link:../../shared
       '@toptal/picasso-tailwind':
         specifier: workspace:^
         version: link:../../picasso-tailwind
       '@toptal/picasso-typography':
         specifier: workspace:*
         version: link:../Typography
+      '@toptal/picasso-utils':
+        specifier: workspace:*
+        version: link:../Utils
       react:
         specifier: ^18.2.0
         version: 18.2.0
-      react-truncate:
-        specifier: ^2.4.0
-        version: 2.4.0(prop-types@15.8.1)(react@18.2.0)
     devDependencies:
       '@toptal/picasso-tailwind-merge':
         specifier: workspace:*
@@ -3362,9 +3362,6 @@ importers:
       react-input-mask:
         specifier: ^3.0.0-alpha.2
         version: 3.0.0-alpha.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-      react-truncate:
-        specifier: ^2.4.0
-        version: 2.4.0(prop-types@15.8.1)(react@18.2.0)
       typescript:
         specifier: ^5.5.0
         version: 5.5.4
@@ -7618,9 +7615,6 @@ packages:
     resolution: {integrity: sha512-8TV6R3h2j7a91c+1DXdJi3Syo69zzIZbz7Lg5tORM5LEJG7X/E6a1V3drRyBRZq7/utz7A+c4OgYLiLcYGHG6w==}
     peerDependencies:
       '@types/react': '17'
-
-  '@types/react-truncate@2.3.4':
-    resolution: {integrity: sha512-+ugDlho66dRn7Sw/lPkE/wlOi0KUIRwY2KOiUiehWjFf7EmiMDjMpHqrBhiLJfH2Z9EC+qRBHC9o7iZoEmmWQw==}
 
   '@types/react@17.0.39':
     resolution: {integrity: sha512-UVavlfAxDd/AgAacMa60Azl7ygyQNRwC/DsHZmKgNvPmRR5p70AJ5Q9EAmL2NWOJmeV+vVUI4IAP7GZrN8h8Ug==}
@@ -15327,12 +15321,6 @@ packages:
     peerDependencies:
       react: ^18.2.0
       react-dom: ^18.2.0
-
-  react-truncate@2.4.0:
-    resolution: {integrity: sha512-3QW11/COYwi6iPUaunUhl06DW5NJBJD1WkmxW5YxqqUu6kvP+msB3jfoLg8WRbu57JqgebjVW8Lknw6T5/QZdA==}
-    peerDependencies:
-      prop-types: <= 15.x.x
-      react: ^18.2.0
 
   react@18.2.0:
     resolution: {integrity: sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==}
@@ -23640,10 +23628,6 @@ snapshots:
       '@types/react': 17.0.39
 
   '@types/react-transition-group@4.4.12(@types/react@17.0.39)':
-    dependencies:
-      '@types/react': 17.0.39
-
-  '@types/react-truncate@2.3.4':
     dependencies:
       '@types/react': 17.0.39
 
@@ -33280,11 +33264,6 @@ snapshots:
       prop-types: 15.8.1
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-
-  react-truncate@2.4.0(prop-types@15.8.1)(react@18.2.0):
-    dependencies:
-      prop-types: 15.8.1
-      react: 18.2.0
 
   react@18.2.0:
     dependencies:


### PR DESCRIPTION
[PF-2236]

### Description

`ShowMore` was blocked from React 19 support by `react-truncate`: unmaintained (last published 2018) and peer-locked to `react <= 16`, so React 19 consumers hit an unresolvable transitive peer conflict.

This PR removes the JS-measurement library entirely and reimplements truncation with **native CSS line-clamp**, reusing idioms the kit already ships:

- The collapsed content renders inside a span with `overflow-hidden [display:-webkit-box] [-webkit-box-orient:vertical] break-words` and an inline `WebkitLineClamp: rows` — the same pattern (and inline-style precedent) as `TypographyOverflow`.
- The "Show more" toggle appears only when content actually overflows, detected in a layout effect via the shared `isOverflown` util from `@toptal/picasso-utils` (same overflow semantics as `TypographyOverflow`), re-checked by a `ResizeObserver`. A zero-size guard keeps the previous assumption in unmeasurable environments (jsdom, `display: none` containers) so the toggle keeps rendering there, matching the old behavior.
- SSR-safe by construction: measurement only happens in `useIsomorphicLayoutEffect` (from `@toptal/picasso-shared`), no `window`/`document` in render.

Package changes: drop `react-truncate` from `@toptal/picasso-show-more`, drop the unused `react-truncate` from `@toptal/picasso` and `@types/react-truncate` from the root; add `@toptal/picasso-shared` + `@toptal/picasso-utils` workspace deps (+ tsconfig references); **lift the React peer cap** (`>=17.0.0 < 19.0.0` → `>=17.0.0`).

**Behavior — verified against the built package in Chrome (Playwright), SSR (`renderToString`), and jest:**

- Collapsed: exactly `rows` visible lines with a native ellipsis; expand/collapse round-trips to the exact full text; content shorter than `rows` hides the toggle; multiline (`\n` → `<br/>`) content clamps correctly; `rows={0}` still hides content and keeps the toggle. Public API unchanged.
- Improvements over the old library: server HTML now arrives **already clamped** (previously truncation happened only client-side after measurement, with a reflow); the full text stays in the DOM when collapsed, so it remains selectable, SEO-visible, and queryable in consumer jsdom tests; re-measure now reacts to container resize, not just window resize.
- Known trade-offs: the ellipsis is painted by the browser, so its exact placement may differ from the old canvas-measured line breaks by a few px — expect small Happo diffs on ShowMore needing visual sign-off. Late-loading fonts can change overflow without a box resize, which can leave the toggle-visibility check stale in rare fits-exactly cases (the old library had the same limitation).

**Reviewer note on snapshots:** the updated jest snapshots show a truncated class string (`[display:-webkit [-webkit-box`). That is a known artifact of davinci-qa's JSS-era snapshot *serializer* (it chops multi-hyphen class names in snapshot output only) — the rendered DOM provably contains the full classes, as visible in the SSR output.

### How to test

<!-- The temploy link will be automatically updated when the temploy is deployed -->
- [Temploy](https://picasso.toptal.net/pf-2236-react-truncate-option-b)
- Open the ShowMore story: collapsed content shows 4 rows with a trailing ellipsis and a "Show more" link; clicking toggles the full text / "Show less"; content shorter than `rows` renders no toggle; resize the viewport and confirm the toggle appears/disappears as the text re-wraps
- Select/copy the collapsed text in the browser — the full text is present (clamping is visual only)
- `pnpm test:unit -- packages/base/ShowMore` — 8 tests green
- Happo: review ShowMore diffs — sub-pixel ellipsis-placement changes are expected; anything larger should be flagged

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| Truncation computed in JS (canvas measurement), ellipsis inserted into the DOM | Native CSS clamp, visually identical (ellipsis painted by the browser); no intended visual change |

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Double check if `picasso-tailwind-merge` requires major update (check its `README.md`)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests ([visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md) included)

**Breaking change**

- [ ] codemod is created and showcased in the changeset
- [ ] test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

<details>
<summary>Alpha packages</summary>
<br />

Manually trigger the [publish.yml](https://github.com/toptal/picasso/actions/workflows/publish.yml) workflow to publish alpha packages. Specify pull request number as a parameter (only digits, e.g. `123`).

</details>

<details>
<summary>PR Review Guidelines</summary>
<br />

#### When to approve? ✅

**You are OK** with merging this PR and

1. You have no extra requests.
2. You have optional requests.
   1. Add `nit:` to your comment. (ex. `nit: I'd rename this variable from makeCircle to getCircle`)

#### When to request changes? ❌

**You are not OK** with merging this PR because

1. Something is broken after the changes.
2. Acceptance criteria is not reached.
3. Code is dirty.

#### When to comment (neither ✅ nor ❌)

**You want your comments to be addressed** before merging this PR in cases like:

1. There are leftovers like unnecessary logs, comments, etc.
2. You have an opinionated comment regarding the code that requires a discussion.
3. You have questions.

#### How to handle the comments?

1. An owner of a comment is the only one who can resolve it.
2. An owner of a comment must resolve it when it's addressed.
3. A PR owner must reply with ✅ when a comment is addressed.

</details>


[PF-2236]: https://toptal-core.atlassian.net/browse/PF-2236?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ