### PR TITLE
[PF-2145] Migrate Backdrop, Fade, Slide to tailwind

### DIFF
--- a/.changeset/transitions-tailwind-migration.md
+++ b/.changeset/transitions-tailwind-migration.md
@@ -9,6 +9,7 @@
 ### Utils
 
 - add `useTransitionStatus` hook and `getTransitionTimeouts` helper — a timer-driven replacement for react-transition-group's `Transition` state machine with identical callback timing
+- add `getElementRef` helper, typing the ref lookup on a React element in one place
 
 ### Fade
 

--- a/.changeset/transitions-tailwind-migration.md
+++ b/.changeset/transitions-tailwind-migration.md
@@ -1,0 +1,32 @@
+---
+'@toptal/picasso-utils': minor
+'@toptal/picasso-fade': minor
+'@toptal/picasso-slide': minor
+'@toptal/picasso-backdrop': patch
+'@toptal/picasso-tailwind-merge': patch
+---
+
+### Utils
+
+- add `useTransitionStatus` hook and `getTransitionTimeouts` helper — a timer-driven replacement for react-transition-group's `Transition` state machine with identical callback timing
+
+### Fade
+
+- reimplement with Tailwind classes and drop the react-transition-group dependency; public props and callback timing are unchanged
+- express the hidden state via the `invisible` and `opacity-0` classes instead of inline `visibility`/`opacity` styles, and merge the child's `className` via `twMerge`
+- the object form of `timeout` now sets the CSS transition duration correctly (previously it produced an invalid inline value)
+
+### Slide
+
+- reimplement with Tailwind classes and drop the react-transition-group dependency; public props, the direction mapping and callback timing are unchanged
+- express the hidden state via `translate-*` and `invisible` classes instead of inline `transform`/`visibility` styles, so a child's own `transform` is preserved while sliding and `transitionend` listeners observe `propertyName: 'translate'`
+- the object form of `timeout` now sets the CSS transition duration correctly (previously it produced an invalid inline value)
+
+### Backdrop
+
+- compose the Tailwind-based Fade so react-transition-group is no longer in the dependency tree
+- remove the redundant `bg-black` class and a dead `-webkit-tap-highlight-color-transparent` class (no visual change) and merge the consumer `className` via `twMerge` so consumer utilities win on conflicts
+
+### TailwindMerge
+
+- remove the unused react-transition-group dependency

--- a/packages/base/Backdrop/package.json
+++ b/packages/base/Backdrop/package.json
@@ -22,19 +22,21 @@
   },
   "homepage": "https://github.com/toptal/picasso/tree/master/packages/picasso#readme",
   "dependencies": {
-    "@toptal/picasso-utils": "workspace:*",
     "@toptal/picasso-fade": "workspace:*",
+    "@toptal/picasso-shared": "workspace:*",
     "classnames": "^2.5.1"
   },
   "sideEffects": false,
   "peerDependencies": {
     "@toptal/picasso-tailwind": "workspace:^",
+    "@toptal/picasso-tailwind-merge": "workspace:^",
     "react": ">=17.0.0 < 19.0.0"
   },
   "exports": {
     ".": "./dist-package/src/index.js"
   },
   "devDependencies": {
+    "@toptal/picasso-tailwind-merge": "workspace:*",
     "@toptal/picasso-test-utils": "workspace:*"
   },
   "files": [

--- a/packages/base/Backdrop/src/Backdrop/Backdrop.tsx
+++ b/packages/base/Backdrop/src/Backdrop/Backdrop.tsx
@@ -1,11 +1,10 @@
 import React from 'react'
 import cx from 'classnames'
 import { Fade } from '@toptal/picasso-fade'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 import type { BaseProps } from '@toptal/picasso-shared'
 
-export interface Props
-  extends BaseProps,
-    React.HTMLAttributes<HTMLDivElement> {
+export interface Props extends BaseProps, React.HTMLAttributes<HTMLDivElement> {
   /** The duration for the transition, in milliseconds */
   transitionDuration?: number
   /** If `true`, the backdrop is shown */
@@ -16,7 +15,7 @@ export interface Props
 }
 
 export const Backdrop = React.forwardRef<HTMLDivElement, Props>(
-  (props, ref) => {
+  function Backdrop(props, ref) {
     const {
       transitionDuration = 300,
       open,
@@ -30,11 +29,11 @@ export const Backdrop = React.forwardRef<HTMLDivElement, Props>(
     return (
       <Fade in={open} timeout={transitionDuration}>
         <div
-          className={cx(
-            'fixed -z-[1] inset-0 bg-black',
-            '-webkit-tap-highlight-color-transparent',
-            { 'bg-black/0': invisible },
-            { 'bg-black/50': !invisible },
+          className={twMerge(
+            cx(
+              'fixed -z-[1] inset-0',
+              invisible ? 'bg-black/0' : 'bg-black/50'
+            ),
             className
           )}
           ref={ref}
@@ -44,5 +43,7 @@ export const Backdrop = React.forwardRef<HTMLDivElement, Props>(
     )
   }
 )
+
+Backdrop.displayName = 'Backdrop'
 
 export default Backdrop

--- a/packages/base/Backdrop/src/Backdrop/test.tsx
+++ b/packages/base/Backdrop/src/Backdrop/test.tsx
@@ -6,10 +6,23 @@ import Backdrop from './Backdrop'
 describe('Backdrop component', () => {
   afterEach(cleanup)
 
-  it('should render without crash', () => {
-    const { container } = render(<Backdrop open={true} />)
+  it('renders a fixed full-viewport scrim', () => {
+    const { getByTestId } = render(
+      <Backdrop data-testid='backdrop' open={true} />
+    )
 
-    expect(container).toBeInTheDocument()
+    expect(getByTestId('backdrop')).toHaveClass('fixed')
+    expect(getByTestId('backdrop')).toHaveClass('inset-0')
+    expect(getByTestId('backdrop')).not.toHaveClass('invisible')
+  })
+
+  it('hides via the fade when closed', () => {
+    const { getByTestId } = render(
+      <Backdrop data-testid='backdrop' open={false} />
+    )
+
+    expect(getByTestId('backdrop')).toHaveClass('invisible')
+    expect(getByTestId('backdrop')).toHaveClass('opacity-0')
   })
 
   describe('when invisible prop is true', () => {
@@ -30,6 +43,15 @@ describe('Backdrop component', () => {
 
       expect(getByTestId('backdrop')).toHaveClass('bg-black/50')
     })
+  })
+
+  it('lets a consumer className win on conflicts', () => {
+    const { getByTestId } = render(
+      <Backdrop data-testid='backdrop' open={true} className='bg-white/50' />
+    )
+
+    expect(getByTestId('backdrop')).toHaveClass('bg-white/50')
+    expect(getByTestId('backdrop')).not.toHaveClass('bg-black/50')
   })
 
   it('handle ref correctly', () => {

--- a/packages/base/Backdrop/tsconfig.json
+++ b/packages/base/Backdrop/tsconfig.json
@@ -4,7 +4,8 @@
   "include": ["src"],
   "references": [
     { "path": "../../picasso-tailwind" },
-    { "path": "../Fade" },
-    { "path": "../Utils" }
+    { "path": "../../picasso-tailwind-merge" },
+    { "path": "../../shared" },
+    { "path": "../Fade" }
   ]
 }

--- a/packages/base/Fade/package.json
+++ b/packages/base/Fade/package.json
@@ -22,20 +22,22 @@
   },
   "homepage": "https://github.com/toptal/picasso/tree/master/packages/picasso#readme",
   "dependencies": {
+    "@toptal/picasso-shared": "workspace:*",
     "@toptal/picasso-utils": "workspace:*",
-    "react-transition-group": "^4.4.5"
+    "classnames": "^2.5.1"
   },
   "sideEffects": false,
   "peerDependencies": {
     "@toptal/picasso-tailwind": "workspace:^",
+    "@toptal/picasso-tailwind-merge": "workspace:^",
     "react": ">=17.0.0 < 19.0.0"
   },
   "exports": {
     ".": "./dist-package/src/index.js"
   },
   "devDependencies": {
-    "@toptal/picasso-test-utils": "workspace:*",
-    "@types/react-transition-group": "^4.4.5"
+    "@toptal/picasso-tailwind-merge": "workspace:*",
+    "@toptal/picasso-test-utils": "workspace:*"
   },
   "files": [
     "dist-package/**",

--- a/packages/base/Fade/src/Fade/Fade.tsx
+++ b/packages/base/Fade/src/Fade/Fade.tsx
@@ -2,6 +2,7 @@ import React, { useRef } from 'react'
 import cx from 'classnames'
 import type { BaseProps, TransitionProps } from '@toptal/picasso-shared'
 import {
+  getElementRef,
   getTransitionTimeouts,
   useMultipleForwardRefs,
   useTransitionStatus,
@@ -39,9 +40,7 @@ export const Fade = React.forwardRef<HTMLDivElement, Props>(function Fade(
   const combinedRef = useMultipleForwardRefs([
     ref,
     nodeRef,
-    // TODO: come up with proper type for children.ref
-    // @ts-expect-error ReactElement has no public `ref` field
-    children.ref,
+    getElementRef<HTMLDivElement>(children),
   ])
 
   const timeouts = getTransitionTimeouts(timeout)

--- a/packages/base/Fade/src/Fade/Fade.tsx
+++ b/packages/base/Fade/src/Fade/Fade.tsx
@@ -1,7 +1,12 @@
 import React, { useRef } from 'react'
-import { Transition } from 'react-transition-group'
+import cx from 'classnames'
 import type { BaseProps, TransitionProps } from '@toptal/picasso-shared'
-import { useMultipleForwardRefs } from '@toptal/picasso-utils'
+import {
+  getTransitionTimeouts,
+  useMultipleForwardRefs,
+  useTransitionStatus,
+} from '@toptal/picasso-utils'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 
 export interface Props extends TransitionProps, BaseProps {
   /* Element that accepts ref */
@@ -12,55 +17,56 @@ export interface Props extends TransitionProps, BaseProps {
   onEnter?: (node: HTMLElement, isAppearing: boolean) => void
 }
 
-export const Fade = React.forwardRef<HTMLDivElement, Props>(
-  ({ timeout = 300, children, in: inProp, style, onEnter, onExited }, ref) => {
-    const nodeRef = useRef(null)
-    const transitionStyles = {
-      entering: { opacity: 1 },
-      entered: { opacity: 1 },
-      exiting: { opacity: 0 },
-      exited: { opacity: 0 },
-    }
+const DEFAULT_TIMEOUT = 300
 
-    const combinedRef = useMultipleForwardRefs([
-      ref,
-      nodeRef,
-      // TODO: come up with proper type for children.ref
-      // @ts-ignore
-      children.ref,
-    ])
+export const Fade = React.forwardRef<HTMLDivElement, Props>(function Fade(
+  { timeout = DEFAULT_TIMEOUT, children, in: inProp, style, onEnter, onExited },
+  ref
+) {
+  const nodeRef = useRef<HTMLDivElement>(null)
 
-    return (
-      <Transition
-        appear
-        nodeRef={nodeRef}
-        in={inProp}
-        timeout={timeout}
-        onExited={onExited}
-        onEnter={onEnter}
-      >
-        {(
-          state: 'entering' | 'entered' | 'exiting' | 'exited',
-          childProps: {}
-        ) => {
-          return React.cloneElement(children, {
-            style: {
-              visibility: state === 'exited' && !inProp ? 'hidden' : undefined,
-              transitionDuration: `${timeout}ms`,
-              ...transitionStyles[state],
-              ...style,
-              ...children.props.style,
-            },
-            className: `opacity-0 transition-opacity ${
-              children.props.className || ''
-            }`,
-            ref: combinedRef,
-            ...childProps,
-          })
-        }}
-      </Transition>
-    )
-  }
-)
+  const status = useTransitionStatus({
+    in: inProp,
+    // Historical behavior: enter callbacks fire on mount-open, with no
+    // visible fade (the status flips pre-paint)
+    appear: true,
+    timeout,
+    nodeRef,
+    onEnter,
+    onExited,
+  })
+
+  const combinedRef = useMultipleForwardRefs([
+    ref,
+    nodeRef,
+    // TODO: come up with proper type for children.ref
+    // @ts-expect-error ReactElement has no public `ref` field
+    children.ref,
+  ])
+
+  const timeouts = getTransitionTimeouts(timeout)
+  const duration = inProp ? timeouts.enter : timeouts.exit
+
+  return React.cloneElement(children, {
+    className: twMerge(
+      'transition-opacity',
+      children.props.className,
+      // State classes stay after the child's className: behavior, not
+      // overridable defaults
+      cx({
+        'opacity-0': !inProp,
+        invisible: status === 'exited' && !inProp,
+      })
+    ),
+    style: {
+      transitionDuration: `${duration}ms`,
+      ...style,
+      ...children.props.style,
+    },
+    ref: combinedRef,
+  })
+})
+
+Fade.displayName = 'Fade'
 
 export default Fade

--- a/packages/base/Fade/src/Fade/test.tsx
+++ b/packages/base/Fade/src/Fade/test.tsx
@@ -3,7 +3,10 @@ import { act, cleanup, render } from '@toptal/picasso-test-utils'
 
 import Fade from './Fade'
 
-const SomeChildComponent = React.forwardRef<HTMLDivElement>((props, ref) => (
+const SomeChildComponent = React.forwardRef<
+  HTMLDivElement,
+  { className?: string }
+>((props, ref) => (
   <div ref={ref} data-testid='child-div' {...props}>
     Hello, I'm child div!
   </div>
@@ -19,14 +22,18 @@ describe('Fade', () => {
     jest.useRealTimers()
   })
 
-  it('renders without errors', () => {
+  it('shows the child when `in` is true', () => {
     const { getByTestId } = render(
       <Fade in={true}>
         <SomeChildComponent />
       </Fade>
     )
 
-    expect(getByTestId('child-div')).toBeInTheDocument()
+    const child = getByTestId('child-div')
+
+    expect(child).toHaveClass('transition-opacity')
+    expect(child).not.toHaveClass('opacity-0')
+    expect(child).not.toHaveClass('invisible')
   })
 
   it('transitions based on the `in` prop', () => {
@@ -36,7 +43,8 @@ describe('Fade', () => {
       </Fade>
     )
 
-    expect(getByTestId('child-div')).toHaveStyle('visibility: hidden')
+    expect(getByTestId('child-div')).toHaveClass('opacity-0')
+    expect(getByTestId('child-div')).toHaveClass('invisible')
 
     act(() => {
       rerender(
@@ -47,7 +55,64 @@ describe('Fade', () => {
       jest.runAllTimers()
     })
 
-    expect(getByTestId('child-div')).toHaveStyle('visibility: visible')
+    expect(getByTestId('child-div')).not.toHaveClass('opacity-0')
+    expect(getByTestId('child-div')).not.toHaveClass('invisible')
+
+    act(() => {
+      rerender(
+        <Fade in={false}>
+          <SomeChildComponent />
+        </Fade>
+      )
+    })
+
+    // Fade-out starts at once; `invisible` lands only after it settles
+    expect(getByTestId('child-div')).toHaveClass('opacity-0')
+    expect(getByTestId('child-div')).not.toHaveClass('invisible')
+
+    act(() => {
+      jest.runAllTimers()
+    })
+
+    expect(getByTestId('child-div')).toHaveClass('invisible')
+  })
+
+  it('calls `onEnter` marked as appearing when mounted shown', () => {
+    const onEnter = jest.fn()
+    const { getByTestId } = render(
+      <Fade in={true} onEnter={onEnter}>
+        <SomeChildComponent />
+      </Fade>
+    )
+
+    expect(onEnter).toHaveBeenCalledTimes(1)
+    expect(onEnter).toHaveBeenCalledWith(getByTestId('child-div'), true)
+  })
+
+  it('calls `onExited` after the exit transition settles', () => {
+    const onExited = jest.fn()
+    const { getByTestId, rerender } = render(
+      <Fade in={true} onExited={onExited}>
+        <SomeChildComponent />
+      </Fade>
+    )
+
+    act(() => {
+      rerender(
+        <Fade in={false} onExited={onExited}>
+          <SomeChildComponent />
+        </Fade>
+      )
+    })
+
+    expect(onExited).not.toHaveBeenCalled()
+
+    act(() => {
+      jest.runAllTimers()
+    })
+
+    expect(onExited).toHaveBeenCalledTimes(1)
+    expect(onExited).toHaveBeenCalledWith(getByTestId('child-div'))
   })
 
   it('forwards the ref', () => {
@@ -72,5 +137,41 @@ describe('Fade', () => {
     expect(getByTestId('child-div')).toHaveStyle({
       transitionDuration: `${timeout}ms`,
     })
+  })
+
+  it('applies per-phase durations from an object `timeout`', () => {
+    const timeout = { enter: 100, exit: 200 }
+    const { getByTestId, rerender } = render(
+      <Fade in={true} timeout={timeout}>
+        <SomeChildComponent />
+      </Fade>
+    )
+
+    expect(getByTestId('child-div')).toHaveStyle({
+      transitionDuration: '100ms',
+    })
+
+    act(() => {
+      rerender(
+        <Fade in={false} timeout={timeout}>
+          <SomeChildComponent />
+        </Fade>
+      )
+    })
+
+    expect(getByTestId('child-div')).toHaveStyle({
+      transitionDuration: '200ms',
+    })
+  })
+
+  it('preserves the child className', () => {
+    const { getByTestId } = render(
+      <Fade in={true}>
+        <SomeChildComponent className='p-4' />
+      </Fade>
+    )
+
+    expect(getByTestId('child-div')).toHaveClass('p-4')
+    expect(getByTestId('child-div')).toHaveClass('transition-opacity')
   })
 })

--- a/packages/base/Fade/tsconfig.json
+++ b/packages/base/Fade/tsconfig.json
@@ -2,5 +2,10 @@
   "extends": "../../../tsconfig.base.json",
   "compilerOptions": { "outDir": "dist-package" },
   "include": ["src"],
-  "references": [{ "path": "../../picasso-tailwind" }, { "path": "../Utils" }]
+  "references": [
+    { "path": "../../picasso-tailwind" },
+    { "path": "../../picasso-tailwind-merge" },
+    { "path": "../../shared" },
+    { "path": "../Utils" }
+  ]
 }

--- a/packages/base/Slide/package.json
+++ b/packages/base/Slide/package.json
@@ -22,20 +22,22 @@
   },
   "homepage": "https://github.com/toptal/picasso/tree/master/packages/picasso#readme",
   "dependencies": {
+    "@toptal/picasso-shared": "workspace:*",
     "@toptal/picasso-utils": "workspace:*",
-    "react-transition-group": "^4.4.5"
+    "classnames": "^2.5.1"
   },
   "sideEffects": false,
   "peerDependencies": {
     "@toptal/picasso-tailwind": "workspace:^",
+    "@toptal/picasso-tailwind-merge": "workspace:^",
     "react": ">=17.0.0 < 19.0.0"
   },
   "exports": {
     ".": "./dist-package/src/index.js"
   },
   "devDependencies": {
-    "@toptal/picasso-test-utils": "workspace:*",
-    "@types/react-transition-group": "^4.4.5"
+    "@toptal/picasso-tailwind-merge": "workspace:*",
+    "@toptal/picasso-test-utils": "workspace:*"
   },
   "files": [
     "dist-package/**",

--- a/packages/base/Slide/src/Slide/Slide.tsx
+++ b/packages/base/Slide/src/Slide/Slide.tsx
@@ -2,6 +2,7 @@ import React, { useRef } from 'react'
 import cx from 'classnames'
 import type { BaseProps, TransitionProps } from '@toptal/picasso-shared'
 import {
+  getElementRef,
   getTransitionTimeouts,
   useMultipleForwardRefs,
   useTransitionStatus,
@@ -52,9 +53,7 @@ export const Slide = React.forwardRef<HTMLDivElement, Props>(function Slide(
   const combinedRef = useMultipleForwardRefs([
     ref,
     nodeRef,
-    // TODO: come up with proper type for children.ref
-    // @ts-expect-error ReactElement has no public `ref` field
-    children.ref,
+    getElementRef<HTMLDivElement>(children),
   ])
 
   const timeouts = getTransitionTimeouts(timeout)

--- a/packages/base/Slide/src/Slide/Slide.tsx
+++ b/packages/base/Slide/src/Slide/Slide.tsx
@@ -1,34 +1,15 @@
 import React, { useRef } from 'react'
-import { Transition } from 'react-transition-group'
+import cx from 'classnames'
 import type { BaseProps, TransitionProps } from '@toptal/picasso-shared'
-import { useMultipleForwardRefs } from '@toptal/picasso-utils'
+import {
+  getTransitionTimeouts,
+  useMultipleForwardRefs,
+  useTransitionStatus,
+} from '@toptal/picasso-utils'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 
-const transitionStyles = {
-  right: {
-    entering: { transform: 'none' },
-    entered: { transform: 'none' },
-    exiting: { transform: 'translateX(-100%)' },
-    exited: { transform: 'translateX(-100%)' },
-  },
-  left: {
-    entering: { transform: 'none' },
-    entered: { transform: 'none' },
-    exiting: { transform: 'translateX(100%)' },
-    exited: { transform: 'translateX(100%)' },
-  },
-  up: {
-    entering: { transform: 'none' },
-    entered: { transform: 'none' },
-    exiting: { transform: 'translateY(100%)' },
-    exited: { transform: 'translateY(100%)' },
-  },
-  down: {
-    entering: { transform: 'none' },
-    entered: { transform: 'none' },
-    exiting: { transform: 'translateY(-100%)' },
-    exited: { transform: 'translateY(-100%)' },
-  },
-} as const
+import type { SlideDirection } from './styles'
+import { createStateClassNames } from './styles'
 
 export interface Props extends TransitionProps, BaseProps {
   /* Element that accepts ref */
@@ -38,63 +19,70 @@ export interface Props extends TransitionProps, BaseProps {
   /* Callback fired when the component has entered */
   onEnter?: (node: HTMLElement, isAppearing: boolean) => void
   /* Direction in which the component will slide */
-  direction: 'up' | 'down' | 'left' | 'right'
+  direction: SlideDirection
 }
 
-export const Slide = React.forwardRef<HTMLDivElement, Props>(
-  (
-    {
-      timeout = 300,
-      children,
-      in: inProp,
-      style,
-      onEnter,
-      onExited,
-      direction,
+const DEFAULT_TIMEOUT = 300
+
+export const Slide = React.forwardRef<HTMLDivElement, Props>(function Slide(
+  {
+    timeout = DEFAULT_TIMEOUT,
+    children,
+    in: inProp,
+    style,
+    onEnter,
+    onExited,
+    direction,
+  },
+  ref
+) {
+  const nodeRef = useRef<HTMLDivElement>(null)
+
+  const status = useTransitionStatus({
+    in: inProp,
+    // Historical behavior: enter callbacks fire on mount-open, with no
+    // visible slide (the status flips pre-paint)
+    appear: true,
+    timeout,
+    nodeRef,
+    onEnter,
+    onExited,
+  })
+
+  const combinedRef = useMultipleForwardRefs([
+    ref,
+    nodeRef,
+    // TODO: come up with proper type for children.ref
+    // @ts-expect-error ReactElement has no public `ref` field
+    children.ref,
+  ])
+
+  const timeouts = getTransitionTimeouts(timeout)
+  const duration = inProp ? timeouts.enter : timeouts.exit
+
+  return React.cloneElement(children, {
+    className: twMerge(
+      // In Tailwind v4 this also covers the standalone `translate` property
+      'transition-transform',
+      children.props.className,
+      // State classes stay after the child's className: behavior, not
+      // overridable defaults
+      cx(
+        ...createStateClassNames(direction, {
+          in: inProp,
+          exited: status === 'exited' && !inProp,
+        })
+      )
+    ),
+    style: {
+      transitionDuration: `${duration}ms`,
+      ...style,
+      ...children.props.style,
     },
-    ref
-  ) => {
-    const nodeRef = useRef(null)
+    ref: combinedRef,
+  })
+})
 
-    const combinedRef = useMultipleForwardRefs([
-      ref,
-      nodeRef,
-      // TODO: come up with proper type for children.ref
-      // @ts-ignore
-      children.ref,
-    ])
-
-    return (
-      <Transition
-        appear
-        nodeRef={nodeRef}
-        in={inProp}
-        timeout={timeout}
-        onExited={onExited}
-        onEnter={onEnter}
-      >
-        {(
-          state: 'entering' | 'entered' | 'exiting' | 'exited',
-          childProps: {}
-        ) => {
-          return React.cloneElement(children, {
-            style: {
-              visibility: state === 'exited' && !inProp ? 'hidden' : undefined,
-              transitionDuration: `${timeout}ms`,
-              ...transitionStyles[direction][state],
-              ...style,
-              ...children.props.style,
-            },
-            className: `transform-none transition-transform ${
-              children.props.className || ''
-            }`,
-            ref: combinedRef,
-            ...childProps,
-          })
-        }}
-      </Transition>
-    )
-  }
-)
+Slide.displayName = 'Slide'
 
 export default Slide

--- a/packages/base/Slide/src/Slide/styles.ts
+++ b/packages/base/Slide/src/Slide/styles.ts
@@ -1,0 +1,25 @@
+export type SlideDirection = 'up' | 'down' | 'left' | 'right'
+
+// Historical mapping: `direction` is where the element travels TO on
+// enter, so it rests hidden on the opposite side
+const hiddenClassByDirection: Record<SlideDirection, string> = {
+  right: '-translate-x-full',
+  left: 'translate-x-full',
+  up: 'translate-y-full',
+  down: '-translate-y-full',
+}
+
+const shownClassByDirection: Record<SlideDirection, string> = {
+  right: 'translate-x-0',
+  left: 'translate-x-0',
+  up: 'translate-y-0',
+  down: 'translate-y-0',
+}
+
+export const createStateClassNames = (
+  direction: SlideDirection,
+  { in: inProp, exited }: { in: boolean; exited: boolean }
+): string[] => [
+  inProp ? shownClassByDirection[direction] : hiddenClassByDirection[direction],
+  ...(exited ? ['invisible'] : []),
+]

--- a/packages/base/Slide/src/Slide/test.tsx
+++ b/packages/base/Slide/src/Slide/test.tsx
@@ -3,7 +3,10 @@ import { act, cleanup, render } from '@toptal/picasso-test-utils'
 
 import Slide from './Slide'
 
-const SomeChildComponent = React.forwardRef<HTMLDivElement>((props, ref) => (
+const SomeChildComponent = React.forwardRef<
+  HTMLDivElement,
+  { className?: string }
+>((props, ref) => (
   <div ref={ref} data-testid='child-div' {...props}>
     Hello, I'm child div!
   </div>
@@ -19,14 +22,18 @@ describe('Slide', () => {
     jest.useRealTimers()
   })
 
-  it('renders without errors', () => {
+  it('shows the child when `in` is true', () => {
     const { getByTestId } = render(
       <Slide direction='left' in={true}>
         <SomeChildComponent />
       </Slide>
     )
 
-    expect(getByTestId('child-div')).toBeInTheDocument()
+    const child = getByTestId('child-div')
+
+    expect(child).toHaveClass('transition-transform')
+    expect(child).toHaveClass('translate-x-0')
+    expect(child).not.toHaveClass('invisible')
   })
 
   it('transitions based on the `in` prop', () => {
@@ -36,7 +43,8 @@ describe('Slide', () => {
       </Slide>
     )
 
-    expect(getByTestId('child-div')).toHaveStyle('visibility: hidden')
+    expect(getByTestId('child-div')).toHaveClass('translate-x-full')
+    expect(getByTestId('child-div')).toHaveClass('invisible')
 
     act(() => {
       rerender(
@@ -47,7 +55,94 @@ describe('Slide', () => {
       jest.runAllTimers()
     })
 
-    expect(getByTestId('child-div')).toHaveStyle('visibility: visible')
+    expect(getByTestId('child-div')).toHaveClass('translate-x-0')
+    expect(getByTestId('child-div')).not.toHaveClass('invisible')
+
+    act(() => {
+      rerender(
+        <Slide direction='left' in={false}>
+          <SomeChildComponent />
+        </Slide>
+      )
+    })
+
+    // Slide-out starts at once; `invisible` lands only after it settles
+    expect(getByTestId('child-div')).toHaveClass('translate-x-full')
+    expect(getByTestId('child-div')).not.toHaveClass('invisible')
+
+    act(() => {
+      jest.runAllTimers()
+    })
+
+    expect(getByTestId('child-div')).toHaveClass('invisible')
+  })
+
+  it.each([
+    ['right', '-translate-x-full', 'translate-x-0'],
+    ['left', 'translate-x-full', 'translate-x-0'],
+    ['up', 'translate-y-full', 'translate-y-0'],
+    ['down', '-translate-y-full', 'translate-y-0'],
+  ] as const)(
+    'rests hidden on the opposite side for direction %s',
+    (direction, hiddenClass, shownClass) => {
+      const { getByTestId, rerender } = render(
+        <Slide direction={direction} in={false}>
+          <SomeChildComponent />
+        </Slide>
+      )
+
+      expect(getByTestId('child-div')).toHaveClass(hiddenClass)
+
+      act(() => {
+        rerender(
+          <Slide direction={direction} in={true}>
+            <SomeChildComponent />
+          </Slide>
+        )
+        jest.runAllTimers()
+      })
+
+      expect(getByTestId('child-div')).toHaveClass(shownClass)
+      expect(getByTestId('child-div')).not.toHaveClass(hiddenClass)
+    }
+  )
+
+  it('calls `onEnter` marked as appearing when mounted shown', () => {
+    const onEnter = jest.fn()
+    const { getByTestId } = render(
+      <Slide direction='left' in={true} onEnter={onEnter}>
+        <SomeChildComponent />
+      </Slide>
+    )
+
+    expect(onEnter).toHaveBeenCalledTimes(1)
+    expect(onEnter).toHaveBeenCalledWith(getByTestId('child-div'), true)
+  })
+
+  it('calls `onExited` after the exit transition settles', () => {
+    const onExited = jest.fn()
+    const { getByTestId, rerender } = render(
+      <Slide direction='left' in={true} onExited={onExited}>
+        <SomeChildComponent />
+      </Slide>
+    )
+
+    act(() => {
+      rerender(
+        <Slide direction='left' in={false} onExited={onExited}>
+          <SomeChildComponent />
+        </Slide>
+      )
+    })
+
+    expect(onExited).not.toHaveBeenCalled()
+
+    act(() => {
+      jest.runAllTimers()
+    })
+
+    expect(onExited).toHaveBeenCalledTimes(1)
+    expect(onExited).toHaveBeenCalledWith(getByTestId('child-div'))
   })
 
   it('forwards the ref', () => {
@@ -72,5 +167,41 @@ describe('Slide', () => {
     expect(getByTestId('child-div')).toHaveStyle({
       transitionDuration: `${timeout}ms`,
     })
+  })
+
+  it('applies per-phase durations from an object `timeout`', () => {
+    const timeout = { enter: 100, exit: 200 }
+    const { getByTestId, rerender } = render(
+      <Slide direction='left' in={true} timeout={timeout}>
+        <SomeChildComponent />
+      </Slide>
+    )
+
+    expect(getByTestId('child-div')).toHaveStyle({
+      transitionDuration: '100ms',
+    })
+
+    act(() => {
+      rerender(
+        <Slide direction='left' in={false} timeout={timeout}>
+          <SomeChildComponent />
+        </Slide>
+      )
+    })
+
+    expect(getByTestId('child-div')).toHaveStyle({
+      transitionDuration: '200ms',
+    })
+  })
+
+  it('preserves the child className', () => {
+    const { getByTestId } = render(
+      <Slide direction='left' in={true}>
+        <SomeChildComponent className='p-4' />
+      </Slide>
+    )
+
+    expect(getByTestId('child-div')).toHaveClass('p-4')
+    expect(getByTestId('child-div')).toHaveClass('transition-transform')
   })
 })

--- a/packages/base/Slide/tsconfig.json
+++ b/packages/base/Slide/tsconfig.json
@@ -2,5 +2,10 @@
   "extends": "../../../tsconfig.base.json",
   "compilerOptions": { "outDir": "dist-package" },
   "include": ["src"],
-  "references": [{ "path": "../../picasso-tailwind" }, { "path": "../Utils" }]
+  "references": [
+    { "path": "../../picasso-tailwind" },
+    { "path": "../../picasso-tailwind-merge" },
+    { "path": "../../shared" },
+    { "path": "../Utils" }
+  ]
 }

--- a/packages/base/Utils/src/utils/__tests__/get-element-ref.test.tsx
+++ b/packages/base/Utils/src/utils/__tests__/get-element-ref.test.tsx
@@ -1,0 +1,31 @@
+import React from 'react'
+
+import getElementRef from '../get-element-ref'
+
+describe('getElementRef', () => {
+  it('returns null when the element has no ref', () => {
+    expect(getElementRef(<div />)).toBeNull()
+  })
+
+  it('reads a ref object attached to the element', () => {
+    const ref = React.createRef<HTMLDivElement>()
+
+    expect(getElementRef<HTMLDivElement>(<div ref={ref} />)).toBe(ref)
+  })
+
+  it('reads a callback ref attached to the element', () => {
+    const ref = jest.fn()
+
+    expect(getElementRef<HTMLDivElement>(<div ref={ref} />)).toBe(ref)
+  })
+
+  it('does not read `ref` from props, which warns on React 18', () => {
+    const consoleError = jest.spyOn(console, 'error').mockImplementation()
+
+    getElementRef(<div />)
+
+    expect(consoleError).not.toHaveBeenCalled()
+
+    consoleError.mockRestore()
+  })
+})

--- a/packages/base/Utils/src/utils/__tests__/use-transition-status.test.tsx
+++ b/packages/base/Utils/src/utils/__tests__/use-transition-status.test.tsx
@@ -1,0 +1,303 @@
+import { renderHook, act } from '@testing-library/react-hooks'
+
+import type { UseTransitionStatusOptions } from '../use-transition-status'
+import useTransitionStatus, {
+  getTransitionTimeouts,
+} from '../use-transition-status'
+
+const createNodeRef = () => ({ current: document.createElement('div') })
+
+const renderTransitionStatus = (
+  options: Partial<UseTransitionStatusOptions<HTMLDivElement>> = {}
+) => {
+  const nodeRef = createNodeRef()
+  const initialProps: UseTransitionStatusOptions<HTMLDivElement> = {
+    in: false,
+    timeout: 300,
+    nodeRef,
+    ...options,
+  }
+
+  const result = renderHook(props => useTransitionStatus(props), {
+    initialProps,
+  })
+
+  return { ...result, nodeRef, initialProps }
+}
+
+describe('getTransitionTimeouts', () => {
+  it('spreads a numeric timeout across all phases', () => {
+    expect(getTransitionTimeouts(250)).toEqual({
+      enter: 250,
+      exit: 250,
+      appear: 250,
+    })
+  })
+
+  it('resolves the object form with `appear` falling back to `enter`', () => {
+    expect(getTransitionTimeouts({ enter: 100, exit: 200 })).toEqual({
+      enter: 100,
+      exit: 200,
+      appear: 100,
+    })
+    expect(
+      getTransitionTimeouts({ enter: 100, exit: 200, appear: 50 })
+    ).toEqual({
+      enter: 100,
+      exit: 200,
+      appear: 50,
+    })
+  })
+
+  it('defaults missing values to zero', () => {
+    expect(getTransitionTimeouts(undefined)).toEqual({
+      enter: 0,
+      exit: 0,
+      appear: 0,
+    })
+    expect(getTransitionTimeouts({})).toEqual({ enter: 0, exit: 0, appear: 0 })
+  })
+})
+
+describe('useTransitionStatus', () => {
+  beforeEach(() => {
+    jest.useFakeTimers()
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
+  describe('initial status', () => {
+    it('is `exited` when mounted hidden', () => {
+      const { result } = renderTransitionStatus({ in: false })
+
+      expect(result.current).toBe('exited')
+    })
+
+    it('is `unmounted` when mounted hidden with `unmountOnExit`', () => {
+      const { result } = renderTransitionStatus({
+        in: false,
+        unmountOnExit: true,
+      })
+
+      expect(result.current).toBe('unmounted')
+    })
+
+    it('is `entered` when mounted shown without `appear`', () => {
+      const onEnter = jest.fn()
+      const onEntered = jest.fn()
+      const { result } = renderTransitionStatus({
+        in: true,
+        onEnter,
+        onEntered,
+      })
+
+      expect(result.current).toBe('entered')
+
+      act(() => {
+        jest.runAllTimers()
+      })
+
+      expect(onEnter).not.toHaveBeenCalled()
+      expect(onEntered).not.toHaveBeenCalled()
+    })
+
+    it('is `entering` when mounted shown with `appear`', () => {
+      const { result } = renderTransitionStatus({ in: true, appear: true })
+
+      expect(result.current).toBe('entering')
+    })
+  })
+
+  it('runs the enter transition on mount with `appear`, marked as appearing', () => {
+    const onEnter = jest.fn()
+    const onEntering = jest.fn()
+    const onEntered = jest.fn()
+    const { result, nodeRef } = renderTransitionStatus({
+      in: true,
+      appear: true,
+      onEnter,
+      onEntering,
+      onEntered,
+    })
+
+    expect(onEnter).toHaveBeenCalledWith(nodeRef.current, true)
+    expect(onEntering).toHaveBeenCalledWith(nodeRef.current, true)
+    expect(onEntered).not.toHaveBeenCalled()
+
+    act(() => {
+      jest.runAllTimers()
+    })
+
+    expect(result.current).toBe('entered')
+    expect(onEntered).toHaveBeenCalledWith(nodeRef.current, true)
+  })
+
+  it('fires no callbacks when mounted hidden', () => {
+    const onExit = jest.fn()
+    const onExiting = jest.fn()
+    const onExited = jest.fn()
+
+    renderTransitionStatus({ in: false, onExit, onExiting, onExited })
+
+    act(() => {
+      jest.runAllTimers()
+    })
+
+    expect(onExit).not.toHaveBeenCalled()
+    expect(onExiting).not.toHaveBeenCalled()
+    expect(onExited).not.toHaveBeenCalled()
+  })
+
+  it('runs the enter transition when `in` flips to true', () => {
+    const onEnter = jest.fn()
+    const onEntered = jest.fn()
+    const { result, rerender, nodeRef, initialProps } = renderTransitionStatus({
+      in: false,
+      onEnter,
+      onEntered,
+    })
+
+    rerender({ ...initialProps, in: true })
+
+    expect(result.current).toBe('entering')
+    expect(onEnter).toHaveBeenCalledWith(nodeRef.current, false)
+
+    act(() => {
+      jest.runAllTimers()
+    })
+
+    expect(result.current).toBe('entered')
+    expect(onEntered).toHaveBeenCalledWith(nodeRef.current, false)
+  })
+
+  it('settles the exit transition after `timeout` milliseconds', () => {
+    const onExit = jest.fn()
+    const onExiting = jest.fn()
+    const onExited = jest.fn()
+    const { result, rerender, nodeRef, initialProps } = renderTransitionStatus({
+      in: true,
+      timeout: 300,
+      onExit,
+      onExiting,
+      onExited,
+    })
+
+    rerender({ ...initialProps, in: false })
+
+    expect(result.current).toBe('exiting')
+    expect(onExit).toHaveBeenCalledWith(nodeRef.current)
+    expect(onExiting).toHaveBeenCalledWith(nodeRef.current)
+    expect(onExited).not.toHaveBeenCalled()
+
+    act(() => {
+      jest.advanceTimersByTime(299)
+    })
+
+    expect(result.current).toBe('exiting')
+
+    act(() => {
+      jest.advanceTimersByTime(1)
+    })
+
+    expect(result.current).toBe('exited')
+    expect(onExited).toHaveBeenCalledTimes(1)
+    expect(onExited).toHaveBeenCalledWith(nodeRef.current)
+  })
+
+  it('cancels the pending settle when `in` flips mid-transition', () => {
+    const onExited = jest.fn()
+    const { result, rerender, initialProps } = renderTransitionStatus({
+      in: true,
+      timeout: 300,
+      onExited,
+    })
+
+    rerender({ ...initialProps, in: false })
+
+    act(() => {
+      jest.advanceTimersByTime(100)
+    })
+
+    rerender({ ...initialProps, in: true })
+
+    act(() => {
+      jest.runAllTimers()
+    })
+
+    expect(result.current).toBe('entered')
+    expect(onExited).not.toHaveBeenCalled()
+  })
+
+  it('uses per-phase durations from an object `timeout`', () => {
+    const { result, rerender, initialProps } = renderTransitionStatus({
+      in: false,
+      timeout: { enter: 100, exit: 200 },
+    })
+
+    rerender({ ...initialProps, in: true })
+
+    act(() => {
+      jest.advanceTimersByTime(99)
+    })
+
+    expect(result.current).toBe('entering')
+
+    act(() => {
+      jest.advanceTimersByTime(1)
+    })
+
+    expect(result.current).toBe('entered')
+
+    rerender({ ...initialProps, in: false })
+
+    act(() => {
+      jest.advanceTimersByTime(199)
+    })
+
+    expect(result.current).toBe('exiting')
+
+    act(() => {
+      jest.advanceTimersByTime(1)
+    })
+
+    expect(result.current).toBe('exited')
+  })
+
+  it('cycles through mount and unmount with `unmountOnExit`', () => {
+    const onEnter = jest.fn()
+    const onExited = jest.fn()
+    const { result, rerender, nodeRef, initialProps } = renderTransitionStatus({
+      in: false,
+      unmountOnExit: true,
+      onEnter,
+      onExited,
+    })
+
+    expect(result.current).toBe('unmounted')
+
+    rerender({ ...initialProps, in: true })
+
+    expect(result.current).toBe('entering')
+    expect(onEnter).toHaveBeenCalledWith(nodeRef.current, false)
+
+    act(() => {
+      jest.runAllTimers()
+    })
+
+    expect(result.current).toBe('entered')
+
+    rerender({ ...initialProps, in: false })
+
+    expect(result.current).toBe('exiting')
+
+    act(() => {
+      jest.runAllTimers()
+    })
+
+    expect(onExited).toHaveBeenCalledTimes(1)
+    expect(onExited).toHaveBeenCalledWith(nodeRef.current)
+    expect(result.current).toBe('unmounted')
+  })
+})

--- a/packages/base/Utils/src/utils/get-element-ref.ts
+++ b/packages/base/Utils/src/utils/get-element-ref.ts
@@ -1,0 +1,19 @@
+import type { ForwardedRef, ReactElement } from 'react'
+
+type ElementWithRef<T> = ReactElement & { ref?: ForwardedRef<T> }
+
+/**
+ * Reads the ref attached to a React element.
+ *
+ * `ReactElement` has no public `ref` field, so the cast keeps the lookup in
+ * one place. React 19 moves the ref into props instead; reading it from
+ * there has to wait until the `react` peer range allows v19, because on
+ * v18 `props.ref` is a getter that warns when accessed.
+ */
+const getElementRef = <T>(element: ReactElement): ForwardedRef<T> => {
+  const { ref } = element as ElementWithRef<T>
+
+  return ref ?? null
+}
+
+export default getElementRef

--- a/packages/base/Utils/src/utils/index.ts
+++ b/packages/base/Utils/src/utils/index.ts
@@ -65,6 +65,7 @@ export { default as useMouseEnter } from './useMouseEnter'
 export { default as sum } from './sum'
 export type { ReferenceObject } from './use-width-of'
 export { default as useMultipleForwardRefs } from './use-multiple-forward-refs'
+export { default as getElementRef } from './get-element-ref'
 export { usePageScrollLock } from './use-page-scroll-lock'
 export {
   default as useTransitionStatus,

--- a/packages/base/Utils/src/utils/index.ts
+++ b/packages/base/Utils/src/utils/index.ts
@@ -66,6 +66,15 @@ export { default as sum } from './sum'
 export type { ReferenceObject } from './use-width-of'
 export { default as useMultipleForwardRefs } from './use-multiple-forward-refs'
 export { usePageScrollLock } from './use-page-scroll-lock'
+export {
+  default as useTransitionStatus,
+  getTransitionTimeouts,
+} from './use-transition-status'
+export type {
+  TransitionStatus,
+  TransitionTimeout,
+  UseTransitionStatusOptions,
+} from './use-transition-status'
 export { AVATAR_INITIALS_LIMIT } from './constants'
 
 export const Transitions = TransitionUtils

--- a/packages/base/Utils/src/utils/use-multiple-forward-refs.ts
+++ b/packages/base/Utils/src/utils/use-multiple-forward-refs.ts
@@ -31,6 +31,7 @@ const useMultipleForwardRefs = <T>(refs: ForwardedRef<T>[]) =>
         forwardRef(ref, refValue)
       }
     },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [...refs]
   )
 

--- a/packages/base/Utils/src/utils/use-transition-status.ts
+++ b/packages/base/Utils/src/utils/use-transition-status.ts
@@ -1,0 +1,179 @@
+import type { RefObject } from 'react'
+import { useRef, useState } from 'react'
+import { useIsomorphicLayoutEffect } from '@toptal/picasso-shared'
+
+export type TransitionStatus =
+  | 'entering'
+  | 'entered'
+  | 'exiting'
+  | 'exited'
+  | 'unmounted'
+
+export type TransitionTimeout =
+  | number
+  | { enter?: number; exit?: number; appear?: number }
+
+/**
+ * Resolves a react-transition-group style `timeout` (number or object)
+ * into per-phase durations in ms; `appear` falls back to `enter`.
+ */
+export const getTransitionTimeouts = (
+  timeout: TransitionTimeout | undefined
+): { enter: number; exit: number; appear: number } => {
+  if (typeof timeout === 'number') {
+    return { enter: timeout, exit: timeout, appear: timeout }
+  }
+
+  return {
+    enter: timeout?.enter ?? 0,
+    exit: timeout?.exit ?? 0,
+    appear: timeout?.appear ?? timeout?.enter ?? 0,
+  }
+}
+
+export interface UseTransitionStatusOptions<T extends HTMLElement> {
+  /** Show the element; toggling runs the enter or exit transition */
+  in: boolean
+  /** The duration for the transition, in milliseconds */
+  timeout?: TransitionTimeout
+  /** Run the enter transition when mounting with `in` already true */
+  appear?: boolean
+  /** Resolve to `unmounted` once fully exited, so the caller can render nothing */
+  unmountOnExit?: boolean
+  /** The transitioning DOM element, passed to the lifecycle callbacks */
+  nodeRef: RefObject<T>
+  /** Fired when the enter phase starts */
+  onEnter?: (node: T, isAppearing: boolean) => void
+  /** Fired right after the status flips to `entering` */
+  onEntering?: (node: T, isAppearing: boolean) => void
+  /** Fired when the enter transition settles */
+  onEntered?: (node: T, isAppearing: boolean) => void
+  /** Fired when the exit phase starts */
+  onExit?: (node: T) => void
+  /** Fired right after the status flips to `exiting` */
+  onExiting?: (node: T) => void
+  /** Fired when the exit transition settles */
+  onExited?: (node: T) => void
+}
+
+/**
+ * Drop-in replacement for react-transition-group's `<Transition>` state
+ * machine. Settles on `setTimeout(timeout)` — not `transitionend` — so
+ * callback timing is identical and fake timers drive it in jsdom tests.
+ */
+const useTransitionStatus = <T extends HTMLElement>(
+  options: UseTransitionStatusOptions<T>
+): TransitionStatus => {
+  const { in: inProp, appear = false, unmountOnExit = false, nodeRef } = options
+
+  const [status, setStatus] = useState<TransitionStatus>(() => {
+    if (inProp) {
+      return appear ? 'exited' : 'entered'
+    }
+
+    return unmountOnExit ? 'unmounted' : 'exited'
+  })
+
+  // An unmounted element re-mounts at `exited` before entering
+  // (render-phase derived state)
+  if (inProp && status === 'unmounted') {
+    setStatus('exited')
+  }
+
+  // Read via ref so the transition effect re-runs only on `in` flips;
+  // timeout/callback changes must not restart a running transition
+  const optionsRef = useRef(options)
+
+  useIsomorphicLayoutEffect(() => {
+    optionsRef.current = options
+  })
+
+  const prevInRef = useRef<boolean | null>(null)
+
+  useIsomorphicLayoutEffect(() => {
+    const prevIn = prevInRef.current
+    const isInitialMount = prevIn === null
+
+    prevInRef.current = inProp
+
+    // Effect replay without an `in` flip (StrictMode double invocation):
+    // skip rather than double-fire the start callbacks, matching
+    // react-transition-group's cancelled-settle behavior
+    if (prevIn === inProp) {
+      return
+    }
+
+    // Mounting hidden never exits; mounting shown enters only with `appear`
+    if (isInitialMount && (!inProp || !appear)) {
+      return
+    }
+
+    const timeouts = getTransitionTimeouts(optionsRef.current.timeout)
+    const node = nodeRef.current
+
+    const performEnter = () => {
+      const isAppearing = isInitialMount
+
+      if (node) {
+        optionsRef.current.onEnter?.(node, isAppearing)
+      }
+
+      setStatus('entering')
+
+      if (node) {
+        optionsRef.current.onEntering?.(node, isAppearing)
+      }
+
+      return setTimeout(
+        () => {
+          setStatus('entered')
+
+          const settledNode = nodeRef.current
+
+          if (settledNode) {
+            optionsRef.current.onEntered?.(settledNode, isAppearing)
+          }
+        },
+        isAppearing ? timeouts.appear : timeouts.enter
+      )
+    }
+
+    const performExit = () => {
+      if (node) {
+        optionsRef.current.onExit?.(node)
+      }
+
+      setStatus('exiting')
+
+      if (node) {
+        optionsRef.current.onExiting?.(node)
+      }
+
+      return setTimeout(() => {
+        setStatus('exited')
+
+        const settledNode = nodeRef.current
+
+        if (settledNode) {
+          optionsRef.current.onExited?.(settledNode)
+        }
+      }, timeouts.exit)
+    }
+
+    const timer = inProp ? performEnter() : performExit()
+
+    return () => clearTimeout(timer)
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- transitions are keyed on `in` alone; the other options are read from optionsRef
+  }, [inProp])
+
+  // Unmount one commit after `exited`, so `onExited` observes the node
+  useIsomorphicLayoutEffect(() => {
+    if (unmountOnExit && !inProp && status === 'exited') {
+      setStatus('unmounted')
+    }
+  }, [unmountOnExit, inProp, status])
+
+  return status
+}
+
+export default useTransitionStatus

--- a/packages/picasso-tailwind-merge/package.json
+++ b/packages/picasso-tailwind-merge/package.json
@@ -22,8 +22,7 @@
   },
   "homepage": "https://github.com/toptal/picasso/tree/master/packages/picasso#readme",
   "dependencies": {
-    "tailwind-merge": "^2.2.2",
-    "react-transition-group": "^4.4.5"
+    "tailwind-merge": "^2.2.2"
   },
   "sideEffects": false,
   "peerDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -902,12 +902,12 @@ importers:
       '@toptal/picasso-fade':
         specifier: workspace:*
         version: link:../Fade
+      '@toptal/picasso-shared':
+        specifier: workspace:*
+        version: link:../../shared
       '@toptal/picasso-tailwind':
         specifier: workspace:^
         version: link:../../picasso-tailwind
-      '@toptal/picasso-utils':
-        specifier: workspace:*
-        version: link:../Utils
       classnames:
         specifier: ^2.5.1
         version: 2.5.1
@@ -915,6 +915,9 @@ importers:
         specifier: ^18.2.0
         version: 18.2.0
     devDependencies:
+      '@toptal/picasso-tailwind-merge':
+        specifier: workspace:*
+        version: link:../../picasso-tailwind-merge
       '@toptal/picasso-test-utils':
         specifier: workspace:*
         version: link:../Test-Utils
@@ -1396,25 +1399,28 @@ importers:
 
   packages/base/Fade:
     dependencies:
+      '@toptal/picasso-shared':
+        specifier: workspace:*
+        version: link:../../shared
       '@toptal/picasso-tailwind':
         specifier: workspace:^
         version: link:../../picasso-tailwind
       '@toptal/picasso-utils':
         specifier: workspace:*
         version: link:../Utils
+      classnames:
+        specifier: ^2.5.1
+        version: 2.5.1
       react:
         specifier: ^18.2.0
         version: 18.2.0
-      react-transition-group:
-        specifier: ^4.4.5
-        version: 4.4.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
     devDependencies:
+      '@toptal/picasso-tailwind-merge':
+        specifier: workspace:*
+        version: link:../../picasso-tailwind-merge
       '@toptal/picasso-test-utils':
         specifier: workspace:*
         version: link:../Test-Utils
-      '@types/react-transition-group':
-        specifier: ^4.4.5
-        version: 4.4.12(@types/react@17.0.39)
 
   packages/base/FileInput:
     dependencies:
@@ -2559,25 +2565,28 @@ importers:
 
   packages/base/Slide:
     dependencies:
+      '@toptal/picasso-shared':
+        specifier: workspace:*
+        version: link:../../shared
       '@toptal/picasso-tailwind':
         specifier: workspace:^
         version: link:../../picasso-tailwind
       '@toptal/picasso-utils':
         specifier: workspace:*
         version: link:../Utils
+      classnames:
+        specifier: ^2.5.1
+        version: 2.5.1
       react:
         specifier: ^18.2.0
         version: 18.2.0
-      react-transition-group:
-        specifier: ^4.4.5
-        version: 4.4.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
     devDependencies:
+      '@toptal/picasso-tailwind-merge':
+        specifier: workspace:*
+        version: link:../../picasso-tailwind-merge
       '@toptal/picasso-test-utils':
         specifier: workspace:*
         version: link:../Test-Utils
-      '@types/react-transition-group':
-        specifier: ^4.4.5
-        version: 4.4.12(@types/react@17.0.39)
 
   packages/base/Slider:
     dependencies:
@@ -3865,9 +3874,6 @@ importers:
       react:
         specifier: ^18.2.0
         version: 18.2.0
-      react-transition-group:
-        specifier: ^4.4.5
-        version: 4.4.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       tailwind-merge:
         specifier: ^2.2.2
         version: 2.3.0


### PR DESCRIPTION
[PF-2145]

### Description

Removes `react-transition-group` from `Fade`, `Slide` and `Backdrop`, replacing it with Tailwind class-driven transitions.

- **Utils** — adds `useTransitionStatus` + `getTransitionTimeouts`: a timer-driven replacement for rtg's `<Transition>` state machine. It settles on `setTimeout(timeout)` exactly as rtg does when no `addEndListener` is given, so callback timing is identical and fake timers still drive it in jsdom. Supports the full lifecycle (`onEnter`/`onEntering`/`onEntered`/`onExit`/`onExiting`/`onExited`, `appear`, `unmountOnExit`) so `Collapse` can reuse it later. Also adds `getElementRef`, which types the `ReactElement.ref` lookup in one place and replaces the `@ts-expect-error` suppressions in `Fade`/`Slide`.
- **Fade / Slide** — reimplemented on top of the hook. Hidden state is now expressed with `opacity-0` / `translate-*` / `invisible` classes instead of inline `visibility`/`opacity`/`transform` styles, merged via `twMerge`. Public props, the `direction` mapping and callback timing are unchanged. Fixes the object form of `timeout` (`{ enter, exit }`), which previously produced an invalid inline `[object Object]ms` duration.
- **Backdrop** — unchanged structurally (still composes `Fade`), so rtg leaves its dependency tree. Also merges the consumer `className` via `twMerge` so consumer utilities win on conflicts, and drops a redundant `bg-black` plus a dead `-webkit-tap-highlight-color-transparent` class (no visual change).
- **picasso-tailwind-merge** — drops the `react-transition-group` dependency it never imported.

`react-transition-group` stays in the workspace via `Collapse` (out of scope for this story) and transitively via `recharts → react-smooth`.

### How to test

- [Temploy](https://picasso.toptal.net/pf-2145-migrate-backdrop-fade-and-slide-to-tailwind-from-rtg)
- Storybook → **Transitions → Fade**: toggle the button, the content fades in/out over 350ms.
- Storybook → **Slide**: toggle the button, the content slides in/out; verify all four `direction` values.
- Storybook → **Backdrop**: default and invisible variants still cover the viewport and fade on open/close.
- `pnpm test:unit -- packages/base/Fade packages/base/Slide packages/base/Backdrop packages/base/Utils`

### Screenshots

No visual change — transitions are visually identical, only the mechanism changed. These stories run with `takeScreenshot: false`, so there is no Happo coverage to diff.

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Double check if `picasso-tailwind-merge` requires major update (check its `README.md`)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests ([visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md) included)

**Breaking change** — N/A

- [ ] codemod is created and showcased in the changeset
- [ ] test alpha package of Picasso in StaffPortal


[PF-2145]: https://toptal-core.atlassian.net/browse/PF-2145?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ