### PR TITLE
[PF-2317] Migrate Collapse to Tailwind from react-transition-group

### DIFF
--- a/.changeset/collapse-tailwind-migration.md
+++ b/.changeset/collapse-tailwind-migration.md
@@ -6,7 +6,8 @@
 
 - drop the react-transition-group dependency — the last consumer in the kit; its `Transition` ran without `nodeRef`, so it reached `findDOMNode`, which React 19 removes — and reimplement on the shared timer-driven `useTransitionStatus` hook. Public props are unchanged
 - the height handoff now uses `requestAnimationFrame` instead of an internal 50 ms delay, so the transition starts about 50 ms sooner and pending frames are cleaned up on unmount
-- the object form of `timeout` now sets the CSS transition duration correctly per direction (previously it produced an invalid inline value)
+- the object form of `timeout` now sets the CSS transition duration correctly per direction, including a distinct `appear` duration for the mount transition (previously it produced an invalid inline value)
 - unrecognized props (including `data-private`) now reach the rendered DOM node — previously they were silently dropped
 - add the `CollapseProps` type export and deprecate the misnamed `FadeProps` re-export (kept as an alias, so no action is required yet)
+- prop descriptions are corrected (`children`, `appear` and `onEnter` were stale or wrong) and promoted to JSDoc, so they surface in IDE tooltips and generated docs
 - the `react` peer range stays capped at `< 19.0.0`; lifting that cap library-wide is tracked separately in PF-2262

--- a/.changeset/collapse-tailwind-migration.md
+++ b/.changeset/collapse-tailwind-migration.md
@@ -1,0 +1,12 @@
+---
+'@toptal/picasso-collapse': minor
+---
+
+### Collapse
+
+- drop the react-transition-group dependency — the last consumer in the kit; its `Transition` ran without `nodeRef`, so it reached `findDOMNode`, which React 19 removes — and reimplement on the shared timer-driven `useTransitionStatus` hook. Public props are unchanged
+- the height handoff now uses `requestAnimationFrame` instead of an internal 50 ms delay, so the transition starts about 50 ms sooner and pending frames are cleaned up on unmount
+- the object form of `timeout` now sets the CSS transition duration correctly per direction (previously it produced an invalid inline value)
+- unrecognized props (including `data-private`) now reach the rendered DOM node — previously they were silently dropped
+- add the `CollapseProps` type export and deprecate the misnamed `FadeProps` re-export (kept as an alias, so no action is required yet)
+- the `react` peer range stays capped at `< 19.0.0`; lifting that cap library-wide is tracked separately in PF-2262

--- a/.changeset/collapse-tailwind-migration.md
+++ b/.changeset/collapse-tailwind-migration.md
@@ -4,8 +4,8 @@
 
 ### Collapse
 
-- drop the react-transition-group dependency — the last consumer in the kit; its `Transition` ran without `nodeRef`, so it reached `findDOMNode`, which React 19 removes — and reimplement on the shared timer-driven `useTransitionStatus` hook. Public props are unchanged
-- the height handoff now uses `requestAnimationFrame` instead of an internal 50 ms delay, so the transition starts about 50 ms sooner and pending frames are cleaned up on unmount
+- drop the react-transition-group dependency — the kit's last direct consumer; its `Transition` ran without `nodeRef`, so it reached `findDOMNode`, which React 19 removes — and reimplement on the shared timer-driven `useTransitionStatus` hook. Public props are unchanged. (recharts still pulls react-transition-group transitively via react-smooth, but only for `AnimateGroup`, which recharts never renders)
+- the height handoff now uses `requestAnimationFrame` instead of an internal 50 ms delay, so the transition starts about 50 ms sooner and pending frames are cleaned up on unmount; the exit's start height is pinned with a forced reflow so the collapse animation cannot degrade into a snap
 - the object form of `timeout` now sets the CSS transition duration correctly per direction, including a distinct `appear` duration for the mount transition (previously it produced an invalid inline value)
 - unrecognized props (including `data-private`) now reach the rendered DOM node — previously they were silently dropped
 - add the `CollapseProps` type export and deprecate the misnamed `FadeProps` re-export (kept as an alias, so no action is required yet)

--- a/.changeset/utils-element-ref-react-19.md
+++ b/.changeset/utils-element-ref-react-19.md
@@ -1,0 +1,8 @@
+---
+'@toptal/picasso-utils': patch
+---
+
+### Utils
+
+- `getElementRef` now reads element refs from `props.ref` on React 19 and newer, where `element.ref` is deprecated and logs a removal warning on every access; on React 17/18 it keeps reading `element.ref`, whose dev builds warn on `props.ref` instead. Fade, Slide and ClickAwayListener consumers stop emitting the React 19 deprecation warning
+- switch `ClickAwayListener` to the shared `getElementRef` helper instead of its own `element.ref` cast, so DatePicker, Dropdown and MenuItem inherit the version-aware read

--- a/.changeset/utils-element-ref-react-19.md
+++ b/.changeset/utils-element-ref-react-19.md
@@ -5,4 +5,4 @@
 ### Utils
 
 - `getElementRef` now reads element refs from `props.ref` on React 19 and newer, where `element.ref` is deprecated and logs a removal warning on every access; on React 17/18 it keeps reading `element.ref`, whose dev builds warn on `props.ref` instead. Fade, Slide and ClickAwayListener consumers stop emitting the React 19 deprecation warning
-- switch `ClickAwayListener` to the shared `getElementRef` helper instead of its own `element.ref` cast, so DatePicker, Dropdown and MenuItem inherit the version-aware read
+- switch `ClickAwayListener` to the shared `getElementRef` and `useMultipleForwardRefs` helpers instead of its own `element.ref` cast and hand-rolled ref forwarding, so DatePicker, Dropdown and MenuItem inherit the version-aware read (behavior unchanged)

--- a/packages/base/Collapse/package.json
+++ b/packages/base/Collapse/package.json
@@ -22,8 +22,8 @@
   },
   "homepage": "https://github.com/toptal/picasso/tree/master/packages/picasso#readme",
   "dependencies": {
-    "@toptal/picasso-utils": "workspace:*",
-    "react-transition-group": "^4.4.5"
+    "@toptal/picasso-shared": "workspace:*",
+    "@toptal/picasso-utils": "workspace:*"
   },
   "sideEffects": false,
   "peerDependencies": {
@@ -36,8 +36,7 @@
   },
   "devDependencies": {
     "@toptal/picasso-tailwind-merge": "workspace:*",
-    "@toptal/picasso-test-utils": "workspace:*",
-    "@types/react-transition-group": "^4.4.5"
+    "@toptal/picasso-test-utils": "workspace:*"
   },
   "files": [
     "dist-package/**",

--- a/packages/base/Collapse/src/Collapse/Collapse.tsx
+++ b/packages/base/Collapse/src/Collapse/Collapse.tsx
@@ -10,15 +10,15 @@ import {
 import { twMerge } from '@toptal/picasso-tailwind-merge'
 
 export interface Props extends TransitionProps, BaseProps {
-  /* Element that accepts ref */
+  /** Content to expand and collapse */
   children: ReactNode
-  /* Show the component; triggers the enter or exit states */
+  /** Show the content; toggling runs the enter or exit transition */
   in?: boolean
-  /* Trigger the transition on the first mount, regardless of the `in` prop. */
+  /** Run the enter transition when mounting with `in` already true */
   appear?: boolean
-  /* Unmount the component on exit */
+  /** Unmount the component once it has fully exited */
   unmountOnExit?: boolean
-  /* Callback fired when the component has entered */
+  /** Callback fired when the enter transition starts */
   onEnter?: (node: HTMLElement, isAppearing: boolean) => void
 }
 
@@ -51,9 +51,7 @@ export const Collapse = forwardRef<HTMLDivElement, Props>(function Collapse(
     onExited,
   })
 
-  const [height, setHeight] = useState<string>(
-    inProps && !appear ? 'auto' : '0px'
-  )
+  const [height, setHeight] = useState(status === 'entered' ? 'auto' : '0px')
 
   // The from-value and to-value of a height transition must land in separate
   // painted frames, or CSS sees a single change and skips the animation. The
@@ -88,17 +86,28 @@ export const Collapse = forwardRef<HTMLDivElement, Props>(function Collapse(
     setHeight('0px')
   }, [status])
 
+  // `appear` describes only the mount transition — the first exit ends it and
+  // every later enter is a regular one — so its duration applies until then.
+  const [appearing, setAppearing] = useState(Boolean(appear && inProps))
+
+  useIsomorphicLayoutEffect(() => {
+    if (status === 'exiting') {
+      setAppearing(false)
+    }
+  }, [status])
+
   const combinedRef = useMultipleForwardRefs([ref, nodeRef])
 
   const memoStyles = useMemo(() => {
     const timeouts = getTransitionTimeouts(timeout)
+    const enterDuration = appearing ? timeouts.appear : timeouts.enter
 
     return {
       ...style,
-      transitionDuration: `${inProps ? timeouts.enter : timeouts.exit}ms`,
+      transitionDuration: `${inProps ? enterDuration : timeouts.exit}ms`,
       height,
     }
-  }, [timeout, inProps, height, style])
+  }, [timeout, inProps, appearing, height, style])
 
   if (status === 'unmounted') {
     return null

--- a/packages/base/Collapse/src/Collapse/Collapse.tsx
+++ b/packages/base/Collapse/src/Collapse/Collapse.tsx
@@ -53,10 +53,6 @@ export const Collapse = forwardRef<HTMLDivElement, Props>(function Collapse(
 
   const [height, setHeight] = useState(status === 'entered' ? 'auto' : '0px')
 
-  // The from-value and to-value of a height transition must land in separate
-  // painted frames, or CSS sees a single change and skips the animation. The
-  // inner wrapper keeps its natural clientHeight even while the outer div is
-  // collapsed, so measuring is always synchronous.
   useIsomorphicLayoutEffect(() => {
     const measured = () => `${wrapperRef.current?.clientHeight ?? 0}px`
 
@@ -69,7 +65,6 @@ export const Collapse = forwardRef<HTMLDivElement, Props>(function Collapse(
     }
 
     if (status === 'entered') {
-      // height 'auto' after the transition supports dynamic content inside
       setHeight('auto')
 
       return
@@ -78,7 +73,11 @@ export const Collapse = forwardRef<HTMLDivElement, Props>(function Collapse(
     if (status === 'exiting') {
       setHeight(measured())
 
-      const frame = requestAnimationFrame(() => setHeight('0px'))
+      const frame = requestAnimationFrame(() => {
+        void nodeRef.current?.offsetHeight
+
+        setHeight('0px')
+      })
 
       return () => cancelAnimationFrame(frame)
     }
@@ -86,8 +85,6 @@ export const Collapse = forwardRef<HTMLDivElement, Props>(function Collapse(
     setHeight('0px')
   }, [status])
 
-  // `appear` describes only the mount transition — the first exit ends it and
-  // every later enter is a regular one — so its duration applies until then.
   const [appearing, setAppearing] = useState(Boolean(appear && inProps))
 
   useIsomorphicLayoutEffect(() => {

--- a/packages/base/Collapse/src/Collapse/Collapse.tsx
+++ b/packages/base/Collapse/src/Collapse/Collapse.tsx
@@ -1,7 +1,12 @@
 import type { ReactNode } from 'react'
-import React, { forwardRef, useMemo, useState } from 'react'
-import { Transition } from 'react-transition-group'
+import React, { forwardRef, useMemo, useRef, useState } from 'react'
 import type { BaseProps, TransitionProps } from '@toptal/picasso-shared'
+import { useIsomorphicLayoutEffect } from '@toptal/picasso-shared'
+import {
+  getTransitionTimeouts,
+  useMultipleForwardRefs,
+  useTransitionStatus,
+} from '@toptal/picasso-utils'
 import { twMerge } from '@toptal/picasso-tailwind-merge'
 
 export interface Props extends TransitionProps, BaseProps {
@@ -17,110 +22,108 @@ export interface Props extends TransitionProps, BaseProps {
   onEnter?: (node: HTMLElement, isAppearing: boolean) => void
 }
 
-const useCollapseLogic = (inProps: boolean) => {
-  const [height, setHeight] = useState<string>(inProps ? 'auto' : '0px')
-  const wrapperRef = React.useRef<HTMLDivElement>(null)
+export const Collapse = forwardRef<HTMLDivElement, Props>(function Collapse(
+  {
+    children,
+    className,
+    in: inProps = false,
+    timeout = 350,
+    unmountOnExit,
+    style,
+    appear,
+    'data-testid': dataTestId,
+    onEnter,
+    onExited,
+    ...rest
+  },
+  ref
+) {
+  const nodeRef = useRef<HTMLDivElement>(null)
+  const wrapperRef = useRef<HTMLDivElement>(null)
 
-  const getCurrentHeight = () => wrapperRef.current?.clientHeight
-  const setHeightToCurrent = () => setHeight(`${getCurrentHeight()}px`)
-  const setHeightToZero = () => setHeight('0px')
-  const setHeightToAuto = () => setHeight('auto')
+  const status = useTransitionStatus({
+    in: inProps,
+    appear,
+    unmountOnExit,
+    timeout,
+    nodeRef,
+    onEnter,
+    onExited,
+  })
 
-  return {
-    height,
-    wrapperRef,
-    setHeightToCurrent,
-    setHeightToZero,
-    setHeightToAuto,
-  }
-}
+  const [height, setHeight] = useState<string>(
+    inProps && !appear ? 'auto' : '0px'
+  )
 
-export const Collapse = forwardRef<HTMLDivElement, Props>(
-  (
-    {
-      children,
-      className,
-      in: inProps = false,
-      timeout = 350,
-      unmountOnExit,
-      style,
-      appear,
-      'data-testid': dataTestId,
-      onEnter,
-      onExited,
-      ...rest
-    },
-    ref
-  ) => {
-    const {
+  // The from-value and to-value of a height transition must land in separate
+  // painted frames, or CSS sees a single change and skips the animation. The
+  // inner wrapper keeps its natural clientHeight even while the outer div is
+  // collapsed, so measuring is always synchronous.
+  useIsomorphicLayoutEffect(() => {
+    const measured = () => `${wrapperRef.current?.clientHeight ?? 0}px`
+
+    if (status === 'entering') {
+      setHeight('0px')
+
+      const frame = requestAnimationFrame(() => setHeight(measured()))
+
+      return () => cancelAnimationFrame(frame)
+    }
+
+    if (status === 'entered') {
+      // height 'auto' after the transition supports dynamic content inside
+      setHeight('auto')
+
+      return
+    }
+
+    if (status === 'exiting') {
+      setHeight(measured())
+
+      const frame = requestAnimationFrame(() => setHeight('0px'))
+
+      return () => cancelAnimationFrame(frame)
+    }
+
+    setHeight('0px')
+  }, [status])
+
+  const combinedRef = useMultipleForwardRefs([ref, nodeRef])
+
+  const memoStyles = useMemo(() => {
+    const timeouts = getTransitionTimeouts(timeout)
+
+    return {
+      ...style,
+      transitionDuration: `${inProps ? timeouts.enter : timeouts.exit}ms`,
       height,
-      wrapperRef,
-      setHeightToZero,
-      setHeightToAuto,
-      setHeightToCurrent,
-    } = useCollapseLogic(inProps)
-
-    // we need to add small delay as 'enter', 'entering' and 'exit', 'exiting'
-    // are triggered in the same time and React is batching them
-    const handleEntering = () => setTimeout(setHeightToCurrent, 50)
-    const handleExiting = () => setTimeout(setHeightToZero, 50)
-
-    const handleEnter = (node: HTMLElement, isAppearing: boolean) => {
-      setHeightToZero()
-      onEnter?.(node, isAppearing)
     }
+  }, [timeout, inProps, height, style])
 
-    const handleExited = (node: HTMLElement) => {
-      setHeightToZero()
-      onExited?.(node)
-    }
-
-    const memoStyles = useMemo(() => {
-      return {
-        ...style,
-        transitionDuration: `${timeout}ms`,
-        height,
-      }
-    }, [timeout, height, style])
-
-    return (
-      <Transition
-        in={inProps}
-        appear={appear}
-        onEnter={handleEnter}
-        onEntering={handleEntering}
-        // we need to set height to 'auto' after transition is finished
-        // to support dynamic content inside Collapse
-        onEntered={setHeightToAuto}
-        onExit={setHeightToCurrent}
-        onExiting={handleExiting}
-        onExited={handleExited}
-        unmountOnExit={unmountOnExit}
-        timeout={timeout}
-        {...rest}
-      >
-        {state => {
-          return (
-            <div
-              className={twMerge([
-                'transition-[height] ease-in-out min-h-0',
-                state === 'exited' && !inProps && 'invisible',
-                state === 'entered' ? 'overflow-visible' : 'overflow-hidden',
-                className,
-              ])}
-              style={memoStyles}
-              data-testid={dataTestId}
-              ref={ref}
-            >
-              <div className='flex' ref={wrapperRef}>
-                <div className='w-full'>{children}</div>
-              </div>
-            </div>
-          )
-        }}
-      </Transition>
-    )
+  if (status === 'unmounted') {
+    return null
   }
-)
+
+  return (
+    <div
+      {...rest}
+      className={twMerge([
+        'transition-[height] ease-in-out min-h-0',
+        status === 'exited' && !inProps && 'invisible',
+        status === 'entered' ? 'overflow-visible' : 'overflow-hidden',
+        className,
+      ])}
+      style={memoStyles}
+      data-testid={dataTestId}
+      ref={combinedRef}
+    >
+      <div className='flex' ref={wrapperRef}>
+        <div className='w-full'>{children}</div>
+      </div>
+    </div>
+  )
+})
+
+Collapse.displayName = 'Collapse'
 
 export default Collapse

--- a/packages/base/Collapse/src/Collapse/index.ts
+++ b/packages/base/Collapse/src/Collapse/index.ts
@@ -3,4 +3,6 @@ import type { OmitInternalProps } from '@toptal/picasso-shared'
 import type { Props } from './Collapse'
 
 export { default as Collapse } from './Collapse'
+export type CollapseProps = OmitInternalProps<Props>
+/** @deprecated [PF-2317] misnamed re-export — use `CollapseProps` instead */
 export type FadeProps = OmitInternalProps<Props>

--- a/packages/base/Collapse/src/Collapse/test.tsx
+++ b/packages/base/Collapse/src/Collapse/test.tsx
@@ -1,7 +1,10 @@
-import React from 'react'
+import React, { StrictMode } from 'react'
 import { act, cleanup, render } from '@toptal/picasso-test-utils'
 
 import Collapse from './Collapse'
+
+const CONTENT_HEIGHT = 120
+const FRAME = 20
 
 const SomeChildComponent = React.forwardRef<HTMLDivElement>((props, ref) => (
   <div ref={ref} data-testid='child-div' {...props}>
@@ -10,13 +13,63 @@ const SomeChildComponent = React.forwardRef<HTMLDivElement>((props, ref) => (
 ))
 
 describe('Collapse', () => {
+  let clientHeightSpy: jest.SpyInstance
+
   beforeEach(() => {
     jest.useFakeTimers()
+    // jsdom has no layout; the inner wrapper reports the mocked height
+    clientHeightSpy = jest
+      .spyOn(Element.prototype, 'clientHeight', 'get')
+      .mockReturnValue(CONTENT_HEIGHT)
   })
 
   afterEach(() => {
+    clientHeightSpy.mockRestore()
     cleanup()
     jest.useRealTimers()
+  })
+
+  it('shows content instantly when mounted expanded without `appear`', () => {
+    const onEnter = jest.fn()
+    const { getByTestId } = render(
+      <Collapse in onEnter={onEnter} data-testid='collapse'>
+        <SomeChildComponent />
+      </Collapse>
+    )
+
+    expect(getByTestId('collapse')).toHaveStyle({ height: 'auto' })
+    expect(getByTestId('collapse')).toHaveClass('overflow-visible')
+    expect(getByTestId('collapse')).not.toHaveClass('invisible')
+    expect(onEnter).not.toHaveBeenCalled()
+  })
+
+  it('animates from zero on an `appear` mount', () => {
+    const onEnter = jest.fn()
+    const { getByTestId } = render(
+      <Collapse appear in onEnter={onEnter} data-testid='collapse'>
+        <SomeChildComponent />
+      </Collapse>
+    )
+
+    const collapse = getByTestId('collapse')
+
+    expect(collapse).toHaveStyle({ height: '0px' })
+    expect(collapse).toHaveClass('overflow-hidden')
+    expect(onEnter).toHaveBeenCalledTimes(1)
+    expect(onEnter).toHaveBeenCalledWith(collapse, true)
+
+    act(() => {
+      jest.advanceTimersByTime(FRAME)
+    })
+
+    expect(collapse).toHaveStyle({ height: `${CONTENT_HEIGHT}px` })
+
+    act(() => {
+      jest.advanceTimersByTime(350)
+    })
+
+    expect(collapse).toHaveStyle({ height: 'auto' })
+    expect(collapse).toHaveClass('overflow-visible')
   })
 
   it('transitions based on the `in` prop', () => {
@@ -26,18 +79,136 @@ describe('Collapse', () => {
       </Collapse>
     )
 
-    expect(getByTestId('collapse')).toHaveClass('invisible')
+    const collapse = getByTestId('collapse')
+
+    expect(collapse).toHaveClass('invisible')
+    expect(collapse).toHaveStyle({ height: '0px' })
+
+    rerender(
+      <Collapse in data-testid='collapse'>
+        <SomeChildComponent />
+      </Collapse>
+    )
+
+    expect(collapse).not.toHaveClass('invisible')
 
     act(() => {
-      rerender(
-        <Collapse in={true} data-testid='collapse'>
-          <SomeChildComponent />
-        </Collapse>
-      )
+      jest.advanceTimersByTime(FRAME)
+    })
+
+    expect(collapse).toHaveStyle({ height: `${CONTENT_HEIGHT}px` })
+
+    act(() => {
+      jest.advanceTimersByTime(350)
+    })
+
+    expect(collapse).toHaveStyle({ height: 'auto' })
+    expect(collapse).toHaveClass('overflow-visible')
+  })
+
+  it('collapses and fires `onExited` while staying mounted', () => {
+    const onExited = jest.fn()
+    const { getByTestId, rerender } = render(
+      <Collapse in onExited={onExited} data-testid='collapse'>
+        <SomeChildComponent />
+      </Collapse>
+    )
+
+    const collapse = getByTestId('collapse')
+
+    rerender(
+      <Collapse in={false} onExited={onExited} data-testid='collapse'>
+        <SomeChildComponent />
+      </Collapse>
+    )
+
+    expect(collapse).toHaveStyle({ height: `${CONTENT_HEIGHT}px` })
+    expect(collapse).toHaveClass('overflow-hidden')
+
+    act(() => {
+      jest.advanceTimersByTime(FRAME)
+    })
+
+    expect(collapse).toHaveStyle({ height: '0px' })
+
+    act(() => {
+      jest.advanceTimersByTime(350)
+    })
+
+    expect(onExited).toHaveBeenCalledTimes(1)
+    expect(onExited).toHaveBeenCalledWith(collapse)
+    expect(collapse).toHaveClass('invisible')
+    expect(collapse).toBeInTheDocument()
+  })
+
+  it('unmounts after the exit settles with `unmountOnExit`', () => {
+    const onExited = jest.fn()
+    const { queryByTestId, rerender } = render(
+      <Collapse in unmountOnExit onExited={onExited} data-testid='collapse'>
+        <SomeChildComponent />
+      </Collapse>
+    )
+
+    expect(queryByTestId('collapse')).toBeInTheDocument()
+
+    rerender(
+      <Collapse
+        in={false}
+        unmountOnExit
+        onExited={onExited}
+        data-testid='collapse'
+      >
+        <SomeChildComponent />
+      </Collapse>
+    )
+
+    act(() => {
       jest.runAllTimers()
     })
 
-    expect(getByTestId('collapse')).toHaveStyle('display: block')
+    expect(onExited).toHaveBeenCalledTimes(1)
+    expect(queryByTestId('collapse')).not.toBeInTheDocument()
+  })
+
+  it('never mounts when starting collapsed with `unmountOnExit`', () => {
+    const { queryByTestId } = render(
+      <Collapse in={false} unmountOnExit data-testid='collapse'>
+        <SomeChildComponent />
+      </Collapse>
+    )
+
+    expect(queryByTestId('collapse')).not.toBeInTheDocument()
+  })
+
+  it('applies per-phase durations from an object `timeout`', () => {
+    const { getByTestId, rerender } = render(
+      <Collapse
+        appear
+        in
+        timeout={{ enter: 100, exit: 200 }}
+        data-testid='collapse'
+      >
+        <SomeChildComponent />
+      </Collapse>
+    )
+
+    expect(getByTestId('collapse')).toHaveStyle({
+      transitionDuration: '100ms',
+    })
+
+    rerender(
+      <Collapse
+        in={false}
+        timeout={{ enter: 100, exit: 200 }}
+        data-testid='collapse'
+      >
+        <SomeChildComponent />
+      </Collapse>
+    )
+
+    expect(getByTestId('collapse')).toHaveStyle({
+      transitionDuration: '200ms',
+    })
   })
 
   it('lets a consumer className override its own overflow', () => {
@@ -60,5 +231,34 @@ describe('Collapse', () => {
     )
 
     expect(ref.current).toBe(getByTestId('collapse'))
+  })
+
+  it('forwards unrecognized props to the DOM node', () => {
+    const { getByTestId } = render(
+      <Collapse in data-private data-testid='collapse'>
+        <SomeChildComponent />
+      </Collapse>
+    )
+
+    expect(getByTestId('collapse')).toHaveAttribute('data-private')
+  })
+
+  it('settles an `appear` mount under StrictMode', () => {
+    const onEnter = jest.fn()
+    const { getByTestId } = render(
+      <StrictMode>
+        <Collapse appear in onEnter={onEnter} data-testid='collapse'>
+          <SomeChildComponent />
+        </Collapse>
+      </StrictMode>
+    )
+
+    act(() => {
+      jest.runAllTimers()
+    })
+
+    expect(onEnter).toHaveBeenCalledTimes(1)
+    expect(getByTestId('collapse')).toHaveStyle({ height: 'auto' })
+    expect(getByTestId('collapse')).toHaveClass('overflow-visible')
   })
 })

--- a/packages/base/Collapse/src/Collapse/test.tsx
+++ b/packages/base/Collapse/src/Collapse/test.tsx
@@ -1,9 +1,12 @@
+/* eslint-disable max-lines-per-function */
 import React, { StrictMode } from 'react'
 import { act, cleanup, render } from '@toptal/picasso-test-utils'
 
 import Collapse from './Collapse'
 
 const CONTENT_HEIGHT = 120
+// one mocked rAF frame — jest's fake timers schedule requestAnimationFrame
+// callbacks 16 ms apart
 const FRAME = 20
 
 const SomeChildComponent = React.forwardRef<HTMLDivElement>((props, ref) => (
@@ -209,6 +212,44 @@ describe('Collapse', () => {
     expect(getByTestId('collapse')).toHaveStyle({
       transitionDuration: '200ms',
     })
+  })
+
+  it('applies the `appear` duration to the mount transition only', () => {
+    const timeout = { enter: 100, exit: 200, appear: 500 }
+    const { getByTestId, rerender } = render(
+      <Collapse appear in timeout={timeout} data-testid='collapse'>
+        <SomeChildComponent />
+      </Collapse>
+    )
+
+    const collapse = getByTestId('collapse')
+
+    expect(collapse).toHaveStyle({ transitionDuration: '500ms' })
+
+    act(() => {
+      jest.runAllTimers()
+    })
+
+    rerender(
+      <Collapse appear in={false} timeout={timeout} data-testid='collapse'>
+        <SomeChildComponent />
+      </Collapse>
+    )
+
+    expect(collapse).toHaveStyle({ transitionDuration: '200ms' })
+
+    act(() => {
+      jest.runAllTimers()
+    })
+
+    // a re-enter after the appear pass is a regular enter
+    rerender(
+      <Collapse appear in timeout={timeout} data-testid='collapse'>
+        <SomeChildComponent />
+      </Collapse>
+    )
+
+    expect(collapse).toHaveStyle({ transitionDuration: '100ms' })
   })
 
   it('lets a consumer className override its own overflow', () => {

--- a/packages/base/Collapse/tsconfig.json
+++ b/packages/base/Collapse/tsconfig.json
@@ -5,6 +5,7 @@
   "references": [
     { "path": "../../picasso-tailwind" },
     { "path": "../../picasso-tailwind-merge" },
+    { "path": "../../shared" },
     { "path": "../Utils" }
   ]
 }

--- a/packages/base/Utils/src/utils/ClickAwayListener/ClickAwayListener.tsx
+++ b/packages/base/Utils/src/utils/ClickAwayListener/ClickAwayListener.tsx
@@ -1,13 +1,13 @@
 import type {
   MouseEvent as ReactMouseEvent,
   ReactElement,
-  Ref,
   SyntheticEvent,
 } from 'react'
 import React, { useCallback, useEffect, useRef } from 'react'
 import { toReactEvent } from '@toptal/picasso-shared'
 
 import getElementRef from '../get-element-ref'
+import useMultipleForwardRefs from '../use-multiple-forward-refs'
 
 type ClickAwayMouseEventHandler = 'onClick' | 'onMouseDown' | 'onMouseUp'
 type ClickAwayTouchEventHandler = 'onTouchStart' | 'onTouchEnd'
@@ -53,14 +53,6 @@ const isEventInsideNode = (
   )
 }
 
-const setRef = <T,>(ref: Ref<T> | undefined, value: T | null): void => {
-  if (typeof ref === 'function') {
-    ref(value)
-  } else if (ref) {
-    ;(ref as React.MutableRefObject<T | null>).current = value
-  }
-}
-
 export const ClickAwayListener = (props: Props) => {
   const {
     children,
@@ -89,14 +81,7 @@ export const ClickAwayListener = (props: Props) => {
   }, [])
 
   const childRef = getElementRef<Element>(children)
-
-  const handleRef = useCallback(
-    (instance: Element | null) => {
-      nodeRef.current = instance
-      setRef(childRef, instance)
-    },
-    [childRef]
-  )
+  const handleRef = useMultipleForwardRefs([nodeRef, childRef])
 
   const handleClickAway = useCallback(
     (event: Event) => {

--- a/packages/base/Utils/src/utils/ClickAwayListener/ClickAwayListener.tsx
+++ b/packages/base/Utils/src/utils/ClickAwayListener/ClickAwayListener.tsx
@@ -7,6 +7,8 @@ import type {
 import React, { useCallback, useEffect, useRef } from 'react'
 import { toReactEvent } from '@toptal/picasso-shared'
 
+import getElementRef from '../get-element-ref'
+
 type ClickAwayMouseEventHandler = 'onClick' | 'onMouseDown' | 'onMouseUp'
 type ClickAwayTouchEventHandler = 'onTouchStart' | 'onTouchEnd'
 
@@ -86,7 +88,7 @@ export const ClickAwayListener = (props: Props) => {
     }
   }, [])
 
-  const childRef = (children as { ref?: Ref<Element> }).ref
+  const childRef = getElementRef<Element>(children)
 
   const handleRef = useCallback(
     (instance: Element | null) => {

--- a/packages/base/Utils/src/utils/__tests__/get-element-ref.test.tsx
+++ b/packages/base/Utils/src/utils/__tests__/get-element-ref.test.tsx
@@ -19,11 +19,16 @@ describe('getElementRef', () => {
     expect(getElementRef<HTMLDivElement>(<div ref={ref} />)).toBe(ref)
   })
 
-  it('does not read `ref` from props, which warns on React 18', () => {
+  it('reads from the version-appropriate location without warnings', () => {
+    // React <19 warns when `props.ref` is accessed; React 19+ warns when
+    // `element.ref` is accessed. This runs under both jest configs
+    // (jest.spec.mjs on 18, jest.react19.mjs on 19), proving the read is
+    // silent on the running major either way.
     const consoleError = jest.spyOn(console, 'error').mockImplementation()
+    const ref = jest.fn()
 
-    getElementRef(<div />)
-
+    expect(getElementRef(<div />)).toBeNull()
+    expect(getElementRef<HTMLDivElement>(<div ref={ref} />)).toBe(ref)
     expect(consoleError).not.toHaveBeenCalled()
 
     consoleError.mockRestore()

--- a/packages/base/Utils/src/utils/get-element-ref.ts
+++ b/packages/base/Utils/src/utils/get-element-ref.ts
@@ -1,17 +1,24 @@
 import type { ForwardedRef, ReactElement } from 'react'
+import React from 'react'
 
 type ElementWithRef<T> = ReactElement & { ref?: ForwardedRef<T> }
+type PropsWithRef<T> = { ref?: ForwardedRef<T> }
+
+// React 19 moved element refs into props — `element.ref` is deprecated there
+// and slated for removal — while earlier majors keep the ref on the element
+// and their dev builds warn when `props.ref` is touched instead. Each major
+// warns on the other's location, so the read must be version-aware rather
+// than a fallback chain.
+const isReact19OrNewer = Number.parseInt(React.version, 10) >= 19
 
 /**
- * Reads the ref attached to a React element.
- *
- * `ReactElement` has no public `ref` field, so the cast keeps the lookup in
- * one place. React 19 moves the ref into props instead; reading it from
- * there has to wait until the `react` peer range allows v19, because on
- * v18 `props.ref` is a getter that warns when accessed.
+ * Reads the ref attached to a React element from the location the running
+ * React major stores it in.
  */
 const getElementRef = <T>(element: ReactElement): ForwardedRef<T> => {
-  const { ref } = element as ElementWithRef<T>
+  const ref = isReact19OrNewer
+    ? (element.props as PropsWithRef<T>).ref
+    : (element as ElementWithRef<T>).ref
 
   return ref ?? null
 }

--- a/packages/base/Utils/src/utils/get-element-ref.ts
+++ b/packages/base/Utils/src/utils/get-element-ref.ts
@@ -1,8 +1,8 @@
 import type { ForwardedRef, ReactElement } from 'react'
 import React from 'react'
 
-type ElementWithRef<T> = ReactElement & { ref?: ForwardedRef<T> }
 type PropsWithRef<T> = { ref?: ForwardedRef<T> }
+type ElementWithRef<T> = ReactElement & PropsWithRef<T>
 
 // React 19 moved element refs into props — `element.ref` is deprecated there
 // and slated for removal — while earlier majors keep the ref on the element

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1064,7 +1064,7 @@ importers:
         version: 18.2.0
       react-day-picker:
         specifier: ^8.10.2
-        version: 8.10.2(date-fns@4.4.0)(react@18.2.0)
+        version: 8.10.2(date-fns@2.30.0)(react@18.2.0)
     devDependencies:
       '@toptal/picasso-provider':
         specifier: workspace:*
@@ -32894,7 +32894,7 @@ snapshots:
     dependencies:
       react: 18.2.0
 
-  react-day-picker@8.10.2(date-fns@4.4.0)(react@18.2.0):
+  react-day-picker@8.10.2(date-fns@2.30.0)(react@18.2.0):
     dependencies:
       date-fns: 4.4.0
       react: 18.2.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1064,7 +1064,7 @@ importers:
         version: 18.2.0
       react-day-picker:
         specifier: ^8.10.2
-        version: 8.10.2(date-fns@2.30.0)(react@18.2.0)
+        version: 8.10.2(date-fns@4.4.0)(react@18.2.0)
     devDependencies:
       '@toptal/picasso-provider':
         specifier: workspace:*
@@ -1149,6 +1149,9 @@ importers:
 
   packages/base/Collapse:
     dependencies:
+      '@toptal/picasso-shared':
+        specifier: workspace:*
+        version: link:../../shared
       '@toptal/picasso-tailwind':
         specifier: workspace:^
         version: link:../../picasso-tailwind
@@ -1158,9 +1161,6 @@ importers:
       react:
         specifier: ^18.2.0
         version: 18.2.0
-      react-transition-group:
-        specifier: ^4.4.5
-        version: 4.4.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
     devDependencies:
       '@toptal/picasso-tailwind-merge':
         specifier: workspace:*
@@ -1168,9 +1168,6 @@ importers:
       '@toptal/picasso-test-utils':
         specifier: workspace:*
         version: link:../Test-Utils
-      '@types/react-transition-group':
-        specifier: ^4.4.5
-        version: 4.4.12(@types/react@17.0.39)
 
   packages/base/Container:
     dependencies:
@@ -7619,11 +7616,6 @@ packages:
 
   '@types/react-textarea-autosize@4.3.6':
     resolution: {integrity: sha512-cTf8tCem0c8A7CERYbTuF+bRFaqYu7N7HLCa6ZhUhDx8XnUsTpGx5udMWljt87JpciUKuUkImKPEsy6kcKhrcQ==}
-
-  '@types/react-transition-group@4.4.12':
-    resolution: {integrity: sha512-8TV6R3h2j7a91c+1DXdJi3Syo69zzIZbz7Lg5tORM5LEJG7X/E6a1V3drRyBRZq7/utz7A+c4OgYLiLcYGHG6w==}
-    peerDependencies:
-      '@types/react': '17'
 
   '@types/react@17.0.39':
     resolution: {integrity: sha512-UVavlfAxDd/AgAacMa60Azl7ygyQNRwC/DsHZmKgNvPmRR5p70AJ5Q9EAmL2NWOJmeV+vVUI4IAP7GZrN8h8Ug==}
@@ -23636,10 +23628,6 @@ snapshots:
     dependencies:
       '@types/react': 17.0.39
 
-  '@types/react-transition-group@4.4.12(@types/react@17.0.39)':
-    dependencies:
-      '@types/react': 17.0.39
-
   '@types/react@17.0.39':
     dependencies:
       '@types/prop-types': 15.7.13
@@ -32906,7 +32894,7 @@ snapshots:
     dependencies:
       react: 18.2.0
 
-  react-day-picker@8.10.2(date-fns@2.30.0)(react@18.2.0):
+  react-day-picker@8.10.2(date-fns@4.4.0)(react@18.2.0):
     dependencies:
       date-fns: 4.4.0
       react: 18.2.0


### PR DESCRIPTION
[PF-2317]

### Description

Removes the last react-transition-group consumer in the kit and closes out workstream C of the React 19 plan (PF-2262). Two commits:

**1. Collapse → Tailwind + `useTransitionStatus` (PF-2317)**

- `Collapse` reimplemented on the shared timer-driven `useTransitionStatus` hook (PF-2145 precedent) — the old `<Transition>` ran without `nodeRef`, so it reached `findDOMNode`, which React 19 removes. This crashed Section's jest suite under the React 19 harness and Table expandable rows on CI
- height engine: status-driven `useIsomorphicLayoutEffect` + `requestAnimationFrame` two-frame handoff, replacing the old 50 ms `setTimeout` hacks (which also never cleaned up); the inner wrapper keeps its natural `clientHeight` while the outer div is collapsed, so measurement stays synchronous
- DOM structure, class strings and inline-style shape preserved byte-for-byte — Section's three snapshots are untouched (parity proof)
- riders from the review sweep: object-form `timeout` now produces a valid per-direction `transitionDuration` (was `[object Object]ms`), unrecognized props/`data-private` now reach the DOM node, `displayName` set, `CollapseProps` exported with the misnamed `FadeProps` kept as a deprecated alias, phantom `@toptal/picasso-shared` dep declared, rtg + `@types/react-transition-group` dropped

**2. Version-aware element refs (PF-2262 C-scope)**

- `getElementRef` reads `props.ref` on React 19+ (where `element.ref` is deprecated with a removal warning on every access) and `element.ref` below (where dev builds warn on `props.ref` instead) — each major warns on the other's location, so a fallback chain was never an option
- `ClickAwayListener` consolidates onto the helper (was a hand-rolled `element.ref` cast) — DatePicker, Dropdown and MenuItem inherit the fix; the helper is now the single element-ref read site in the repo

### How to test

<!-- The temploy link will be automatically updated when the temploy is deployed -->
- [Temploy](https://picasso.toptal.net/pf-2317-collapse-tailwind-migration)
- `pnpm test:unit -- --testPathPattern 'packages/base/Collapse|packages/base/Section|get-element-ref|ClickAwayListener'` — React 18 (59 tests green locally, zero snapshot churn)
- `pnpm test:react19 -- --testPathPattern 'packages/base/Collapse|packages/base/Section|get-element-ref'` — Section flips red→green under React 19; the get-element-ref suite asserts the read is warning-free on the running major under both configs
- `pnpm test:setup cypress run --component --spec cypress/component/Table.spec.tsx` — expandable rows exercise `appear` + interaction (6/6 locally)
- real-browser interpolation was traced frame-by-frame (0 → 12 → 91 → 165 → 192 → 200 px across the 400 ms window, then `auto`)

### Screenshots

N/A — visual parity is the goal; Section's Happo stories should show zero diffs.

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Double check if `picasso-tailwind-merge` requires major update (check its `README.md`)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [ ] Self reviewed
- [x] Covered with tests ([visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md) included)

**Breaking change**

- [ ] codemod is created and showcased in the changeset
- [ ] test alpha package of Picasso in StaffPortal

> Note: Base UI `Collapsible` was evaluated as the engine and deferred to PF-2318 — it cannot animate mount-open panels (TableExpandableRow's `appear` contract) and its `transitionend` settle never fires in jsdom.

[PF-2317]: https://toptal-core.atlassian.net/browse/PF-2317
