### PR TITLE
[PF-2292] Unlock picass-rich-text-editor React v19

### DIFF
--- a/.changeset/emoji-mart-react-19-support.md
+++ b/.changeset/emoji-mart-react-19-support.md
@@ -1,0 +1,8 @@
+---
+'@toptal/picasso-rich-text-editor': patch
+---
+
+### RichTextEditor
+
+- drop the `@emoji-mart/react` dependency and render emoji-mart's `Picker` through a local component instead. `@emoji-mart/react@1.1.1` is the latest release, was last published in January 2023, and declares a `react` peer range of `^16.8 || ^17 || ^18` that excludes React 19 — so no upgrade could unblock React 19 support. The wrapper was around 20 lines and used no API React 19 removes, so owning it removes the constraint without changing behavior. `emoji-mart` and `@emoji-mart/data` were already direct dependencies and are unchanged, so nothing is added to the dependency tree
+- the local component pushes prop updates into the picker from an effect. The upstream wrapper did this during render, which is a render-phase side effect

--- a/packages/picasso-rich-text-editor/package.json
+++ b/packages/picasso-rich-text-editor/package.json
@@ -37,7 +37,6 @@
   },
   "dependencies": {
     "@emoji-mart/data": "^1.2.1",
-    "@emoji-mart/react": "^1.1.1",
     "@lexical/html": "0.11.3",
     "@lexical/react": "0.11.3",
     "@toptal/picasso-container": "workspace:*",

--- a/packages/picasso-rich-text-editor/src/RichTextEditorEmojiPicker/EmojiMartPicker.test.tsx
+++ b/packages/picasso-rich-text-editor/src/RichTextEditorEmojiPicker/EmojiMartPicker.test.tsx
@@ -1,0 +1,20 @@
+import React from 'react'
+import data from '@emoji-mart/data'
+import { render, waitFor } from '@toptal/picasso-test-utils'
+
+import EmojiMartPicker from './EmojiMartPicker'
+
+const onEmojiSelect = jest.fn()
+
+const renderEmojiMartPicker = () =>
+  render(<EmojiMartPicker data={data} onEmojiSelect={onEmojiSelect} />)
+
+describe('EmojiMartPicker', () => {
+  it('mounts the emoji-mart picker element', async () => {
+    const { container } = renderEmojiMartPicker()
+
+    await waitFor(() =>
+      expect(container.querySelector('em-emoji-picker')).toBeInTheDocument()
+    )
+  })
+})

--- a/packages/picasso-rich-text-editor/src/RichTextEditorEmojiPicker/EmojiMartPicker.tsx
+++ b/packages/picasso-rich-text-editor/src/RichTextEditorEmojiPicker/EmojiMartPicker.tsx
@@ -1,0 +1,50 @@
+import React, { useEffect, useRef } from 'react'
+import { Picker } from 'emoji-mart'
+
+import type { CustomEmojiGroup, Emoji } from '../plugins/EmojiPlugin'
+
+interface Props {
+  /** Emoji dataset to render, as exported by `@emoji-mart/data` */
+  data: unknown
+  /** Additional groups of custom emojis appended to the picker */
+  custom?: CustomEmojiGroup[]
+  /** Called with the picked emoji when a selection is made */
+  onEmojiSelect: (emoji: Emoji) => void
+  /** Called when a click lands outside the picker */
+  onClickOutside?: () => void
+}
+
+/**
+ * Renders emoji-mart's `Picker` custom element.
+ *
+ * `Picker` appends itself to the element passed as `ref` and is fed prop
+ * changes through `update`, so it is constructed after the first commit and
+ * updated on every commit after that.
+ */
+const EmojiMartPicker = (props: Props) => {
+  const containerRef = useRef<HTMLDivElement>(null)
+  const pickerRef = useRef<Picker | null>(null)
+
+  useEffect(() => {
+    if (!pickerRef.current) {
+      pickerRef.current = new Picker({ ...props, ref: containerRef })
+
+      return
+    }
+
+    pickerRef.current.update(props)
+  })
+
+  useEffect(
+    () => () => {
+      pickerRef.current = null
+    },
+    []
+  )
+
+  return <div ref={containerRef} />
+}
+
+EmojiMartPicker.displayName = 'EmojiMartPicker'
+
+export default EmojiMartPicker

--- a/packages/picasso-rich-text-editor/src/RichTextEditorEmojiPicker/RichTextEditorEmojiPicker.tsx
+++ b/packages/picasso-rich-text-editor/src/RichTextEditorEmojiPicker/RichTextEditorEmojiPicker.tsx
@@ -1,11 +1,11 @@
 /* eslint-disable no-inline-styles/no-inline-styles */
 import React, { useEffect } from 'react'
 import data from '@emoji-mart/data'
-import Picker from '@emoji-mart/react'
 import cx from 'classnames'
 import { Container } from '@toptal/picasso-container'
 
 import RichTextEditorButton from '../RichTextEditorButton'
+import EmojiMartPicker from './EmojiMartPicker'
 import type { CustomEmojiGroup, Emoji } from '../plugins/EmojiPlugin'
 
 interface Props {
@@ -82,11 +82,11 @@ export const RichTextEditorEmojiPicker = ({
           showEmojiPicker && classes.activePointers
         )}
       >
-        <Picker
+        <EmojiMartPicker
           data={data}
           custom={customEmojis}
           onEmojiSelect={handleEmojiInsert}
-          onClickOutside={showEmojiPicker && closePicker}
+          onClickOutside={showEmojiPicker ? closePicker : undefined}
         />
       </Container>
     </Container>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3726,9 +3726,6 @@ importers:
       '@emoji-mart/data':
         specifier: ^1.2.1
         version: 1.2.1
-      '@emoji-mart/react':
-        specifier: ^1.1.1
-        version: 1.1.1(emoji-mart@5.5.2)(react@18.2.0)
       '@lexical/html':
         specifier: 0.11.3
         version: 0.11.3(lexical@0.11.3)
@@ -5188,12 +5185,6 @@ packages:
 
   '@emoji-mart/data@1.2.1':
     resolution: {integrity: sha512-no2pQMWiBy6gpBEiqGeU77/bFejDqUTRY7KX+0+iur13op3bqUsXdnwoZs6Xb1zbv0gAj5VvS1PWoUUckSr5Dw==}
-
-  '@emoji-mart/react@1.1.1':
-    resolution: {integrity: sha512-NMlFNeWgv1//uPsvLxvGQoIerPuVdXwK/EUek8OOkJ6wVOWPUizRBJU0hDqWZCOROVpfBgCemaC3m6jDOXi03g==}
-    peerDependencies:
-      emoji-mart: ^5.2
-      react: ^18.2.0
 
   '@emotion/cache@10.0.29':
     resolution: {integrity: sha512-fU2VtSVlHiF27empSbxi1O2JFdNWZO+2NFHfwO0pxgTep6Xa3uGb+3pVKfLww2l/IBGLNEZl5Xf/++A4wAYDYQ==}
@@ -19606,11 +19597,6 @@ snapshots:
       tslib: 2.8.1
 
   '@emoji-mart/data@1.2.1': {}
-
-  '@emoji-mart/react@1.1.1(emoji-mart@5.5.2)(react@18.2.0)':
-    dependencies:
-      emoji-mart: 5.5.2
-      react: 18.2.0
 
   '@emotion/cache@10.0.29':
     dependencies:


### PR DESCRIPTION
[PF-2292]

### Description

Remove the `@emoji-mart/react` dependency from `@toptal/picasso-rich-text-editor`
and render emoji-mart's `Picker` through a small local component instead, so the
package no longer carries a `react` peer range that excludes React 19. This
unblocks the peer-cap lift on the PF-2262 branch; Picasso's own `react` peer is
untouched here.

**Why not just upgrade.** `@emoji-mart/react@1.1.1` *is* the latest release — last
published January 2023 — and declares `react: ^16.8 || ^17 || ^18`. No version
exists that supports React 19, so there is nothing to bump to. Relaxing the peer
locally (pnpm patch or `peerDependencyRules`) would fix only this repo's install:
patches aren't published, so consumers on React 19 would still resolve
`@emoji-mart/react@1.1.1` and hit a peer warning or a failed install.

Owning the wrapper is cheap and permanent. It was ~20 lines, exactly one file
imported it, and `emoji-mart` plus `@emoji-mart/data` were **already** direct
dependencies — so nothing is added to the dependency tree, only removed.

**The new component** (`EmojiMartPicker`) constructs the `Picker` on the first
commit and feeds later prop changes through `picker.update(props)` — both from
effects. The upstream wrapper called `update` during render, which is a
render-phase side effect; owning the code let us fix that. It also nulls its
instance on unmount.

It is fully typed with no escape hatches: `Picker` imports from `emoji-mart` as
both a value and a type, so there is no `any` and no boundary cast at all. `data`
is deliberately typed `unknown` — `@emoji-mart/data`'s `.d.ts` exports only
interfaces with no default export, so typing it as `EmojiMartData` would break the
call site.

**One call-site change:** `onClickOutside={showEmojiPicker && closePicker}` passed
literal `false` when closed and now passes `undefined`. Both are falsy to
emoji-mart, so this is parity rather than a behaviour change.

Not addressed here, deliberately:

- **No story that opens the picker.** It renders behind `opacity-0` until toggled,
  so Happo almost certainly never captures it open. Adding one would genuinely
  improve coverage but moves the visual baseline, so it deserves its own decision.
- **SSR is unchanged.** `emoji-mart` calls `customElements.define(...)` and probes
  canvas at module scope, so importing it needs a DOM. That is pre-existing — the
  old import chain reached the same module — and this change neither improves nor
  worsens it.
- **`emoji-mart` 5.5.2 → 5.6.0** (which would enable the Emoji 15 additions) is
  tracked as a separate follow-up ticket, since it is a user-visible content
  change and not a React 19 blocker.

### How to test

- [Temploy](https://picasso.toptal.net/pf-2292-upgrade-rich-text-editor-package-to-allow-react-v19-support)
- Open the **RichText → Default** story and use the emoji button in the toolbar:
  the picker opens and closes, standard emojis insert into the editor, and the
  **custom emojis** from that story's `customEmojis` still appear and insert.
- Confirm `Escape` closes the picker, and that clicking outside it closes it.
- Confirm no console errors on open/close/insert.
- Check the **Happo report**: no visual change is expected.

Note the new unit test proves the picker *mounts*, but cannot exercise its UI — the
picker's contents live in a shadow DOM that testing-library cannot query. The
manual pass above is the real verification.

Verified locally:

- `@emoji-mart/react` is gone from the manifest, `pnpm-lock.yaml` (0 occurrences)
  and `node_modules`; no reference remains anywhere in the repo
- `emoji-mart@5.5.2` and `@emoji-mart/data@1.2.1` unchanged — nothing added
- `tsc -b --force` exit 0 for `picasso-rich-text-editor` **and** `picasso-forms`
  (its only dependent)
- Jest: picasso-rich-text-editor 22 suites / 91 tests pass, run three times with
  identical results; picasso-forms 17 suites / 66 tests / 11 snapshots pass
- ESLint (which runs with `--fix`) reported nothing and rewrote nothing; Prettier
  clean on all touched files
- The new test is non-vacuous: `em-emoji-picker` is a custom element only
  emoji-mart creates, so it fails if the picker never mounts

> Reviewer note: `pnpm typecheck` is a no-op in this repo — the root
> `tsconfig.json` is `"files": []` plus project references, and `tsc --noEmit` does
> not follow references. Use `tsc -b` as above.

### Screenshots

No visual change is intended — the picker renders the same emoji-mart element as
before, just constructed by our own component. The Happo report is the evidence;
see **How to test**.

| Before.                         | After.                          |
| ------------------------------- | ------------------------------- |
| n/a — no visual change expected | n/a — no visual change expected |

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed) — `patch` for `@toptal/picasso-rich-text-editor`: internal implementation change, no public API change
- [x] Double check if `picasso-tailwind-merge` requires major update (check its `README.md`) — n/a, no Tailwind or styling changes
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core — n/a, no design change
- [x] Annotate all `props` in component with documentation — the new internal component's props are JSDoc'd; no public props added or changed
- [x] Create `examples` for component — n/a, no new public component; the picker is already covered by the RichText story
- [ ] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [ ] Self reviewed
- [x] Covered with tests ([visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md) included) — added a mount test for the new component; existing 22 RTE suites and picasso-forms suites pass unchanged; visual coverage via Happo

**Breaking change**

Not a breaking change — no public API change and no codemod needed. The only
theoretical impact is on a consumer that imported `@emoji-mart/react` without
declaring it and relied on Picasso hoisting it; such a consumer would now need to
declare it themselves.

- [ ] codemod is created and showcased in the changeset
- [ ] test alpha package of Picasso in StaffPortal


[PF-2292]: https://toptal-core.atlassian.net/browse/PF-2292?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ