### PR TITLE
[PF-2434] Fix TableExpandableRow animation

### DIFF
--- a/.changeset/table-expandable-row-colspan-collapse.md
+++ b/.changeset/table-expandable-row-colspan-collapse.md
@@ -1,0 +1,10 @@
+---
+'@toptal/picasso-table': minor
+---
+
+### Table.ExpandableRow
+
+- add `colSpan` for the collapsible content cell, defaulting to the previous hardcoded `100`. Under `table-layout: fixed` that span rendered as phantom columns that crushed the real ones — pass the table's actual column count instead
+- animate closing. The content row used to unmount the moment `expanded` turned `false`, so only opening was animated; it now stays mounted until the transition ends
+- always grow from zero height when opening. `Collapse` used to mount already open and reset to `0` on mount, which showed as a stutter; it now mounts closed and opens one commit later
+- narrow `defaultExpanded` to what it documents — skipping the transition for a row already expanded on the first render. It also used to skip the first expansion triggered later by a click, which now animates like any other

--- a/packages/base/Table/src/Table/story/ExpandableRows.example.tsx
+++ b/packages/base/Table/src/Table/story/ExpandableRows.example.tsx
@@ -142,6 +142,7 @@ const TableExpandableRowsExample = () => {
             key={id}
             content={<ExpandableContent />}
             expanded={expandedData[id]}
+            colSpan={6}
           >
             <Table.Cell>
               <Checkbox />

--- a/packages/base/Table/src/TableExpandableRow/TableExpandableRow.tsx
+++ b/packages/base/Table/src/TableExpandableRow/TableExpandableRow.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode, HTMLAttributes } from 'react'
-import React, { forwardRef, useRef, useEffect } from 'react'
+import React, { forwardRef, useEffect, useState } from 'react'
 import { Collapse } from '@toptal/picasso-collapse'
 import { type BaseProps } from '@toptal/picasso-shared'
 import { twJoin } from '@toptal/picasso-tailwind-merge'
@@ -7,7 +7,7 @@ import { twJoin } from '@toptal/picasso-tailwind-merge'
 import { TableRow } from '../TableRow'
 import { TableCell } from '../TableCell'
 
-const MAX_COL_SPAN = 100
+const DEFAULT_COL_SPAN = 100
 
 export interface Props extends BaseProps, HTMLAttributes<HTMLTableRowElement> {
   /** Should be valid `<tr>` children such as `Table.Cell`. */
@@ -16,51 +16,65 @@ export interface Props extends BaseProps, HTMLAttributes<HTMLTableRowElement> {
   content: ReactNode
   /** Whether the row is in collapsed or expanded state */
   expanded?: boolean
+  /** Number of columns the collapsible content spans */
+  colSpan?: number
   /** Set a stripe even background for the row */
   stripeEven?: boolean
-  /** Makes the row appear without transition when it is expanded the very first time */
+  /** Skips the opening transition for a row already expanded on first render */
   defaultExpanded?: boolean
 }
 
 export const TableExpandableRow = forwardRef<HTMLTableRowElement, Props>(
   function TableExpandableRow(
-    { expanded = false, stripeEven = false, ...props },
+    {
+      expanded = false,
+      stripeEven = false,
+      colSpan = DEFAULT_COL_SPAN,
+      ...props
+    },
     ref
   ) {
     const { children, content, defaultExpanded, className, style, ...rest } =
       props
 
-    const wasExpandedOnce = useRef(false)
-    const shouldTransition = !defaultExpanded || wasExpandedOnce.current
+    // the row outlives `open` so it can animate closed; `open` flips one commit
+    // after mounting so the height always has a zero to grow from
+    const [mounted, setMounted] = useState(expanded)
+    const [open, setOpen] = useState(Boolean(expanded && defaultExpanded))
 
     useEffect(() => {
-      if (!wasExpandedOnce.current && expanded) {
-        wasExpandedOnce.current = true
+      if (!expanded) {
+        setOpen(false)
+      } else if (mounted) {
+        setOpen(true)
+      } else {
+        setMounted(true)
       }
-    }, [expanded])
-
-    const row = (
-      <TableRow
-        {...rest}
-        ref={ref}
-        className={className}
-        style={style}
-        stripeEven={stripeEven}
-      >
-        {children}
-      </TableRow>
-    )
+    }, [expanded, mounted])
 
     return (
       <>
-        {row}
-        {expanded && (
+        <TableRow
+          {...rest}
+          ref={ref}
+          className={className}
+          style={style}
+          stripeEven={stripeEven}
+        >
+          {children}
+        </TableRow>
+        {mounted && (
           <TableRow
-            className={twJoin(className, stripeEven && 'bg-gray-200/[0.32]')}
+            className={twJoin(
+              className,
+              stripeEven && 'bg-gray-200/[0.32]',
+              // no hairline under a zero-height row
+              !open && 'border-b-0'
+            )}
             style={style}
           >
-            <TableCell className='p-0 last:pr-0' colSpan={MAX_COL_SPAN}>
-              <Collapse appear={shouldTransition} in>
+            <TableCell className='h-auto p-0' colSpan={colSpan}>
+              <Collapse in={open} onExited={() => setMounted(false)}>
                 {content}
               </Collapse>
             </TableCell>

--- a/packages/base/Table/src/TableExpandableRow/TableExpandableRow.tsx
+++ b/packages/base/Table/src/TableExpandableRow/TableExpandableRow.tsx
@@ -2,7 +2,7 @@ import type { ReactNode, HTMLAttributes } from 'react'
 import React, { forwardRef, useEffect, useState } from 'react'
 import { Collapse } from '@toptal/picasso-collapse'
 import { type BaseProps } from '@toptal/picasso-shared'
-import { twJoin } from '@toptal/picasso-tailwind-merge'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 
 import { TableRow } from '../TableRow'
 import { TableCell } from '../TableCell'
@@ -29,18 +29,18 @@ export const TableExpandableRow = forwardRef<HTMLTableRowElement, Props>(
     {
       expanded = false,
       stripeEven = false,
+      defaultExpanded = false,
       colSpan = DEFAULT_COL_SPAN,
       ...props
     },
     ref
   ) {
-    const { children, content, defaultExpanded, className, style, ...rest } =
-      props
+    const { children, content, className, style, ...rest } = props
 
     // the row outlives `open` so it can animate closed; `open` flips one commit
     // after mounting so the height always has a zero to grow from
     const [mounted, setMounted] = useState(expanded)
-    const [open, setOpen] = useState(Boolean(expanded && defaultExpanded))
+    const [open, setOpen] = useState(expanded && defaultExpanded)
 
     useEffect(() => {
       if (!expanded) {
@@ -65,11 +65,11 @@ export const TableExpandableRow = forwardRef<HTMLTableRowElement, Props>(
         </TableRow>
         {mounted && (
           <TableRow
-            className={twJoin(
-              className,
+            className={twMerge(
               stripeEven && 'bg-gray-200/[0.32]',
               // no hairline under a zero-height row
-              !open && 'border-b-0'
+              !open && 'border-b-0',
+              className
             )}
             style={style}
           >

--- a/packages/base/Table/src/TableExpandableRow/__snapshots__/test.tsx.snap
+++ b/packages/base/Table/src/TableExpandableRow/__snapshots__/test.tsx.snap
@@ -1,0 +1,86 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`TableExpandableRow renders collapsed 1`] = `
+<div>
+  <div
+    class="flex-1 box-border [:where(&)_*]:font-sans [&_*]:[box-sizing:inherit] [&_*::before]:[box-sizing:inherit] [&_*::after]:[box-sizing:inherit]"
+  >
+    <table
+      class="w-full border-collapse border-spacing"
+    >
+      <tbody>
+        <tr
+          class="border-0 border-solid border-b border-gray"
+        >
+          <td
+            class="h-10 py-2 border-none px-4"
+          >
+            <div
+              class="m-0 text-sm text-graphite font-inherit text-align"
+            >
+              Task
+            </div>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</div>
+`;
+
+exports[`TableExpandableRow renders expanded 1`] = `
+<div>
+  <div
+    class="flex-1 box-border [:where(&)_*]:font-sans [&_*]:[box-sizing:inherit] [&_*::before]:[box-sizing:inherit] [&_*::after]:[box-sizing:inherit]"
+  >
+    <table
+      class="w-full border-collapse border-spacing"
+    >
+      <tbody>
+        <tr
+          class="border-0 border-solid border-b border-gray"
+        >
+          <td
+            class="h-10 py-2 border-none px-4"
+          >
+            <div
+              class="m-0 text-sm text-graphite font-inherit text-align"
+            >
+              Task
+            </div>
+          </td>
+        </tr>
+        <tr
+          class="border-0 border-solid border-b border-gray"
+        >
+          <td
+            class="border-none h-auto p-0"
+            colspan="100"
+          >
+            <div
+              class="m-0 text-sm text-graphite font-inherit text-align"
+            >
+              <div
+                class="transition-[height] ease-in min-h overflow-visible"
+                style="transition-duration: 350ms; height: auto;"
+              >
+                <div
+                  class="flex"
+                >
+                  <div
+                    class="w-full"
+                  >
+                    <div>
+                      Expandable row content
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</div>
+`;

--- a/packages/base/Table/src/TableExpandableRow/test.tsx
+++ b/packages/base/Table/src/TableExpandableRow/test.tsx
@@ -1,0 +1,164 @@
+import React from 'react'
+import { act, cleanup, render } from '@toptal/picasso-test-utils'
+
+import { TableCompound as Table } from '../TableCompound'
+import type { Props } from './TableExpandableRow'
+
+const CONTENT = 'Expandable row content'
+const TRIGGER = 'Task'
+const TRANSITION_DURATION = 350
+
+const buildTable = (props: Omit<Partial<Props>, 'children'> = {}) => (
+  <Table>
+    <Table.Body>
+      <Table.ExpandableRow content={<div>{CONTENT}</div>} {...props}>
+        <Table.Cell>{TRIGGER}</Table.Cell>
+      </Table.ExpandableRow>
+    </Table.Body>
+  </Table>
+)
+
+const renderComponent = (props: Omit<Partial<Props>, 'children'> = {}) =>
+  render(buildTable(props))
+
+const contentCell = (content: HTMLElement) => content.closest('td')
+const contentRow = (content: HTMLElement) => content.closest('tr')
+const collapse = (content: HTMLElement) =>
+  content.closest('[class*="transition-[height]"]')
+
+const runTransition = () =>
+  act(() => {
+    jest.advanceTimersByTime(TRANSITION_DURATION)
+  })
+
+describe('TableExpandableRow', () => {
+  beforeEach(() => {
+    jest.useFakeTimers()
+  })
+
+  afterEach(() => {
+    cleanup()
+    jest.useRealTimers()
+  })
+
+  it('renders collapsed', () => {
+    const { container } = renderComponent()
+
+    expect(container).toMatchSnapshot()
+  })
+
+  it('renders expanded', () => {
+    const { container } = renderComponent({
+      expanded: true,
+      defaultExpanded: true,
+    })
+
+    expect(container).toMatchSnapshot()
+  })
+
+  it('does not render the content row while collapsed', () => {
+    const { container, queryByText } = renderComponent()
+
+    expect(queryByText(CONTENT)).not.toBeInTheDocument()
+    expect(container.querySelectorAll('tr')).toHaveLength(1)
+  })
+
+  it('spans every column by default', () => {
+    const { getByText } = renderComponent({ expanded: true })
+
+    expect(contentCell(getByText(CONTENT))).toHaveAttribute('colspan', '100')
+  })
+
+  it('spans the given number of columns', () => {
+    const { getByText } = renderComponent({ expanded: true, colSpan: 6 })
+
+    expect(contentCell(getByText(CONTENT))).toHaveAttribute('colspan', '6')
+  })
+
+  it('keeps colSpan off the row itself', () => {
+    const { getByText } = renderComponent({ expanded: true, colSpan: 6 })
+
+    expect(getByText(TRIGGER).closest('tr')).not.toHaveAttribute('colspan')
+  })
+
+  it('forwards className to both rows', () => {
+    const { getByText } = renderComponent({
+      expanded: true,
+      className: 'custom',
+    })
+
+    expect(getByText(TRIGGER).closest('tr')).toHaveClass('custom')
+    expect(contentRow(getByText(CONTENT))).toHaveClass('custom')
+  })
+
+  it('shades the content row when stripeEven is set', () => {
+    const { getByText } = renderComponent({ expanded: true, stripeEven: true })
+
+    expect(contentRow(getByText(CONTENT))).toHaveClass('bg-gray-200/[0.32]')
+  })
+
+  it('grows from zero height when it opens', () => {
+    const { getByText } = renderComponent({ expanded: true })
+    const content = getByText(CONTENT)
+
+    // already transitioning, but still at the height it has to grow from
+    expect(collapse(content)).not.toHaveClass('invisible')
+    expect(collapse(content)).toHaveStyle({ height: '0px' })
+
+    runTransition()
+
+    expect(collapse(content)).toHaveStyle({ height: 'auto' })
+  })
+
+  it('shows a defaultExpanded row without a transition', () => {
+    const { getByText } = renderComponent({
+      expanded: true,
+      defaultExpanded: true,
+    })
+
+    expect(collapse(getByText(CONTENT))).toHaveStyle({ height: 'auto' })
+  })
+
+  it('keeps the content mounted while it collapses, then unmounts it', () => {
+    const { getByText, queryByText, rerender } = renderComponent({
+      expanded: true,
+    })
+
+    runTransition()
+    act(() => {
+      rerender(buildTable({ expanded: false }))
+    })
+
+    const content = getByText(CONTENT)
+
+    expect(contentRow(content)).toHaveClass('border-b-0')
+    expect(collapse(content)).toHaveStyle({ height: '0px' })
+
+    runTransition()
+
+    expect(queryByText(CONTENT)).not.toBeInTheDocument()
+  })
+
+  it('never unmounts the content when it reopens mid-collapse', () => {
+    const { getByText, rerender } = renderComponent({ expanded: true })
+
+    runTransition()
+
+    const content = getByText(CONTENT)
+
+    act(() => {
+      rerender(buildTable({ expanded: false }))
+    })
+    act(() => {
+      jest.advanceTimersByTime(TRANSITION_DURATION / 2)
+    })
+    act(() => {
+      rerender(buildTable({ expanded: true }))
+    })
+    // long enough for a stale exit callback to have fired
+    runTransition()
+    runTransition()
+
+    expect(getByText(CONTENT)).toBe(content)
+  })
+})


### PR DESCRIPTION
[PF-2434]

### Description

Three defects in `Table.ExpandableRow`:

- the content cell was hardcoded `colSpan={100}` — under `table-layout: fixed` Chrome renders the excess as phantom columns and crushes the real ones
- no collapse animation — the content row unmounted the moment `expanded` turned `false`
- opening stuttered — `Collapse` mounted with `in` + `appear`, so it started at `height: auto`, was reset to `0` on mount, and only then grew

Fix:

- add `colSpan?: number`, defaulting to the previous `100` so existing consumers are unchanged, forwarded to the content `Table.Cell`
- keep the content row mounted while it closes and unmount it in `Collapse`'s `onExited`, so closing animates too
- mount `Collapse` closed and open it one commit later from `useEffect`, so the height always grows from zero. `defaultExpanded` still renders at full height with no transition
- content cell is `h-auto p-0`; the content row drops its bottom border while closed, so a collapsed row is zero height with no hairline

`h-auto` is load-bearing rather than cosmetic: `TableCell` sets `h-10`, and `height` on a `<td>` acts as a minimum, so a mounted-but-closed row would have been 40px tall.

Opening is flipped from `useEffect`, not `requestAnimationFrame` — after a click an rAF flip batches with the mount render, `Collapse` mounts already open and nothing animates.

One behavior narrowing, also called out in the changeset: `defaultExpanded` now skips the transition only for a row already expanded on the first render. It used to also skip the first expansion triggered later by a click, which now animates like any other.

### How to test

- [Temploy](https://picasso.toptal.net/pf-2434-fix-tableexpandablerow-column-animation)
- Storybook → `base/Table` → **Expandable rows**: expand and collapse a row. Both directions animate, and opening no longer jumps to full height before growing. The example now passes `colSpan={6}`.
- **Expandable rows, expanded by default**: toggle the table on — rows appear already expanded, with no transition.
- Collapse a row fully and confirm no leftover 1px line between it and the next row.
- For the `colSpan` defect, add `className='table-fixed'` to the `Table` in either example: on master the columns collapse, with `colSpan={6}` they hold.
- `pnpm test:unit -- packages/base/Table`

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Double check if `picasso-tailwind-merge` requires major update (check its `README.md`)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [ ] Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [ ] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [ ] Self reviewed
- [x] Covered with tests ([visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md) included)

**Breaking change**

- [ ] codemod is created and showcased in the changeset
- [ ] test alpha package of Picasso in StaffPortal


[PF-2434]: https://toptal-core.atlassian.net/browse/PF-2434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ