### PR TITLE
[PF-2444] Tweak Modal focus trap

### DIFF
--- a/.changeset/modal-focus-trap-event-target.md
+++ b/.changeset/modal-focus-trap-event-target.md
@@ -1,0 +1,7 @@
+---
+'@toptal/picasso-modal': patch
+---
+
+### Modal
+
+- fix a `Select` or `Autocomplete` popup inside a modal closing the instant it opens. The focus trap read `document.activeElement`, which has not moved yet during the capture-phase `focus` dispatch, so focus landing in a popper portaled outside the modal looked like an escape and got pulled back. The incoming element is now read off the event

--- a/.changeset/modal-focus-trap-event-target.md
+++ b/.changeset/modal-focus-trap-event-target.md
@@ -4,4 +4,5 @@
 
 ### Modal
 
-- fix a `Select` or `Autocomplete` popup inside a modal closing the instant it opens. The focus trap read `document.activeElement`, which has not moved yet during the capture-phase `focus` dispatch, so focus landing in a popper portaled outside the modal looked like an escape and got pulled back. The incoming element is now read off the event
+- fix a `Select` or `Autocomplete` popup inside a `Modal` closing as soon as it opens. The focus trap read `document.activeElement`, which is still the outgoing element during capture-phase `focus` dispatch, so focus entering a popper portaled outside the modal looked like an escape and was pulled back
+- the trap did nothing in modals whose first focusable match was a hidden input, so it now applies where it previously did not

--- a/packages/base/Modal/src/Modal/Modal.tsx
+++ b/packages/base/Modal/src/Modal/Modal.tsx
@@ -75,32 +75,22 @@ const focusFirstFocusableElement = (node: Element) => {
   node.querySelector<HTMLElement>(focusableElementsString)?.focus()
 }
 
-const isFocusInsideModal = (modalNode: Element) => {
-  const modalContainsFocusedElement = modalNode.contains(document.activeElement)
+// The incoming element is read off the focus event rather than from
+// `document.activeElement`, which has not moved yet during capture-phase
+// dispatch and would make both guards below test the outgoing element.
+const isFocusInsideModal = (modalNode: Element, focused: Node | null) =>
+  focused !== null && modalNode.contains(focused)
 
-  if (modalContainsFocusedElement) {
-    return true
-  }
-
-  return false
-}
-
-const isFocusInsideExemptPopup = () => {
-  const popupContainers = document.querySelectorAll(exemptPopupContainerString)
-
-  if (popupContainers.length === 0) {
+const isFocusInsideExemptPopup = (focused: Node | null) => {
+  if (focused === null) {
     return false
   }
 
-  const popupContainsFocusedElement = Array.from(popupContainers).some(
-    container => container.contains(document.activeElement)
+  const popupContainers = document.querySelectorAll(exemptPopupContainerString)
+
+  return Array.from(popupContainers).some(container =>
+    container.contains(focused)
   )
-
-  if (popupContainsFocusedElement) {
-    return true
-  }
-
-  return false
 }
 
 const generateKey = (() => {
@@ -152,7 +142,9 @@ export const Modal = forwardRef<HTMLDivElement, Props>(function Modal(
   const { rootRef } = useContext(RootContext)
 
   useEffect(() => {
-    const handleDocumentFocus = () => {
+    const handleDocumentFocus = (event: FocusEvent) => {
+      const focused = (event.target as Node | null) ?? document.activeElement
+
       if (!rootRef?.current) {
         console.warn(
           'Modal is not rendered inside PicassoRoot, some things might not work as expected. Please open the Modal on mount using useEffect.'
@@ -167,11 +159,11 @@ export const Modal = forwardRef<HTMLDivElement, Props>(function Modal(
         return
       }
 
-      if (isFocusInsideModal(modalRef.current)) {
+      if (isFocusInsideModal(modalRef.current, focused)) {
         return
       }
 
-      if (isFocusInsideExemptPopup()) {
+      if (isFocusInsideExemptPopup(focused)) {
         return
       }
 

--- a/packages/base/Modal/src/Modal/Modal.tsx
+++ b/packages/base/Modal/src/Modal/Modal.tsx
@@ -75,9 +75,6 @@ const focusFirstFocusableElement = (node: Element) => {
   node.querySelector<HTMLElement>(focusableElementsString)?.focus()
 }
 
-// The incoming element is read off the focus event rather than from
-// `document.activeElement`, which has not moved yet during capture-phase
-// dispatch and would make both guards below test the outgoing element.
 const isFocusInsideModal = (modalNode: Element, focused: Node | null) =>
   focused !== null && modalNode.contains(focused)
 

--- a/packages/base/Modal/src/Modal/test.tsx
+++ b/packages/base/Modal/src/Modal/test.tsx
@@ -406,6 +406,25 @@ describe('Modal', () => {
 
       expect(popupButton).toHaveFocus()
     })
+
+    it('leaves focus inside an exempt popup before activeElement moves', async () => {
+      const field = await renderModal(<input data-testid='field' />)
+
+      render(
+        <div data-picasso-popper=''>
+          <Button>Popup action</Button>
+        </div>
+      )
+
+      const popupButton = screen.getByRole('button', { name: 'Popup action' })
+
+      // browsers can dispatch the capture-phase `focus` while
+      // `document.activeElement` still points at the outgoing element
+      ;(document.activeElement as HTMLElement | null)?.blur()
+      popupButton.dispatchEvent(new FocusEvent('focus'))
+
+      expect(field).not.toHaveFocus()
+    })
   })
 
   describe('page scroll lock', () => {

--- a/packages/base/Modal/src/Modal/test.tsx
+++ b/packages/base/Modal/src/Modal/test.tsx
@@ -418,8 +418,7 @@ describe('Modal', () => {
 
       const popupButton = screen.getByRole('button', { name: 'Popup action' })
 
-      // browsers can dispatch the capture-phase `focus` while
-      // `document.activeElement` still points at the outgoing element
+      // fake the browser order: capture-phase focus before activeElement moves
       ;(document.activeElement as HTMLElement | null)?.blur()
       popupButton.dispatchEvent(new FocusEvent('focus'))
 


### PR DESCRIPTION
[PF-2444]

### Description

Fixes a regression from #5103 (`@toptal/picasso-modal@100.1.3`): opening a
`Select` or `Autocomplete` inside a `Modal` closes its popup immediately —
`[data-picasso-popper]` never becomes visible.

`handleDocumentFocus` is registered on `document` in the **capture** phase, but
both of its guards read `document.activeElement`. During capture-phase `focus`
dispatch `activeElement` has not moved to the incoming element yet, so both
guards test the *outgoing* one. When focus moves into a popper portaled outside
the modal, neither guard recognises it and the trap yanks focus back, closing
the popup.

The guards now take the incoming node, read off `event.target`.

The `input:not([disabled]):not([type="hidden"])` selector from #5103 is **kept
as-is** — it is not the bug, it only unmasked it. Before #5103 the selector
usually matched an `input[type="hidden"]` first and `.focus()` on a hidden input
is a no-op, so the broken guard had no visible effect. The trap has therefore
been inert for many modals; this makes it work for the first time, which may
surface other focus behaviour.

### How to test

- [Temploy](https://picasso.toptal.net/pf-2444-modal-focus-trap)
- Storybook → `Modal` → `Default`, open the modal, click the **State** select.
  The popup must open and stay open.
- `Modal` → `Tooltips` still keeps focus in tooltips.
- Unit: `pnpm test:unit -- packages/base/Modal/src`. The new test
  `leaves focus inside an exempt popup before activeElement moves` reproduces
  the browser ordering (blur to `body`, then a capture-phase `focus` targeting a
  `[data-picasso-popper]`) and fails on `master`.

### Screenshots

No visual change — behaviour only, no Happo diffs expected.

### Development checks

- [x] Add changeset according to [guidelines](https://github.com/toptal/picasso/blob/master/docs/contribution/changeset-guidelines.md) (if needed)
- [x] Double check if `picasso-tailwind-merge` requires major update (check its `README.md`) — no styling change
- [x] Read [CONTRIBUTING.md](https://github.com/toptal/picasso/blob/master/CONTRIBUTING.md) and [Component API principles](https://github.com/toptal/picasso/blob/master/docs/contribution/component-api.md)
- [x] Make sure that additions and changes on the design follow [Toptal's BASE design](https://design.toptal.net/) — n/a, no design change
- [x] Annotate all `props` in component with documentation — n/a, no prop change
- [x] Create `examples` for component — n/a, existing `Default` example covers it
- [x] Ensure that deployed demo has expected results and good examples
- [x] Ensure the changed/created components have not caused accessibility issues — fixes an a11y bug (focus trap fighting popovers)
- [x] Self reviewed
- [x] Covered with tests ([visual tests](https://github.com/toptal/picasso/blob/master/docs/contribution/visual-testing.md) included)


[PF-2444]: https://toptal-core.atlassian.net/browse/PF-2444?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ