### PR TITLE
[PF] Fix modal focus trap logic

### DIFF
--- a/.changeset/modal-focus-return-hidden-input.md
+++ b/.changeset/modal-focus-return-hidden-input.md
@@ -1,0 +1,7 @@
+---
+'@toptal/picasso-modal': patch
+---
+
+### Modal
+
+- return focus to the first focusable element even when a hidden input precedes it. `Select` and `Autocomplete` render one to carry the field `name`, so a modal starting with either let focus escape to the page behind it

--- a/packages/base/Modal/src/Modal/Modal.tsx
+++ b/packages/base/Modal/src/Modal/Modal.tsx
@@ -64,20 +64,15 @@ const defaultManager = new ModalManager()
 
 // https://github.com/udacity/ud891/blob/gh-pages/lesson2-focus/07-modals-and-keyboard-traps/solution/modal.js#L25
 // found in https://developers.google.com/web/fundamentals/accessibility/focus/using-tabindex
+// hidden inputs cannot take focus
 const focusableElementsString =
-  'a[href], area[href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), button:not([disabled]), iframe, object, embed, [tabindex="0"], [contenteditable]'
+  'a[href], area[href], input:not([disabled]):not([type="hidden"]), select:not([disabled]), textarea:not([disabled]), button:not([disabled]), iframe, object, embed, [tabindex="0"], [contenteditable]'
 // Popups portaled outside the modal that must keep focus: tooltips and any
 // Picasso Popper popup (marked `data-picasso-popper` — roles vary per consumer).
 const exemptPopupContainerString = '[role=tooltip], [data-picasso-popper]'
 
 const focusFirstFocusableElement = (node: Element) => {
-  const elements = node.querySelectorAll(focusableElementsString)
-  // Convert NodeList to Array
-  const focusableElements = Array.prototype.slice.call(elements)
-
-  if (focusableElements.length > 0) {
-    focusableElements[0].focus()
-  }
+  node.querySelector<HTMLElement>(focusableElementsString)?.focus()
 }
 
 const isFocusInsideModal = (modalNode: Element) => {

--- a/packages/base/Modal/src/Modal/test.tsx
+++ b/packages/base/Modal/src/Modal/test.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from 'react'
 import React, { useState } from 'react'
 import {
   render,
@@ -344,6 +345,66 @@ describe('Modal', () => {
       fireEvent.mouseDown(popup)
 
       expect(onMouseDown).toHaveBeenCalled()
+    })
+  })
+
+  describe('focus return', () => {
+    let outsideButton: HTMLButtonElement
+
+    const renderModal = (children: ReactNode) => {
+      render(
+        <Modal open onClose={() => {}}>
+          <TestModalContent>{children}</TestModalContent>
+        </Modal>
+      )
+
+      return screen.findByTestId('field')
+    }
+
+    beforeEach(() => {
+      outsideButton = document.createElement('button')
+      document.body.appendChild(outsideButton)
+    })
+
+    afterEach(() => {
+      cleanup()
+      outsideButton.remove()
+    })
+
+    it('returns focus to the first focusable element when it leaves the modal', async () => {
+      const field = await renderModal(<input data-testid='field' />)
+
+      outsideButton.focus()
+
+      expect(field).toHaveFocus()
+    })
+
+    it('skips hidden inputs', async () => {
+      const field = await renderModal(
+        <>
+          <input type='hidden' name='hiddenField' />
+          <input data-testid='field' />
+        </>
+      )
+
+      outsideButton.focus()
+
+      expect(field).toHaveFocus()
+    })
+
+    it('leaves focus inside an exempt popup', async () => {
+      await renderModal(<input data-testid='field' />)
+      render(
+        <div data-picasso-popper=''>
+          <Button>Popup action</Button>
+        </div>
+      )
+
+      const popupButton = screen.getByRole('button', { name: 'Popup action' })
+
+      popupButton.focus()
+
+      expect(popupButton).toHaveFocus()
     })
   })
 


### PR DESCRIPTION
### Description

`Modal` renders Base UI's dialog with `modal={false}`, so there is no focus
trap. Focus is kept inside by a document-level `focus` listener that calls
`focusFirstFocusableElement` whenever focus lands outside the modal.

That helper picks the first element matching `focusableElementsString`, whose
`input:not([disabled])` clause also matches `<input type="hidden">`. Calling
`.focus()` on a hidden input is a no-op, so the handler ran, corrected
nothing, and focus stayed outside.

`NonNativeSelect` and `Autocomplete` both render
`<input type="hidden" name={name} />` as the first child of their root
whenever `enableAutofill` is `false` (the default), so any modal whose first
field is a `Form.Select` or `Form.Autocomplete` let Tab escape onto the page
behind it. Reproduced in staff-portal on `picasso-modal@100.1.2`.

Changes:

- **Exclude hidden inputs** from the selector:
  `input:not([disabled]):not([type="hidden"])` — the same guard
  `picasso-forms` already uses in `scroll-to.ts`.
- **`focusFirstFocusableElement` queries only the first match**
  (`querySelector(…)?.focus()`) instead of materialising every focusable
  element into an array to read `[0]`. Same element, same order.
- **First focus tests for `Modal`** (`describe('focus return')`): baseline
  return, hidden-input regression, and the `[data-picasso-popper]` exemption.

Scope: `modal={false}`, the scroll lock, backdrop and pointer-dismissal are
untouched. A real focus trap would fight Picasso's portaled popups
(`Select`, `Autocomplete`, `Tooltip`, `Dropdown`) — separate discussion.

### How to test

- [Temploy](https://picasso.toptal.net/fix-picasso-modal-focus-trap)
- `pnpm test:unit -- packages/base/Modal` — `skips hidden inputs` fails on
  `master` (focus stays on the outside element) and passes here
- Manually: open a modal whose first field is a `Select` or `Autocomplete`
  with a `name` prop, Tab past the modal's last control. Before: focus stays
  on the page behind. After: it returns to the first field.

### Screenshots

N/A — focus behaviour only, no visual change.

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Double check if `picasso-tailwind-merge` requires major update (check its `README.md`)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [ ] Self reviewed
- [x] Covered with tests ([visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md) included)

**Breaking change**

- [ ] codemod is created and showcased in the changeset
- [ ] test alpha package of Picasso in StaffPortal

[FX-NNNN]: https://toptal-core.atlassian.net/browse/FX-NNNN
