### PR TITLE
[PF-2295] Upgrade picasso-calendar to support React v19

### DIFF
--- a/.changeset/calendar-react-day-picker-react-19.md
+++ b/.changeset/calendar-react-day-picker-react-19.md
@@ -1,0 +1,8 @@
+---
+'@toptal/picasso-calendar': patch
+---
+
+### Calendar
+
+- upgrade `react-day-picker` to `^8.10.2` so the package can run under React 19. `8.10.2` is the first release whose `react` peer range admits `^19.0.0`, and it is the last release of the `8.x` line. It also stops inlining React 18's `react-jsx-runtime` into its bundle and imports `react/jsx-runtime` instead — the inlined copy read `React.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED`, which React 19 removes, so under React 19 importing `8.10.0` threw `Cannot read properties of undefined` before anything rendered
+- no `@toptal/picasso-calendar` API or behavior change. `8.10.2` keeps the whole v8 export surface, including the `useDayRender`, `useDayPicker` and `useNavigation` hooks that `Calendar`, `CalendarDay` and `CalendarMonthHeader` build on, and it renders identically under React 18. The `react` peer range stays capped at `< 19.0.0`; lifting that cap library-wide is tracked separately in PF-2262

--- a/packages/base/Calendar/package.json
+++ b/packages/base/Calendar/package.json
@@ -29,7 +29,7 @@
     "@toptal/picasso-typography": "workspace:*",
     "@toptal/picasso-utils": "workspace:*",
     "date-fns": "^2.30.0",
-    "react-day-picker": "^8.10.0"
+    "react-day-picker": "^8.10.2"
   },
   "sideEffects": [
     "**/styles.ts",

--- a/packages/picasso/package.json
+++ b/packages/picasso/package.json
@@ -118,7 +118,6 @@
     "detect-browser": "^5.3.0",
     "glider-js": "^1.7.8",
     "react-content-loader": "^6.2.1",
-    "react-day-picker": "^8.10.0",
     "react-dropzone": "^14.2.3",
     "react-input-mask": "^3.0.0-alpha.2",
     "react-truncate": "^2.4.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1060,8 +1060,8 @@ importers:
         specifier: ^18.2.0
         version: 18.2.0
       react-day-picker:
-        specifier: ^8.10.0
-        version: 8.10.0(date-fns@2.30.0)(react@18.2.0)
+        specifier: ^8.10.2
+        version: 8.10.2(date-fns@2.30.0)(react@18.2.0)
     devDependencies:
       '@toptal/picasso-provider':
         specifier: workspace:*
@@ -3341,9 +3341,6 @@ importers:
       react-content-loader:
         specifier: ^6.2.1
         version: 6.2.1(react@18.2.0)
-      react-day-picker:
-        specifier: ^8.10.0
-        version: 8.10.0(date-fns@2.30.0)(react@18.2.0)
       react-dom:
         specifier: ^18.2.0
         version: 18.2.0(react@18.2.0)
@@ -15090,8 +15087,8 @@ packages:
     peerDependencies:
       react: ^18.2.0
 
-  react-day-picker@8.10.0:
-    resolution: {integrity: sha512-mz+qeyrOM7++1NCb1ARXmkjMkzWVh2GL9YiPbRjKe0zHccvekk4HE+0MPOZOrosn8r8zTHIIeOUXTmXRqmkRmg==}
+  react-day-picker@8.10.2:
+    resolution: {integrity: sha512-LK68OTbHB3oJNhl9cA0qVizzp3o26w61YSjAFkYi67N86iro32wx86kSNeFU/hq+gI8m1yzWhnomMLfZ041RzQ==}
     peerDependencies:
       date-fns: ^2.28.0 || ^3.0.0
       react: ^18.2.0
@@ -32917,7 +32914,7 @@ snapshots:
     dependencies:
       react: 18.2.0
 
-  react-day-picker@8.10.0(date-fns@2.30.0)(react@18.2.0):
+  react-day-picker@8.10.2(date-fns@2.30.0)(react@18.2.0):
     dependencies:
       date-fns: 2.30.0
       react: 18.2.0


### PR DESCRIPTION
[PF-2295]

### Description

Upgrade `react-day-picker` from `^8.10.0` to `^8.10.2` in
`@toptal/picasso-calendar` so the package can run under React 19. This is one
step towards lifting the `< 19.0.0` React peer cap library-wide (PF-2262); the
peer range itself is **not** touched here.

`react-day-picker@8.10.0` blocked React 19 in two independent ways:

1. **Declared peer range excluded it** — `^16.8.0 || ^17.0.0 || ^18.0.0`.
   Upstream added React 19 in `8.10.2`; `8.10.1` still excludes it, so 8.10.2 is
   the minimum. It is also the final release of the `8.x` line.
2. **Runtime break.** `8.10.0` *inlines* React 18's `react-jsx-runtime` into its
   own bundle — both the development and the production copy — instead of
   importing it. That inlined code reads
   `React.__SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED`, which React 19
   removed, and it does so unguarded at module top level. Importing the package
   under React 19 therefore throws before anything renders:
   `Cannot read properties of undefined (reading 'ReactCurrentDispatcher')` in
   development, `... (reading 'ReactCurrentOwner')` in production. `8.10.2`
   externalises `react/jsx-runtime`, so no `__SECRET_INTERNALS_*` access remains.

A tarball diff of 8.10.0 → 8.10.2 shows the release contains nothing beyond the
peer range, the jsx-runtime externalisation, and `JSX.Element` → `ReactElement`
in the public type definitions. The export list is byte-identical, so the whole
v8 surface Calendar builds on survives — `useDayRender` (`CalendarDay`),
`useDayPicker` and `useNavigation` (`CalendarMonthHeader`), and `DayPicker`
itself.

`date-fns` is unaffected: 8.10.x peers `^2.28.0 || ^3.0.0` and the repo is on
`^2.30.0`.

Also removes `react-day-picker` from `@toptal/picasso`, which declared it as a
direct dependency but never imported it — `@toptal/picasso-calendar` owns the
real one.

**Note for reviewers.** `pnpm-workspace.yaml` pins `react: '^18.2.0'`,
`react-dom: '^18.2.0'` and `@types/react: '17'` in its repo-wide `overrides`.
pnpm applies overrides to peer ranges too, which is why the lockfile records
react-day-picker's peer as `react: ^18.2.0` rather than the React 19-admitting
range it actually publishes. Published consumers are unaffected — they resolve
from the real manifests — but it does mean nothing in this repo can execute
under React 19 until those three overrides change. Worth confirming that sits
inside PF-2262's scope, since it gates ever running the suite against React 19.

No `@toptal/picasso-calendar` API or behaviour change. Deliberately **not** in
scope: widening the `react` peer range, upgrading the repo's own React,
react-day-picker v9/v10 (a full rewrite — `useDayRender` and `useNavigation` are
removed, `DropdownProps` loses `caption`, and every `classNames` key Calendar
sets is gone — and not needed for React 19), and the `@types/react` v19 type
fixes Calendar will need when the types migration lands (three unqualified
`JSX.Element` references and one `RefObject<HTMLButtonElement | null>` mismatch
at `useDayRender`; none are errors under the pinned `@types/react` 17).

### How to test

- [Temploy](https://picasso.toptal.net/pf-2295-upgrade-calendar-package-to-allow-react-v19-support)
- Open the **Calendar** stories — `Default`, `Range`, `WithTwoMonths`,
  `WithDisabledIntervals`, `WithIndicatedIntervals`, `WithSelectableDaysLimit`,
  `WithWeekStartsOnSunday`, `WithCustomDayRendering`.
- Pick a range and confirm start / middle / end days highlight correctly, and
  that hovering mid-selection previews the range. This exercises the
  `range_middle` modifier that `Calendar`'s `handleRangeChange` branches on.
- Confirm month navigation works in both the arrow-button caption and, on the
  DatePicker examples using `dropdownNavigation`, the month + year selects.
- Confirm disabled intervals and orange indicator dots still render.
- Check the **Happo report**: 8 Calendar + 20 DatePicker story examples. No
  visual change is expected; any diff needs triage before merge.

Verified locally:

- `react-day-picker@8.10.2` resolves with react peer
  `^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0`
- zero `__SECRET_INTERNALS_*` references remain in the resolved bundle
- `pnpm typecheck` → exit 0. This is the one real risk of the bump, since 8.10.2
  rewrote its public `.d.ts` return types from `JSX.Element` to `ReactElement`
- `tsc -b` for `@toptal/picasso-calendar` and `@toptal/picasso-date-picker` →
  exit 0
- Jest: 4 suites / 50 tests pass across Calendar and DatePicker; 2 snapshots
  pass **unchanged**, which is the local evidence that the bump is
  behaviour-neutral
- `pnpm-lock.yaml` diff is 5 lines — exactly the version bump, no transitive
  movement
- Independently, against React 19.2.8: a faithful mirror of Calendar's usage
  (custom `Day` via `useDayRender`, custom `Caption` via
  `useDayPicker`/`useNavigation`, custom `Dropdown`) renders 35 day cells with
  correct `weekend` modifiers and both dropdown selects, and client-side range
  selection fires `onSelect` carrying the `range_middle` flag. Under React
  18.3.1, 8.10.2 emits byte-identical HTML to 8.10.0
- Cypress could **not** be run locally — the Cypress 13.6.0 Electron binary will
  not start in WSL2. `cypress/component/Calendar.spec.tsx` and
  `DatePicker.spec.tsx` are covered by CI

### Screenshots

No visual change is intended — this is a dependency upgrade with no source
changes. The Happo report is the evidence; see **How to test**.

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| n/a — no visual change expected         | n/a — no visual change expected         |

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Double check if `picasso-tailwind-merge` requires major update (check its `README.md`) — n/a, no Tailwind or styling changes
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core — n/a, no design change
- [x] Annotate all `props` in component with documentation — n/a, no props added or changed
- [x] Create `examples` for component — n/a, no new component or behaviour
- [ ] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [ ] Self reviewed
- [x] Covered with tests ([visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md) included) — existing unit tests pass unchanged; visual coverage via Happo on 28 story examples. No new tests added, since there is no new behaviour to cover.

**Breaking change**

Not a breaking change — no codemod or alpha-package testing needed.

- [ ] codemod is created and showcased in the changeset
- [ ] test alpha package of Picasso in StaffPortal


[PF-2295]: https://toptal-core.atlassian.net/browse/PF-2295?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ