### PR TITLE
[PF-2289] Upgrade picasso-charts to support React v19

### DIFF
--- a/.changeset/charts-recharts-react-19.md
+++ b/.changeset/charts-recharts-react-19.md
@@ -1,0 +1,9 @@
+---
+'@toptal/picasso-charts': patch
+---
+
+### Charts
+
+- upgrade `recharts` to `^2.15.4` so the package can run under React 19. `2.15.0` is the first recharts release whose `react` peer range admits `^19.0.0`, and it also rewrites the function components that carried `defaultProps` — `XAxis`, `YAxis`, `ReferenceArea` and `ReferenceLine`, all used by `LineChart` and `BarChart`. React 19 no longer applies `defaultProps` on function components, which would have dropped defaults such as `xAxisId`/`yAxisId`, `orientation` and `type` and left charts blank or misaligned
+- `react-smooth` moves to `4.0.4` and `react-is` to 18 inside recharts' dependency tree; `react-smooth@4.0.4` is the first release whose peer range admits React 19
+- no `@toptal/picasso-charts` API or behavior change. The `react` peer range stays capped at `< 19.0.0`; lifting that cap library-wide is tracked separately in PF-2262

--- a/packages/picasso-charts/package.json
+++ b/packages/picasso-charts/package.json
@@ -35,7 +35,7 @@
     "classnames": "^2.5.1",
     "d3-array": "^3.2.2",
     "debounce": "^1.2.1",
-    "recharts": "^2.12.3"
+    "recharts": "^2.15.4"
   },
   "exports": {
     ".": "./dist-package/src/index.js",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3412,8 +3412,8 @@ importers:
         specifier: ^18.2.0
         version: 18.2.0
       recharts:
-        specifier: ^2.12.3
-        version: 2.12.3(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        specifier: ^2.15.4
+        version: 2.15.4(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       typescript:
         specifier: ^5.5.0
         version: 5.5.4
@@ -15285,8 +15285,8 @@ packages:
   react-sizeme@3.0.2:
     resolution: {integrity: sha512-xOIAOqqSSmKlKFJLO3inBQBdymzDuXx4iuwkNcJmC96jeiOg5ojByvL+g3MW9LPEsojLbC6pf68zOfobK8IPlw==}
 
-  react-smooth@4.0.0:
-    resolution: {integrity: sha512-2NMXOBY1uVUQx1jBeENGA497HK20y6CPGYL1ZnJLeoQ8rrc3UfmOM82sRxtzpcoCkUMy4CS0RGylfuVhuFjBgg==}
+  react-smooth@4.0.4:
+    resolution: {integrity: sha512-gnGKTpYwqL0Iii09gHobNolvX4Kiq4PKx6eWBCYYix+8cdw+cGo3do906l1NBPKkSWx1DghC1dlWG9L2uGd61Q==}
     peerDependencies:
       react: ^18.2.0
       react-dom: ^18.2.0
@@ -15448,9 +15448,10 @@ packages:
   recharts-scale@0.4.5:
     resolution: {integrity: sha512-kivNFO+0OcUNu7jQquLXAxz1FIwZj8nrj+YkOKc5694NbjCvcT6aSZiIzNzd2Kul4o4rTto8QVR9lMNtxD4G1w==}
 
-  recharts@2.12.3:
-    resolution: {integrity: sha512-vE/F7wTlokf5mtCqVDJlVKelCjliLSJ+DJxj79XlMREm7gpV7ljwbrwE3CfeaoDlOaLX+6iwHaVRn9587YkwIg==}
+  recharts@2.15.4:
+    resolution: {integrity: sha512-UT/q6fwS3c1dHbXv2uFgYJ9BMFHu3fwnd7AYZaEQhXuYQ4hgsxLvsUXzGdKeZrW5xopzDCvuA2N41WJ88I7zIw==}
     engines: {node: '>=14'}
+    deprecated: 1.x and 2.x branches are no longer active. Bump to Recharts v3 to receive latest features and bugfixes. See https://github.com/recharts/recharts/wiki/3.0-migration-guide
     peerDependencies:
       react: ^18.2.0
       react-dom: ^18.2.0
@@ -33193,7 +33194,7 @@ snapshots:
       shallowequal: 1.1.0
       throttle-debounce: 3.0.1
 
-  react-smooth@4.0.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
+  react-smooth@4.0.4(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
     dependencies:
       fast-equals: 5.0.1
       prop-types: 15.8.1
@@ -33451,15 +33452,15 @@ snapshots:
     dependencies:
       decimal.js-light: 2.5.0
 
-  recharts@2.12.3(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
+  recharts@2.15.4(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
     dependencies:
       clsx: 2.1.1
       eventemitter3: 4.0.7
       lodash: 4.17.21
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      react-is: 16.13.1
-      react-smooth: 4.0.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      react-is: 18.3.1
+      react-smooth: 4.0.4(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       recharts-scale: 0.4.5
       tiny-invariant: 1.3.1
       victory-vendor: 36.6.8


### PR DESCRIPTION
[PF-2262]

### Description

Upgrade `recharts` from `^2.12.3` to `^2.15.4` in `@toptal/picasso-charts` so the
package can run under React 19. This is one step towards lifting the
`< 19.0.0` React peer cap library-wide (PF-2262); the peer range itself is
**not** touched here.

`recharts@2.12.3` blocked React 19 in two independent ways:

1. **Declared peer range excluded it** — `^16.0.0 || ^17.0.0 || ^18.0.0`.
   Upstream added React 19 in `2.15.0`; every version from 2.12.4 through
   2.14.1 still excludes it, so 2.15.x is the minimum.
2. **Runtime break.** React 19 no longer applies `defaultProps` on function
   components, and 2.12.3 set `defaultProps` on seven of them — `XAxis`,
   `YAxis`, `ReferenceArea`, `ReferenceLine`, `ReferenceDot`, `ZAxis`,
   `ErrorBar`. `LineChart` and `BarChart` use four of these, so defaults such
   as `xAxisId`/`yAxisId: 0`, `orientation`, `type`, `tickCount` and
   `ifOverflow` would silently become `undefined` — axis lookup fails and
   charts render blank or misaligned. In 2.15.4 all seven are class components
   or read a module-level defaults constant, so React 19 applies them
   correctly.

Transitive effects, both resolved by the same bump:

- `react-smooth` 4.0.0 → **4.0.4** (4.0.4 is the first release whose peer range
  admits React 19)
- `react-is` 16.13.1 → **18.3.1** inside recharts' dependency tree

The `findDOMNode` hazard (API removed in React 19) lives only in react-smooth's
`AnimateGroup`/`AnimateGroupChild` via react-transition-group. recharts imports
neither module in 2.12.3 or 2.15.4, so that path is unreachable.

No `@toptal/picasso-charts` API or behaviour change. Deliberately **not** in
scope: widening the `react` peer range, upgrading the repo's own React,
recharts 3.x (breaking major, not needed for React 19), and the unrelated
`d3-array`/`debounce` bumps.

### How to test

- [Temploy](https://picasso.toptal.net/pf-2289-upgrade-charts-package-to-allow-react-v19-support)
- Open the **LineChart** and **BarChart** stories and confirm axes render with
  correct orientation, tick count and labels — a dropped `defaultProps` would
  show up as a missing or misplaced axis.
- Hover a chart and confirm the tooltip follows the cursor and stays inside the
  viewport at the chart edges.
- Confirm `ReferenceArea` / `ReferenceLine` still render in the LineChart
  examples that use them.
- Check the **Happo report**: 14 picasso-charts + 8 topkit-analytics-charts
  story examples. No visual change is expected; any diff needs triage before
  merge.

Verified locally:

- `recharts@2.15.4` resolves with react peer `^16 || ^17 || ^18 || ^19`;
  `react-smooth@4.0.4` likewise
- no function-component `.defaultProps` assignment remains in the resolved
  package (checked both `es6/` and the `lib/` CJS build Jest consumes)
- `tsc -b packages/picasso-charts packages/topkit-analytics-charts --force` →
  exit 0, including the `CategoricalChartProps` module augmentation in
  `src/types.ts`
- Jest: 17 suites / 44 tests pass across picasso-charts and
  topkit-analytics-charts; 0 snapshots, none updated
- `@toptal/topkit-analytics-charts` (depends on picasso-charts) builds and
  passes

### Screenshots

No visual change is intended — this is a dependency upgrade with no source
changes. The Happo report is the evidence; see **How to test**.

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| n/a — no visual change expected         | n/a — no visual change expected         |

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Double check if `picasso-tailwind-merge` requires major update (check its `README.md`) — n/a, no Tailwind or styling changes
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core — n/a, no design change
- [x] Annotate all `props` in component with documentation — n/a, no props added or changed
- [x] Create `examples` for component — n/a, no new component or behaviour
- [ ] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [ ] Self reviewed
- [x] Covered with tests ([visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md) included) — existing unit tests pass unchanged; visual coverage via Happo on 22 story examples. No new tests added, since there is no new behaviour to cover.

**Breaking change**

Not a breaking change — no codemod or alpha-package testing needed.

- [ ] codemod is created and showcased in the changeset
- [ ] test alpha package of Picasso in StaffPortal


[PF-2262]: https://toptal-core.atlassian.net/browse/PF-2262?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ