### PR TITLE
[PF-2282] Fix useBreakpoint md media query

### DIFF
--- a/.changeset/provider-non-responsive-md-breakpoint.md
+++ b/.changeset/provider-non-responsive-md-breakpoint.md
@@ -1,0 +1,29 @@
+---
+'@toptal/picasso-provider': minor
+---
+
+### Picasso, PicassoLight
+
+- fix `useBreakpoint` reporting `false` for `md` at every viewport width under
+  `responsive={false}`. `disableMobileBreakpoints()` blanks the `xs`/`sm`/`md`
+  media queries but left `lg` starting at 1024px, so nothing matched between
+  768px and 1023.98px and desktop-gated UI keyed off `md` —
+  `useBreakpoint(['md', 'lg', 'xl'])` — rendered its mobile branch on desktop.
+  `lg` now widens to `(max-width: 1439.98px)`, the desktop floor: desktop
+  checks hold at every width, compact checks
+  (`useBreakpoint(['xs', 'sm', 'md'])`) keep returning `false`. The default
+  `responsive` path is unaffected
+
+### FixViewport
+
+- add `responsive` prop (`<Picasso>` passes it through); when `false` it pins
+  the layout viewport to `width=768` instead of `width=device-width`, so mobile
+  browsers evaluate CSS media queries (Tailwind's static `md:` variants
+  included) at the width the JS breakpoints assume. Zoom stays enabled in this
+  mode (WCAG 1.4.4); desktop browsers ignore `width`
+
+### PicassoBreakpoints
+
+- add `reset()` to restore the responsive defaults —
+  `disableMobileBreakpoints()` is process-wide and one-way, so call `reset()`
+  in an `afterEach` to keep `responsive={false}` tests from leaking

--- a/docs/migration-to-new-picasso-v2.md
+++ b/docs/migration-to-new-picasso-v2.md
@@ -516,7 +516,7 @@ Assert **semantically**:
 | Wrapped-subject chains (`this.modal.findByTestId(…).find(…)`) failing with _"the page updated"_                                                                                               | Use one **atomic** selector — `cy.get('div[role="dialog"] [data-testid=…] …')` — so Cypress retries the whole query; give each action its own fresh chain instead of `.click().clear().type()`.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
 | Async-populated options/radios intermittently "not found" on CI                                                                                                                               | Use a retryable atomic selector that includes the expected value (`.find('input[value="…"]')`, `.contains(text)`), let `.should()` gate on it, then assert the resulting state — this waits for the option to actually mount.                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
 | Selectors coupled to old markup (`label.picasso-checkbox`, `span[role="slider"]`, tag+structure)                                                                                              | Query by role or testid — the role survived the migration, the tag and structure did not.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
-| Desktop-only UI missing at the component viewport                                                                                                                                             | See [`responsive={false}` breakpoint gap](#the-responsivefalse-breakpoint-gap); add `cy.viewport(1280, 800)`.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
+| Desktop-only UI missing at the component viewport                                                                                                                                             | Fixed upstream (PF-2282) — see [`responsive={false}` breakpoint gap](#the-responsivefalse-breakpoint-gap); on older versions add `cy.viewport(1280, 800)`.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
 
 > **Checkbox/switch input relationship in Cypress:** because the hidden input is
 > a **sibling** of the role element, from a testid on the role element the input
@@ -529,19 +529,34 @@ Assert **semantically**:
 
 ### The `responsive={false}` breakpoint gap
 
-If your test wrapper mounts `<Picasso responsive={false}>` (common), be aware of
-a real upstream bug: `responsive={false}` calls `disableMobileBreakpoints()`,
-which **empties** the `xs`/`sm`/`md` media-query strings and leaves `lg` starting
-at 1024px. That creates a **dead zone at 768–1023.98px** where _no_ breakpoint
-matches, so at the default Cypress component viewport (822px) desktop checks like
-`useBreakpoint(['md','lg','xl'])` return `false` and components render their
-**mobile** branch — the opposite of what `responsive={false}` intends.
+**Fixed upstream in PF-2282** — no workaround needed on a Picasso version that
+includes it.
 
-- **Consumer-side fix:** `cy.viewport(1280, 800)` in specs that assert
+If your test wrapper mounts `<Picasso responsive={false}>` (common), older
+Picasso versions hit a real upstream bug: `responsive={false}` calls
+`disableMobileBreakpoints()`, which **empties** the `xs`/`sm`/`md` media-query
+strings and left `lg` starting at 1024px. That created a **dead zone at
+768–1023.98px** where _no_ breakpoint matched, so at the default Cypress
+component viewport (822px) desktop checks like `useBreakpoint(['md','lg','xl'])`
+returned `false` and components rendered their **mobile** branch — the opposite
+of what `responsive={false}` intends.
+
+PF-2282 widens `lg` to `(max-width: 1439.98px)` when mobile breakpoints are
+disabled, making it the desktop floor: desktop checks now hold at every width,
+and compact checks (`useBreakpoint(['xs','sm','md'])`) stay `false`. It also
+pins the layout viewport to `width=768` so **mobile browsers** evaluate CSS
+media queries (Tailwind's `md:` variants included) at the width the JS
+breakpoints assume.
+
+- **On an older version:** `cy.viewport(1280, 800)` in specs that assert
   desktop-gated UI (pick a width comfortably inside `lg`; exactly 1024 can flip
   on scrollbar width).
-- This is an upstream bug (`md` should match everything below `lg`, not nothing)
-  — report it rather than baking workarounds into app code.
+- **Still true after PF-2282:** the viewport pin does not reach **iframes**, so
+  Cypress component tests rely on the hook fix, not on it. Component-level CSS
+  breakpoints in an iframe still follow the real frame width.
+- **Isolate tests that mount it:** `disableMobileBreakpoints()` is process-wide
+  and one-way, so call `PicassoBreakpoints.reset()` in an `afterEach` — otherwise
+  a `responsive={false}` case leaks into every test after it.
 
 **Done when:** the Cypress component + e2e suites pass without deleting
 assertions.
@@ -942,8 +957,8 @@ version matrices; reconcile required-check names. **Gate:** Happo reviewed,
 2. **Cypress can't find / interact with an element** → identify the primitive
    (Select / Checkbox / Button-as-Link / Drawer) and apply the matching Cypress
    matrix row.
-3. **Desktop UI mysteriously absent** → `responsive={false}` breakpoint gap; add
-   the viewport.
+3. **Desktop UI mysteriously absent** → `responsive={false}` breakpoint gap;
+   fixed in PF-2282, otherwise add the viewport.
 4. **Happo diff** → vendor Tailwind package missing from `content` globs? Drawer/
    Modal sass `position` on the paper? Otherwise compare against the intended
    restyle before accepting a new baseline.
@@ -960,16 +975,16 @@ version matrices; reconcile required-check names. **Gate:** Happo reviewed,
 
 ### Upstream issue status (as of the v100 line)
 
-| Item                                                                   | Status                      | Consumer impact                                                                                                                                                                                                                                             |
-| ---------------------------------------------------------------------- | --------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| PF-2243 duplicate `role="dialog"`                                      | **Fixed**                   | Plain `findByRole('dialog')` works; remove `findAllByRole('dialog')[0]` workarounds.                                                                                                                                                                        |
-| PF-2244 duplicate checkbox/switch label node                           | **Fixed**                   | Labels render once; no workaround.                                                                                                                                                                                                                          |
-| PF-2230 Popper default role                                            | **Fixed**                   | Popper defaults to `role="tooltip"`; Select/Dropdown poppers are `presentation`.                                                                                                                                                                            |
-| PF-2256 / PR #5040 label-activation click no-op                        | **Intentional (permanent)** | Opening a Select by clicking its `<label>` no longer works — click the control.                                                                                                                                                                             |
-| PF-2253 focus-opened tooltip flips over its trigger and steals a click | **Fixed**                   | Pointer-modality focus no longer opens tooltips — remove `click({ force: true })` exceptions and hide-before-Happo workarounds; guard full-page snapshots with `cy.get('[role="tooltip"]').should('not.exist')`.                                            |
-| Label-wrapper clicks on Checkbox/Switch didn't toggle (early alphas)   | **Fixed**                   | `FormControlLabel` (`labelId` variant) forwards non-interactive wrapper clicks to the hidden input — testid/wrapper-click tests written against pre-migration code work again; revert early-alpha rewrites (verified: staff-portal reverted two wholesale). |
-| PF-2248 body-center click lands inside an open DatePicker popup        | **Open**                    | Corner click: `cy.get('body').click(5, 5)`.                                                                                                                                                                                                                 |
-| `responsive={false}` empties `md`, dead zone 768–1023.98px             | **Open — report upstream**  | Add `cy.viewport(1280, 800)` in specs; do not work around in app code.                                                                                                                                                                                      |
+| Item                                                                                             | Status                                | Consumer impact                                                                                                                                                                                                                                                                                                    |
+| ------------------------------------------------------------------------------------------------ | ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| PF-2243 duplicate `role="dialog"`                                                                | **Fixed**                             | Plain `findByRole('dialog')` works; remove `findAllByRole('dialog')[0]` workarounds.                                                                                                                                                                                                                               |
+| PF-2244 duplicate checkbox/switch label node                                                     | **Fixed**                             | Labels render once; no workaround.                                                                                                                                                                                                                                                                                 |
+| PF-2230 Popper default role                                                                      | **Fixed**                             | Popper defaults to `role="tooltip"`; Select/Dropdown poppers are `presentation`.                                                                                                                                                                                                                                   |
+| PF-2256 / PR #5040 label-activation click no-op                                                  | **Intentional (permanent)**           | Opening a Select by clicking its `<label>` no longer works — click the control.                                                                                                                                                                                                                                    |
+| PF-2253 focus-opened tooltip flips over its trigger and steals a click                           | **Fixed**                             | Pointer-modality focus no longer opens tooltips — remove `click({ force: true })` exceptions and hide-before-Happo workarounds; guard full-page snapshots with `cy.get('[role="tooltip"]').should('not.exist')`.                                                                                                   |
+| Label-wrapper clicks on Checkbox/Switch didn't toggle (early alphas)                             | **Fixed**                             | `FormControlLabel` (`labelId` variant) forwards non-interactive wrapper clicks to the hidden input — testid/wrapper-click tests written against pre-migration code work again; revert early-alpha rewrites (verified: staff-portal reverted two wholesale).                                                        |
+| PF-2248 body-center click lands inside an open DatePicker popup                                  | **Open**                              | Corner click: `cy.get('body').click(5, 5)`.                                                                                                                                                                                                                                                                        |
+| PF-2282 `responsive={false}` dead zone 768–1023.98px                                             | **Fixed**                             | `lg` is the desktop floor when mobile breakpoints are off; drop `cy.viewport` workarounds.                                                                                                                                                                                                                         |
 | Nested-dialog backdrop suppressed — a Modal opened above an open Drawer renders no grey backdrop | **Open — fix in progress in Picasso** | Base UI suppresses backdrops of dialogs nested in another dialog's portal. Interim: staff-portal patches `@toptal/picasso-modal` to pass `forceRender` to `BaseUIDialog.Backdrop` (exposed as `forceRenderBackdrop`, default `true`) — take the same pnpm patch if your app opens dialogs above dialogs (Step 8c). |
 
 ### DOM / role cheat-sheet

--- a/packages/base/Page/src/Page/test.tsx
+++ b/packages/base/Page/src/Page/test.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import type { RenderResult } from '@toptal/picasso-test-utils'
 import { render } from '@toptal/picasso-test-utils'
-import Picasso from '@toptal/picasso-provider'
+import Picasso, { PicassoBreakpoints } from '@toptal/picasso-provider'
 
 import { Page } from './Page'
 
@@ -14,6 +14,12 @@ describe('Page', () => {
 
   beforeEach(() => {
     api = renderPage(<div>Test</div>)
+  })
+
+  // `responsive={false}` below disables mobile breakpoints process-wide —
+  // hand the defaults back
+  afterEach(() => {
+    PicassoBreakpoints.reset()
   })
   it('renders', () => {
     const { container } = api

--- a/packages/picasso-provider/src/Picasso/FixViewport.test.tsx
+++ b/packages/picasso-provider/src/Picasso/FixViewport.test.tsx
@@ -1,0 +1,53 @@
+import React from 'react'
+import { render, waitFor } from '@testing-library/react'
+import { HelmetProvider } from 'react-helmet-async'
+
+import FixViewport from './FixViewport'
+
+const renderFixViewport = (responsive?: boolean) =>
+  render(
+    <HelmetProvider>
+      <FixViewport responsive={responsive} />
+    </HelmetProvider>
+  )
+
+const getViewportContent = () =>
+  document
+    .querySelector('meta[name="viewport"][data-picasso="true"]')
+    ?.getAttribute('content')
+
+describe('FixViewport', () => {
+  afterEach(() => {
+    document
+      .querySelectorAll('meta[name="viewport"]')
+      .forEach(tag => tag.remove())
+  })
+
+  it('follows the device width by default', async () => {
+    renderFixViewport()
+
+    await waitFor(() => {
+      expect(getViewportContent()).toBe('width=device-width, user-scalable=no')
+    })
+  })
+
+  describe('when the app is not responsive', () => {
+    it('pins the layout viewport to the md breakpoint', async () => {
+      renderFixViewport(false)
+
+      await waitFor(() => {
+        expect(getViewportContent()).toBe('width=768')
+      })
+    })
+
+    it('leaves zoom enabled', async () => {
+      renderFixViewport(false)
+
+      await waitFor(() => {
+        expect(getViewportContent()).toBeTruthy()
+      })
+
+      expect(getViewportContent()).not.toContain('user-scalable=no')
+    })
+  })
+})

--- a/packages/picasso-provider/src/Picasso/FixViewport.tsx
+++ b/packages/picasso-provider/src/Picasso/FixViewport.tsx
@@ -1,16 +1,28 @@
 import React, { useState } from 'react'
 import { Helmet } from 'react-helmet-async'
 
+import { PicassoBreakpoints } from './config'
 import { isBrowser } from '../utils'
 
-const FixViewport = () => {
+export interface FixViewportProps {
+  /** Set to false for apps without mobile layouts, to pin the layout viewport */
+  responsive?: boolean
+}
+
+const FixViewport = ({ responsive = true }: FixViewportProps) => {
   const [warned, setWarned] = useState(false)
 
   if (!isBrowser()) {
     return null
   }
 
-  const content = 'width=device-width, user-scalable=no'
+  // Non-responsive apps have no mobile layouts, so pin the viewport to `md` —
+  // mobile browsers then evaluate CSS media queries (Tailwind's static `md:`
+  // variants included) at the width the JS breakpoints assume; desktop ignores
+  // `width`. Zoom stays enabled: the pin already scales pages down (WCAG 1.4.4).
+  const content = responsive
+    ? 'width=device-width, user-scalable=no'
+    : `width=${PicassoBreakpoints.breakpoints.values.md}`
   // eslint-disable-next-line ssr-friendly/no-dom-globals-in-react-fc
   const nonPicassoViewportTags = document.querySelectorAll(
     'meta[name="viewport"]:not([data-picasso="true"])'

--- a/packages/picasso-provider/src/Picasso/Picasso.tsx
+++ b/packages/picasso-provider/src/Picasso/Picasso.tsx
@@ -60,7 +60,7 @@ const Picasso = ({
       responsive={responsive}
     >
       <HelmetProvider disabled={disableHelmet}>
-        {fixViewport && <FixViewport />}
+        {fixViewport && <FixViewport responsive={responsive} />}
         {loadFonts && <FontsLoader />}
         {loadFavicon && <Favicon environment={environment} />}
         <NotificationsProvider container={notificationContainer}>

--- a/packages/picasso-provider/src/Picasso/config/breakpoints.ts
+++ b/packages/picasso-provider/src/Picasso/config/breakpoints.ts
@@ -11,40 +11,60 @@ type BreakpointsList = {
   [key: string]: number
 }
 
+const DEFAULT_BREAKPOINT_VALUES: BreakpointValues = {
+  xs: 0,
+  sm: 480,
+  md: 768,
+  lg: 1024,
+  xl: 1440,
+}
+
+const createMediaQueries = ({ sm, md, lg, xl }: BreakpointValues) => ({
+  xs: `(max-width: ${sm - 0.02}px)`,
+  sm: `(min-width: ${sm}px) and (max-width: ${md - 0.02}px)`,
+  md: `(min-width: ${md}px) and (max-width: ${lg - 0.02}px)`,
+  lg: `(min-width: ${lg}px) and (max-width: ${xl - 0.02}px)`,
+  xl: `(min-width: ${xl}px)`,
+})
+
 class BreakpointProvider {
   breakpoints: Record<'values', BreakpointValues> = {
-    values: {
-      xs: 0,
-      sm: 480,
-      md: 768,
-      lg: 1024,
-      xl: 1440,
-    },
+    values: { ...DEFAULT_BREAKPOINT_VALUES },
   }
 
   mediaQueries: {
     [key in BreakpointKeys]: string
-  }
+  } = createMediaQueries(DEFAULT_BREAKPOINT_VALUES)
 
-  constructor() {
-    const { sm, md, lg, xl } = this.breakpoints.values
-
-    this.mediaQueries = {
-      xs: `(max-width: ${sm - 0.02}px)`,
-      sm: `(min-width: ${sm}px) and (max-width: ${md - 0.02}px)`,
-      md: `(min-width: ${md}px) and (max-width: ${lg - 0.02}px)`,
-      lg: `(min-width: ${lg}px) and (max-width: ${xl - 0.02}px)`,
-      xl: `(min-width: ${xl}px)`,
-    }
-  }
-
+  /**
+   * Stops `xs`/`sm`/`md` from matching, for `<Picasso responsive={false}>`.
+   * `lg` widens to the desktop floor — left at 1024px it made 768–1023.98px
+   * match nothing, so `useBreakpoint(['md', 'lg', 'xl'])` was `false` there.
+   */
   disableMobileBreakpoints() {
+    const { xl } = this.breakpoints.values
+
     this.breakpoints.values.xs = 768
     this.breakpoints.values.sm = 768
 
     this.mediaQueries.xs = ''
     this.mediaQueries.sm = ''
     this.mediaQueries.md = ''
+    this.mediaQueries.lg = `(max-width: ${xl - 0.02}px)`
+  }
+
+  /**
+   * Restores the responsive defaults, in place so the exported
+   * `breakpointsList` alias stays live. `disableMobileBreakpoints()` is
+   * process-wide and one-way — tests mounting `responsive={false}` call this
+   * in an `afterEach` to avoid leaking.
+   */
+  reset() {
+    Object.assign(this.breakpoints.values, DEFAULT_BREAKPOINT_VALUES)
+    Object.assign(
+      this.mediaQueries,
+      createMediaQueries(DEFAULT_BREAKPOINT_VALUES)
+    )
   }
 }
 

--- a/packages/picasso-provider/src/Picasso/config/test.ts
+++ b/packages/picasso-provider/src/Picasso/config/test.ts
@@ -1,10 +1,38 @@
-import { isScreenSize, screens, PicassoBreakpoints } from './'
+import { renderHook } from '@testing-library/react'
+
+import {
+  breakpointsList,
+  isScreenSize,
+  screens,
+  useBreakpoint,
+  PicassoBreakpoints,
+} from './'
 
 const SCREEN_SIZES = {
   small: 500,
   medium: 800,
   large: 1060,
   extraLarge: 1500,
+}
+
+// jsdom's `matchMedia` never evaluates the query, so resolve the
+// `min-width`/`max-width` pairs against a fixed width ourselves.
+const mockViewportWidth = (width: number) => {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: (query: string) => ({
+      matches: query.split(',').some(singleQuery => {
+        const min = singleQuery.match(/min-width:\s*([\d.]+)px/)
+        const max = singleQuery.match(/max-width:\s*([\d.]+)px/)
+
+        return (
+          (!min || width >= Number(min[1])) && (!max || width <= Number(max[1]))
+        )
+      }),
+      addEventListener: () => {},
+      removeEventListener: () => {},
+    }),
+  })
 }
 
 describe('responsive breakpoint utils', () => {
@@ -36,6 +64,32 @@ describe('responsive breakpoint utils', () => {
       expect(mediaQuery).toBe(
         '@media (min-width: 480px) and (max-width: 767.98px), (min-width: 768px) and (max-width: 1023.98px), (min-width: 1024px) and (max-width: 1439.98px)'
       )
+    })
+  })
+
+  describe('useBreakpoint', () => {
+    it('matches the desktop range on a medium screen', () => {
+      mockViewportWidth(SCREEN_SIZES.medium)
+
+      const { result } = renderHook(() => useBreakpoint(['md', 'lg', 'xl']))
+
+      expect(result.current).toBe(true)
+    })
+
+    it('matches the compact range on a small screen', () => {
+      mockViewportWidth(SCREEN_SIZES.small)
+
+      const { result } = renderHook(() => useBreakpoint(['xs', 'sm', 'md']))
+
+      expect(result.current).toBe(true)
+    })
+
+    it('does not match the compact range on a large screen', () => {
+      mockViewportWidth(SCREEN_SIZES.large)
+
+      const { result } = renderHook(() => useBreakpoint(['xs', 'sm', 'md']))
+
+      expect(result.current).toBe(false)
     })
   })
 
@@ -113,6 +167,11 @@ describe('non-responsive breakpoint utils', () => {
     PicassoBreakpoints.disableMobileBreakpoints()
   })
 
+  // `disableMobileBreakpoints()` is process-wide — hand the defaults back
+  afterAll(() => {
+    PicassoBreakpoints.reset()
+  })
+
   describe('media query generation', () => {
     it('xs', () => {
       const mediaQuery = screens('xs')
@@ -135,9 +194,44 @@ describe('non-responsive breakpoint utils', () => {
     it('small medium large', () => {
       const mediaQuery = screens('sm', 'md', 'lg')
 
+      expect(mediaQuery).toBe('@media (max-width: 1439.98px)')
+    })
+
+    it('medium large extra large covers every width', () => {
+      const mediaQuery = screens('md', 'lg', 'xl')
+
       expect(mediaQuery).toBe(
-        '@media (min-width: 1024px) and (max-width: 1439.98px)'
+        '@media (max-width: 1439.98px), (min-width: 1440px)'
       )
+    })
+  })
+
+  describe('useBreakpoint', () => {
+    // `lg` is the desktop floor here, so desktop checks hold at every width —
+    // including the 768–1023.98px band that used to match nothing
+    it.each([
+      ['small', SCREEN_SIZES.small],
+      ['medium', SCREEN_SIZES.medium],
+      ['large', SCREEN_SIZES.large],
+      ['extra large', SCREEN_SIZES.extraLarge],
+    ])('matches the desktop range on a %s screen', (_name, width) => {
+      mockViewportWidth(width)
+
+      const { result } = renderHook(() => useBreakpoint(['md', 'lg', 'xl']))
+
+      expect(result.current).toBe(true)
+    })
+
+    it.each([
+      ['small', SCREEN_SIZES.small],
+      ['medium', SCREEN_SIZES.medium],
+      ['large', SCREEN_SIZES.large],
+    ])('does not match the compact range on a %s screen', (_name, width) => {
+      mockViewportWidth(width)
+
+      const { result } = renderHook(() => useBreakpoint(['xs', 'sm', 'md']))
+
+      expect(result.current).toBe(false)
     })
   })
 
@@ -206,6 +300,21 @@ describe('non-responsive breakpoint utils', () => {
       const isExtraLarge = isScreenSize('xl', SCREEN_SIZES.extraLarge)
 
       expect(isExtraLarge).toBeTruthy()
+    })
+  })
+
+  describe('reset', () => {
+    it('restores the responsive breakpoints', () => {
+      PicassoBreakpoints.reset()
+
+      expect(screens('md')).toBe(
+        '@media (min-width: 768px) and (max-width: 1023.98px)'
+      )
+      expect(isScreenSize('md', SCREEN_SIZES.medium)).toBeTruthy()
+      expect(breakpointsList.sm).toBe(480)
+
+      // hand the suite's own fixture back
+      PicassoBreakpoints.disableMobileBreakpoints()
     })
   })
 })

--- a/packages/picasso-provider/src/Picasso/index.ts
+++ b/packages/picasso-provider/src/Picasso/index.ts
@@ -1,7 +1,7 @@
 export { default } from './Picasso'
 export { default as PicassoLight } from './PicassoLight'
 export { default as FontsLoader } from './FontsLoader'
-export { default as FixViewport } from './FixViewport'
+export { default as FixViewport, FixViewportProps } from './FixViewport'
 export {
   default as NotificationsProvider,
   NotificationsProviderProps,

--- a/packages/picasso-provider/src/index.ts
+++ b/packages/picasso-provider/src/index.ts
@@ -1,6 +1,7 @@
 export {
   default,
   FixViewport,
+  FixViewportProps,
   FontsLoader,
   NotificationsProvider,
   NotificationsProviderProps,


### PR DESCRIPTION
[PF-2282]

### Description

Rebase of #5078 onto **master** — same PF-2282 fix, without the React 19
groundwork it was stacked on (`feature/pf-2262-lift-the-react-19-peer-dep`).
Only `@toptal/picasso-provider` changes; no `pnpm-lock.yaml`, no peer-dep
touches, no `picasso-charts` bump. #5078 can be closed in favour of this.

Under `<Picasso responsive={false}>`, `useBreakpoint('md')` returned `false` at
every viewport width. `disableMobileBreakpoints()` blanks the `xs`/`sm`/`md`
media queries but left `lg` starting at 1024px, creating a dead zone at
768–1023.98px where no breakpoint matched — desktop-gated UI keyed off `md`
(`useBreakpoint(['md','lg','xl'])`) rendered its mobile branch on desktop,
including at the default Cypress component viewport (822px). Surfaced from
client-portal (PR #11476).

Changes:

- **`lg` widens to `(max-width: 1439.98px)`** when mobile breakpoints are
  disabled, making it the desktop floor: desktop checks hold at every width,
  compact checks (`['xs','sm','md']` — what `PageTopBarMenu`/`Popper` query)
  keep returning `false`.
- **`FixViewport` takes a `responsive` prop** (passed through by `<Picasso>`):
  when `false` it emits `width=768` instead of `width=device-width`, so mobile
  browsers evaluate CSS media queries (Tailwind's static `md:` variants) at the
  width the JS breakpoints assume. Zoom stays enabled (WCAG 1.4.4).
- **`PicassoBreakpoints.reset()`** restores the responsive defaults —
  `disableMobileBreakpoints()` is process-wide and one-way, so tests mounting
  `responsive={false}` can now isolate themselves.

The default `responsive` path is unaffected. The pixel-based
`isScreenSize`/`useScreens` API is deliberately untouched (still reports `md`
in the 768–1023.98px band); aligning it is a follow-up.

The `docs/migration-to-new-picasso-v2.md` edits were re-resolved against
master's current tables — master's newer rows (PF-2253 fixed, label-wrapper
clicks, nested-dialog backdrop) are preserved and only the `responsive={false}`
rows flip to "Fixed".

### How to test

- PR preview: see the deploy bot comment on this PR
- `pnpm test:unit -- packages/picasso-provider` — breakpoint + FixViewport
  suites (61 tests) and `pnpm test:unit -- packages/base/Page` both pass on
  this branch
- In a consumer under `<Picasso responsive={false}>` at a ~800px viewport:
  `useBreakpoint(['md','lg','xl'])` returns `true`,
  `useBreakpoint(['xs','sm','md'])` returns `false`

### Screenshots

N/A — no visual changes on the default responsive path; no component queries
`lg`/`xl` through `useBreakpoint`.

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Double check if `picasso-tailwind-merge` requires major update (check its `README.md`)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests ([visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md) included)

**Breaking change**

- [ ] codemod is created and showcased in the changeset
- [ ] test alpha package of Picasso in StaffPortal

[PF-2282]: https://toptal-core.atlassian.net/browse/PF-2282?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
