### PR TITLE
Authenticate the Claude Code Action via ANTHROPIC_API_KEY

### DIFF
--- a/.github/workflows/design-patterns-check.yaml
+++ b/.github/workflows/design-patterns-check.yaml
@@ -31,8 +31,9 @@ jobs:
 
       - name: Run Claude design-patterns review
         uses: anthropics/claude-code-action@v1
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         with:
-          anthropic_api_key: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_args: '--allowed-tools "Bash(git diff:*),Bash(git fetch:*),Read,Write"'
           prompt: |
             You are reviewing this pull request against the Picasso component

--- a/.github/workflows/design-patterns-check.yaml
+++ b/.github/workflows/design-patterns-check.yaml
@@ -32,7 +32,7 @@ jobs:
       - name: Run Claude design-patterns review
         uses: anthropics/claude-code-action@v1
         with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          anthropic_api_key: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_args: '--allowed-tools "Bash(git diff:*),Bash(git fetch:*),Read,Write"'
           prompt: |
             You are reviewing this pull request against the Picasso component


### PR DESCRIPTION
The `design-patterns-check` workflow now hands the Claude Code Action an `ANTHROPIC_API_KEY` environment variable, sourced from an `ANTHROPIC_API_KEY` repository secret, rather than a `claude_code_oauth_token` auth input.

**Blocker:** picasso reads its key from a GitHub repo secret, not GSM, so [inf-terraform#5846](https://github.com/toptal/inf-terraform/pull/5846) does not cover it. `ANTHROPIC_API_KEY` has to be added as a repo secret on `toptal/picasso` before this merges — today only `CLAUDE_CODE_OAUTH_TOKEN` exists.

One caveat worth knowing: the action falls back to `env.ANTHROPIC_API_KEY` for its main run step, but its "Post buffered inline comments" step reads `inputs.anthropic_api_key` only. If we ever turn on `classify_inline_comments`, that step will not see the key via env.

Part of an org-wide sweep moving every `anthropics/claude-code-action` usage onto API key auth.

### How to test
Open a PR touching a component and confirm the Picasso design patterns check still runs and comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)