### PR TITLE
[PF] Fix emoji picker clicks falling through in RichTextEditor

### DIFF
--- a/.changeset/rte-emoji-picker-click-through.md
+++ b/.changeset/rte-emoji-picker-click-through.md
@@ -1,0 +1,7 @@
+---
+'@toptal/picasso-rich-text-editor': patch
+---
+
+### RichTextEditor
+
+- fix the emoji picker ignoring every emoji click: the open picker kept `pointer-events: none`, so clicks fell through to the editor underneath and only closed the picker. Its hidden-state classes are now dropped while it is open, and picking an emoji inserts it again. Regression from the Tailwind migration in `v100`

--- a/cypress/component/RichTextEditor/EmojiPlugin.spec.tsx
+++ b/cypress/component/RichTextEditor/EmojiPlugin.spec.tsx
@@ -1,0 +1,44 @@
+import React from 'react'
+import { EmojiPlugin } from '@toptal/picasso-rich-text-editor'
+
+import {
+  Editor,
+  editorSelector,
+  makeEditorProps,
+  resultContainerTestId,
+} from './test-helpers'
+
+// EmojiPlugin renders its toolbar trigger with this fixed id
+const emojiTriggerSelector = '#trigger-emoji-picker'
+// first entry of emoji-mart's default "Frequently used" row, so it is
+// rendered as soon as the picker opens
+const emoji = '👍'
+
+const defaultProps = makeEditorProps()
+
+describe('EmojiPlugin', () => {
+  it('inserts the picked emoji into the editor', () => {
+    cy.mount(<Editor {...defaultProps} plugins={[<EmojiPlugin />]} />)
+
+    cy.get(editorSelector).click()
+    cy.get(editorSelector).type('hello ')
+    cy.get(emojiTriggerSelector).realClick()
+
+    // the wrapper two levels above the emoji-mart element fades the picker in
+    cy.get('em-emoji-picker').parent().parent().should('be.visible')
+
+    // emoji-mart renders inside a shadow root and labels each grid button
+    // with the emoji it inserts. Not a forced click: the open picker has to
+    // receive pointer events itself, or the click lands on the editor
+    // underneath and emoji-mart treats it as a click outside
+    cy.get('em-emoji-picker')
+      .shadow()
+      .find(`button[aria-label="${emoji}"]`)
+      // the same emoji is listed under "Frequently used" and its own category
+      .first()
+      .click()
+
+    cy.get(editorSelector).should('contain.text', `hello ${emoji}`)
+    cy.getByTestId(resultContainerTestId).should('contain.text', emoji)
+  })
+})

--- a/packages/picasso-rich-text-editor/src/RichTextEditorEmojiPicker/RichTextEditorEmojiPicker.test.tsx
+++ b/packages/picasso-rich-text-editor/src/RichTextEditorEmojiPicker/RichTextEditorEmojiPicker.test.tsx
@@ -1,0 +1,38 @@
+import React from 'react'
+import { fireEvent, render, screen } from '@toptal/picasso-test-utils'
+
+import { RichTextEditorEmojiPicker } from './RichTextEditorEmojiPicker'
+
+const renderEmojiPicker = () =>
+  render(<RichTextEditorEmojiPicker onInsertEmoji={jest.fn()} />)
+
+// The wrapper that shows and hides the picker sits two levels above the
+// emoji-mart element: wrapper > EmojiMartPicker's div > em-emoji-picker
+const getPickerWrapper = (container: HTMLElement) =>
+  container.querySelector('em-emoji-picker')?.parentElement
+    ?.parentElement as HTMLElement
+
+describe('RichTextEditorEmojiPicker', () => {
+  it('keeps the picker hidden and click-through until opened', () => {
+    const { container } = renderEmojiPicker()
+
+    const wrapper = getPickerWrapper(container)
+
+    expect(wrapper).toHaveClass('opacity-0', 'pointer-events-none')
+    expect(wrapper).not.toHaveClass('pointer-events-auto')
+  })
+
+  it('opens the picker with pointer events on, so emoji clicks reach it', () => {
+    const { container } = renderEmojiPicker()
+
+    fireEvent.click(screen.getByRole('button'))
+
+    const wrapper = getPickerWrapper(container)
+
+    expect(wrapper).toHaveClass('opacity-100', 'pointer-events-auto')
+    // a leftover `pointer-events-none` wins on stylesheet order and swallows
+    // every click on the open picker
+    expect(wrapper).not.toHaveClass('pointer-events-none')
+    expect(wrapper).not.toHaveClass('opacity-0')
+  })
+})

--- a/packages/picasso-rich-text-editor/src/RichTextEditorEmojiPicker/RichTextEditorEmojiPicker.tsx
+++ b/packages/picasso-rich-text-editor/src/RichTextEditorEmojiPicker/RichTextEditorEmojiPicker.tsx
@@ -2,7 +2,6 @@
 import React, { useEffect } from 'react'
 import data from '@emoji-mart/data'
 import Picker from '@emoji-mart/react'
-import cx from 'classnames'
 import { Container } from '@toptal/picasso-container'
 import { twMerge } from '@toptal/picasso-tailwind-merge'
 
@@ -76,7 +75,7 @@ export const RichTextEditorEmojiPicker = ({
         // and it wins, so clicks fall through the open picker to the editor
         className={twMerge(
           'absolute top-[34px] left-0 z-10 opacity-0 pointer-events-none',
-          cx({ 'opacity-100 pointer-events-auto': showEmojiPicker })
+          showEmojiPicker && 'opacity-100 pointer-events-auto'
         )}
       >
         <Picker

--- a/packages/picasso-rich-text-editor/src/RichTextEditorEmojiPicker/RichTextEditorEmojiPicker.tsx
+++ b/packages/picasso-rich-text-editor/src/RichTextEditorEmojiPicker/RichTextEditorEmojiPicker.tsx
@@ -4,6 +4,7 @@ import data from '@emoji-mart/data'
 import Picker from '@emoji-mart/react'
 import cx from 'classnames'
 import { Container } from '@toptal/picasso-container'
+import { twMerge } from '@toptal/picasso-tailwind-merge'
 
 import RichTextEditorButton from '../RichTextEditorButton'
 import type { CustomEmojiGroup, Emoji } from '../plugins/EmojiPlugin'
@@ -15,12 +16,6 @@ interface Props {
 }
 
 const TRIGGER_EMOJI_PICKER_ID = 'trigger-emoji-picker'
-
-const classes = {
-  emojiPicker: 'absolute top-[34px] left-0 z-10 opacity-0 pointer-events-none',
-  activeOpacity: 'opacity-100',
-  activePointers: '[pointer-events:all]',
-}
 
 const handleEmojiPickerEscBehaviour = (
   event: KeyboardEvent,
@@ -76,10 +71,12 @@ export const RichTextEditorEmojiPicker = ({
         disabled={disabled}
       />
       <Container
-        className={cx(
-          classes.emojiPicker,
-          showEmojiPicker && classes.activeOpacity,
-          showEmojiPicker && classes.activePointers
+        // twMerge drops the hidden-state classes when open; leaving
+        // `pointer-events-none` in place would let stylesheet order decide,
+        // and it wins, so clicks fall through the open picker to the editor
+        className={twMerge(
+          'absolute top-[34px] left-0 z-10 opacity-0 pointer-events-none',
+          cx({ 'opacity-100 pointer-events-auto': showEmojiPicker })
         )}
       >
         <Picker


### PR DESCRIPTION
### Description

Picking an emoji in the RichTextEditor emoji picker did nothing: the popper closed and the editor kept its text. This is broken on master and on every deploy since the Tailwind migration (#5059).

**Cause.** The picker wrapper always carried `pointer-events-none` and toggled `[pointer-events:all]` on open through `cx`. Both utilities have the same specificity, so stylesheet order decides, and the arbitrary-property rule is emitted three rules before `.pointer-events-none`. The open picker was therefore transparent to clicks: each click landed on the editor underneath, emoji-mart's document-level listener treated it as a click outside and closed the picker, and `onEmojiSelect` never ran. Insertion itself was fine; forcing `pointer-events: auto` on the wrapper in DevTools made the same click insert the emoji.

**Fix.** Compose the wrapper with `twMerge` and toggle `opacity-100 pointer-events-auto` while open, so the hidden-state classes are dropped instead of competing on order. The private `classes` constant goes with it. Public props, the `EmojiPlugin` API, the `#trigger-emoji-picker` id and the closed-state markup are unchanged; only the open picker's class list differs, which is the fix.

**Tests.**

- `RichTextEditorEmojiPicker.test.tsx` (jsdom) asserts the wrapper is hidden and click-through until opened, and carries a single pointer-events class once open.
- `cypress/component/RichTextEditor/EmojiPlugin.spec.tsx` opens the picker with a real click, clicks 👍 inside emoji-mart's shadow root without forcing, and asserts the emoji lands in the editor and in the serialized value. Against the previous code it fails at the click: Cypress reports the emoji button covered by the editor.

**Why nothing caught it.** The plugin's unit test mocks all of Lexical, no Cypress spec covered the picker, and Happo only sees that the open picker looks right.

### How to test

<!-- The temploy link will be automatically updated when the temploy is deployed -->
- [Temploy](https://picasso.toptal.net/pf-fix-emoji-picker-rte)
- On the temploy Storybook open Forms → RichTextEditor → Emojis (`?path=/story/forms-richtexteditor--richtexteditor#emojis`): click into the editor, type some text, click 🙂, then click any emoji. Expected: the emoji is inserted at the caret, shows up in the value panel below the editor, and the picker closes. On [master's Storybook](https://toptal.github.io/picasso/?path=/story/forms-richtexteditor--richtexteditor#emojis) the same steps only close the picker.
- `pnpm test:unit -- packages/picasso-rich-text-editor/src/RichTextEditorEmojiPicker`
- `pnpm test:setup cypress run --component --spec cypress/component/RichTextEditor/EmojiPlugin.spec.tsx`

### Screenshots

| Before                                                                  | After                                                  |
| ----------------------------------------------------------------------- | ------------------------------------------------------ |
| Clicking an emoji only closes the picker; the editor still reads `hello ` | The emoji is inserted and the editor reads `hello 👍` |

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Double check if `picasso-tailwind-merge` requires major update (check its `README.md`)
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/), and it's been already discussed with designers at #-base-core
- [x] Annotate all `props` in component with documentation
- [x] Create `examples` for component
- [ ] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues. [How to use accessibility plugin in storybook](https://github.com/toptal/picasso/blob/master/docs/contribution/accessibility.md).
- [ ] Self reviewed
- [x] Covered with tests ([visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md) included)

**Breaking change**

None. The changeset is a `patch` for `@toptal/picasso-rich-text-editor`; no codemod or alpha verification is needed.
