### PR TITLE
[PF-2324] Fix show backdrop for nested dialogs on Modal/Drawer

### DIFF
--- a/.changeset/modal-force-render-backdrop.md
+++ b/.changeset/modal-force-render-backdrop.md
@@ -1,0 +1,8 @@
+---
+'@toptal/picasso-modal': minor
+'@toptal/picasso-drawer': minor
+---
+
+### Modal, Drawer
+
+- add a `forceRender` prop, defaulting to `true`, so a modal or drawer nested inside another dialog keeps rendering its backdrop. `@base-ui/react`'s `Dialog.Backdrop` skips rendering whenever it detects a parent dialog in the React tree unless `forceRender` is set, which silently dropped the backdrop of such modals and drawers (for example a `Modal` opened from inside a `Drawer`). Pass `forceRender={false}` to opt into the `@base-ui/react` behavior and render a single, outermost backdrop

--- a/.changeset/modal-force-render-backdrop.md
+++ b/.changeset/modal-force-render-backdrop.md
@@ -5,4 +5,4 @@
 
 ### Modal, Drawer
 
-- add a `forceRender` prop, defaulting to `true`, so a modal or drawer nested inside another dialog keeps rendering its backdrop. `@base-ui/react`'s `Dialog.Backdrop` skips rendering whenever it detects a parent dialog in the React tree unless `forceRender` is set, which silently dropped the backdrop of such modals and drawers (for example a `Modal` opened from inside a `Drawer`). Pass `forceRender={false}` to opt into the `@base-ui/react` behavior and render a single, outermost backdrop
+- add a `forceRenderBackdrop` prop, defaulting to `true`, so a modal or drawer nested inside another dialog keeps rendering its backdrop. `@base-ui/react`'s `Dialog.Backdrop` skips rendering whenever it detects a parent dialog in the React tree unless `forceRender` is set, which silently dropped the backdrop of such modals and drawers (for example a `Modal` opened from inside a `Drawer`). Pass `forceRenderBackdrop={false}` to opt into the `@base-ui/react` behavior and render a single, outermost backdrop

--- a/packages/base/Drawer/src/Drawer/Drawer.tsx
+++ b/packages/base/Drawer/src/Drawer/Drawer.tsx
@@ -43,7 +43,7 @@ export interface Props extends BaseProps {
   /** Remove the backdrop and leave elements behind interactive  */
   disableBackdrop?: boolean
   /** If `true`, the backdrop is rendered even when nested in another dialog */
-  forceRender?: boolean
+  forceRenderBackdrop?: boolean
   /** Disable drawer scrolling and let children manage their own scroll */
   disableScroll?: boolean
 }
@@ -82,7 +82,7 @@ export const Drawer = ({
     maintainBodyScrollLock = true,
     transparentBackdrop,
     disableBackdrop,
-    forceRender = true,
+    forceRenderBackdrop = true,
     className,
     style,
     'data-testid': testId,
@@ -120,7 +120,7 @@ export const Drawer = ({
     <>
       {!disableBackdrop && (
         <BaseUIDialog.Backdrop
-          forceRender={forceRender}
+          forceRender={forceRenderBackdrop}
           className={twMerge(
             'z-drawer fixed inset-0 bg-black transition-opacity duration-300',
             'data-starting-style:opacity-0 data-ending-style:opacity-0',

--- a/packages/base/Drawer/src/Drawer/Drawer.tsx
+++ b/packages/base/Drawer/src/Drawer/Drawer.tsx
@@ -42,6 +42,8 @@ export interface Props extends BaseProps {
   transparentBackdrop?: boolean
   /** Remove the backdrop and leave elements behind interactive  */
   disableBackdrop?: boolean
+  /** If `true`, the backdrop is rendered even when nested in another dialog */
+  forceRender?: boolean
   /** Disable drawer scrolling and let children manage their own scroll */
   disableScroll?: boolean
 }
@@ -80,6 +82,7 @@ export const Drawer = ({
     maintainBodyScrollLock = true,
     transparentBackdrop,
     disableBackdrop,
+    forceRender = true,
     className,
     style,
     'data-testid': testId,
@@ -117,6 +120,7 @@ export const Drawer = ({
     <>
       {!disableBackdrop && (
         <BaseUIDialog.Backdrop
+          forceRender={forceRender}
           className={twMerge(
             'z-drawer fixed inset-0 bg-black transition-opacity duration-300',
             'data-starting-style:opacity-0 data-ending-style:opacity-0',

--- a/packages/base/Drawer/src/Drawer/test.tsx
+++ b/packages/base/Drawer/src/Drawer/test.tsx
@@ -78,10 +78,10 @@ describe('Drawer', () => {
     expect(getBackdrops(baseElement)).toHaveLength(2)
   })
 
-  it('given forceRender is false, does not render a backdrop for a nested drawer', () => {
+  it('given forceRenderBackdrop is false, does not render a backdrop for a nested drawer', () => {
     const { baseElement } = renderDrawer(
       {},
-      <Drawer open forceRender={false} onClose={jest.fn()}>
+      <Drawer open forceRenderBackdrop={false} onClose={jest.fn()}>
         <span>Nested drawer body</span>
       </Drawer>
     )

--- a/packages/base/Drawer/src/Drawer/test.tsx
+++ b/packages/base/Drawer/src/Drawer/test.tsx
@@ -13,6 +13,9 @@ const renderDrawer = (props: Partial<Props> = {}, children: ReactNode = null) =>
     </Drawer>
   )
 
+const getBackdrops = (element: HTMLElement) =>
+  element.querySelectorAll('.bg-black\\/50')
+
 describe('Drawer', () => {
   it('renders content when open', () => {
     const { getByTestId } = renderDrawer()
@@ -61,7 +64,29 @@ describe('Drawer', () => {
   it('does not render a backdrop when disableBackdrop is set', () => {
     const { baseElement } = renderDrawer({ disableBackdrop: true })
 
-    expect(baseElement.querySelector('.bg-black\\/50')).toBeNull()
+    expect(getBackdrops(baseElement)).toHaveLength(0)
+  })
+
+  it('renders a backdrop for a nested drawer by default', () => {
+    const { baseElement } = renderDrawer(
+      {},
+      <Drawer open onClose={jest.fn()}>
+        <span>Nested drawer body</span>
+      </Drawer>
+    )
+
+    expect(getBackdrops(baseElement)).toHaveLength(2)
+  })
+
+  it('given forceRender is false, does not render a backdrop for a nested drawer', () => {
+    const { baseElement } = renderDrawer(
+      {},
+      <Drawer open forceRender={false} onClose={jest.fn()}>
+        <span>Nested drawer body</span>
+      </Drawer>
+    )
+
+    expect(getBackdrops(baseElement)).toHaveLength(1)
   })
 
   it('disables paper scrolling when disableScroll is set', () => {

--- a/packages/base/Modal/src/Modal/Modal.tsx
+++ b/packages/base/Modal/src/Modal/Modal.tsx
@@ -44,7 +44,7 @@ export interface Props extends BaseProps, HTMLAttributes<HTMLDivElement> {
   /** If `true`, the backdrop is not rendered */
   hideBackdrop?: boolean
   /** If `true`, the backdrop is rendered even when nested in another dialog */
-  forceRender?: boolean
+  forceRenderBackdrop?: boolean
   /** Position of the modal relative to the browser's viewport */
   align?: Alignment
   /** Animation lifecycle callbacks. Backed by [react-transition-group/Transition](https://reactcommunity.org/react-transition-group/transition#Transition-props) */
@@ -118,7 +118,7 @@ const generateKey = (() => {
 export const Modal = forwardRef<HTMLDivElement, Props>(function Modal(
   {
     hideBackdrop = false,
-    forceRender = true,
+    forceRenderBackdrop = true,
     disableBackdropClick = false,
     size = 'medium',
     transitionDuration = 300,
@@ -246,7 +246,7 @@ export const Modal = forwardRef<HTMLDivElement, Props>(function Modal(
       <BaseUIDialog.Portal container={resolvedContainer}>
         {!hideBackdrop && (
           <BaseUIDialog.Backdrop
-            forceRender={forceRender}
+            forceRender={forceRenderBackdrop}
             className='fixed z-modal inset-0 bg-black/50 transition-opacity data-starting-style:opacity-0 data-ending-style:opacity-0'
             style={durationStyle}
           />

--- a/packages/base/Modal/src/Modal/Modal.tsx
+++ b/packages/base/Modal/src/Modal/Modal.tsx
@@ -43,6 +43,8 @@ export interface Props extends BaseProps, HTMLAttributes<HTMLDivElement> {
   container?: ContainerValue
   /** If `true`, the backdrop is not rendered */
   hideBackdrop?: boolean
+  /** If `true`, the backdrop is rendered even when nested in another dialog */
+  forceRender?: boolean
   /** Position of the modal relative to the browser's viewport */
   align?: Alignment
   /** Animation lifecycle callbacks. Backed by [react-transition-group/Transition](https://reactcommunity.org/react-transition-group/transition#Transition-props) */
@@ -116,6 +118,7 @@ const generateKey = (() => {
 export const Modal = forwardRef<HTMLDivElement, Props>(function Modal(
   {
     hideBackdrop = false,
+    forceRender = true,
     disableBackdropClick = false,
     size = 'medium',
     transitionDuration = 300,
@@ -243,6 +246,7 @@ export const Modal = forwardRef<HTMLDivElement, Props>(function Modal(
       <BaseUIDialog.Portal container={resolvedContainer}>
         {!hideBackdrop && (
           <BaseUIDialog.Backdrop
+            forceRender={forceRender}
             className='fixed z-modal inset-0 bg-black/50 transition-opacity data-starting-style:opacity-0 data-ending-style:opacity-0'
             style={durationStyle}
           />

--- a/packages/base/Modal/src/Modal/test.tsx
+++ b/packages/base/Modal/src/Modal/test.tsx
@@ -224,11 +224,11 @@ describe('Modal', () => {
       expect(getBackdrops(baseElement)).toHaveLength(2)
     })
 
-    it('given forceRender is false, does not render a backdrop for a nested modal', () => {
+    it('given forceRenderBackdrop is false, does not render a backdrop for a nested modal', () => {
       const { baseElement } = render(
         <Modal open>
           <p>Outer modal content</p>
-          <Modal open forceRender={false}>
+          <Modal open forceRenderBackdrop={false}>
             <p>Nested modal content</p>
           </Modal>
         </Modal>

--- a/packages/base/Modal/src/Modal/test.tsx
+++ b/packages/base/Modal/src/Modal/test.tsx
@@ -207,6 +207,47 @@ describe('Modal', () => {
     expect(baseElement).toMatchSnapshot()
   })
 
+  describe('backdrop', () => {
+    const getBackdrops = (element: HTMLElement) =>
+      element.querySelectorAll('[role="presentation"]')
+
+    it('renders a backdrop for a nested modal by default', () => {
+      const { baseElement } = render(
+        <Modal open>
+          <p>Outer modal content</p>
+          <Modal open>
+            <p>Nested modal content</p>
+          </Modal>
+        </Modal>
+      )
+
+      expect(getBackdrops(baseElement)).toHaveLength(2)
+    })
+
+    it('given forceRender is false, does not render a backdrop for a nested modal', () => {
+      const { baseElement } = render(
+        <Modal open>
+          <p>Outer modal content</p>
+          <Modal open forceRender={false}>
+            <p>Nested modal content</p>
+          </Modal>
+        </Modal>
+      )
+
+      expect(getBackdrops(baseElement)).toHaveLength(1)
+    })
+
+    it('given hideBackdrop is true, does not render a backdrop', () => {
+      const { baseElement } = render(
+        <Modal open hideBackdrop>
+          <p>Modal content</p>
+        </Modal>
+      )
+
+      expect(getBackdrops(baseElement)).toHaveLength(0)
+    })
+  })
+
   describe('page scroll lock', () => {
     afterEach(() => {
       cleanup()


### PR DESCRIPTION
[PF-2324]

### Description

`@base-ui/react`'s `Dialog.Backdrop` renders only when `forceRender || !nested`,
and `nested` is detected via React context — so since the Base UI migration a
`Modal` opened inside a `Drawer` silently lost its backdrop, with no way to
override it.

`Modal` and `Drawer` now expose `forceRender`, defaulting to `true`, restoring
the v99 backdrop-per-dialog behavior. `hideBackdrop`/`disableBackdrop` still take
precedence; `PromptModal` inherits the prop via its `ModalProps` spread. These
are the only two places Picasso renders a Base UI backdrop. Nested backdrops
stack (~0.75 opacity), as they did in v99.

Once released, staff-portal can drop
`patches/@toptal__picasso-modal@100.0.0.patch`, which patches in this exact fix.

### How to test

- [Temploy](https://picasso.toptal.net/pf-2324-modal-renders-without-backdrop-when-nested)
- `Modal` and `Drawer` stories still render exactly one backdrop — no regression
  in the un-nested case
- Publish an alpha, install in staff-portal without its patch, open a `Modal`
  from inside a `Drawer` — the page behind is dimmed; `forceRender={false}`
  leaves only the drawer's backdrop
- `pnpm test:unit -- packages/base/Modal packages/base/Drawer` — 31 pass

### Screenshots

| Before.                                             | After.                                     |
| --------------------------------------------------- | ------------------------------------------ |
| Modal inside a Drawer — no backdrop, page undimmed  | Same Modal — backdrop dims everything below |

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Double check if `picasso-tailwind-merge` requires major update (check its `README.md`)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [x] Annotate all `props` in component with documentation
- [ ] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [ ] Self reviewed
- [ ] Covered with tests ([visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md) included)

**Breaking change** — N/A

- [ ] codemod is created and showcased in the changeset
- [ ] test alpha package of Picasso in StaffPortal


[PF-2324]: https://toptal-core.atlassian.net/browse/PF-2324?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ