### PR TITLE
[PF-2333] Fix Popper scrolling the page to top

### DIFF
--- a/.changeset/popper-prepositioned-frame-fixed.md
+++ b/.changeset/popper-prepositioned-frame-fixed.md
@@ -1,0 +1,7 @@
+---
+'@toptal/picasso-popper': patch
+---
+
+### Popper
+
+- keep the floating element `position: fixed` until positioned, so mount-time autofocus inside the popper no longer scrolls the page to the top

--- a/packages/base/Dropdown/src/Dropdown/__snapshots__/test.tsx.snap
+++ b/packages/base/Dropdown/src/Dropdown/__snapshots__/test.tsx.snap
@@ -65,7 +65,7 @@ exports[`Dropdown should render menu 1`] = `
           class="z-modal xs:max-md:w-screen xs:max-md:max-w xs:max-md:p-0 xs:max-md:m-0 [&[x-out-of shadow-2"
           data-picasso-popper=""
           role="presentation"
-          style="position: absolute; left: 0px; top: 0px; transform: translate(0px, 0px);"
+          style="position: fixed; left: 0px; top: 0px; transform: translate(0px, 0px);"
           x-placement="bottom-end"
         >
           <div

--- a/packages/base/Popper/src/Popper/Popper.tsx
+++ b/packages/base/Popper/src/Popper/Popper.tsx
@@ -220,8 +220,6 @@ export const Popper = forwardRef<PopperHandle, Props>(function Popper(
       )}
       style={{
         ...floatingStyles,
-        // keeps the not-yet-positioned popper viewport-relative, so focusing
-        // content inside (autoFocus) cannot scroll the page
         ...(isPositioned ? {} : { position: 'fixed' as const }),
         ...style,
         ...anchorElWidthStyle,

--- a/packages/base/Popper/src/Popper/Popper.tsx
+++ b/packages/base/Popper/src/Popper/Popper.tsx
@@ -220,6 +220,9 @@ export const Popper = forwardRef<PopperHandle, Props>(function Popper(
       )}
       style={{
         ...floatingStyles,
+        // keeps the not-yet-positioned popper viewport-relative, so focusing
+        // content inside (autoFocus) cannot scroll the page
+        ...(isPositioned ? {} : { position: 'fixed' as const }),
         ...style,
         ...anchorElWidthStyle,
         ...(!open && keepMounted ? { display: 'none' } : {}),

--- a/packages/base/Popper/src/Popper/test.tsx
+++ b/packages/base/Popper/src/Popper/test.tsx
@@ -149,6 +149,30 @@ describe('Popper', () => {
     expect(screen.getByRole('tooltip')).toHaveStyle({ position: 'fixed' })
   })
 
+  describe('pre-positioned frame', () => {
+    // fixed keeps the not-yet-positioned popper in view, so autoFocus
+    // content cannot scroll the page
+    it('stays position fixed until positioned', async () => {
+      renderPopper()
+
+      expect(screen.getByRole('tooltip')).toHaveStyle({ position: 'fixed' })
+
+      await flushPosition()
+
+      expect(screen.getByRole('tooltip')).toHaveStyle({ position: 'absolute' })
+    })
+
+    it('stays position fixed until positioned when portal is disabled', async () => {
+      renderPopper({ disablePortal: true })
+
+      expect(screen.getByRole('tooltip')).toHaveStyle({ position: 'fixed' })
+
+      await flushPosition()
+
+      expect(screen.getByRole('tooltip')).toHaveStyle({ position: 'absolute' })
+    })
+  })
+
   describe('role', () => {
     it('defaults the floating element to role="tooltip"', async () => {
       renderPopper()


### PR DESCRIPTION
[PF-2333]

### Description

Since the Floating UI rework (v100), Popper renders with Floating UI's initial
`position: absolute; top: 0; left: 0` until the async `computePosition` resolves.
If the popper content autofocuses an element on mount (e.g. an Autocomplete inside
a Dropdown), the browser scrolls the focused element into view while the popup is
still at the document top — the page jumps to the top.

Keep the floating element `position: fixed` until `isPositioned` is true, then fall
back to the configured strategy. Fixed elements are viewport-relative, so focusing
them never scrolls the document — same pre-positioning the MUI v4 Popper had.

- Verified in a real browser: no scroll jump, and a `disablePortal` popper inside a
  positioned ancestor self-corrects after the first measurement (offset parent
  resolves as window, the initial `autoUpdate` pass re-computes it).
- Consumer tests that snapshot an open popper before positioning resolves will see
  a one-line diff (`absolute` → `fixed`); one Dropdown snapshot updated in-repo.
- StaffPortal works around this with `patches/@toptal__picasso-popper@100.0.0.patch`
  applying the same change — it can be removed once this is released.

### How to test

<!-- The temploy link will be automatically updated when the temploy is deployed -->
- [Temploy](https://picasso.toptal.net/pf-2333-fix-popper-scrolling-the-page-to-top)
- Place a Dropdown whose content contains an `autoFocus` input far down a scrollable
  page, scroll to it and open it — the page must not scroll; the popup opens at the anchor
- `pnpm test:unit -- packages/base/Popper`

### Screenshots

No visual change — only the transient pre-positioning frame differs, screenshots
capture the settled state.

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Double check if `picasso-tailwind-merge` requires major update (check its `README.md`)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests ([visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md) included)

**Breaking change**

Not a breaking change — patch fix, no API change.


[PF-2333]: https://toptal-core.atlassian.net/browse/PF-2333?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ