### PR TITLE
[PF] Remove legacy image-rendering from Avatar

### DIFF
--- a/.changeset/avatar-image-rendering.md
+++ b/.changeset/avatar-image-rendering.md
@@ -1,0 +1,7 @@
+---
+'@toptal/picasso-avatar': patch
+---
+
+### Avatar
+
+- remove the legacy `-webkit-optimize-contrast` image-rendering hint from image avatars — Chrome now aliases it to `crisp-edges`, which forces low-quality downscaling; photos use the browser's default high-quality resampling again

--- a/packages/base/AccountSelect/src/AccountSelect/__snapshots__/test.tsx.snap
+++ b/packages/base/AccountSelect/src/AccountSelect/__snapshots__/test.tsx.snap
@@ -199,7 +199,7 @@ exports[`AccountSelect renders 1`] = `
                         >
                           <img
                             alt="Phil Leif 3"
-                            class="block object-cover w-full h-full [image-rendering:-webkit-optimize"
+                            class="block object-cover w-full h-full"
                             src="./jacqueline-with-flowers-1954-square.jpg"
                           />
                         </div>

--- a/packages/base/Avatar/src/Avatar/Avatar.tsx
+++ b/packages/base/Avatar/src/Avatar/Avatar.tsx
@@ -52,8 +52,6 @@ export const Avatar = ({ size = 'xsmall', ...props }: Props) => {
           alt={alt}
           className={className}
           name={name}
-          /* eslint-disable-next-line @typescript-eslint/no-non-null-assertion */
-          size={size!}
           src={src}
           style={style}
           data-testid={testIds?.image}

--- a/packages/base/Avatar/src/Avatar/ImageAvatar/ImageAvatar.tsx
+++ b/packages/base/Avatar/src/Avatar/ImageAvatar/ImageAvatar.tsx
@@ -24,19 +24,14 @@ const ImageAvatar = (props: Props) => {
   } = props
 
   return (
-    <>
-      <Image
-        alt={alt || name || ''}
-        className={twMerge(
-          'object-cover w-full h-full [image-rendering:-webkit-optimize-contrast]',
-          className
-        )}
-        src={src}
-        style={style}
-        data-testid={dataTestId}
-        data-private={dataPrivate}
-      />
-    </>
+    <Image
+      alt={alt || name || ''}
+      className={twMerge('object-cover w-full h-full', className)}
+      src={src}
+      style={style}
+      data-testid={dataTestId}
+      data-private={dataPrivate}
+    />
   )
 }
 

--- a/packages/base/Avatar/src/Avatar/ImageAvatar/ImageAvatar.tsx
+++ b/packages/base/Avatar/src/Avatar/ImageAvatar/ImageAvatar.tsx
@@ -1,12 +1,9 @@
 import React from 'react'
-import type { BaseProps, SizeType } from '@toptal/picasso-shared'
+import type { BaseProps } from '@toptal/picasso-shared'
 import { Image } from '@toptal/picasso-image'
 import { twMerge } from '@toptal/picasso-tailwind-merge'
 
-export type Size = SizeType<'xxsmall' | 'xsmall' | 'small' | 'medium' | 'large'>
-
 export interface Props extends BaseProps {
-  size: Size
   src: string
   alt?: string
   name?: string

--- a/packages/base/Page/src/PageTopBarMenu/__snapshots__/test.tsx.snap
+++ b/packages/base/Page/src/PageTopBarMenu/__snapshots__/test.tsx.snap
@@ -23,7 +23,7 @@ exports[`PageTopBarMenu renders 1`] = `
               >
                 <img
                   alt="Jacqueline Roque"
-                  class="block object-cover w-full h-full [image-rendering:-webkit-optimize"
+                  class="block object-cover w-full h-full"
                   src="./jacqueline-with-flowers-1954-square.jpg"
                 />
               </div>


### PR DESCRIPTION
### Description

Removes the `[image-rendering:-webkit-optimize-contrast]` arbitrary class from `ImageAvatar`.

It was a hack for a long-fixed Chrome bug with blurry downscaled images. Chrome now aliases `-webkit-optimize-contrast` to `crisp-edges`, which forces low-quality (nearest-neighbor-style) scaling — the opposite of its original intent. With it removed, avatar photos use the browser's default high-quality resampling.

Jest snapshots for `AccountSelect` and `PageTopBarMenu` updated (they embed the avatar class list).

### How to test

- [Temploy](https://picasso.toptal.net/pf-avatar-image-optimization)
- Open Avatar stories with photo sources — downscaled photos should look slightly smoother, no other changes
- Review the Happo report: only avatar-bearing snapshots re-render, with minor edge/sharpness diffs on the photos (intended)

### Screenshots

| Before.                                 | After.                                  |
| --------------------------------------- | --------------------------------------- |
| See Happo report                        | See Happo report                        |

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Double check if `picasso-tailwind-merge` requires major update (check its `README.md`)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [x] Self reviewed
- [x] Covered with tests ([visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md) included)
