### PR TITLE
[PF-2291] Upgrade notistack and react-helmet-async versions

### DIFF
--- a/.changeset/notistack-react-19-support.md
+++ b/.changeset/notistack-react-19-support.md
@@ -1,0 +1,12 @@
+---
+'@toptal/picasso': minor
+'@toptal/picasso-shared': minor
+'@toptal/picasso-provider': patch
+'@toptal/picasso-notification': patch
+---
+
+### Notification
+
+- upgrade `notistack` from `3.0.1` to `3.0.2`, the first release whose peer range admits React 19 (`^17.0.0 || ^18.0.0 || ^19.0.0`). `3.0.2` ships no code changes — every published file is byte-identical to `3.0.1` — so notification behavior and appearance are unchanged
+- **consumer action** for `@toptal/picasso` and `@toptal/picasso-shared`: `notistack` is a pinned peer dependency, so consumers must move to `notistack@3.0.2`. The pin stays exact to guarantee a single notistack instance, since `SnackbarProvider` and `useSnackbar` communicate through React context and would not find each other across two copies
+- the `react` peer range is unchanged (still `>=17.0.0 < 19.0.0`); lifting that cap library-wide is tracked in PF-2262

--- a/.changeset/react-helmet-async-react-19-support.md
+++ b/.changeset/react-helmet-async-react-19-support.md
@@ -1,0 +1,13 @@
+---
+'@toptal/picasso-provider': patch
+'@toptal/picasso-page': patch
+---
+
+### Provider
+
+- upgrade `react-helmet-async` from `2.0.3` to `3.0.0`, the only release whose peer range admits React 19. No 2.x release supports it. The public API is unchanged — `Helmet` remains a class component, and `HelmetProvider`, `HelmetData` and the `HelmetProps` type are still exported — and React 16–18 keeps the existing code path, so behavior is unchanged for current consumers
+- on React 19, `<Helmet>` renders real DOM elements for React to hoist and `<HelmetProvider>` becomes a transparent passthrough. This changes four behaviors once consumers move to React 19: the SSR `context` object is no longer populated, and `prioritizeSeoTags`, `helmetData` and `canUseDOM` become inert. `htmlAttributes` and `bodyAttributes` continue to work on both code paths
+
+### Page
+
+- declare `react-helmet-async` as a dependency. `Page.Helmet` imported it without declaring it, so the import resolved to whatever copy the consumer happened to hoist — or to none at all. The dependency is now explicit and pinned to the same version the provider uses, which keeps `Page.Helmet` and `<HelmetProvider>` on one instance

--- a/packages/base/Notification/package.json
+++ b/packages/base/Notification/package.json
@@ -29,7 +29,7 @@
     "@toptal/picasso-typography": "workspace:*",
     "@toptal/picasso-utils": "workspace:*",
     "classnames": "^2.5.1",
-    "notistack": "3.0.1"
+    "notistack": "3.0.2"
   },
   "sideEffects": [
     "**/styles.ts",

--- a/packages/base/Page/package.json
+++ b/packages/base/Page/package.json
@@ -38,7 +38,8 @@
     "@toptal/picasso-tooltip": "workspace:*",
     "@toptal/picasso-typography": "workspace:*",
     "@toptal/picasso-user-badge": "workspace:*",
-    "@toptal/picasso-utils": "workspace:*"
+    "@toptal/picasso-utils": "workspace:*",
+    "react-helmet-async": "3.0.0"
   },
   "sideEffects": [
     "**/styles.ts",

--- a/packages/base/Page/src/PageHelmet/PageHelmet.tsx
+++ b/packages/base/Page/src/PageHelmet/PageHelmet.tsx
@@ -1,8 +1,6 @@
 import type { ReactNode } from 'react'
 import React from 'react'
-// eslint-disable-next-line import/no-extraneous-dependencies
 import type { HelmetProps } from 'react-helmet-async'
-// eslint-disable-next-line import/no-extraneous-dependencies
 import { Helmet } from 'react-helmet-async'
 
 export interface Props extends HelmetProps {

--- a/packages/picasso-provider/package.json
+++ b/packages/picasso-provider/package.json
@@ -29,8 +29,8 @@
   },
   "dependencies": {
     "classnames": "^2.5.1",
-    "notistack": "3.0.1",
-    "react-helmet-async": "2.0.3"
+    "notistack": "3.0.2",
+    "react-helmet-async": "3.0.0"
   },
   "devDependencies": {
     "@testing-library/react": "^14.1.2",

--- a/packages/picasso/package.json
+++ b/packages/picasso/package.json
@@ -29,7 +29,7 @@
   "peerDependencies": {
     "@toptal/picasso-provider": "workspace:^",
     "@toptal/picasso-tailwind": "workspace:^",
-    "notistack": "3.0.1",
+    "notistack": "3.0.2",
     "react": ">=17.0.0 < 19.0.0",
     "react-dom": ">=17.0.0 < 19.0.0",
     "typescript": "^5.5.0"

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -28,7 +28,7 @@
     "react": ">=17.0.0 < 19.0.0",
     "typescript": "^5.5.0",
     "@toptal/picasso-provider": "workspace:^",
-    "notistack": "3.0.1",
+    "notistack": "3.0.2",
     "react-dom": ">=17.0.0 < 19.0.0"
   },
   "dependencies": {
@@ -39,7 +39,7 @@
   "devDependencies": {
     "@types/classnames": "^2.3.1",
     "@toptal/picasso-provider": "workspace:*",
-    "notistack": "3.0.1"
+    "notistack": "3.0.2"
   },
   "sideEffects": [
     "**/styles.ts",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2003,8 +2003,8 @@ importers:
         specifier: ^2.5.1
         version: 2.5.1
       notistack:
-        specifier: 3.0.1
-        version: 3.0.1(csstype@3.1.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        specifier: 3.0.2
+        version: 3.0.2(csstype@3.1.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react:
         specifier: ^18.2.0
         version: 18.2.0
@@ -2186,6 +2186,9 @@ importers:
       react:
         specifier: ^18.2.0
         version: 18.2.0
+      react-helmet-async:
+        specifier: 3.0.0
+        version: 3.0.0(react@18.2.0)
     devDependencies:
       '@toptal/picasso-provider':
         specifier: workspace:*
@@ -3342,8 +3345,8 @@ importers:
         specifier: ^1.7.8
         version: 1.7.8
       notistack:
-        specifier: 3.0.1
-        version: 3.0.1(csstype@3.1.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        specifier: 3.0.2
+        version: 3.0.2(csstype@3.1.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react:
         specifier: ^18.2.0
         version: 18.2.0
@@ -3614,14 +3617,14 @@ importers:
         specifier: ^2.5.1
         version: 2.5.1
       notistack:
-        specifier: 3.0.1
-        version: 3.0.1(csstype@3.1.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        specifier: 3.0.2
+        version: 3.0.2(csstype@3.1.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       react:
         specifier: ^18.2.0
         version: 18.2.0
       react-helmet-async:
-        specifier: 2.0.3
-        version: 2.0.3(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        specifier: 3.0.0
+        version: 3.0.0(react@18.2.0)
       typescript:
         specifier: ^5.5.0
         version: 5.5.4
@@ -3913,8 +3916,8 @@ importers:
         specifier: ^2.3.1
         version: 2.3.1
       notistack:
-        specifier: 3.0.1
-        version: 3.0.1(csstype@3.1.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+        specifier: 3.0.2
+        version: 3.0.2(csstype@3.1.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
 
   packages/topkit-analytics-charts:
     dependencies:
@@ -13868,8 +13871,8 @@ packages:
     resolution: {integrity: sha512-uVFpKhj5MheNBJRTiMZ9pE/7hD1QTeEvugSJW/OmLzAp78PB5O6adfMNTvmfKhXBkvCzC+rqifWcVYpGFwTjnw==}
     engines: {node: '>=14.16'}
 
-  notistack@3.0.1:
-    resolution: {integrity: sha512-ntVZXXgSQH5WYfyU+3HfcXuKaapzAJ8fBLQ/G618rn3yvSzEbnOB8ZSOwhX+dAORy/lw+GC2N061JA0+gYWTVA==}
+  notistack@3.0.2:
+    resolution: {integrity: sha512-0R+/arLYbK5Hh7mEfR2adt0tyXJcCC9KkA2hc56FeWik2QN6Bm/S4uW+BjzDARsJth5u06nTjelSw/VSnB1YEA==}
     engines: {node: '>=12.0.0', npm: '>=6.0.0'}
     peerDependencies:
       react: ^18.2.0
@@ -15198,11 +15201,10 @@ packages:
       react: ^18.2.0
       react-dom: ^18.2.0
 
-  react-helmet-async@2.0.3:
-    resolution: {integrity: sha512-7/X3ehSCbjCaIljWa39Bb7F1Y2JWM23FN80kLozx2TdgzUmxKDSLN6qu06NG0Srzm8ljGOjgk7r7CXeEOx4MPw==}
+  react-helmet-async@3.0.0:
+    resolution: {integrity: sha512-nA3IEZfXiclgrz4KLxAhqJqIfFDuvzQwlKwpdmzZIuC1KNSghDEIXmyU0TKtbM+NafnkICcwx8CECFrZ/sL/1w==}
     peerDependencies:
       react: ^18.2.0
-      react-dom: ^18.2.0
 
   react-hot-loader@4.13.1:
     resolution: {integrity: sha512-ZlqCfVRqDJmMXTulUGic4lN7Ic1SXgHAFw7y/Jb7t25GBgTR0fYAJ8uY4mrpxjRyWGWmqw77qJQGnYbzCvBU7g==}
@@ -31461,7 +31463,7 @@ snapshots:
 
   normalize-url@8.0.0: {}
 
-  notistack@3.0.1(csstype@3.1.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
+  notistack@3.0.2(csstype@3.1.2)(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
     dependencies:
       clsx: 1.2.1
       goober: 2.1.13(csstype@3.1.2)
@@ -33062,11 +33064,10 @@ snapshots:
       react-fast-compare: 3.2.2
       shallowequal: 1.1.0
 
-  react-helmet-async@2.0.3(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
+  react-helmet-async@3.0.0(react@18.2.0):
     dependencies:
       invariant: 2.2.4
       react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
       react-fast-compare: 3.2.2
       shallowequal: 1.1.0
 


### PR DESCRIPTION
[PF-2291]

Base branch: `feature/pf-2262-lift-the-react-19-peer-dep`

### Description

Upgrade the two dependencies of `picasso-provider`, `picasso-notification` and
`picasso-page` whose `react` peer ranges exclude React 19, so the peer-cap lift on
the PF-2262 branch is unblocked. Both are version bumps — no component logic
changes. This PR does **not** touch Picasso's own `react` peer range; it stays
`>=17.0.0 < 19.0.0` on this branch, and lifting it remains PF-2262's job.

**notistack `3.0.1` → `3.0.2`** (5 declarations across 4 packages: peer in
`picasso` and `picasso-shared`, devDep in `picasso-shared`, dep in
`picasso-provider` and `picasso-notification`).

3.0.2 is the first release whose peer range admits React 19
(`^17.0.0 || ^18.0.0 || ^19.0.0`) and it is a **peer-range-only release** — every
published file is byte-identical to 3.0.1 (verified with `cmp` on `index.js`,
`index.d.ts`, `notistack.esm.js` and both CJS bundles). Only the version, the
peers and one devDependency changed upstream, so notification behaviour and
appearance cannot change.

3.0.1 was in fact already React-19-safe at runtime — the bundle's only
`defaultProps` sits on `Transition`, a **class** component (React 19 dropped
`defaultProps` only for *function* components), `SnackbarProvider` is also a
class, and there are zero `findDOMNode` occurrences. The block was purely the
declared peer range.

Pins are kept **exact** deliberately: `SnackbarProvider` and `useSnackbar`
communicate through React context, so two notistack copies in one tree would stop
them finding each other. Consumers must therefore move to `notistack@3.0.2`,
which is why `picasso` and `picasso-shared` are tiered `minor`.

**react-helmet-async `2.0.3` → `3.0.0`** (dependency of `picasso-provider`).

3.0.0 is the only release whose peer range admits React 19 — no 2.x version does,
including 2.0.5. The public API is unchanged (`Helmet` is still a class
component; `HelmetProvider`, `HelmetData` and `HelmetProps` are still exported),
runtime dependencies are identical to 2.0.3, and React 16–18 keeps the existing
code path — so behaviour is unchanged for consumers today. Two upstream deltas
worth noting: the `react-dom` peer is dropped, and `export * from './types'`
became an explicit named type list.

Once consumers reach React 19, `<Helmet>` renders real DOM elements for React to
hoist and `<HelmetProvider>` becomes a passthrough. That changes four behaviours:
the SSR `context` object is no longer populated, and `prioritizeSeoTags`,
`helmetData` and `canUseDOM` become inert. `htmlAttributes`/`bodyAttributes` still
work on both paths. All four are documented in the changeset.

**`picasso-page` now declares `react-helmet-async`.**

`PageHelmet` imported `Helmet` and `HelmetProps` without the package being
declared anywhere in `packages/base/Page/package.json`. Under
`nodeLinker: hoisted` that import silently resolved to the root copy — **1.3.0, a
transitive of `@storybook/components@5.3.21`/`5.3.22`**:

    require.resolve('react-helmet-async', { paths: ['packages/base/Page/src/PageHelmet'] })
      before -> node_modules/react-helmet-async                        (1.3.0)
      after  -> packages/base/Page/node_modules/react-helmet-async     (3.0.0)

So `Page.Helmet` was being built against helmet 1.x while its provider came from
picasso-provider's 2.0.3, and published `@toptal/picasso-page` declared no helmet
dependency at all, leaving consumers' resolution incidental. Declaring it fixes a
pre-existing packaging bug and is also required for React 19 — without it,
base/Page would keep compiling against the React-18-capped 1.3.0.

#### Known limitation (pre-existing, repo-local)

`base/Page` and `picasso-provider` now each hold a **nested** copy of helmet
3.0.0. Same file inode, but different resolved paths, so Node and webpack treat
them as two module instances (`a.HelmetProvider === b.HelmetProvider` is `false`).
Because helmet passes state through React context, rendering a `<Helmet>` from one
copy inside a `<HelmetProvider>` from the other falls back to the default `{}`
context and then throws
`TypeError: Cannot read properties of undefined (reading 'add')`.

Verified in jsdom: same instance renders fine; cross instance throws; and the
**pre-change shape** (provider 3.x + Page's root 1.3.0) throws identically — so
this is not introduced here. Root `node_modules` is still occupied by Storybook 6's
helmet 1.3.0, which is why both packages get nested copies; this PR makes the two
copies the same version but does not collapse them.

**Consumers are unaffected** — both published packages pin exactly 3.0.0, so a
consumer install hoists a single copy and gets one instance. It only affects this
repo (Storybook, and any test rendering `Page.Helmet` under the provider). If we
want it fixed in-repo, the options are a repo-wide pnpm override for
`react-helmet-async` (which would also replace Storybook's 1.3.0), or re-exporting
`Helmet` from picasso-provider so `PageHelmet` imports it from there. Both are out
of scope here — happy to open a follow-up.

### How to test

- [Temploy](https://picasso.toptal.net/pf-2291-upgrade-notification-and-provider-package-to-allow-react-v19-support)
- **Notification stories** — trigger snackbars via `useNotifications`; confirm
  they appear, stack, auto-dismiss and close as before. No code ships in notistack
  3.0.2, so any difference would be a resolution problem.
- **Page.Helmet story** — confirm it renders and the document title updates. Note
  the known limitation above: if it errors with `... (reading 'add')`, that is the
  pre-existing dual-instance issue, not a regression from this PR.
- **Favicon and viewport** — confirm `<PicassoProvider>` still sets the favicon and
  the `viewport` meta tag (`Favicon`, `Picasso/FixViewport`).
- Check the **Happo report**: no visual change is expected from either bump.

Verified locally:

- notistack resolves to a single 3.0.2 copy, peer `^17.0.0 || ^18.0.0 || ^19.0.0`
- react-helmet-async resolves to 3.0.0 from both `base/Page` and
  `picasso-provider`, peer includes `^19.0.0`
- `tsc -b --force` exit 0 for `picasso-provider`, `base/Page`, `base/Notification`,
  `shared` and the `picasso` aggregate — the helmet 1.x → 3.x type shift in
  `PageHelmet` required no source changes
- Jest: 20 suites / 117 tests pass across the affected packages; 27 snapshots
  unchanged, none updated
- Prettier clean on all touched files

> Note for reviewers: `pnpm typecheck` is a no-op in this repo — the root
> `tsconfig.json` is `"files": []` plus project references, and `tsc --noEmit` does
> not follow references. Use `tsc -b` as above.

### Screenshots

No visual change is intended — dependency bumps only, with no source changes to
any component. The Happo report is the evidence; see **How to test**.

| Before.                         | After.                          |
| ------------------------------- | ------------------------------- |
| n/a — no visual change expected | n/a — no visual change expected |

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed) — two changesets: `picasso`/`picasso-shared` minor (peer change requires consumer action), `picasso-provider`/`picasso-notification`/`picasso-page` patch (internal dependency bumps)
- [x] Double check if `picasso-tailwind-merge` requires major update (check its `README.md`) — n/a, no Tailwind or styling changes
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core — n/a, no design change
- [x] Annotate all `props` in component with documentation — n/a, no props added or changed
- [x] Create `examples` for component — n/a, no new component or behaviour
- [ ] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [ ] Self reviewed
- [x] Covered with tests ([visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md) included) — existing unit tests pass unchanged (20 suites / 117 tests, 27 snapshots untouched); visual coverage via Happo. No new tests added, as no new behaviour is introduced.

**Breaking change**

Not a breaking change — no codemod needed. Consumers of `@toptal/picasso` and
`@toptal/picasso-shared` do need to move `notistack` to `3.0.2` (it is a pinned
peer dependency); this is called out in the changeset and reflected in the `minor`
tier. Testing an alpha package in StaffPortal is recommended even so, since the
peer pin changes.

- [ ] codemod is created and showcased in the changeset
- [ ] test alpha package of Picasso in StaffPortal


[PF-2291]: https://toptal-core.atlassian.net/browse/PF-2291?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ