### PR TITLE
[PF-2287] Unlock Form package react v19 support

### DIFF
--- a/.changeset/final-form-v5-upgrade.md
+++ b/.changeset/final-form-v5-upgrade.md
@@ -1,0 +1,8 @@
+---
+'@toptal/picasso-forms': patch
+---
+
+### Form
+
+- upgrade the final-form ecosystem to the versions that support React 19: `final-form@^5.0.1`, `final-form-arrays@^4.0.1`, `react-final-form@^7.0.1`, `react-final-form-arrays@^5.0.0` and `react-final-form-listeners@^3.0.1`. These majors are upstream's Flow-to-TypeScript rewrite and carry no intentional API changes; the re-exported `FieldArray`, `useFieldArray`, `OnChange`, `OnFocus`, `OnBlur` and `ExternallyChanged` surfaces are unchanged. `react-final-form-listeners@3.0.1` ships a broken `types` path, corrected by a pnpm patch
+- drop the `@types/react-final-form-listeners` dev dependency — the package now ships its own types

--- a/packages/picasso-forms/package.json
+++ b/packages/picasso-forms/package.json
@@ -56,17 +56,16 @@
     "classnames": "^2.5.1",
     "debounce": "^1.2.1",
     "detect-browser": "^5.3.0",
-    "final-form": "^4.20.9",
-    "final-form-arrays": "3.0.2",
-    "react-final-form": "^6.5.9",
-    "react-final-form-arrays": "^3.1.4",
-    "react-final-form-listeners": "^1.0.3"
+    "final-form": "^5.0.1",
+    "final-form-arrays": "^4.0.1",
+    "react-final-form": "^7.0.1",
+    "react-final-form-arrays": "^5.0.0",
+    "react-final-form-listeners": "^3.0.1"
   },
   "devDependencies": {
     "@testing-library/react-hooks": "^8.0.1",
     "@toptal/picasso-test-utils": "workspace:*",
     "@types/classnames": "^2.3.1",
-    "@types/react-final-form-listeners": "^1.0.0",
     "type-fest": "^4.15.0"
   },
   "sideEffects": false,

--- a/packages/picasso-forms/src/Checkbox/__snapshots__/test.tsx.snap
+++ b/packages/picasso-forms/src/Checkbox/__snapshots__/test.tsx.snap
@@ -157,6 +157,7 @@ exports[`Form.Checkbox default render for single checkbox 1`] = `
                 style="clip-path: inset(50%); overflow: hidden; white-space: nowrap; border: 0px; padding: 0px; width: 1px; height: 1px; margin: -1px; position: absolute;"
                 tabindex="-1"
                 type="checkbox"
+                value=""
               />
             </span>
             <span
@@ -216,6 +217,7 @@ exports[`Form.Checkbox required with asterisk single checkbox 1`] = `
                 style="clip-path: inset(50%); overflow: hidden; white-space: nowrap; border: 0px; padding: 0px; width: 1px; height: 1px; margin: -1px; position: absolute;"
                 tabindex="-1"
                 type="checkbox"
+                value=""
               />
             </span>
             <span
@@ -249,5 +251,6 @@ exports[`Form.Checkbox when required prop is passed does not set "required" attr
   style="clip-path: inset(50%); overflow: hidden; white-space: nowrap; border: 0px; padding: 0px; width: 1px; height: 1px; margin: -1px; position: absolute;"
   tabindex="-1"
   type="checkbox"
+  value=""
 />
 `;

--- a/packages/picasso-forms/src/Form/mutators/set-active-field-touched.ts
+++ b/packages/picasso-forms/src/Form/mutators/set-active-field-touched.ts
@@ -2,7 +2,7 @@ import type { MutableState } from 'final-form'
 
 export const setActiveFieldTouched = <
   FormValues = object,
-  InitialFormValues = Partial<FormValues>
+  InitialFormValues extends Partial<FormValues> = Partial<FormValues>
 >(
   _: any[],
   state: MutableState<FormValues, InitialFormValues>

--- a/packages/picasso-forms/src/Form/mutators/set-has-multiline-counter.ts
+++ b/packages/picasso-forms/src/Form/mutators/set-has-multiline-counter.ts
@@ -2,12 +2,12 @@ import type { MutableState } from 'final-form'
 
 export const setHasMultilineCounter = <
   FormValues = object,
-  InitialFormValues = Partial<FormValues>
+  InitialFormValues extends Partial<FormValues> = Partial<FormValues>
 >(
-  args: [name: string, hasCounter: boolean],
+  args: any[],
   state: MutableState<FormValues, InitialFormValues>
 ) => {
-  const [name, hasCounter] = args
+  const [name, hasCounter] = args as [name: string, hasCounter: boolean]
   const field = state.fields[name]
 
   if (field) {

--- a/packages/picasso-forms/src/Form/mutators/set-has-multiline-counter.ts
+++ b/packages/picasso-forms/src/Form/mutators/set-has-multiline-counter.ts
@@ -1,5 +1,7 @@
 import type { MutableState } from 'final-form'
 
+// `final-form` types a Mutator's `args` as `any[]`, so the parameter cannot be
+// the tuple this mutator expects. The cast documents the expected shape.
 export const setHasMultilineCounter = <
   FormValues = object,
   InitialFormValues extends Partial<FormValues> = Partial<FormValues>

--- a/packages/picasso-forms/src/NumberInput/test.tsx
+++ b/packages/picasso-forms/src/NumberInput/test.tsx
@@ -29,7 +29,6 @@ describe('Form.NumberInput', () => {
         name: 'test-input',
       })
 
-      expect(numberInputMock).toHaveBeenCalledTimes(1)
       expect(numberInputMock).toHaveBeenCalledWith(
         expect.objectContaining({
           min: '8',

--- a/patches/react-final-form-listeners@3.0.1.patch
+++ b/patches/react-final-form-listeners@3.0.1.patch
@@ -1,0 +1,13 @@
+diff --git a/package.json b/package.json
+index d57e0335a19f5d5cd3db041d61cd2b7d31fc708a..974ea241f83d956655f871cae34cf9562815f153 100644
+--- a/package.json
++++ b/package.json
+@@ -5,7 +5,7 @@
+   "main": "dist/react-final-form-listeners.cjs.js",
+   "jsnext:main": "dist/react-final-form-listeners.es.js",
+   "module": "dist/react-final-form-listeners.es.js",
+-  "types": "dist/index.d.ts",
++  "types": "dist/src/index.d.ts",
+   "sideEffects": false,
+   "files": [
+     "dist"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,6 +46,9 @@ patchedDependencies:
   '@storybook/react-docgen-typescript-plugin@1.0.2-canary.6.9d540b91e815f8fc2f8829189deb00553559ff63.0':
     hash: 3a803b2ccc5ad4e7f8e8870883868ad8f4f8343d06c7021e31ba4ad10928251a
     path: patches/@storybook__react-docgen-typescript-plugin@1.0.2-canary.6.9d540b91e815f8fc2f8829189deb00553559ff63.0.patch
+  react-final-form-listeners@3.0.1:
+    hash: 267ee13c92b1d81c3016dd0b8d2ca4b7b95003e6479058644735ece6376f3e6e
+    path: patches/react-final-form-listeners@3.0.1.patch
   webpack@5.98.0:
     hash: e2c4e4364d7f63ce4220ac564a0eb0a6789525608c04a20b13e962e3eccec20c
     path: patches/webpack@5.98.0.patch
@@ -3540,11 +3543,11 @@ importers:
         specifier: ^5.3.0
         version: 5.3.0
       final-form:
-        specifier: ^4.20.9
-        version: 4.20.9
+        specifier: ^5.0.1
+        version: 5.0.1
       final-form-arrays:
-        specifier: 3.0.2
-        version: 3.0.2(final-form@4.20.9)
+        specifier: ^4.0.1
+        version: 4.0.1(final-form@5.0.1)
       react:
         specifier: ^18.2.0
         version: 18.2.0
@@ -3552,14 +3555,14 @@ importers:
         specifier: ^18.2.0
         version: 18.2.0(react@18.2.0)
       react-final-form:
-        specifier: ^6.5.9
-        version: 6.5.9(final-form@4.20.9)(react@18.2.0)
+        specifier: ^7.0.1
+        version: 7.0.1(final-form@5.0.1)(react@18.2.0)
       react-final-form-arrays:
-        specifier: ^3.1.4
-        version: 3.1.4(final-form-arrays@3.0.2(final-form@4.20.9))(final-form@4.20.9)(react-final-form@6.5.9(final-form@4.20.9)(react@18.2.0))(react@18.2.0)
+        specifier: ^5.0.0
+        version: 5.0.0(final-form-arrays@4.0.1(final-form@5.0.1))(final-form@5.0.1)(react-final-form@7.0.1(final-form@5.0.1)(react@18.2.0))(react@18.2.0)
       react-final-form-listeners:
-        specifier: ^1.0.3
-        version: 1.0.3(final-form@4.20.9)(prop-types@15.8.1)(react-final-form@6.5.9(final-form@4.20.9)(react@18.2.0))(react@18.2.0)
+        specifier: ^3.0.1
+        version: 3.0.1(patch_hash=267ee13c92b1d81c3016dd0b8d2ca4b7b95003e6479058644735ece6376f3e6e)(final-form@5.0.1)(react-final-form@7.0.1(final-form@5.0.1)(react@18.2.0))(react@18.2.0)
       typescript:
         specifier: ^5.5.0
         version: 5.5.4
@@ -3573,9 +3576,6 @@ importers:
       '@types/classnames':
         specifier: ^2.3.1
         version: 2.3.1
-      '@types/react-final-form-listeners':
-        specifier: ^1.0.0
-        version: 1.0.0
       type-fest:
         specifier: ^4.15.0
         version: 4.15.0
@@ -7602,9 +7602,6 @@ packages:
   '@types/react-dom@18.0.0':
     resolution: {integrity: sha512-49897Y0UiCGmxZqpC8Blrf6meL8QUla6eb+BBhn69dTXlmuOlzkfr7HHY/O8J25e1lTUMs+YYxSlVDAaGHCOLg==}
 
-  '@types/react-final-form-listeners@1.0.0':
-    resolution: {integrity: sha512-DovKaDfBqBzPnThFV8mGXL4iAbMCObEFIPUkH7wbD/EN3jZEjpDuPibrqY+w4W1dzicO109YP1LT9KsDDxdYnw==}
-
   '@types/react-input-mask@3.0.0':
     resolution: {integrity: sha512-W8I2GRt1wkFgEJJ4dleSCw1ly2lL+pW71OPkJSz6G93V77io4ulSSnZyiyCv3uljmQDOr94NMbNr5V5hfkMaUg==}
 
@@ -10784,13 +10781,14 @@ packages:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
 
-  final-form-arrays@3.0.2:
-    resolution: {integrity: sha512-TfO8aZNz3RrsZCDx8GHMQcyztDNpGxSSi9w4wpSNKlmv2PfFWVVM8P7Yj5tj4n0OWax+x5YwTLhT5BnqSlCi+w==}
+  final-form-arrays@4.0.1:
+    resolution: {integrity: sha512-aIGGN1ibtxxmRR4LsIEhSbWbUKyHAy9BCAUEcG19U1OpYqD1M9dU9MxgXHmGoM6JLegD4DEVKFLxJjI0q1VjhQ==}
     peerDependencies:
-      final-form: ^4.18.2
+      final-form: ^5.0.0
 
-  final-form@4.20.9:
-    resolution: {integrity: sha512-shA1X/7v8RmukWMNRHx0l7+Bm41hOivY78IvOiBrPVHjyWFIyqqIEMCz7yTVRc9Ea+EU4WkZ5r4MH6whSo5taw==}
+  final-form@5.0.1:
+    resolution: {integrity: sha512-Ohygw2lDgc2HNynfUu82Jp5U45+OLLeBQcwWbrex1IAbQw0uNaFMUbm5dhYCF6y7jcORgl5tg19/1zYxlJtLmg==}
+    engines: {node: '>=18'}
 
   finalhandler@1.3.1:
     resolution: {integrity: sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ==}
@@ -15171,26 +15169,25 @@ packages:
   react-fast-compare@3.2.2:
     resolution: {integrity: sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==}
 
-  react-final-form-arrays@3.1.4:
-    resolution: {integrity: sha512-siVFAolUAe29rMR6u8VwepoysUcUdh6MLV2OWnCtKpsPRUdT9VUgECjAPaVMAH2GROZNiVB9On1H9MMrm9gdpg==}
+  react-final-form-arrays@5.0.0:
+    resolution: {integrity: sha512-M7J73727AaK0YPJbvf/NiBKZrxnCiYZWSuRSHjg6iiA9+KrSuuRm5Y+8gLsah1ziVk4jH4eLK/Atl26LPkB1Dg==}
     peerDependencies:
-      final-form: ^4.15.0
-      final-form-arrays: '>=1.0.4'
+      final-form: ^5.0.1
+      final-form-arrays: ^4.0.1
       react: ^18.2.0
-      react-final-form: ^6.2.1
+      react-final-form: ^7.0.1
 
-  react-final-form-listeners@1.0.3:
-    resolution: {integrity: sha512-OrdCNxSS4JQS/EXD+R530kZKFqaPfa+WcXPgVro/h4BpaBDF/Ja+BtHyCzDezCIb5rWaGGdOJIj+tN2YdtvrXg==}
+  react-final-form-listeners@3.0.1:
+    resolution: {integrity: sha512-oJbPJsqDLs65oxMoo4kSkN7IbtjeqoVEkU7pPKjGnR/meDj83KDjsJj4aTnDCAbocxpjEcV30y+26CfMODFB/g==}
     peerDependencies:
-      final-form: '>=4.0.0'
-      prop-types: ^15.6.0
+      final-form: '>=5.0.0'
       react: ^18.2.0
-      react-final-form: '>=3.0.0'
+      react-final-form: '>=7.0.0'
 
-  react-final-form@6.5.9:
-    resolution: {integrity: sha512-x3XYvozolECp3nIjly+4QqxdjSSWfcnpGEL5K8OBT6xmGrq5kBqbA6+/tOqoom9NwqIPPbxPNsOViFlbKgowbA==}
+  react-final-form@7.0.1:
+    resolution: {integrity: sha512-8K1ITLecBI7F+jCxiMA/JI1amHT/+klQB+nhl5YFZu3R1sQftbiQk/UfwRDvE7ZxIqIvCf8nYLDQRrfwaDT3kQ==}
     peerDependencies:
-      final-form: ^4.20.4
+      final-form: ^5.0.0
       react: ^18.2.0
 
   react-focus-lock@2.6.0:
@@ -23625,10 +23622,6 @@ snapshots:
     dependencies:
       '@types/react': 17.0.39
 
-  '@types/react-final-form-listeners@1.0.0':
-    dependencies:
-      '@types/react': 17.0.39
-
   '@types/react-input-mask@3.0.0':
     dependencies:
       '@types/react': 17.0.39
@@ -27421,13 +27414,13 @@ snapshots:
     dependencies:
       to-regex-range: 5.0.1
 
-  final-form-arrays@3.0.2(final-form@4.20.9):
+  final-form-arrays@4.0.1(final-form@5.0.1):
     dependencies:
-      final-form: 4.20.9
+      final-form: 5.0.1
 
-  final-form@4.20.9:
+  final-form@5.0.1:
     dependencies:
-      '@babel/runtime': 7.28.4
+      '@babel/runtime': 7.29.2
 
   finalhandler@1.3.1:
     dependencies:
@@ -33032,26 +33025,25 @@ snapshots:
 
   react-fast-compare@3.2.2: {}
 
-  react-final-form-arrays@3.1.4(final-form-arrays@3.0.2(final-form@4.20.9))(final-form@4.20.9)(react-final-form@6.5.9(final-form@4.20.9)(react@18.2.0))(react@18.2.0):
+  react-final-form-arrays@5.0.0(final-form-arrays@4.0.1(final-form@5.0.1))(final-form@5.0.1)(react-final-form@7.0.1(final-form@5.0.1)(react@18.2.0))(react@18.2.0):
     dependencies:
-      '@babel/runtime': 7.28.4
-      final-form: 4.20.9
-      final-form-arrays: 3.0.2(final-form@4.20.9)
+      '@babel/runtime': 7.29.2
+      final-form: 5.0.1
+      final-form-arrays: 4.0.1(final-form@5.0.1)
       react: 18.2.0
-      react-final-form: 6.5.9(final-form@4.20.9)(react@18.2.0)
+      react-final-form: 7.0.1(final-form@5.0.1)(react@18.2.0)
 
-  react-final-form-listeners@1.0.3(final-form@4.20.9)(prop-types@15.8.1)(react-final-form@6.5.9(final-form@4.20.9)(react@18.2.0))(react@18.2.0):
+  react-final-form-listeners@3.0.1(patch_hash=267ee13c92b1d81c3016dd0b8d2ca4b7b95003e6479058644735ece6376f3e6e)(final-form@5.0.1)(react-final-form@7.0.1(final-form@5.0.1)(react@18.2.0))(react@18.2.0):
     dependencies:
-      '@babel/runtime': 7.28.4
-      final-form: 4.20.9
-      prop-types: 15.8.1
+      '@babel/runtime': 7.29.2
+      final-form: 5.0.1
       react: 18.2.0
-      react-final-form: 6.5.9(final-form@4.20.9)(react@18.2.0)
+      react-final-form: 7.0.1(final-form@5.0.1)(react@18.2.0)
 
-  react-final-form@6.5.9(final-form@4.20.9)(react@18.2.0):
+  react-final-form@7.0.1(final-form@5.0.1)(react@18.2.0):
     dependencies:
-      '@babel/runtime': 7.28.4
-      final-form: 4.20.9
+      '@babel/runtime': 7.29.2
+      final-form: 5.0.1
       react: 18.2.0
 
   react-focus-lock@2.6.0(@types/react@17.0.39)(react@18.2.0):

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -64,6 +64,7 @@ overrides:
 patchedDependencies:
   '@changesets/get-github-info@0.6.0': patches/@changesets__get-github-info@0.6.0.patch
   '@storybook/react-docgen-typescript-plugin@1.0.2-canary.6.9d540b91e815f8fc2f8829189deb00553559ff63.0': 'patches/@storybook__react-docgen-typescript-plugin@1.0.2-canary.6.9d540b91e815f8fc2f8829189deb00553559ff63.0.patch'
+  react-final-form-listeners@3.0.1: patches/react-final-form-listeners@3.0.1.patch
   'webpack@5.98.0': 'patches/webpack@5.98.0.patch'
 resolvePeersFromWorkspaceRoot: true
 strictPeerDependencies: false


### PR DESCRIPTION
[PF-2287]

### Description

Upgrades the final-form ecosystem in `@toptal/picasso-forms` to the versions that support React 19. The versions we were on do not declare React 19 in their peer ranges, which blocks consumers from adopting React 19:

| Package | Before | After |
| --- | --- | --- |
| `final-form` | `^4.20.9` | `^5.0.1` |
| `final-form-arrays` | `3.0.2` | `^4.0.1` |
| `react-final-form` | `^6.5.9` | `^7.0.1` |
| `react-final-form-arrays` | `^3.1.4` | `^5.0.0` |
| `react-final-form-listeners` | `^1.0.3` | `^3.0.1` |

Upstream will not patch the old lines — the request to widen `react-final-form@6.5.9`'s peer range ([final-form/react-final-form#1043](https://github.com/final-form/react-final-form/issues/1043)) was closed in favour of the v7 major. These majors are upstream's Flow-to-TypeScript rewrite and carry no intentional API changes ("There _should_ be **NO BREAKING CHANGES**, but because so much code was touched, I'm bumping to a major version out of precaution"). The upgrade is all-or-nothing because the new majors peer-depend on each other, which is why `final-form` and `final-form-arrays` move too.

The public API of `@toptal/picasso-forms` is unchanged — the re-exported `FieldArray`, `useFieldArray`, `OnChange`, `OnFocus`, `OnBlur` and `ExternallyChanged` surfaces are identical.

**Notes for reviewers**

- **`patches/react-final-form-listeners@3.0.1.patch` (new).** Upstream v3.0.1 has a broken publish: `package.json` declares `"types": "dist/index.d.ts"` but the file ships at `dist/src/index.d.ts`, so TypeScript treats the module as untyped and the build fails with TS7016. The patch corrects that one path. It also lets us drop the `@types/react-final-form-listeners` dev dependency, since the package now ships its own types. To be reported upstream; the patch and its `pnpm-workspace.yaml` entry can be deleted once a fixed version is published.
- **Mutator type signatures.** `final-form` v5 constrains `MutableState`'s second type parameter (`InitialFormValues extends Partial<FormValues>`) and types `Mutator`'s first argument as `any[]`. `setActiveFieldTouched` and `setHasMultilineCounter` were adjusted to match; in the latter the argument tuple moved from the signature into a local cast. Runtime behaviour is unchanged.
- **Checkbox snapshots (3 updated).** v7 changed what `input.value` returns for `checkbox`/`radio` fields: v6 returned the `_value` prop unconditionally (`undefined` for a standalone checkbox, so React omitted the attribute), whereas v7 returns it only when defined and otherwise falls through to the field value. A standalone checkbox's visually-hidden native input therefore now renders `value=""`. Verified as cosmetic — submitted values are byte-identical on both versions (`{ 'single-checkbox': true }` standalone, `{ 'checkbox-group': ['checkbox-value-1'] }` in a group), and checked-state handling is untouched. Consumers with their own snapshots covering a `Form.Checkbox` should expect a one-time regeneration.
- **`NumberInput` test assertion removed.** v7 renders the field twice on mount instead of once, breaking `expect(numberInputMock).toHaveBeenCalledTimes(1)`. Both calls are identical and carry the correct props, so rather than re-pin the test to an upstream render count that can shift again on any minor, the count assertion was dropped. The `toHaveBeenCalledWith` assertion below it still covers what the test is named for — that `min`/`max` reach the underlying component.

**Out of scope.** Widening the `react`/`react-dom` peer range of `@toptal/picasso-forms` itself (still `>=17.0.0 < 19.0.0`). This PR is the prerequisite; declaring React 19 support is a separate decision affecting the whole Picasso release line and will be its own ticket.

### How to test

- [Temploy](https://picasso.toptal.net/pf-2287-form-package-react-support)
- `pnpm install` — no unmet-peer warnings for the final-form family
- `pnpm typecheck` and `pnpm test:unit` — both green locally (full workspace: 306 suites / 1411 tests / 274 snapshots, 0 failures)
- In the deployed Storybook, exercise the behaviour that touches final-form internals most directly, since unit coverage there is thinner:
  - TextArea with a character counter (uses the `setHasMultilineCounter` mutator)
  - `validateOnBlur` flows (uses the `setActiveFieldTouched` mutator)
  - scroll-to-error on submit, and form autosave
  - `OnChange` / `OnBlur` / `OnFocus` listeners, and `FieldArray` add/remove
  - single checkboxes and checkbox groups — verify submitted values and click-to-toggle

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| No visual change — dependency upgrade only; Happo expected clean | No visual change — dependency upgrade only; Happo expected clean |

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Double check if `picasso-tailwind-merge` requires major update (check its `README.md`)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests ([visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md) included)

**Breaking change**

- [ ] codemod is created and showcased in the changeset
- [ ] test alpha package of Picasso in StaffPortal

[PF-2287]: https://toptal-core.atlassian.net/browse/PF-2287?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ