### PR TITLE
[PF-2398] Upgrade react-querybuilder from v6 to v8 in picasso-query-builder

### DIFF
--- a/.changeset/query-builder-rqb-v8-react-19.md
+++ b/.changeset/query-builder-rqb-v8-react-19.md
@@ -1,0 +1,13 @@
+---
+'@toptal/picasso-query-builder': major
+---
+
+### QueryBuilder
+
+- narrow the `react` and `react-dom` peer ranges from `>=17.0.0 < 19.0.0` to `>=18` (BREAKING). `react-querybuilder` v7.1+ requires React 18 (its internals moved to `react-redux` v9); consumers still on React 17 must stay on the previous major of this package. This diverges from the library-wide `react` range on purpose — see the package README
+- upgrade `react-querybuilder` and `@react-querybuilder/dnd` from `6.5.4` to `^8.23.1` so the package can run under React 19 and stays current with upstream fixes
+- change `useQueryBuilderValidator` to take `{ fields, query }` instead of `{ fields }` and derive `validationErrors`/`queryBuilderValid` from the passed query (BREAKING); the returned `validator` is a pure function. react-querybuilder v7+ invokes the validator during render, so the previous implementation, which updated state from inside it, re-rendered in an endless loop
+- the public `Field`, `Operator`, `OptionGroup`, `RuleType`, `RuleGroupType`, `RuleGroupTypeAny`, `ValidationResult` and `OperatorSelectorProps` types keep their names and stay source-compatible for typical use; option objects received by custom selectors and entries of `defaultOperators` now carry a `value` property alongside `name` (`value` is the preferred identifier upstream)
+- custom properties on `Field` definitions and `fieldData` beyond the documented ones now surface as `unknown` instead of `any`, mirroring react-querybuilder v7+
+- `react-querybuilder` now brings `react-redux` v9 and `@reduxjs/toolkit` v2 as internal dependencies scoped to its own React context; this does not interact with a consumer's Redux store
+- no visual change to the rendered query builder; rule-group elements gain a `title` attribute for accessibility, which may show up in consumer snapshot tests

--- a/packages/picasso-query-builder/README.md
+++ b/packages/picasso-query-builder/README.md
@@ -24,6 +24,14 @@ The following peer dependencies are required:
 
 - `@toptal/picasso`
 
+### React compatibility
+
+This package requires `react >= 18`, unlike the rest of the Picasso packages,
+which also support React 17. The floor comes from `react-querybuilder` v7.1+
+(the library this package wraps), whose internals depend on `react-redux` v9
+and therefore React 18. Consumers still on React 17 must stay on the previous
+major of this package.
+
 ## Setup
 
 - `yarn add @toptal/picasso-query-builder`

--- a/packages/picasso-query-builder/package.json
+++ b/packages/picasso-query-builder/package.json
@@ -23,13 +23,13 @@
   },
   "peerDependencies": {
     "@toptal/picasso-provider": "workspace:^",
-    "react": ">=17.0.0 < 19.0.0",
+    "react": ">=18",
     "@toptal/picasso-tailwind": "workspace:^",
-    "react-dom": ">=17.0.0 < 19.0.0",
+    "react-dom": ">=18",
     "typescript": "^5.5.0"
   },
   "dependencies": {
-    "@react-querybuilder/dnd": "6.5.4",
+    "@react-querybuilder/dnd": "^8.23.1",
     "@toptal/picasso-button": "workspace:*",
     "@toptal/picasso-select": "workspace:*",
     "@toptal/picasso-typography": "workspace:*",
@@ -49,7 +49,7 @@
     "classnames": "^2.5.1",
     "react-dnd": "^16.0.1",
     "react-dnd-html5-backend": "^16.0.1",
-    "react-querybuilder": "6.5.4",
+    "react-querybuilder": "^8.23.1",
     "use-debounce": "^10.0.0"
   },
   "devDependencies": {

--- a/packages/picasso-query-builder/src/AutoComplete/AutoComplete.tsx
+++ b/packages/picasso-query-builder/src/AutoComplete/AutoComplete.tsx
@@ -51,7 +51,7 @@ export const AutoComplete = ({
   }, [fieldData?.options, inputValue])
 
   const handleChangeDebounced = useDebouncedCallback((searchterm: string) => {
-    fieldData?.onSearch(searchterm)
+    fieldData?.onSearch?.(searchterm)
   }, 1000)
 
   const handleInputChange = useCallback(

--- a/packages/picasso-query-builder/src/BooleanInput/BooleanInput.tsx
+++ b/packages/picasso-query-builder/src/BooleanInput/BooleanInput.tsx
@@ -7,10 +7,12 @@ const OPTIONS = [
   {
     label: 'Yes',
     name: 'true',
+    value: 'true',
   },
   {
     label: 'No',
     name: 'false',
+    value: 'false',
   },
 ]
 

--- a/packages/picasso-query-builder/src/CombinatorSelector/RadioOptions.tsx
+++ b/packages/picasso-query-builder/src/CombinatorSelector/RadioOptions.tsx
@@ -15,8 +15,8 @@ export const RadioOptions = ({ options, disabled }: Props) => {
         {option.options.map(opt => (
           <Radio
             disabled={disabled}
-            key={opt.name}
-            value={opt.name}
+            key={opt.value ?? opt.name}
+            value={opt.value ?? opt.name}
             label={opt.label}
           />
         ))}
@@ -28,8 +28,8 @@ export const RadioOptions = ({ options, disabled }: Props) => {
     return options.map(option => (
       <Radio
         disabled={disabled}
-        key={option.name}
-        value={option.name}
+        key={option.value ?? option.name}
+        value={option.value ?? option.name}
         label={option.label}
       />
     ))

--- a/packages/picasso-query-builder/src/ControlElementsContext/ControlElementsContext.tsx
+++ b/packages/picasso-query-builder/src/ControlElementsContext/ControlElementsContext.tsx
@@ -1,4 +1,4 @@
-import type { Controls } from 'react-querybuilder'
+import type { ControlElementsProp, FullField } from 'react-querybuilder'
 import { getCompatContextProvider } from 'react-querybuilder'
 
 import { AddGroupButton } from '../AddGroupButton'
@@ -13,7 +13,7 @@ import { Select } from '../Select'
 import { OperatorSelector } from '../OperatorSelector'
 import { FieldSelector } from '../FieldSelector'
 
-export const picassoControlElements: Partial<Controls> = {
+export const picassoControlElements: ControlElementsProp<FullField, string> = {
   addGroupAction: AddGroupButton,
   addRuleAction: AddRuleButton,
   cloneGroupAction: CloneGroupButton,
@@ -28,6 +28,5 @@ export const picassoControlElements: Partial<Controls> = {
 }
 
 export const ControlElementsContext = getCompatContextProvider({
-  key: 'picasso',
   controlElements: picassoControlElements,
 })

--- a/packages/picasso-query-builder/src/QueryBuilder/QueryBuilder.test.tsx
+++ b/packages/picasso-query-builder/src/QueryBuilder/QueryBuilder.test.tsx
@@ -1,0 +1,55 @@
+import React from 'react'
+import { render, screen } from '@toptal/picasso-test-utils'
+import type { RuleGroupType } from 'react-querybuilder'
+
+import type { Field } from '../types/query-builder'
+import QueryBuilder from './QueryBuilder'
+
+// react-dnd ships untranspiled ESM that jest cannot parse; drag and drop
+// behavior is covered by the DragDrop story and Happo instead
+jest.mock('react-dnd', () => ({}))
+jest.mock('react-dnd-html5-backend', () => ({}))
+jest.mock('@react-querybuilder/dnd', () => ({
+  QueryBuilderDnD: ({ children }: { children: React.ReactNode }) => children,
+}))
+
+const fields: Field[] = [
+  { name: 'firstName', label: 'First Name' },
+  { name: 'age', label: 'Age', inputType: 'number' },
+]
+
+const query: RuleGroupType = {
+  combinator: 'and',
+  rules: [{ field: 'firstName', operator: '=', value: '' }],
+}
+
+const renderComponent = (
+  props: Partial<React.ComponentProps<typeof QueryBuilder>> = {}
+) =>
+  render(
+    <QueryBuilder
+      fields={fields}
+      query={query}
+      onQueryChange={jest.fn()}
+      {...props}
+    />
+  )
+
+describe('QueryBuilder', () => {
+  it('renders the rule with field selector, combinator label and controls', () => {
+    renderComponent()
+
+    expect(screen.getByText('Query')).toBeInTheDocument()
+    expect(screen.getByDisplayValue('First Name')).toBeInTheDocument()
+    expect(screen.getByText('Run Query')).toBeInTheDocument()
+    expect(screen.getByText('Clear Query')).toBeInTheDocument()
+  })
+
+  it('reports validity through onValidationChange', () => {
+    const onValidationChange = jest.fn()
+
+    renderComponent({ onValidationChange })
+
+    expect(onValidationChange).toHaveBeenCalledWith(true)
+  })
+})

--- a/packages/picasso-query-builder/src/QueryBuilder/QueryBuilder.tsx
+++ b/packages/picasso-query-builder/src/QueryBuilder/QueryBuilder.tsx
@@ -1,10 +1,11 @@
-import React, { useCallback, useEffect, useState } from 'react'
+import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import type { ComponentType, ReactNode } from 'react'
 import { Container } from '@toptal/picasso-container'
 import { useNotifications } from '@toptal/picasso-notification'
 import type {
   ValueEditorProps as DefaultValueEditorProps,
   Field as QueryBuilderField,
+  RuleGroupType,
   RuleGroupTypeAny,
   Operator,
 } from 'react-querybuilder'
@@ -108,6 +109,7 @@ const QueryBuilder = ({
   const { validator, validationErrors, queryBuilderValid } =
     useQueryBuilderValidator({
       fields,
+      query,
     })
 
   const resetQuery = useCallback(() => {
@@ -178,6 +180,41 @@ const QueryBuilder = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [queryBuilderValid])
 
+  // react-querybuilder v7+ memoizes aggressively and expects stable prop references
+  const controlElements = useMemo(() => ({ valueEditor }), [valueEditor])
+
+  // v8 types its props as a discriminated union over RuleGroupType vs
+  // RuleGroupTypeIC and cannot accept the RuleGroupTypeAny union statically;
+  // at runtime it detects independent combinators from the query shape
+  const standardTypeQuery = query as RuleGroupType
+
+  const queryBuilder = (
+    <ReactQueryBuilder
+      resetOnFieldChange={resetOnFieldChange}
+      fields={fields as QueryBuilderField[]}
+      addRuleToNewGroups
+      controlClassnames={controlClassnames}
+      query={standardTypeQuery}
+      validator={validator}
+      onQueryChange={handleQueryChange}
+      showCloneButtons
+      getOperators={getOperators}
+      context={
+        {
+          removeGroup: handleRemoveGroup,
+          maxDepth: maxGroupDepth,
+          queryBuilderValid: queryBuilderValid,
+          submitButtonClicked,
+          resetSubmitButtonClicked,
+          getDisabledFields,
+          testIds,
+        } as QueryBuilderContext
+      }
+      controlElements={controlElements}
+      enableDragAndDrop={enableDragAndDrop}
+    />
+  )
+
   return (
     <ControlElementsContext>
       <Container
@@ -190,34 +227,17 @@ const QueryBuilder = ({
         {header && (
           <Container data-testid={testIds?.header}>{header}</Container>
         )}
-        <QueryBuilderDnD dnd={{ ...ReactDnD, ...ReactDndHtml5Backend }}>
-          <ReactQueryBuilder
-            resetOnFieldChange={resetOnFieldChange}
-            fields={fields as QueryBuilderField[]}
-            addRuleToNewGroups
-            controlClassnames={controlClassnames}
-            query={query}
-            validator={validator}
-            onQueryChange={handleQueryChange}
-            showCloneButtons
-            getOperators={getOperators}
-            context={
-              {
-                removeGroup: handleRemoveGroup,
-                maxDepth: maxGroupDepth,
-                queryBuilderValid: queryBuilderValid,
-                submitButtonClicked,
-                resetSubmitButtonClicked,
-                getDisabledFields,
-                testIds,
-              } as QueryBuilderContext
-            }
-            controlElements={{
-              valueEditor,
-            }}
-            enableDragAndDrop={enableDragAndDrop}
-          />
-        </QueryBuilderDnD>
+        {/* QueryBuilderDnD mounts a react-dnd HTML5 backend per instance and
+        the backend is a per-window singleton, so only wrap when drag and drop
+        is actually enabled — otherwise multiple query builders on one page
+        throw "Cannot have two HTML5 backends at the same time" */}
+        {enableDragAndDrop ? (
+          <QueryBuilderDnD dnd={{ ...ReactDnD, ...ReactDndHtml5Backend }}>
+            {queryBuilder}
+          </QueryBuilderDnD>
+        ) : (
+          queryBuilder
+        )}
         {!hideControls && (
           <Container
             flex

--- a/packages/picasso-query-builder/src/Select/Select.tsx
+++ b/packages/picasso-query-builder/src/Select/Select.tsx
@@ -2,14 +2,16 @@ import type { ComponentProps } from 'react'
 import React, { useMemo } from 'react'
 import { Container } from '@toptal/picasso-container'
 import { Select as PicassoSelect } from '@toptal/picasso-select'
-import type { VersatileSelectorProps } from 'react-querybuilder'
 import { twMerge } from '@toptal/picasso-tailwind-merge'
 
 import { generateSelectOptions, validateValueEditor } from '../utils'
-import type { ValueEditorValidationProps } from '../types/query-builder'
+import type {
+  BaseVersatileSelectorProps,
+  ValueEditorValidationProps,
+} from '../types/query-builder'
 
 interface Props
-  extends Omit<VersatileSelectorProps, 'path' | 'level' | 'schema'>,
+  extends Omit<BaseVersatileSelectorProps, 'path' | 'level'>,
     Pick<ComponentProps<typeof PicassoSelect>, 'renderOption'>,
     ValueEditorValidationProps {
   valueEditorTestId?: string

--- a/packages/picasso-query-builder/src/types/query-builder.ts
+++ b/packages/picasso-query-builder/src/types/query-builder.ts
@@ -1,6 +1,7 @@
-import type { ReactNode } from 'react'
+import type { MouseEventHandler, ReactNode } from 'react'
 import type {
   Field as QueryBuilderField,
+  FullField,
   ValidationResult,
   ValueEditorProps,
   VersatileSelectorProps,
@@ -18,31 +19,49 @@ export type RangeValue = {
   to?: number
 }
 
+/**
+ * react-querybuilder's `Field` carries a `[key: string]: unknown` index
+ * signature, which makes `Omit` collapse every declared property to the index
+ * type — strip it before deriving the field variants below.
+ */
+type RemoveIndexSignature<T> = {
+  [K in keyof T as string extends K
+    ? never
+    : number extends K
+    ? never
+    : K]: T[K]
+}
+
+type StrictQueryBuilderField = RemoveIndexSignature<QueryBuilderField>
+
 interface BasicField
-  extends Omit<QueryBuilderField, 'inputType' | 'valueEditorType'> {
+  extends Omit<StrictQueryBuilderField, 'inputType' | 'valueEditorType'> {
   inputType?: 'text' | 'number' | null
   valueEditorType?: 'text' | 'number' | 'select' | null
   hideOperator?: boolean
 }
 interface RangeField
-  extends Omit<QueryBuilderField, 'inputType' | 'valueEditorType'>,
+  extends Omit<StrictQueryBuilderField, 'inputType' | 'valueEditorType'>,
     Partial<RangeFieldOptions> {
   valueEditorType?: 'range'
 }
 
 interface BooleanField
-  extends Omit<QueryBuilderField, 'inputType' | 'valueEditorType' | 'values'> {
+  extends Omit<
+    StrictQueryBuilderField,
+    'inputType' | 'valueEditorType' | 'values'
+  > {
   valueEditorType?: 'boolean'
 }
 interface MultiSelectField
-  extends Omit<QueryBuilderField, 'inputType' | 'valueEditorType'> {
+  extends Omit<StrictQueryBuilderField, 'inputType' | 'valueEditorType'> {
   valueEditorType?: 'multiselect'
   enableReset?: boolean
   enableResetSearch?: boolean
 }
 
 interface AutoCompleteField
-  extends Omit<QueryBuilderField, 'inputType' | 'valueEditorType'> {
+  extends Omit<StrictQueryBuilderField, 'inputType' | 'valueEditorType'> {
   valueEditorType: 'autocomplete'
   /**
    * Callback for autocomplete input change
@@ -58,14 +77,47 @@ interface AutoCompleteField
   loading: boolean
 }
 
-export type BaseValueEditorProps = Omit<ValueEditorProps, 'schema'>
-export type BaseVersatileSelectorProps = Omit<VersatileSelectorProps, 'schema'>
-export type Field =
+/**
+ * Everything Picasso's custom editors and selectors read off `fieldData`.
+ * Upstream types `fieldData` as `FullField`, whose index signature yields
+ * `unknown` for the custom properties Picasso fields carry, so the upstream
+ * prop types are instantiated with this type instead.
+ */
+type EditorFieldData = FullField &
+  RangeFieldOptions & {
+    hideOperator?: boolean
+    onClick?: MouseEventHandler<HTMLInputElement>
+    loading?: boolean
+    enableReset?: boolean
+    enableResetSearch?: boolean
+    onSearch?: (searchTerm: string) => void
+    options?: { label: string; name: string }[]
+  }
+
+export type BaseValueEditorProps = Omit<
+  ValueEditorProps<EditorFieldData>,
+  'schema'
+>
+export type BaseVersatileSelectorProps = Omit<
+  VersatileSelectorProps,
+  'schema' | 'fieldData'
+> & {
+  fieldData?: EditorFieldData
+}
+/**
+ * Custom properties beyond the variants below are still allowed (v6's `Field`
+ * permitted them through an `any` index signature); they surface as `unknown`,
+ * mirroring react-querybuilder v7+.
+ */
+export type Field = (
   | BasicField
   | RangeField
   | AutoCompleteField
   | BooleanField
   | MultiSelectField
+) & {
+  [key: string]: unknown
+}
 export type QueryBuilderErrors = {
   [key: string]: ValidationResult | true
 }
@@ -74,7 +126,7 @@ export type QueryBuilderContext = {
   maxDepth: number
   queryBuilderValid?: boolean
   submitButtonClicked: boolean
-  getDisabledFields: () => Field[]
+  getDisabledFields: () => string[]
   testIds?: TestId
 }
 export type ValueEditorValidationProps = {

--- a/packages/picasso-query-builder/src/utils/generate-select-options.ts
+++ b/packages/picasso-query-builder/src/utils/generate-select-options.ts
@@ -7,7 +7,7 @@ export const generateSelectOptions = (options?: OptionList) => {
 
     options.forEach(option => {
       groupOptions[option.label] = option.options.map(subOption => ({
-        value: subOption.name,
+        value: subOption.value ?? subOption.name,
         text: subOption.label,
       }))
     })
@@ -17,9 +17,9 @@ export const generateSelectOptions = (options?: OptionList) => {
 
   if (Array.isArray(options)) {
     return options.map(option => ({
-      value: option.name,
+      value: option.value ?? option.name,
       text: option.label,
-      tooltip: option.tooltip,
+      tooltip: option.tooltip as string | undefined,
     }))
   }
 

--- a/packages/picasso-query-builder/src/utils/use-query-builder-validation.test.ts
+++ b/packages/picasso-query-builder/src/utils/use-query-builder-validation.test.ts
@@ -1,4 +1,4 @@
-import { act, renderHook } from '@testing-library/react-hooks'
+import { renderHook } from '@testing-library/react-hooks'
 import type { RuleGroupTypeAny, RuleType } from 'react-querybuilder'
 
 import type { Field } from '../types/query-builder'
@@ -104,17 +104,14 @@ describe('useQueryBuilderValidation', () => {
         const { result } = renderHook(() =>
           useQueryBuilderValidation({
             fields,
+            query: query(),
           })
         )
 
-        const { validator } = result.current
+        const { validator, validationErrors, queryBuilderValid } =
+          result.current
 
-        act(() => {
-          expect(validator(query())).toBe(true)
-        })
-
-        const { validationErrors, queryBuilderValid } = result.current
-
+        expect(validator(query())).toBe(true)
         expect(queryBuilderValid).toBe(true)
         expect(validationErrors).toEqual({
           rule1: true,
@@ -129,17 +126,14 @@ describe('useQueryBuilderValidation', () => {
         const { result } = renderHook(() =>
           useQueryBuilderValidation({
             fields,
+            query: query('invalid value for field2'),
           })
         )
 
-        const { validator } = result.current
+        const { validator, validationErrors, queryBuilderValid } =
+          result.current
 
-        act(() => {
-          expect(validator(query('invalid value for field2'))).toBe(false)
-        })
-
-        const { validationErrors, queryBuilderValid } = result.current
-
+        expect(validator(query('invalid value for field2'))).toBe(false)
         expect(queryBuilderValid).toBe(false)
         expect(validationErrors).toEqual({
           rule1: true,
@@ -159,17 +153,14 @@ describe('useQueryBuilderValidation', () => {
         const { result } = renderHook(() =>
           useQueryBuilderValidation({
             fields,
+            query: groupedQuery(),
           })
         )
 
-        const { validator } = result.current
+        const { validator, validationErrors, queryBuilderValid } =
+          result.current
 
-        act(() => {
-          expect(validator(groupedQuery())).toBe(true)
-        })
-
-        const { validationErrors, queryBuilderValid } = result.current
-
+        expect(validator(groupedQuery())).toBe(true)
         expect(queryBuilderValid).toBe(true)
         expect(validationErrors).toEqual({
           group1: true,
@@ -186,17 +177,14 @@ describe('useQueryBuilderValidation', () => {
         const { result } = renderHook(() =>
           useQueryBuilderValidation({
             fields,
+            query: groupedQuery('invalid rule'),
           })
         )
 
-        const { validator } = result.current
+        const { validator, validationErrors, queryBuilderValid } =
+          result.current
 
-        act(() => {
-          expect(validator(groupedQuery('invalid rule'))).toBe(false)
-        })
-
-        const { validationErrors, queryBuilderValid } = result.current
-
+        expect(validator(groupedQuery('invalid rule'))).toBe(false)
         expect(queryBuilderValid).toBe(false)
         expect(validationErrors).toEqual({
           group1: true,

--- a/packages/picasso-query-builder/src/utils/use-query-builder-validation.ts
+++ b/packages/picasso-query-builder/src/utils/use-query-builder-validation.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from 'react'
+import { useCallback, useMemo } from 'react'
 import type {
   RuleGroupTypeAny,
   RuleType,
@@ -9,11 +9,12 @@ import { isRuleGroup } from 'react-querybuilder'
 
 import type { Field } from '../types/query-builder'
 
-type ValidatorMap = Record<string, RuleValidator>
+type ValidatorMap = Record<string, RuleValidator | null>
 export type ValidatorResult = Record<string, ValidationResult | boolean>
 
 type Props = {
   fields: Field[]
+  query: RuleGroupTypeAny
 }
 
 const validateRule = (rule: RuleType, fieldValidatorMap: ValidatorMap) => {
@@ -70,11 +71,7 @@ const validateQuery = (
   return validateRule(query as RuleType, fieldValidatorMap)
 }
 
-const useQueryBuilderValidation = ({ fields }: Props) => {
-  const [validationErrors, setValidationErrors] = useState<ValidatorResult>({})
-  const [queryBuilderValid, setIsQueryBuilderValid] = useState<
-    boolean | undefined
-  >()
+const useQueryBuilderValidation = ({ fields, query }: Props) => {
   const fieldValidatorMap: ValidatorMap = useMemo(() => {
     return fields.reduce(
       (acc, field) => ({
@@ -85,6 +82,18 @@ const useQueryBuilderValidation = ({ fields }: Props) => {
     )
   }, [fields])
 
+  const validationErrors: ValidatorResult = useMemo(
+    () => (query ? validateQuery(query, fieldValidatorMap) : {}),
+    [query, fieldValidatorMap]
+  )
+
+  const queryBuilderValid = useMemo(
+    () => !Object.values(validationErrors).some(result => result !== true),
+    [validationErrors]
+  )
+
+  // react-querybuilder invokes the validator during render, so it must stay
+  // pure — updating state from it makes v7+ re-render in an endless loop
   const validator = useCallback(
     (queryToValidate: RuleGroupTypeAny) => {
       if (!queryToValidate) {
@@ -93,12 +102,7 @@ const useQueryBuilderValidation = ({ fields }: Props) => {
 
       const valResult = validateQuery(queryToValidate, fieldValidatorMap)
 
-      const isValid = !Object.values(valResult).some(result => result !== true)
-
-      setIsQueryBuilderValid?.(isValid)
-      setValidationErrors?.(valResult)
-
-      return isValid
+      return !Object.values(valResult).some(result => result !== true)
     },
     [fieldValidatorMap]
   )

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1064,7 +1064,7 @@ importers:
         version: 18.2.0
       react-day-picker:
         specifier: ^8.10.2
-        version: 8.10.2(date-fns@2.30.0)(react@18.2.0)
+        version: 8.10.2(date-fns@4.4.0)(react@18.2.0)
     devDependencies:
       '@toptal/picasso-provider':
         specifier: workspace:*
@@ -3645,8 +3645,8 @@ importers:
   packages/picasso-query-builder:
     dependencies:
       '@react-querybuilder/dnd':
-        specifier: 6.5.4
-        version: 6.5.4(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1(@types/node@24.5.2)(@types/react@17.0.39)(react@18.2.0))(react-querybuilder@6.5.4(react@18.2.0))(react@18.2.0)
+        specifier: ^8.23.1
+        version: 8.23.1(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1(@types/node@24.5.2)(@types/react@17.0.39)(react@18.2.0))(react-querybuilder@8.23.1(@types/react@17.0.39)(react@18.2.0)(redux@5.0.1))(react@18.2.0)
       '@toptal/picasso-button':
         specifier: workspace:*
         version: link:../base/Button
@@ -3717,8 +3717,8 @@ importers:
         specifier: ^18.2.0
         version: 18.2.0(react@18.2.0)
       react-querybuilder:
-        specifier: 6.5.4
-        version: 6.5.4(react@18.2.0)
+        specifier: ^8.23.1
+        version: 8.23.1(@types/react@17.0.39)(react@18.2.0)(redux@5.0.1)
       typescript:
         specifier: ^5.5.0
         version: 5.5.4
@@ -6331,13 +6331,67 @@ packages:
   '@react-dnd/shallowequal@4.0.2':
     resolution: {integrity: sha512-/RVXdLvJxLg4QKvMoM5WlwNR9ViO9z8B/qPcc+C0Sa/teJY7QG7kJ441DwzOjMYEY7GmU4dj5EcGHIkKZiQZCA==}
 
-  '@react-querybuilder/dnd@6.5.4':
-    resolution: {integrity: sha512-s1whkpgeRCS5Xkmbr3PCvRBNtepZT8sbZvJmTbhthgFQOzHJeI7Bv5+U/yhMNNUiXggmuxITSNnQakJVAWSm6A==}
+  '@react-querybuilder/core@8.23.1':
+    resolution: {integrity: sha512-cj9QC/xaxw/unNpGZ6dOuiUNUBU9SzccIbMAZTBF2Sb64OERA70HzmBEmn8e4+RwPe9U0zEiTz1mkhDLDmFnNw==}
     peerDependencies:
+      '@tanstack/db': '>=0.6.9'
+      '@traqula/parser-sparql-1-2': '>=0.1.0'
+      chevrotain: '>=11'
+      drizzle-orm: '>=0.38.0'
+      json-logic-js: '>=2'
+      jsonata: '>=2'
+      sequelize: '>=6'
+      spel2js: '>=0.2.0'
+    peerDependenciesMeta:
+      '@tanstack/db':
+        optional: true
+      '@traqula/parser-sparql-1-2':
+        optional: true
+      chevrotain:
+        optional: true
+      drizzle-orm:
+        optional: true
+      json-logic-js:
+        optional: true
+      jsonata:
+        optional: true
+      sequelize:
+        optional: true
+      spel2js:
+        optional: true
+
+  '@react-querybuilder/dnd@8.23.1':
+    resolution: {integrity: sha512-4VCQ3KUc/dYp/zMbK5D9OSOVNrvdyEZdpisyk6+IKBvWZMEdsSJ5om9X6FNVIbvUvk07ykdtQK/9hdQcc7EYbg==}
+    peerDependencies:
+      '@atlaskit/pragmatic-drag-and-drop': '>=1.0.0'
+      '@dnd-kit/core': '>=6.0.0'
       react: ^18.2.0
       react-dnd: '>=14.0.0'
       react-dnd-html5-backend: '>=14.0.0'
-      react-querybuilder: ^6.5.4
+      react-dnd-touch-backend: '>=14.0.0'
+      react-querybuilder: 8.23.1
+    peerDependenciesMeta:
+      '@atlaskit/pragmatic-drag-and-drop':
+        optional: true
+      '@dnd-kit/core':
+        optional: true
+      react-dnd:
+        optional: true
+      react-dnd-html5-backend:
+        optional: true
+      react-dnd-touch-backend:
+        optional: true
+
+  '@reduxjs/toolkit@2.12.0':
+    resolution: {integrity: sha512-KiT+RzZbp6mQET+Mg+h2c97+9j1sNflUxQkIHI7Yuzf6Peu+OYpmkn6nbHWmLLWj+1ZODUJFwGZ7gx3L9R9EOw==}
+    peerDependencies:
+      react: ^18.2.0
+      react-redux: ^7.2.1 || ^8.1.3 || ^9.0.0
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-redux:
+        optional: true
 
   '@rollup/plugin-babel@5.3.1':
     resolution: {integrity: sha512-WFfdLWU/xVWKeRQnKmIAQULUI7Il0gZnBIH/ZFO069wYIfPu+8zrfp/KMW0atmELoRDq8FbiP3VCss9MhCut7Q==}
@@ -6550,6 +6604,12 @@ packages:
     engines: {node: ^14.0.0 || ^16.0.0 || >=18.0.0}
     peerDependencies:
       size-limit: 8.2.6
+
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@standard-schema/utils@0.3.0':
+    resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
 
   '@storybook/addon-a11y@6.5.16':
     resolution: {integrity: sha512-/e9s34o+TmEhy+Q3/YzbRJ5AJ/Sy0gjZXlvsCrcRpiQLdt5JRbN8s+Lbn/FWxy8U1Tb1wlLYlqjJ+fYi5RrS3A==}
@@ -7242,6 +7302,15 @@ packages:
     resolution: {integrity: sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==}
     engines: {node: '>=10.13.0'}
 
+  '@ts-jison/common@0.4.1-alpha.1':
+    resolution: {integrity: sha512-SDbHzq+UMD+V3ciKVBHwCEgVqSeyQPTCjOsd/ZNTGySUVg4x3EauR9ZcEfdVFAsYRR38XWgDI+spq5LDY46KvQ==}
+
+  '@ts-jison/lexer@0.4.1-alpha.1':
+    resolution: {integrity: sha512-5C1Wr+wixAzn2MOFtgy7KbT6N6j9mhmbjAtyvOqZKsikKtNOQj22MM5HxT+ooRexG2NbtxnDSXYdhHR1Lg58ow==}
+
+  '@ts-jison/parser@0.4.1-alpha.1':
+    resolution: {integrity: sha512-xNj+qOez/7dju44LlYiTlCjxMzW5oek9EckUAElfln/GBK9vgMSk0swWcnacMr0TYbGjUQuXvL2wEgmDf5WajQ==}
+
   '@tsconfig/node10@1.0.9':
     resolution: {integrity: sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==}
 
@@ -7509,6 +7578,9 @@ packages:
   '@types/jsdom@21.1.7':
     resolution: {integrity: sha512-yOriVnggzrnQ3a9OKOCxaVuSug3w3/SbOj5i7VwXWZEyUNl3bLF9V3MfxGbZKuwqJOQyRfqXyROBB1CoZLFWzA==}
 
+  '@types/json-logic-js@2.0.8':
+    resolution: {integrity: sha512-WgNsDPuTPKYXl0Jh0IfoCoJoAGGYZt5qzpmjuLSEg7r0cKp/kWtWp0HAsVepyPSPyXiHo6uXp/B/kW/2J1fa2Q==}
+
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
@@ -7682,6 +7754,9 @@ packages:
 
   '@types/unist@3.0.0':
     resolution: {integrity: sha512-MFETx3tbTjE7Uk6vvnWINA/1iJ7LuMdO4fcq8UfF0pRbj01aGLduVvQcRyswuACJdpnHgg8E3rQLhaRdNEJS0w==}
+
+  '@types/use-sync-external-store@0.0.6':
+    resolution: {integrity: sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==}
 
   '@types/webpack-env@1.16.3':
     resolution: {integrity: sha512-9gtOPPkfyNoEqCQgx4qJKkuNm/x0R2hKR7fdl7zvTJyHnIisuE/LfvXOsYWL0o3qq6uiBnKZNNNzi3l0y/X+xw==}
@@ -11776,8 +11851,8 @@ packages:
   imagetracerjs@1.2.6:
     resolution: {integrity: sha512-LKJlnKmXFzDdh6IZtXTyBxXcCLTAkwgKYS+NMiPXiXVnlTLjQC8fq7U89laUSgHtypJB3TdMMDK4ecG5NI/Cgw==}
 
-  immer@10.0.3:
-    resolution: {integrity: sha512-pwupu3eWfouuaowscykeckFmVTpqbzW+rXFCX8rQLkZzM9ftBmU/++Ra+o+L27mz03zJTlyV4UUr+fdKNffo4A==}
+  immer@11.1.18:
+    resolution: {integrity: sha512-EQyQtLiYW029lyoczMl/Hh4Xu7cDecSc58JRYpHyL4tIAu3eqd1yJzQX04d2BZHDkzFFvm6qJEJWOtfDSWAXbQ==}
 
   immer@9.0.21:
     resolution: {integrity: sha512-bc4NBHqOqSfRW7POMkHd51LvClaeMXpm8dx0e8oE2GORbq5aRK7Bxl4FyzVLdGtLmvLKL7BTDBG5ACQm4HWjTA==}
@@ -14073,6 +14148,10 @@ packages:
   num2fraction@1.2.2:
     resolution: {integrity: sha512-Y1wZESM7VUThYY+4W+X4ySH2maqcA+p7UR+w8VWNWVAd6lwuXXWz/w/Cz43J/dI2I+PS6wD5N+bJUF+gjWvIqg==}
 
+  numeric-quantity@3.3.0:
+    resolution: {integrity: sha512-ZipHfkPGxKjIzWmGDeE9G0Sg/yGRZ22f9+EDJH+UJuqeTd6gRbH1URe8PUrcT15LNjyFeRoYWz6Hqk/ailyAQg==}
+    engines: {node: '>=16'}
+
   nwsapi@2.2.22:
     resolution: {integrity: sha512-ujSMe1OWVn55euT1ihwCI1ZcAaAU3nxUiDwfDQldc51ZXaB9m2AyOn6/jh1BLe2t/G8xd6uKG1UBF2aZJeg2SQ==}
 
@@ -15250,10 +15329,22 @@ packages:
     peerDependencies:
       react: ^18.2.0
 
-  react-querybuilder@6.5.4:
-    resolution: {integrity: sha512-m7LShwKQsFJTbGj8UxdYhbyhrVZmJ0VZV7JDElGui6jv7KsUPaIfXP8FtBBTiaP7SWbhXI1p7sGY7Z6eaU8MTg==}
+  react-querybuilder@8.23.1:
+    resolution: {integrity: sha512-QrzjpB9/jc8Ak3ghH6gbyc4Qe0hKFQEUD3+7rmSEYhP9XnssOgO8hMBhZPzsz80cetCXvSIBIZX8Ik+Ywg2YHA==}
     peerDependencies:
       react: ^18.2.0
+
+  react-redux@9.3.0:
+    resolution: {integrity: sha512-KQopgqFo/p/fgmAs5qz6p5RWaNAzq40WAu7fJIXnQpYxFPbJYtsJPWvGeF2rOBaY/kEuV77AVsX8TsQzKm+A/g==}
+    peerDependencies:
+      '@types/react': '17'
+      react: ^18.2.0
+      redux: ^5.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      redux:
+        optional: true
 
   react-refresh@0.11.0:
     resolution: {integrity: sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A==}
@@ -15468,8 +15559,16 @@ packages:
   redeyed@2.1.1:
     resolution: {integrity: sha512-FNpGGo1DycYAdnrKFxCMmKYgo/mILAqtRYbkdQD8Ep/Hk2PQ5+aEAEx+IU713RTDmuBaH0c8P5ZozurNu5ObRQ==}
 
+  redux-thunk@3.1.0:
+    resolution: {integrity: sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==}
+    peerDependencies:
+      redux: ^5.0.0
+
   redux@4.2.1:
     resolution: {integrity: sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==}
+
+  redux@5.0.1:
+    resolution: {integrity: sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==}
 
   refractor@2.10.1:
     resolution: {integrity: sha512-Xh9o7hQiQlDbxo5/XkOX6H+x/q8rmlmZKr97Ie1Q8ZM32IRRd3B/UxuA/yXDW79DBSXGWxm2yRTbcTVmAciJRw==}
@@ -21275,12 +21374,33 @@ snapshots:
 
   '@react-dnd/shallowequal@4.0.2': {}
 
-  '@react-querybuilder/dnd@6.5.4(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1(@types/node@24.5.2)(@types/react@17.0.39)(react@18.2.0))(react-querybuilder@6.5.4(react@18.2.0))(react@18.2.0)':
+  '@react-querybuilder/core@8.23.1':
+    dependencies:
+      '@ts-jison/lexer': 0.4.1-alpha.1
+      '@ts-jison/parser': 0.4.1-alpha.1
+      '@types/json-logic-js': 2.0.8
+      immer: 11.1.18
+      numeric-quantity: 3.3.0
+
+  '@react-querybuilder/dnd@8.23.1(react-dnd-html5-backend@16.0.1)(react-dnd@16.0.1(@types/node@24.5.2)(@types/react@17.0.39)(react@18.2.0))(react-querybuilder@8.23.1(@types/react@17.0.39)(react@18.2.0)(redux@5.0.1))(react@18.2.0)':
     dependencies:
       react: 18.2.0
+      react-querybuilder: 8.23.1(@types/react@17.0.39)(react@18.2.0)(redux@5.0.1)
+    optionalDependencies:
       react-dnd: 16.0.1(@types/node@24.5.2)(@types/react@17.0.39)(react@18.2.0)
       react-dnd-html5-backend: 16.0.1
-      react-querybuilder: 6.5.4(react@18.2.0)
+
+  '@reduxjs/toolkit@2.12.0(react-redux@9.3.0(@types/react@17.0.39)(react@18.2.0)(redux@5.0.1))(react@18.2.0)':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@standard-schema/utils': 0.3.0
+      immer: 11.1.18
+      redux: 5.0.1
+      redux-thunk: 3.1.0(redux@5.0.1)
+      reselect: 5.2.0
+    optionalDependencies:
+      react: 18.2.0
+      react-redux: 9.3.0(@types/react@17.0.39)(react@18.2.0)(redux@5.0.1)
 
   '@rollup/plugin-babel@5.3.1(@babel/core@7.28.4)(@types/babel__core@7.1.19)(rollup@2.79.2)':
     dependencies:
@@ -21572,6 +21692,10 @@ snapshots:
     dependencies:
       semver: 7.5.3
       size-limit: 8.2.6
+
+  '@standard-schema/spec@1.1.0': {}
+
+  '@standard-schema/utils@0.3.0': {}
 
   '@storybook/addon-a11y@6.5.16(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:
@@ -23194,6 +23318,17 @@ snapshots:
 
   '@trysound/sax@0.2.0': {}
 
+  '@ts-jison/common@0.4.1-alpha.1': {}
+
+  '@ts-jison/lexer@0.4.1-alpha.1':
+    dependencies:
+      '@ts-jison/common': 0.4.1-alpha.1
+
+  '@ts-jison/parser@0.4.1-alpha.1':
+    dependencies:
+      '@ts-jison/common': 0.4.1-alpha.1
+      '@ts-jison/lexer': 0.4.1-alpha.1
+
   '@tsconfig/node10@1.0.9': {}
 
   '@tsconfig/node12@1.0.11': {}
@@ -23522,6 +23657,8 @@ snapshots:
       '@types/tough-cookie': 4.0.2
       parse5: 7.3.0
 
+  '@types/json-logic-js@2.0.8': {}
+
   '@types/json-schema@7.0.15': {}
 
   '@types/json5@0.0.29': {}
@@ -23690,6 +23827,8 @@ snapshots:
       source-map: 0.6.1
 
   '@types/unist@3.0.0': {}
+
+  '@types/use-sync-external-store@0.0.6': {}
 
   '@types/webpack-env@1.16.3': {}
 
@@ -28637,7 +28776,7 @@ snapshots:
 
   imagetracerjs@1.2.6: {}
 
-  immer@10.0.3: {}
+  immer@11.1.18: {}
 
   immer@9.0.21: {}
 
@@ -31671,6 +31810,8 @@ snapshots:
 
   num2fraction@1.2.2: {}
 
+  numeric-quantity@3.3.0: {}
+
   nwsapi@2.2.22: {}
 
   nx@22.7.5(@swc/core@1.13.5):
@@ -32894,7 +33035,7 @@ snapshots:
     dependencies:
       react: 18.2.0
 
-  react-day-picker@8.10.2(date-fns@2.30.0)(react@18.2.0):
+  react-day-picker@8.10.2(date-fns@4.4.0)(react@18.2.0):
     dependencies:
       date-fns: 4.4.0
       react: 18.2.0
@@ -33121,11 +33262,32 @@ snapshots:
       typed-styles: 0.0.7
       warning: 4.0.3
 
-  react-querybuilder@6.5.4(react@18.2.0):
+  react-querybuilder@8.23.1(@types/react@17.0.39)(react@18.2.0)(redux@5.0.1):
     dependencies:
-      clsx: 2.1.1
-      immer: 10.0.3
+      '@react-querybuilder/core': 8.23.1
+      '@reduxjs/toolkit': 2.12.0(react-redux@9.3.0(@types/react@17.0.39)(react@18.2.0)(redux@5.0.1))(react@18.2.0)
       react: 18.2.0
+      react-redux: 9.3.0(@types/react@17.0.39)(react@18.2.0)(redux@5.0.1)
+    transitivePeerDependencies:
+      - '@tanstack/db'
+      - '@traqula/parser-sparql-1-2'
+      - '@types/react'
+      - chevrotain
+      - drizzle-orm
+      - json-logic-js
+      - jsonata
+      - redux
+      - sequelize
+      - spel2js
+
+  react-redux@9.3.0(@types/react@17.0.39)(react@18.2.0)(redux@5.0.1):
+    dependencies:
+      '@types/use-sync-external-store': 0.0.6
+      react: 18.2.0
+      use-sync-external-store: 1.6.0(react@18.2.0)
+    optionalDependencies:
+      '@types/react': 17.0.39
+      redux: 5.0.1
 
   react-refresh@0.11.0: {}
 
@@ -33460,9 +33622,15 @@ snapshots:
     dependencies:
       esprima: 4.0.1
 
+  redux-thunk@3.1.0(redux@5.0.1):
+    dependencies:
+      redux: 5.0.1
+
   redux@4.2.1:
     dependencies:
       '@babel/runtime': 7.29.2
+
+  redux@5.0.1: {}
 
   refractor@2.10.1:
     dependencies:


### PR DESCRIPTION
[PF-2398]

### Description

Upgrades `react-querybuilder` and `@react-querybuilder/dnd` from exact `6.5.4` to `^8.23.1` (two majors, single hop — v7→v8 has no breaking changes for our usage) and narrows this package's `react`/`react-dom` peer ranges from `>=17.0.0 < 19.0.0` to `>=18`, since `react-querybuilder` v7+ requires React 18 via `react-redux` v9. This makes `@toptal/picasso-query-builder` the first Picasso package to drop React 17 — the exception is documented in the package README and the decision is recorded on [PF-2398](https://toptal-core.atlassian.net/browse/PF-2398).

Beyond the mechanical migration (`ControlElementsProp` typing, `getCompatContextProvider` without `key`, FullOption `value ?? name` handling, typed `fieldData` boundary), two real runtime bugs surfaced and are fixed, both covered by a new full-mount unit test:

1. **Endless re-render loop**: `useQueryBuilderValidator` updated state from inside the `validator` callback, which v7+ invokes during render. The hook now takes `{ fields, query }` and derives validation with memos; the returned validator is pure. BREAKING for direct hook consumers (called out in the changeset).
2. **"Cannot have two HTML5 backends"**: v8's `QueryBuilderDnD` eagerly mounts a react-dnd HTML5 backend (per-window singleton) per instance. The wrapper now mounts the DnD provider only when `enableDragAndDrop` is true.

Validated with the PF-2262 React 19 harness: `pnpm test:react19` on v6 (baseline) and v8 produce an identical failure set — only the 8 pre-existing harness artifacts (React 19 passes `undefined` instead of `{}` as the mock second argument); zero new failures.

### How to test

- [Temploy](https://picasso.toptal.net/feature/pf-2398-upgrade-react-querybuilder)
- Open Storybook → Picasso Query Builder → QueryBuilder with the browser console open (should stay clean):
  - **Default / Initial Values**: add/clone/remove rules and groups, switch fields/operators, type continuously in a text value editor (focus must not drop — exercises the memoization fix)
  - **Drag and Drop**: drag a rule to reorder; confirm no drag handles appear in any other example (DnD provider fix)
  - **Validation on Rule Level**: Run Query with empty/invalid inputs → error notification (rewritten validator)
  - **Maximum Group Depth / ValueEditor with Async Values**: depth capping, autocomplete editor
- `pnpm test:unit -- packages/picasso-query-builder` (37 tests, includes new full-mount `QueryBuilder.test.tsx`)
- `pnpm test:react19 --testPathPattern picasso-query-builder` (expect only the 8 pre-existing harness failures)
- Note: `pnpm test:integration` fails locally on this branch with a pre-existing `css-loader` error unrelated to this change — rely on the CI Cypress run

### Screenshots

No intended visual change — all visible controls are Picasso-owned, so the Happo expectation is zero diffs. Rule-group elements gain a `title` attribute (upstream accessibility addition).

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Double check if `picasso-tailwind-merge` requires major update (check its `README.md`)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [ ] Self reviewed
- [x] Covered with tests ([visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md) included)

**Breaking change**

- [ ] codemod is created and showcased in the changeset
- [ ] test alpha package of Picasso in StaffPortal

> All **_development checks_** should be done and set checked to pass the
> **GitHub Bot: TODOLess** action

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[PF-2398]: https://toptal-core.atlassian.net/browse/PF-2398?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PF-2398]: https://toptal-core.atlassian.net/browse/PF-2398?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ